### PR TITLE
Fix mcp server test failure

### DIFF
--- a/lib/msf/core/mcp/server.rb
+++ b/lib/msf/core/mcp/server.rb
@@ -109,7 +109,7 @@ module Msf::MCP
     # @return [MCP::Server] The MCP server instance (for testing purposes)
     #
     def start_http(host, port)
-      require 'rack'
+      require 'rackup'
       require 'rack/handler/puma'
 
       transport = ::MCP::Server::Transports::StreamableHTTPTransport.new(@mcp_server)
@@ -121,15 +121,7 @@ module Msf::MCP
         run transport
       end
 
-      # Start Puma server using the handler appropriate for the Rack version.
-      # Rackup::Handler is available with rackup >= 2.x / Rack 3+;
-      # Rack::Handler is used with Rack < 3 and rackup 1.x.
-      puma_handler = if defined?(Rackup::Handler)
-                       Rackup::Handler::Puma
-                     else
-                       Rack::Handler::Puma
-                     end
-      puma_handler.run(
+      Rackup::Handler::Puma.run(
         rack_app,
         Port: port,
         Host: host,

--- a/spec/lib/msf/core/mcp/server_spec.rb
+++ b/spec/lib/msf/core/mcp/server_spec.rb
@@ -180,21 +180,17 @@ RSpec.describe Msf::MCP::Server do
       let(:mock_http_transport) do
         instance_double(::MCP::Server::Transports::StreamableHTTPTransport)
       end
-      let(:puma_handler) { double('puma_handler') }
+
       let(:rack_app) { double('rack_app') }
 
       before do
-        # Stub #require to prevent actually loading rack and rack/handler/puma
-        allow(server).to receive(:require).with('rack').and_return(true)
-        allow(server).to receive(:require).with('rack/handler/puma').and_return(true)
-
-        stub_const('Rack::Handler::Puma', puma_handler)
-        stub_const('Rack::Builder', double('Rack::Builder'))
+        require 'rackup'
+        require 'rack/handler/puma'
 
         allow(::MCP::Server::Transports::StreamableHTTPTransport).to receive(:new).and_return(mock_http_transport)
         allow(Rack::Builder).to receive(:new).and_return(rack_app)
 
-        allow(puma_handler).to receive(:run)
+        allow(Rackup::Handler::Puma).to receive(:run)
       end
 
       it 'creates http transport' do
@@ -204,7 +200,7 @@ RSpec.describe Msf::MCP::Server do
       end
 
       it 'starts Puma server via Rack handler' do
-        expect(puma_handler).to receive(:run).with(
+        expect(Rackup::Handler::Puma).to receive(:run).with(
           anything,  # Rack app
           hash_including(
             Port: 3000,
@@ -216,7 +212,7 @@ RSpec.describe Msf::MCP::Server do
       end
 
       it 'allows custom port' do
-        expect(puma_handler).to receive(:run).with(
+        expect(Rackup::Handler::Puma).to receive(:run).with(
           anything,
           hash_including(Port: 8080)
         )
@@ -225,7 +221,7 @@ RSpec.describe Msf::MCP::Server do
       end
 
       it 'creates a Rack application' do
-        expect(puma_handler).to receive(:run) do |rack_app, options|
+        expect(Rackup::Handler::Puma).to receive(:run) do |rack_app, options|
           expect(rack_app).to be(rack_app)
           expect(options).to include(Port: 3000, Host: 'localhost')
         end


### PR DESCRIPTION
Fix mcp server test failure

```
Failure/Error: Rackup::Handler::Puma

     NameError:
       uninitialized constant Rackup::Handler::Puma
     # ./lib/msf/core/mcp/server.rb:128:in `start_http'
     # ./lib/msf/core/mcp/server.rb:72:in `start'
     # ./spec/lib/msf/core/mcp/server_spec.rb:215:in `block (4 levels) in <top (required)>'
```

## Verification

Ensure CI passes