### PR TITLE
Add service hierarchy reporting to HTTP & modify Jenkins login scanner

### DIFF
--- a/lib/metasploit/framework/login_scanner/advantech_webaccess.rb
+++ b/lib/metasploit/framework/login_scanner/advantech_webaccess.rb
@@ -24,6 +24,7 @@ module Metasploit
           })
 
           if res && res.body =~ /Welcome to Advantech WebAccess/i
+            report_service(service_opts)
             return false
           end
 
@@ -67,9 +68,7 @@ module Metasploit
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           begin
@@ -80,6 +79,10 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('advantech_webaccess')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/axis2.rb
+++ b/lib/metasploit/framework/login_scanner/axis2.rb
@@ -18,15 +18,8 @@ module Metasploit
         def attempt_login(credential)
           result_opts = {
               credential: credential,
-              host: host,
-              port: port,
-              protocol: 'tcp'
+              **service_as_result(service_opts)
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
 
           begin
             # Refactor to access Metasploit::Framework::LoginScanner::HTTP#send_request()
@@ -67,6 +60,10 @@ module Metasploit
         # @raise [RuntimeError]
         def method=(_)
           raise RuntimeError, "Method must be POST for Axis2"
+        end
+
+        def service_opts
+          build_service_opts('axis2')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -140,6 +140,10 @@ module Metasploit
             ::IO.select(nil,nil,nil,time) unless sleep_time.zero?
           end
 
+          def workspace
+            framework_module&.workspace || framework&.db&.workspace&.name
+          end
+
           def each_credential
             cred_details.each do |raw_cred|
 

--- a/lib/metasploit/framework/login_scanner/bavision_cameras.rb
+++ b/lib/metasploit/framework/login_scanner/bavision_cameras.rb
@@ -25,6 +25,8 @@ module Metasploit
             return "Unable to locate \"realm=IPCamera Login\" in headers. (Is this really a BAVision camera?)"
           end
 
+          report_service(service_opts)
+
           false
         end
 
@@ -105,9 +107,7 @@ module Metasploit
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           begin
@@ -118,6 +118,10 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('bavision_cameras')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/buffalo.rb
+++ b/lib/metasploit/framework/login_scanner/buffalo.rb
@@ -24,15 +24,8 @@ module Metasploit
         def attempt_login(credential)
           result_opts = {
               credential: credential,
-              host: host,
-              port: port,
-              protocol: 'tcp'
+              **service_as_result(service_opts)
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
           begin
             res = send_request({
               'method'=>'POST',
@@ -56,6 +49,10 @@ module Metasploit
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
           end
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('buffalo')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/caidao.rb
+++ b/lib/metasploit/framework/login_scanner/caidao.rb
@@ -82,16 +82,8 @@ module Metasploit
             credential:  credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
-
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
 
           begin
             result_opts.merge!(try_login(credential.public, credential.private))
@@ -99,6 +91,10 @@ module Metasploit
             result_opts.merge!(status: LOGIN_STATUS::UNABLE_TO_CONNECT, proof: e.message)
           end
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('caidao')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/chef_webui.rb
+++ b/lib/metasploit/framework/login_scanner/chef_webui.rb
@@ -28,9 +28,7 @@ module Metasploit
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           begin
@@ -62,6 +60,8 @@ module Metasploit
           rescue ::EOFError, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError, Rex::ConnectionError, ::Timeout::Error
             return "Unable to connect to target"
           end
+
+          report_service(service_opts)
 
           false
         end
@@ -142,6 +142,10 @@ module Metasploit
           end
 
           {:status => Metasploit::Model::Login::Status::INCORRECT, :proof => res.body}
+        end
+
+        def service_opts
+          build_service_opts('chef_webui')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/cisco_firepower.rb
+++ b/lib/metasploit/framework/login_scanner/cisco_firepower.rb
@@ -18,6 +18,7 @@ module Metasploit
           })
 
           if res && res.code == 200 && res.body.include?('/img/favicon.png?v=6.0.1-1213')
+            report_service(service_opts)
             return false
           end
 
@@ -58,9 +59,7 @@ module Metasploit
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           begin
@@ -71,6 +70,10 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('cisco_firepower')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/directadmin.rb
+++ b/lib/metasploit/framework/login_scanner/directadmin.rb
@@ -20,6 +20,7 @@ module Metasploit
           res = send_request({'uri'=> login_uri})
 
           if res && res.body.include?('DirectAdmin Login')
+            report_service(service_opts)
             return false
           end
 
@@ -99,10 +100,7 @@ module Metasploit
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp',
-            service_name: ssl ? 'https' : 'http'
+            **service_as_result(service_opts)
           }
 
           begin
@@ -113,6 +111,10 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('directadmin')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/gitlab.rb
+++ b/lib/metasploit/framework/login_scanner/gitlab.rb
@@ -21,10 +21,7 @@ module Metasploit
         def attempt_login(credential)
           result_opts = {
             credential: credential,
-            host: host,
-            port: port,
-            protocol: 'tcp',
-            service_name: ssl ? 'https' : 'http'
+            **service_as_result(service_opts)
           }
           begin 
             # Get a valid session cookie and authenticity_token for the next step
@@ -76,6 +73,10 @@ module Metasploit
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('gitlab')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -68,6 +68,8 @@ module Metasploit
             return "Unable to connect to target"
           end
 
+          report_service(service_opts)
+
           false
         end
 
@@ -203,7 +205,10 @@ module Metasploit
         # @param credential [Metasploit::Framework::Credential] The credential object
         # @return [Result]
         def attempt_login(credential)
-          result_opts = { credential: credential }
+          result_opts = {
+            credential: credential,
+            **service_as_result(service_opts)
+          }
 
           begin
             case self.version
@@ -248,6 +253,9 @@ module Metasploit
           return @version
         end
 
+        def service_opts
+          build_service_opts('glassfish')
+        end
 
       end
     end

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -10,6 +10,7 @@ module Metasploit
       class HTTP
         include Metasploit::Framework::LoginScanner::Base
         include Metasploit::Framework::LoginScanner::RexSocket
+        include Msf::Auxiliary::Report
 
         AUTHORIZATION_HEADER = 'WWW-Authenticate'.freeze
         DEFAULT_REALM = nil
@@ -218,6 +219,8 @@ module Metasploit
           end
 
           if authentication_required?(response)
+            # TODO: we might be able to do this, but look into potential false positives first.
+            # report_service(service)
             return false
           end
 
@@ -274,17 +277,8 @@ module Metasploit
           result_opts = {
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
-            proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(build_http_service_opts)
           }
-
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
 
           request_opts = {'credential'=>credential, 'uri'=>uri, 'method'=>method}
           if keep_connection_alive
@@ -325,6 +319,75 @@ module Metasploit
 
           self.class::DEFAULT_HTTP_NOT_AUTHED_CODES.include?(response.code) &&
             response.headers[self.class::AUTHORIZATION_HEADER]
+        end
+
+        def build_http_service_opts
+          if ssl
+            {
+              name: 'https',
+              host: host,
+              port: port,
+              proto: 'tcp',
+              parents: [
+                {
+                  name: 'ssl',
+                  host: host,
+                  port: port,
+                  proto: 'tcp',
+                  parents: [
+                    {
+                      name: 'tcp',
+                      host: host,
+                      port: port,
+                      proto: 'tcp'
+                    }
+                  ]
+                }
+              ]
+            }
+          else
+            {
+              name: 'http',
+              host: host,
+              port: port,
+              proto: 'tcp',
+              parents: [
+                {
+                  name: 'tcp',
+                  host: host,
+                  port: port,
+                  proto: 'tcp'
+                }
+              ]
+            }
+          end
+        end
+
+        def service_as_result(service)
+          transform_map = { name: :service_name, proto: :protocol }
+          service.transform_keys { |key| transform_map[key] || key }
+        end
+
+        def service_opts
+          raise NotImplementedError
+        end
+
+        # @see Msf::Auxiliary::Report#db
+        def db
+          framework&.db&.active
+        end
+
+        def build_service_opts(software_name)
+          parents = build_http_service_opts
+
+          {
+            name: software_name.downcase,
+            host: host,
+            port: port,
+            proto: 'tcp',
+            resource: uri,
+            parents: [ parents ]
+          }
         end
 
         private

--- a/lib/metasploit/framework/login_scanner/ipboard.rb
+++ b/lib/metasploit/framework/login_scanner/ipboard.rb
@@ -19,15 +19,8 @@ module Metasploit
         def attempt_login(credential)
           result_opts = {
               credential: credential,
-              host: host,
-              port: port,
-              protocol: 'tcp'
+              **service_as_result(service_opts)
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
 
           begin
 
@@ -93,6 +86,10 @@ module Metasploit
         # @raise [RuntimeError]
         def method=(_)
           raise RuntimeError, "Method must be POST for IPBoard"
+        end
+
+        def service_opts
+          build_service_opts('ipboard')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/ivanti_login.rb
+++ b/lib/metasploit/framework/login_scanner/ivanti_login.rb
@@ -27,6 +27,7 @@ module Metasploit
           res = send_request(request_params)
 
           if res && res.code == 200 && res.body&.include?('Ivanti Connect Secure')
+            report_service(service_opts)
             return false
           end
 
@@ -169,10 +170,7 @@ module Metasploit
           # focus on creating Result object, pass it to #login routine and return Result object
           result_options = {
             credential: credential,
-            host: @host,
-            port: @port,
-            protocol: 'tcp',
-            service_name: 'ivanti'
+            **service_as_result(service_opts)
           }
 
           if @use_admin_endpoint
@@ -183,6 +181,10 @@ module Metasploit
 
           result_options.merge!(login_result)
           Result.new(result_options)
+        end
+
+        def service_opts
+          build_service_opts('ivanti')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/jenkins.rb
+++ b/lib/metasploit/framework/login_scanner/jenkins.rb
@@ -5,12 +5,14 @@ module Metasploit
     module LoginScanner
       # Jenkins login scanner
       class Jenkins < HTTP
+
         # Inherit LIKELY_PORTS,LIKELY_SERVICE_NAMES, and REALM_KEY from HTTP
         CAN_GET_SESSION = true
         DEFAULT_HTTP_NOT_AUTHED_CODES = [403]
         DEFAULT_PORT = 8080
         PRIVATE_TYPES = [:password].freeze
         LOGIN_PATH_REGEX = /action="(j_([a-z0-9_]+))"/
+        # TODO: We can potentially append 'Jenkins'/'jenkins' to the LIKELY_SERVICE_NAME as now our service fingerprinting is more granular.
 
         # Checks the setup for the Jenkins Login scanner.
         #
@@ -21,6 +23,8 @@ module Metasploit
           return 'Unable to locate the Jenkins login path' if login_uri.nil?
 
           self.uri = normalize_uri(login_uri)
+
+          report_service(service_opts)
 
           false
         end
@@ -39,16 +43,8 @@ module Metasploit
         def attempt_login(credential)
           result_opts = {
             credential: credential,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
-
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
 
           status, proof = jenkins_login(credential.public, credential.private)
 
@@ -67,6 +63,11 @@ module Metasploit
           return false unless response
 
           self.class::DEFAULT_HTTP_NOT_AUTHED_CODES.include?(response.code)
+        end
+
+        # This needs some tweaking in order to work with credentials
+        def service_opts
+          build_service_opts('jenkins')
         end
 
         private

--- a/lib/metasploit/framework/login_scanner/jupyter.rb
+++ b/lib/metasploit/framework/login_scanner/jupyter.rb
@@ -23,10 +23,7 @@ module Metasploit
         def attempt_login(credential)
           result_opts = {
             credential: credential,
-            host: host,
-            port: port,
-            protocol: 'tcp',
-            service_name: ssl ? 'https' : 'http'
+            **service_as_result(service_opts)
           }
 
           begin
@@ -54,6 +51,10 @@ module Metasploit
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
           end
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('jupyter')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
+++ b/lib/metasploit/framework/login_scanner/manageengine_desktop_central.rb
@@ -23,6 +23,7 @@ module Metasploit
 
           fingerprint = 'ManageEngine Desktop Central'
           if res && res.body.include?(fingerprint)
+            report_service(service_opts)
             return false
           end
 
@@ -115,10 +116,7 @@ module Metasploit
             credential: credential,
             status: LOGIN_STATUS::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp',
-            service_name: ssl ? 'https' : 'http',
+            **service_as_result(service_opts),
           }
 
           begin
@@ -129,6 +127,10 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('manageengine_desktop_central')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -23,15 +23,8 @@ module Metasploit
         def attempt_login(credential)
           result_opts = {
             credential: credential,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
           begin
             res = send_request({
               'method' => method,
@@ -53,6 +46,10 @@ module Metasploit
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
           end
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('mybook_live')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/nessus.rb
+++ b/lib/metasploit/framework/login_scanner/nessus.rb
@@ -22,6 +22,7 @@ module Metasploit
           login_uri = "/server/properties"
           res = send_request({'uri'=> login_uri})
           if res && res.body.include?('Nessus')
+            report_service(service_opts)
             return false
           end
 
@@ -67,9 +68,7 @@ module Metasploit
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           begin
@@ -87,6 +86,10 @@ module Metasploit
           # nessus_rest_login has the same default in TARGETURI, but rspec doesn't check nessus_rest_login
           # so we have to set the default here, too.
           self.uri = '/session'
+        end
+
+        def service_opts
+          build_service_opts('nessus')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/octopusdeploy.rb
+++ b/lib/metasploit/framework/login_scanner/octopusdeploy.rb
@@ -24,15 +24,8 @@ module Metasploit
         def attempt_login(credential)
           result_opts = {
             credential: credential,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
           begin
             json_post_data = JSON.pretty_generate({ Username: credential.public, Password: credential.private })
             res = send_request({
@@ -54,6 +47,10 @@ module Metasploit
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
           end
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('octopusdeploy')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/opnsense.rb
+++ b/lib/metasploit/framework/login_scanner/opnsense.rb
@@ -28,6 +28,7 @@ module Metasploit
           res = send_request(request_params)
 
           if res && res.code == 200 && res.body&.include?('Login | OPNsense')
+            report_service(service_opts)
             return false
           end
 
@@ -97,10 +98,7 @@ module Metasploit
         def attempt_login(credential)
           result_options = {
             credential:   credential,
-            host:         @host,
-            port:         @port,
-            protocol:     'tcp',
-            service_name: 'opnsense'
+            **service_as_result(service_opts)
           }
 
           # Each login needs its own magic name and value
@@ -131,6 +129,10 @@ module Metasploit
         rescue ::Rex::ConnectionError => _e
           result_options.merge!(status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Unable to connect to OPNSense')
           return Result.new(result_options)
+        end
+
+        def service_opts
+          build_service_opts('opnsense')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/pfsense.rb
+++ b/lib/metasploit/framework/login_scanner/pfsense.rb
@@ -21,6 +21,7 @@ module Metasploit
           res = send_request(request_params)
 
           if res&.code == 200 && res.body&.include?('Login to pfSense')
+            report_service(service_opts)
             return false
           end
 
@@ -75,10 +76,7 @@ module Metasploit
         def attempt_login(credential)
           result_options = {
             credential:   credential,
-            host:         @host,
-            port:         @port,
-            protocol:     'tcp',
-            service_name: 'pfsense'
+            **service_as_result(service_opts)
           }
 
           # Each login needs its own csrf magic tokens
@@ -109,6 +107,10 @@ module Metasploit
         rescue ::Rex::ConnectionError => _e
           result_options.merge!(status: ::Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: 'Unable to connect to pfSense')
           return Result.new(result_options)
+        end
+
+        def service_opts
+          build_service_opts('pfsense')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/phpmyadmin.rb
+++ b/lib/metasploit/framework/login_scanner/phpmyadmin.rb
@@ -15,6 +15,7 @@ module Metasploit
             version = Rex::Version.new($1).to_s
             if version.present?
               framework_module.print_status("PhpMyAdmin Version: #{version}") if framework_module
+              report_service(service_opts)
               return false
             end
           end
@@ -72,14 +73,16 @@ module Metasploit
             credential: credential,
             status: LOGIN_STATUS::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           result_opts.merge!(do_login(credential.public, credential.private))
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('phpmyadmin')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/result.rb
+++ b/lib/metasploit/framework/login_scanner/result.rb
@@ -20,6 +20,9 @@ module Metasploit
         # @!attribute port
         #   @return [Integer] the port number of the service for this result
         attr_accessor :port
+        # @!attribute parents
+        #   @return [Object] the service parents of this result's service. These get reported when creating credentials.
+        attr_accessor :parents
         # @!attribute proof
         #   @return [#to_s] the proof of the login's success or failure
         attr_accessor :proof
@@ -35,6 +38,9 @@ module Metasploit
         # @!attribute connection
         #   @return [Object] the post-authenticated connection object (if the scanner chooses to leave it open)
         attr_accessor :connection
+        # @!attribute resource
+        #   @return [Object] the service's resource, if any, e.g. website URI
+        attr_accessor :resource
 
         validates :status,
           inclusion: {
@@ -72,7 +78,9 @@ module Metasploit
               proof: proof,
               protocol: protocol,
               service_name: service_name,
-              status: status
+              status: status,
+              parents: parents,
+              resource: resource
           )
           result_hash.delete_if { |k,v| v.nil? }
         end

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -16,7 +16,8 @@ module Metasploit
         # (see Base#attempt_login)
         def attempt_login(credential)
           result_opts = {
-            credential: credential
+            credential: credential,
+            **service_as_result(service_opts)
           }
 
           req_opts = {
@@ -47,6 +48,10 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('smh')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/softing_sis.rb
+++ b/lib/metasploit/framework/login_scanner/softing_sis.rb
@@ -26,6 +26,7 @@ module Metasploit
             if res_json['version']
               # report the version
               framework_module.print_brute(level: :good, ip: ip, msg: "Softing Secure Integration Server #{res_json['version']}") if framework_module
+              report_service(service_opts)
               return false
             end
           end
@@ -149,9 +150,7 @@ module Metasploit
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           begin
@@ -162,6 +161,10 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('softing_sis')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/sonicwall.rb
+++ b/lib/metasploit/framework/login_scanner/sonicwall.rb
@@ -81,6 +81,7 @@ module Metasploit
           }
           res = send_request(request_params)
           if res&.code == 200 && res.body&.include?('SonicWall')
+            report_service(service_opts)
             return false
           end
 
@@ -139,13 +140,14 @@ module Metasploit
         def attempt_login(credential)
           result_options = {
             credential: credential,
-            host: @host,
-            port: @port,
-            protocol: 'tcp',
-            service_name: 'sonicwall'
+            **service_as_result(service_opts)
           }
           result_options.merge!(do_login(credential.public, credential.private, 1))
           Result.new(result_options)
+        end
+
+        def service_opts
+          build_service_opts('sonicwall')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
+++ b/lib/metasploit/framework/login_scanner/symantec_web_gateway.rb
@@ -22,6 +22,7 @@ module Metasploit
           res = send_request({'uri'=> login_uri})
 
           if res && res.body.include?('Symantec Web Gateway')
+            report_service(service_opts)
             return false
           end
 
@@ -101,9 +102,7 @@ module Metasploit
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           begin
@@ -114,6 +113,10 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('symantec_web_gateway')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
+++ b/lib/metasploit/framework/login_scanner/syncovery_file_sync_backup.rb
@@ -20,6 +20,7 @@ module Metasploit
           res = send_request({ 'uri' => login_uri })
 
           if res && res.code == 200 && res.body.include?('Syncovery')
+            report_service(service_opts)
             return false
           end
 
@@ -106,9 +107,7 @@ module Metasploit
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           begin
@@ -119,6 +118,10 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('syncovery')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/teamcity.rb
+++ b/lib/metasploit/framework/login_scanner/teamcity.rb
@@ -152,6 +152,7 @@ module Metasploit
           res = send_request(request_params)
 
           if res && res.code == 200 && res.body&.include?('Log in to TeamCity')
+            report_service(service_opts)
             return false
           end
 
@@ -265,10 +266,7 @@ module Metasploit
         def attempt_login(credential)
           result_options = {
             credential:   credential,
-            host:         @host,
-            port:         @port,
-            protocol:     'tcp',
-            service_name: 'teamcity'
+            **service_as_result(service_opts)
           }
 
           if @public_key.nil?
@@ -286,6 +284,10 @@ module Metasploit
 
           result_options[:status] = ::Metasploit::Model::Login::Status::SUCCESSFUL
           Result.new(result_options)
+        end
+
+        def service_opts
+          build_service_opts('teamcity')
         end
 
         private

--- a/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
@@ -120,9 +120,7 @@ module Metasploit
                 credential.private = pass
                 result_opts = {
                   credential: credential,
-                  host: host,
-                  port: port,
-                  protocol: 'tcp'
+                  **service_as_result(service_opts)
                 }
                 result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL)
                 return Result.new(result_opts)
@@ -132,13 +130,15 @@ module Metasploit
 
           result_opts = {
             credential: credential,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT)
           return Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('wordpress')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
@@ -11,15 +11,8 @@ module Metasploit
         def attempt_login(credential)
           result_opts = {
               credential: credential,
-              host: host,
-              port: port,
-              protocol: 'tcp'
+              **service_as_result(service_opts)
           }
-          if ssl
-            result_opts[:service_name] = 'https'
-          else
-            result_opts[:service_name] = 'http'
-          end
 
           begin
 
@@ -66,6 +59,10 @@ module Metasploit
         def set_sane_defaults
           @method = "POST".freeze
           super
+        end
+
+        def service_opts
+          build_service_opts('wordpress')
         end
 
       end

--- a/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
+++ b/lib/metasploit/framework/login_scanner/wowza_streaming_engine_manager.rb
@@ -16,6 +16,7 @@ module Metasploit
           res = send_request({ 'uri' => normalize_uri('/enginemanager/login.htm') })
 
           if res && res.code == 200 && res.body.include?('Wowza Streaming Engine Manager')
+            report_service(service_opts)
             return false
           end
 
@@ -33,9 +34,7 @@ module Metasploit
             credential: credential,
             status: Metasploit::Model::Login::Status::INCORRECT,
             proof: nil,
-            host: host,
-            port: port,
-            protocol: 'tcp'
+            **service_as_result(service_opts)
           }
 
           res = send_request({
@@ -59,6 +58,10 @@ module Metasploit
           end
 
           Result.new(result_opts)
+        end
+
+        def service_opts
+          build_service_opts('wowza')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/zabbix.rb
+++ b/lib/metasploit/framework/login_scanner/zabbix.rb
@@ -25,7 +25,10 @@ module Metasploit
         # @param credential [Metasploit::Framework::Credential] The credential object
         # @return [Result]
         def attempt_login(credential)
-          result_opts = { credential: credential }
+          result_opts = {
+            credential: credential,
+            **service_as_result(service_opts)
+          }
 
           begin
             status = try_login(credential)
@@ -62,6 +65,8 @@ module Metasploit
           rescue ::EOFError, Errno::ETIMEDOUT, OpenSSL::SSL::SSLError, Rex::ConnectionError, ::Timeout::Error
             return "Unable to connect to target"
           end
+
+          report_service(service_opts)
 
           false
         end
@@ -144,6 +149,10 @@ module Metasploit
           rescue ::EOFError, Errno::ETIMEDOUT, Errno::ECONNRESET, Rex::ConnectionError, OpenSSL::SSL::SSLError, ::Timeout::Error => e
             return {:status => Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e}
           end
+        end
+
+        def service_opts
+          build_service_opts('zabbix')
         end
 
       end

--- a/spec/lib/metasploit/framework/login_scanner/manageengine_desktop_central_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/manageengine_desktop_central_spec.rb
@@ -54,7 +54,9 @@ RSpec.describe Metasploit::Framework::LoginScanner::ManageEngineDesktopCentral d
           res
         end
         it 'returns false' do
+          allow(subject).to receive(:report_service)
           expect(subject.check_setup).to be(false)
+          expect(subject).to have_received(:report_service).with(hash_including(name: 'manageengine_desktop_central', proto: 'tcp'))
         end
       end
 

--- a/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/nessus_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe Metasploit::Framework::LoginScanner::Nessus do
       context 'when target is Nessus' do
         let(:response) { msp_html_response }
         it 'returns false' do
+          allow(http_scanner).to receive(:report_service)
           expect(http_scanner.check_setup).to be(false)
+          expect(http_scanner).to have_received(:report_service).with(hash_including(name: 'nessus', proto: 'tcp'))
         end
       end
 

--- a/spec/lib/metasploit/framework/login_scanner/phpmyadmin_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/phpmyadmin_spec.rb
@@ -70,7 +70,9 @@ RSpec.describe Metasploit::Framework::LoginScanner::PhpMyAdmin do
     context 'when the version of PhpMyAdmin is detected' do
       let(:response) { phpMyAdmin_res }
       it 'should return false' do
+        allow(subject).to receive(:report_service)
         expect(subject.check_setup).to eql(false)
+        expect(subject).to have_received(:report_service).with(hash_including(name: 'phpmyadmin', proto: 'tcp'))
       end
     end
 

--- a/spec/lib/metasploit/framework/login_scanner/symantec_web_gateway_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/symantec_web_gateway_spec.rb
@@ -61,7 +61,9 @@ RSpec.describe Metasploit::Framework::LoginScanner::SymantecWebGateway do
       context 'when target is Symantec Web Gateway' do
         let(:response) { swg_html_response }
         it 'returns false' do
+          allow(subject).to receive(:report_service)
           expect(subject.check_setup).to be(false)
+          expect(subject).to have_received(:report_service).with(hash_including(name: 'symantec_web_gateway', proto: 'tcp'))
         end
       end
 


### PR DESCRIPTION
Updates HTTP login scanners to report the detected service hierarchy.

Relevant Metasploit Credential PR: https://github.com/rapid7/metasploit-credential/pull/201

## Verification

- [ ] Start `msfconsole`
- [ ] `use jenkins login scanner`
- [ ] `run`
- [ ] **Verify** the `services` command returns `jenkins`, `http` and `tcp` services correctly.
