### PR TITLE
Fix http version scanner

### DIFF
--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -107,6 +107,7 @@ module Msf::DBManager::Service
     ostate = service.state
     opts.each { |k,v|
       if (service.attribute_names.include?(k.to_s))
+        v = v.delete("\x00") if v.is_a?(String)
         service[k] = ((v and k == :name) ? v.to_s.downcase : v)
       elsif !v.blank?
         dlog("Unknown attribute for Service: #{k}")

--- a/lib/msf/core/db_manager/web.rb
+++ b/lib/msf/core/db_manager/web.rb
@@ -224,7 +224,7 @@ module Msf::DBManager::Web
     )
 
     if host.name.to_s.empty?
-      host.name = vhost
+      host.name = vhost.to_s.delete("\x00")
       host.save!
     end
 
@@ -242,9 +242,9 @@ module Msf::DBManager::Web
       name = opts[:ssl] ? 'https' : 'http'
       serv.name = name
     end
-    # Add the info if it's there.
+    # Add the info if it's there. Strip null bytes — PostgreSQL rejects them.
     unless info.to_s.empty?
-      serv.info = info
+      serv.info = info.to_s.delete("\x00")
     end
     serv.save! if serv.changed?
 =begin


### PR DESCRIPTION
While using MSF Pro autodiscovery, it scanned a hardware device that doesn't seem to conform to proper HTTP spec.

Curl refuses to open it

```
$ curl http://1.1.1.1
curl: (8) Nul byte in header
```

NMAP shows what we actually want to see:
```
PORT   STATE SERVICE VERSION
80/tcp open  http    lighttpd
|_http-title: Did not follow redirect to https://1.1.1.1:443/\x00
```

The ending null byte shouldn't be there, but it is. MSF crashes on this:

```
[*] [2026.05.20-06:33:16] 1.1.1.1:80 (HTTP Version Detection) - Running module.
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version] Auxiliary failed: ArgumentError string contains null byte
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version] Call stack:
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:894:in `exec_params'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:894:in `block (2 levels) in exec_no_cache'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract_adapter.rb:1004:in `block in with_raw_connection'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract_adapter.rb:976:in `with_raw_connection'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:893:in `block in exec_no_cache'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract_adapter.rb:1119:in `log'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:892:in `exec_no_cache'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/postgresql_adapter.rb:872:in `execute_and_clear'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/postgresql/database_statements.rb:79:in `exec_delete'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/database_statements.rb:208:in `update'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `update'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/persistence.rb:280:in `block in _update_record'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:415:in `with_connection'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_handling.rb:296:in `with_connection'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/persistence.rb:279:in `_update_record'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/persistence.rb:887:in `_update_row'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/locking/optimistic.rb:93:in `_update_row'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/persistence.rb:909:in `_update_record'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/attribute_methods/dirty.rb:234:in `_update_record'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/callbacks.rb:449:in `block (2 levels) in _update_record'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/timestamp.rb:140:in `record_update_timestamps'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/callbacks.rb:449:in `block in _update_record'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/callbacks.rb:110:in `run_callbacks'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/callbacks.rb:913:in `_run_update_callbacks'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/callbacks.rb:449:in `_update_record'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/timestamp.rb:122:in `_update_record'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/persistence.rb:896:in `create_or_update'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/callbacks.rb:441:in `block in create_or_update'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/autosave_association.rb:362:in `around_save_collection_association'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/callbacks.rb:130:in `block in run_callbacks'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/callbacks.rb:141:in `run_callbacks'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/callbacks.rb:913:in `_run_save_callbacks'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/callbacks.rb:441:in `create_or_update'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/timestamp.rb:127:in `create_or_update'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/persistence.rb:426:in `save!'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/validations.rb:54:in `save!'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/transactions.rb:366:in `block in save!'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/transactions.rb:418:in `block (2 levels) in with_transaction_returning_status'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/transaction.rb:616:in `block in within_new_transaction'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/transaction.rb:613:in `within_new_transaction'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/database_statements.rb:361:in `transaction'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/transactions.rb:414:in `block in with_transaction_returning_status'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:415:in `with_connection'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_handling.rb:296:in `with_connection'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/transactions.rb:410:in `with_transaction_returning_status'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/transactions.rb:366:in `save!'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/suppressor.rb:56:in `save!'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/metasploit-framework-6.4.132/lib/msf/core/db_manager/web.rb:249:in `block in report_web_site'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:415:in `with_connection'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/metasploit-framework-6.4.132/lib/msf/core/db_manager/web.rb:192:in `report_web_site'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/metasploit-framework-6.4.132/lib/metasploit/framework/data_service/proxy/web_data_proxy.rb:5:in `block in report_web_site'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/metasploit-framework-6.4.132/lib/metasploit/framework/data_service/proxy/core.rb:164:in `data_service_operation'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/metasploit-framework-6.4.132/lib/metasploit/framework/data_service/proxy/web_data_proxy.rb:4:in `report_web_site'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/metasploit-framework-6.4.132/lib/msf/core/auxiliary/report.rb:372:in `report_web_site'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/metasploit-framework-6.4.132/lib/msf/core/exploit/remote/http_client.rb:965:in `http_fingerprint'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/metasploit-framework-6.4.132/modules/auxiliary/scanner/http/http_version.rb:33:in `run_host'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/metasploit-framework-6.4.132/lib/msf/core/auxiliary/scanner.rb:130:in `block (2 levels) in run'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/metasploit-framework-6.4.132/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[-] [2026.05.20-06:33:16] [auxiliary/scanner/http/http_version]   /opt/metasploit/apps/pro/vendor/bundle/ruby/3.3.0/gems/logging-2.4.0/lib/logging/diagnostic_context.rb:474:in `block in create_with_logging_context'
```

## Fix

This PR strips that null byte so that we can't crash.

```
msf auxiliary(scanner/http/http_version) > rerun
[*] Reloading module...
[+] 127.0.0.1:8080 BadServer
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```


## Verification

Run a python server which emulates this problem since I can't give you my physical hardware, and you're not invited over.

```
python3 -c "
import socket
s = socket.socket()
s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
s.bind(('', 8080))
s.listen(1)
while True:
    c, _ = s.accept()
    c.recv(4096)
    c.send(b'HTTP/1.1 200 OK\r\nServer: Bad\x00Server\r\nContent-Length: 0\r\n\r\n')
    c.close()
"
```

- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/http_version`
- [ ] `set rhosts 127.0.0.1`
- [ ] `set rport 8080`
- [ ] `run`
- [ ] **Verify** it doesn't crash any more
