### PR TITLE
fix snmp enum bug/crash in null system_date

### DIFF
--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Auxiliary
     output_data['Uptime snmp'] = hr_system_uptime =~ /Null/ ? '-' : hr_system_uptime.strip
 
     system_date = snmp.get_value('1.3.6.1.2.1.25.1.2.0')
-    if system_date.blank? || system_date =~ /Null/ || system_date =~ /^noSuch/
+    if system_date.blank? || system_date.to_s =~ /Null/ || system_date.to_s =~ /^noSuch/
       output_data['System date'] = '-'
     else
 


### PR DESCRIPTION
`auxiliary/scanner/snmp/snmp_enum` has a bug where if the system_date is Null, the module will bomb.

```
msf > use auxiliary/scanner/snmp/snmp_enum
msf auxiliary(scanner/snmp/snmp_enum) > set rhosts 1.1.1.1
rhosts => 1.1.1.1
msf auxiliary(scanner/snmp/snmp_enum) > set rport 161
rport => 161
msf auxiliary(scanner/snmp/snmp_enum) > set verbose true
verbose => true
msf auxiliary(scanner/snmp/snmp_enum) > check
[-] This module does not support check.
msf auxiliary(scanner/snmp/snmp_enum) > run
[+] 1.1.1.1, Connected.
[-] Unknown error: NoMethodError undefined method `=~' for class SNMP::Null
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

After the fix:
```
msf auxiliary(scanner/snmp/snmp_enum) > rerun
[*] Reloading module...
[+] 1.1.1.1, Connected.

[*] System information:

Host IP                       : 1.1.1.1
Hostname                      : HOME
Description                   : NOT IMPORTANT
Contact                       : -
Location                      : DESK
Uptime snmp                   : -
Uptime system                 : 16 days, 00:56:38.00
System date                   : -
```

Note the last line.

Claude assisted with this PR.

## Verification

### Start a server w/ a null system time:

1. Make the dockerfile

```
FROM python:3.11-slim

RUN pip install --no-cache-dir snmpsim-lextudio

RUN mkdir -p /snmpsim/data && printf '%s\n' \
    '1.3.6.1.2.1.1.1.0|4|Linux test-host 5.15.0' \
    '1.3.6.1.2.1.1.3.0|67|12345' \
    '1.3.6.1.2.1.1.4.0|4|admin@localhost' \
    '1.3.6.1.2.1.1.5.0|4|test-host' \
    '1.3.6.1.2.1.1.6.0|4|TestLab' \
    '1.3.6.1.2.1.25.1.1.0|67|54321' \
    '1.3.6.1.2.1.25.1.2.0|5|' \
    > /snmpsim/data/public.snmprec

EXPOSE 161/udp

CMD ["snmpsim-command-responder-lite", \
     "--data-dir=/snmpsim/data", \
     "--agent-udpv4-endpoint=0.0.0.0:161", \
     "--process-user=nobody", \
     "--process-group=nogroup", \
     "--log-level=error"]
```

Now run it:
```
docker build -t snmp-null-test .
docker run -d -p 161:161/udp snmp-null-test
```

Now run the module:
```
msf auxiliary(scanner/snmp/snmp_enum) > rerun
[*] Reloading module...
[+] 127.0.0.1, Connected.
[-] Unknown error: NoMethodError undefined method `=~' for class SNMP::Null
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Pull in the fix:
```
git checkout fix_snmp_no_system_date
```

And now we're fixed

```
msf auxiliary(scanner/snmp/snmp_enum) > rerun
[*] Reloading module...
[+] 127.0.0.1, Connected.

[*] System information:

Host IP                       : 127.0.0.1
Hostname                      : test-host
Description                   : Linux test-host 5.15.0
Contact                       : admin@localhost
Location                      : TestLab
Uptime snmp                   : 00:09:03.21
Uptime system                 : 00:02:03.45
System date                   : -


[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```