### PR TITLE
add more info for documentation in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Metasploit Framework is an open-source penetration testing and exploitation fram
 - `tools/` — Developer and operational tools
 - `plugins/` — msfconsole plugins
 - `scripts/` — Example automation scripts
+- `documentation/modules/` — Markdown documentation for Metasploit modules
 
 ## Coding Conventions
 
@@ -41,7 +42,7 @@ Metasploit Framework is an open-source penetration testing and exploitation fram
 - License new code with `MSF_LICENSE` (the project default, defined in `lib/msf/core/constants.rb`)
 - When overriding `cleanup`, always call `super` to ensure the parent mixin chain cleans up connections and sessions properly
 - When possible don't set a default payload (`DefaultOptions` with `'PAYLOAD'`) in modules — let the framework choose the most appropriate payload automatically
-- New modules require an associated markdown file in the `documentation/modules` folder with the same structure, including steps to set up the vulnerable environment for testing
+- New modules require an associated markdown file in the `documentation/modules` folder with the same structure, including steps to set up the vulnerable environment for testing. NEVER add content into the Scenarios section, this must be filled out by a human at all times. Follow `documentation/modules/module_doc_template.md` as a template.
 - Module descriptions or documentation should list the range of vulnerable versions and the fixed version of the affected software, when known
 - `report_service` method called when a service can be reported
 - `report_vuln` method called when a vuln can be reported

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Metasploit Framework is an open-source penetration testing and exploitation fram
 - When possible don't set a default payload (`DefaultOptions` with `'PAYLOAD'`) in modules — let the framework choose the most appropriate payload automatically
 - New modules require an associated markdown file in the `documentation/modules` folder with the same structure, including steps to set up the vulnerable environment for testing. NEVER add content into the Scenarios section, this must be filled out by a human at all times. Follow `documentation/modules/module_doc_template.md` as a template.
 - Module descriptions or documentation should list the range of vulnerable versions and the fixed version of the affected software, when known
+- Module descriptions should only use ASCII characters
 - `report_service` method called when a service can be reported
 - `report_vuln` method called when a vuln can be reported
 - When creating a fake account / username use FAKER not `rand_test_alphanumeric`


### PR DESCRIPTION
While going over what Claude produced for #21497 I noticed the markdown docs used a table for options, and included a reference section which is not needed. I don't remember if I copied my module output to the markdown docs, Claude took my output from a session and put them in the docs, or hallucinated them. They were getting replaced anyway, so it didn't matter, but we want to also make sure that section is filled out by a human always. @bwatters-r7 previously noted screenshots should be human created, this falls in the same category.

This PR attempts to enhance `AGENTS.md` to:

1. include the doc folder
2. specify the module doc template so docs won't go off the rails with its own format (or use old/bad docs)
3. put in a mention that AI should never generate the proof section
