### PR TITLE
convert module dates to newer standard

### DIFF
--- a/lib/rubocop/cop/lint/module_disclosure_date_format.rb
+++ b/lib/rubocop/cop/lint/module_disclosure_date_format.rb
@@ -23,11 +23,20 @@ module RuboCop
           (def :initialize _args (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...)) ...))
         PATTERN
 
+        def_node_matcher :find_super_hash_node, <<~PATTERN
+          {(def :initialize _args (begin (super $(hash ...)) ...))
+           (def :initialize _args (super $(hash ...)))}
+        PATTERN
+
         def on_def(node)
           update_info_node = find_update_info_node(node) || find_nested_update_info_node(node)
-          return if update_info_node.nil?
+          hash = if update_info_node
+                   update_info_node.arguments.find { |argument| hash_arg?(argument) }
+                 else
+                   find_super_hash_node(node)
+                 end
+          return if hash.nil?
 
-          hash = update_info_node.arguments.find { |argument| hash_arg?(argument) }
           hash.each_pair do |key, value|
             next unless key.value == 'DisclosureDate'
             next if valid_disclosure_date?(value)

--- a/modules/auxiliary/admin/http/cfme_manageiq_evm_pass_reset.rb
+++ b/modules/auxiliary/admin/http/cfme_manageiq_evm_pass_reset.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
       'DefaultOptions' => {
         'SSL' => true
       },
-      'DisclosureDate' => 'Nov 12 2013',
+      'DisclosureDate' => '2013-11-12',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],

--- a/modules/auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb
+++ b/modules/auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=966804'],
         ['URL', 'https://projects.theforeman.org/issues/2630']
       ],
-      'DisclosureDate' => 'Jun 6 2013',
+      'DisclosureDate' => '2013-06-06',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],

--- a/modules/auxiliary/admin/http/katello_satellite_priv_esc.rb
+++ b/modules/auxiliary/admin/http/katello_satellite_priv_esc.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         ['CWE', '862'],
         ['URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=970849']
       ],
-      'DisclosureDate' => 'Mar 24 2014',
+      'DisclosureDate' => '2014-03-24',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],

--- a/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
+++ b/modules/auxiliary/admin/http/netgear_soap_password_extractor.rb
@@ -37,7 +37,7 @@ class MetasploitModule < Msf::Auxiliary
         'h00die <mike@shorebreaksecurity.com>' # Metasploit enhancements/docs
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Feb 11 2015',
+      'DisclosureDate' => '2015-02-11',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [IOC_IN_LOGS],

--- a/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
+++ b/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'Author' => [ 'aushack', 'guerrino <ruggine> di massa' ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Jan 9 2009',
+      'DisclosureDate' => '2009-01-09',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [IOC_IN_LOGS],

--- a/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
+++ b/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       'Author' => [ 'aushack' ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Jan 9 2009',
+      'DisclosureDate' => '2009-01-09',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [IOC_IN_LOGS],

--- a/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'http://blog.c22.cc/advisories/typo3-sa-2009-001'],
         ['URL', 'http://typo3.org/teams/security/security-bulletins/typo3-sa-2009-001/'],
       ],
-      'DisclosureDate' => 'Jan 20 2009',
+      'DisclosureDate' => '2009-01-20',
       'Author' => [ 'Chris John Riley' ],
       'License' => MSF_LICENSE,
       'Notes' => {

--- a/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
+++ b/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'http://marc.info/?l=bugtraq&m=104326556329850&w=2']
       ],
       # Tested OK against sol8.tor 20100624 -jjd
-      'DisclosureDate' => 'Jan 22 2003')
+      'DisclosureDate' => '2003-01-22')
 
     register_options(
       [

--- a/modules/auxiliary/dos/mdns/avahi_portzero.rb
+++ b/modules/auxiliary/dos/mdns/avahi_portzero.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'CVE', '2008-5081' ],
         [ 'OSVDB', '50929' ],
       ],
-      'DisclosureDate' => 'Nov 14 2008',
+      'DisclosureDate' => '2008-11-14',
       'Notes' => {
         'Stability' => [CRASH_SERVICE_DOWN],
         'SideEffects' => [],

--- a/modules/auxiliary/dos/syslog/rsyslog_long_tag.rb
+++ b/modules/auxiliary/dos/syslog/rsyslog_long_tag.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://www.rsyslog.com/potential-dos-with-malformed-tag/'],
         ['URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=727644'],
       ],
-      'DisclosureDate' => 'Sep 01 2011',
+      'DisclosureDate' => '2011-09-01',
       'Notes' => {
         'Stability' => [CRASH_SERVICE_DOWN],
         'SideEffects' => [],

--- a/modules/auxiliary/dos/windows/llmnr/ms11_030_dnsapi.rb
+++ b/modules/auxiliary/dos/windows/llmnr/ms11_030_dnsapi.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'OSVDB', '71780' ],
         [ 'MSB', 'MS11-030' ]
       ],
-      'DisclosureDate' => 'Apr 12 2011',
+      'DisclosureDate' => '2011-04-12',
       'Notes' => {
         'Stability' => [CRASH_SERVICE_DOWN],
         'SideEffects' => [],

--- a/modules/auxiliary/dos/wireshark/ldap.rb
+++ b/modules/auxiliary/dos/wireshark/ldap.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'CVE', '2008-1562' ],
         [ 'OSVDB', '43840' ],
       ],
-      'DisclosureDate' => 'Mar 28 2008',
+      'DisclosureDate' => '2008-03-28',
       'Notes' => {
         'Stability' => [CRASH_SERVICE_DOWN],
         'SideEffects' => [],

--- a/modules/auxiliary/fileformat/odt_badodt.rb
+++ b/modules/auxiliary/fileformat/odt_badodt.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
         ['CVE', '2018-10583'],
         ['URL', 'https://secureyourit.co.uk/wp/2018/05/01/creating-malicious-odt-files/'],
       ],
-      'DisclosureDate' => 'May 01 2018',
+      'DisclosureDate' => '2018-05-01',
       'License' => MSF_LICENSE
 
     )

--- a/modules/auxiliary/gather/c2s_dvr_password_disclosure.rb
+++ b/modules/auxiliary/gather/c2s_dvr_password_disclosure.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         'h00die', # module
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Aug 19 2016'
+      'DisclosureDate' => '2016-08-19'
     )
 
     register_options([

--- a/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.rb
+++ b/modules/auxiliary/gather/cerberus_helpdesk_hash_disclosure.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         'h00die', # module
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Mar 7 2016'
+      'DisclosureDate' => '2016-03-07'
     )
 
     register_options(

--- a/modules/auxiliary/gather/ipcamera_password_disclosure.rb
+++ b/modules/auxiliary/gather/ipcamera_password_disclosure.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
         'h00die', # module
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Aug 16 2016'
+      'DisclosureDate' => '2016-08-16'
     )
 
     register_options([

--- a/modules/auxiliary/scanner/chargen/chargen_probe.rb
+++ b/modules/auxiliary/scanner/chargen/chargen_probe.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'CVE', '1999-0103' ], # Note, does not actually trigger a flood.
         [ 'URL', 'http://tools.ietf.org/html/rfc864' ]
       ],
-      'DisclosureDate' => 'Feb 08 1996',
+      'DisclosureDate' => '1996-02-08',
       'Notes' => {
         'Stability' => [CRASH_SAFE],
         'SideEffects' => [],

--- a/modules/auxiliary/scanner/dlsw/dlsw_leak_capture.rb
+++ b/modules/auxiliary/scanner/dlsw/dlsw_leak_capture.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         ['CVE', '2014-7992'],
         ['URL', 'https://github.com/tt5555/dlsw_exploit']
       ],
-      'DisclosureDate' => 'Nov 17 2014',
+      'DisclosureDate' => '2014-11-17',
       'License' => MSF_LICENSE
     )
 

--- a/modules/auxiliary/scanner/etcd/open_key_scanner.rb
+++ b/modules/auxiliary/scanner/etcd/open_key_scanner.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         'h00die' # msf module
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => "Mar 16 2018"
+      'DisclosureDate' => '2018-03-16'
     )
   end
 

--- a/modules/auxiliary/scanner/etcd/version.rb
+++ b/modules/auxiliary/scanner/etcd/version.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         'Jon Hart <jon_hart@rapid7.com>' # msf module
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => "Mar 16 2018"
+      'DisclosureDate' => '2018-03-16'
     )
   end
 

--- a/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
@@ -34,7 +34,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'OSVDB', '65533'],
         [ 'URL', 'https://seclists.org/bugtraq/2010/Jun/160' ]
       ],
-      'DisclosureDate' => 'Jun 15 2010'
+      'DisclosureDate' => '2010-06-15'
     )
 
     register_options(

--- a/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author' => [
         'Tiago Ferreira <tiago.ccna[at]gmail.com>'
       ],
-      'DisclosureDate' => 'Oct 08 2010',
+      'DisclosureDate' => '2010-10-08',
       'License' => MSF_LICENSE
     )
 

--- a/modules/auxiliary/scanner/http/dlink_user_agent_backdoor.rb
+++ b/modules/auxiliary/scanner/http/dlink_user_agent_backdoor.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
       ],
       # First documented in detail by Craig, but looks like it's been known
       # (at least to the Russians :-) ) since 2010 - see post at forum.codenet.ru
-      'DisclosureDate' => "Oct 12 2013"
+      'DisclosureDate' => '2013-10-12'
     )
   end
 

--- a/modules/auxiliary/scanner/http/es_file_explorer_open_port.rb
+++ b/modules/auxiliary/scanner/http/es_file_explorer_open_port.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Auxiliary
         'fs0c131y', # poc
         'h00die' # msf module
       ],
-      'DisclosureDate' => 'Jan 16 2019',
+      'DisclosureDate' => '2019-01-16',
       'License' => MSF_LICENSE,
       'Actions' => [
         ['LISTFILES', 'Description' => 'List all the files on the sdcard'],

--- a/modules/auxiliary/scanner/http/intel_amt_digest_bypass.rb
+++ b/modules/auxiliary/scanner/http/intel_amt_digest_bypass.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'http://web.archive.org/web/20191225124314/https://www.embedi.com/news/what-you-need-know-about-intel-amt-vulnerability' ],
         [ 'URL', 'http://web.archive.org/web/20250208090258/https://www.intel.com/content/www/us/en/security-center/default.html?intelid=INTEL-SA-00075' ],
       ],
-      'DisclosureDate' => 'May 05 2017'
+      'DisclosureDate' => '2017-05-05'
     )
 
     register_options(

--- a/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://www.sotiriu.de/adv/NSOADV-2011-003.txt'],
         ['EDB', '16103']
       ],
-      'DisclosureDate' => 'Mar 08 2011',
+      'DisclosureDate' => '2011-03-08',
       'License' => MSF_LICENSE
     )
 

--- a/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         'juan vazquez'
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => "Nov 16 2012"
+      'DisclosureDate' => '2012-11-16'
     )
 
     register_options(

--- a/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         'juan vazquez'
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => "Nov 16 2012"
+      'DisclosureDate' => '2012-11-16'
     )
 
     register_options(

--- a/modules/auxiliary/scanner/http/owa_iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/owa_iis_internal_ip.rb
@@ -18,7 +18,7 @@ class MetasploitModule < Msf::Auxiliary
       'Author' => [
         'Nate Power'
       ],
-      'DisclosureDate' => 'Dec 17 2012',
+      'DisclosureDate' => '2012-12-17',
       'License' => MSF_LICENSE,
       'DefaultOptions' => {
         'SSL' => true

--- a/modules/auxiliary/scanner/http/riverbed_steelhead_vcx_file_read.rb
+++ b/modules/auxiliary/scanner/http/riverbed_steelhead_vcx_file_read.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         'Gregory DRAPERI <gregory.draper_at_gmail.com>', # Exploit
         'h00die' # Module
       ],
-      'DisclosureDate' => 'Jun 01 2017',
+      'DisclosureDate' => '2017-06-01',
       'License' => MSF_LICENSE
     )
 

--- a/modules/auxiliary/scanner/http/smt_ipmi_static_cert_scanner.rb
+++ b/modules/auxiliary/scanner/http/smt_ipmi_static_cert_scanner.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'CVE', '2013-3619' ],
         [ 'URL', 'https://www.rapid7.com/blog/post/2013/11/06/supermicro-ipmi-firmware-vulnerabilities/']
       ],
-      'DisclosureDate' => 'Nov 06 2013'
+      'DisclosureDate' => '2013-11-06'
     )
 
     register_options(

--- a/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         ['OSVDB', '93040'],
 
       ],
-      'DisclosureDate' => 'Jun 20 2013'
+      'DisclosureDate' => '2013-06-20'
     )
 
     register_options(

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -25,7 +25,7 @@ class MetasploitModule < Msf::Auxiliary
         ['OSVDB', '95057'],
         ['BID', '61076'],
       ],
-      'DisclosureDate' => 'Jun 20 2013'
+      'DisclosureDate' => '2013-06-20'
     )
 
     register_options(

--- a/modules/auxiliary/scanner/memcached/memcached_amp.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_amp.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         'Jon Hart <jon_hart@rapid7.com>', # Metasploit scanner module
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Feb 27 2018',
+      'DisclosureDate' => '2018-02-27',
       'References' => [
         ['URL', 'https://blog.cloudflare.com/memcrashed-major-amplification-attacks-from-port-11211/'],
         ['CVE', '2018-1000115']

--- a/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
+++ b/modules/auxiliary/scanner/memcached/memcached_udp_version.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Auxiliary
         'Jon Hart <jon_hart@rapid7.com>' # Metasploit scanner module
       ],
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Jul 23 2003',
+      'DisclosureDate' => '2003-07-23',
       'References' => [
         ['URL', 'https://github.com/memcached/memcached/blob/master/doc/protocol.txt']
       ]

--- a/modules/auxiliary/scanner/misc/java_jmx_server.rb
+++ b/modules/auxiliary/scanner/misc/java_jmx_server.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         ['CVE', '2015-2342']
       ],
       'Platform' => 'java',
-      'DisclosureDate' => 'May 22 2013'
+      'DisclosureDate' => '2013-05-22'
     )
 
     register_options(

--- a/modules/auxiliary/scanner/misc/java_rmi_server.rb
+++ b/modules/auxiliary/scanner/misc/java_rmi_server.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'http://www.securitytracker.com/id?1026215'],
         [ 'CVE', '2011-3556']
       ],
-      'DisclosureDate' => 'Oct 15 2011'
+      'DisclosureDate' => '2011-10-15'
     )
 
     register_options(

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -39,7 +39,7 @@ class MetasploitModule < Msf::Auxiliary
         ['OSVDB', '82804'],
         ['URL', 'https://www.rapid7.com/blog/post/2012/06/11/cve-2012-2122-a-tragically-comedic-security-flaw-in-mysql/']
       ],
-      'DisclosureDate' => 'Jun 09 2012',
+      'DisclosureDate' => '2012-06-09',
       'License' => MSF_LICENSE
     )
 

--- a/modules/auxiliary/scanner/ntp/ntp_peer_list_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_peer_list_dos.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3696'],
         ['URL', 'https://www.rapid7.com/blog/post/2014/08/25/r7-2014-12-more-amplification-vulnerabilities-in-ntp-allow-even-more-drdos-attacks/']
       ],
-      'DisclosureDate' => 'Aug 25 2014',
+      'DisclosureDate' => '2014-08-25',
       'License' => MSF_LICENSE
     )
   end

--- a/modules/auxiliary/scanner/ntp/ntp_peer_list_sum_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_peer_list_sum_dos.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3696'],
         ['URL', 'https://www.rapid7.com/blog/post/2014/08/25/r7-2014-12-more-amplification-vulnerabilities-in-ntp-allow-even-more-drdos-attacks/']
       ],
-      'DisclosureDate' => 'Aug 25 2014',
+      'DisclosureDate' => '2014-08-25',
       'License' => MSF_LICENSE
     )
   end

--- a/modules/auxiliary/scanner/ntp/ntp_req_nonce_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_req_nonce_dos.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3696'],
         ['URL', 'https://www.rapid7.com/blog/post/2014/08/25/r7-2014-12-more-amplification-vulnerabilities-in-ntp-allow-even-more-drdos-attacks/']
       ],
-      'DisclosureDate' => 'Aug 25 2014',
+      'DisclosureDate' => '2014-08-25',
       'License' => MSF_LICENSE
     )
   end

--- a/modules/auxiliary/scanner/ntp/ntp_reslist_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_reslist_dos.rb
@@ -28,7 +28,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3696'],
         ['URL', 'https://www.rapid7.com/blog/post/2014/08/25/r7-2014-12-more-amplification-vulnerabilities-in-ntp-allow-even-more-drdos-attacks/']
       ],
-      'DisclosureDate' => 'Aug 25 2014',
+      'DisclosureDate' => '2014-08-25',
       'License' => MSF_LICENSE
     )
   end

--- a/modules/auxiliary/scanner/ntp/ntp_unsettrap_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_unsettrap_dos.rb
@@ -26,7 +26,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'https://github.com/rapid7/metasploit-framework/pull/3696'],
         ['URL', 'https://www.rapid7.com/blog/post/2014/08/25/r7-2014-12-more-amplification-vulnerabilities-in-ntp-allow-even-more-drdos-attacks/']
       ],
-      'DisclosureDate' => 'Aug 25 2014',
+      'DisclosureDate' => '2014-08-25',
       'License' => MSF_LICENSE
     )
   end

--- a/modules/auxiliary/scanner/scada/koyo_login.rb
+++ b/modules/auxiliary/scanner/scada/koyo_login.rb
@@ -27,7 +27,7 @@ class MetasploitModule < Msf::Auxiliary
         'K. Reid Wightman <wightman[at]digitalbond.com>', # original module
         'todb' # Metasploit fixups
       ],
-      'DisclosureDate' => 'Jan 19 2012',
+      'DisclosureDate' => '2012-01-19',
       'License' => MSF_LICENSE,
       'References' => [
         [ 'URL', 'http://www.digitalbond.com/tools/basecamp/metasploit-modules/' ]

--- a/modules/auxiliary/scanner/scada/modbusdetect.rb
+++ b/modules/auxiliary/scanner/scada/modbusdetect.rb
@@ -21,7 +21,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'https://en.wikipedia.org/wiki/Modbus:TCP' ]
       ],
       'Author' => [ 'EsMnemon <esm[at]mnemonic.no>' ],
-      'DisclosureDate' => 'Nov 1 2011',
+      'DisclosureDate' => '2011-11-01',
       'License' => MSF_LICENSE
       )
 

--- a/modules/auxiliary/scanner/ssl/openssl_ccs.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_ccs.rb
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'http://www.tripwire.com/state-of-security/incident-detection/detection-script-for-cve-2014-0224-openssl-cipher-change-spec-injection/'],
         ['URL', 'https://www.imperialviolet.org/2014/06/05/earlyccs.html']
       ],
-      'DisclosureDate' => 'Jun 5 2014',
+      'DisclosureDate' => '2014-06-05',
       'License' => MSF_LICENSE
     )
 

--- a/modules/auxiliary/scanner/ssl/ssl_version.rb
+++ b/modules/auxiliary/scanner/ssl/ssl_version.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
         # certificate inadequate encryption strength
         [ 'CWE', '326' ]
       ],
-      'DisclosureDate' => 'Oct 14 2014'
+      'DisclosureDate' => '2014-10-14'
     )
 
     register_options(

--- a/modules/auxiliary/server/dhclient_bash_env.rb
+++ b/modules/auxiliary/server/dhclient_bash_env.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'https://seclists.org/oss-sec/2014/q3/649' ],
         [ 'URL', 'https://www.trustedsec.com/september-2014/shellshock-dhcp-rce-proof-concept/' ]
       ],
-      'DisclosureDate' => 'Sep 24 2014',
+      'DisclosureDate' => '2014-09-24',
       'Notes' => {
         'AKA' => ['Shellshock']
       }

--- a/modules/auxiliary/server/jsse_skiptls_mitm_proxy.rb
+++ b/modules/auxiliary/server/jsse_skiptls_mitm_proxy.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Auxiliary
         ['URL', 'http://www.oracle.com/technetwork/topics/security/cpujan2015-1972971.html'],
         ['URL', 'https://www-304.ibm.com/support/docview.wss?uid=swg21695474']
       ],
-      'DisclosureDate' => 'Jan 20 2015'
+      'DisclosureDate' => '2015-01-20'
     )
 
     register_options(

--- a/modules/auxiliary/server/netbios_spoof_nat.rb
+++ b/modules/auxiliary/server/netbios_spoof_nat.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
         ['CVE', '2016-3236'],
         ['MSB', 'MS16-077']
       ],
-      'DisclosureDate' => 'Jun 14 2016'
+      'DisclosureDate' => '2016-06-14'
     )
 
     register_options(

--- a/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
+++ b/modules/auxiliary/server/openssl_altchainsforgery_mitm_proxy.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Auxiliary
         ['CWE', '754'],
         ['URL', 'http://git.openssl.org/?p=openssl.git;a=commit;h=f404943bcab4898d18f3ac1b36479d1d7bbbb9e6']
       ],
-      'DisclosureDate' => 'Jul 9 2015'
+      'DisclosureDate' => '2015-07-09'
     )
 
     register_options(

--- a/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
+++ b/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'https://www.cisa.gov/uscert/ncas/alerts/TA14-098A' ],
         [ 'URL', 'http://heartbleed.com/' ]
       ],
-      'DisclosureDate' => 'Apr 07 2014',
+      'DisclosureDate' => '2014-04-07',
       'Notes' => {
         'AKA' => ['Heartbleed']
       }

--- a/modules/auxiliary/server/wget_symlink_file_write.rb
+++ b/modules/auxiliary/server/wget_symlink_file_write.rb
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Auxiliary
         [ 'URL', 'https://www.rapid7.com/blog/post/2014/10/28/r7-2014-15-gnu-wget-ftp-symlink-arbitrary-filesystem-access' ]
       ],
       'DefaultAction' => 'Service',
-      'DisclosureDate' => 'Oct 27 2014'
+      'DisclosureDate' => '2014-10-27'
     )
 
     register_options(

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -23,7 +23,7 @@ class MetasploitModule < Msf::Auxiliary
         ['CVE', '1999-0667'],
         ['URL', 'https://en.wikipedia.org/wiki/ARP_spoofing']
       ],
-      'DisclosureDate' => 'Dec 22 1999', # osvdb date
+      'DisclosureDate' => '1999-12-22', # osvdb date
       'Notes' => {
         'Stability' => [OS_RESOURCE_LOSS],
         'SideEffects' => [IOC_IN_LOGS],

--- a/modules/exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
+++ b/modules/exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets' => [
         ['Automatic', {}]
       ],
-      'DisclosureDate' => 'Sep 4 2013',
+      'DisclosureDate' => '2013-09-04',
       'DefaultOptions' => {
         'PrependFork' => true,
         'SSL' => true

--- a/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
+++ b/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
@@ -32,7 +32,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'Targets' => [
         ['Automatic', {}]
       ],
-      'DisclosureDate' => 'Jun 6 2013',
+      'DisclosureDate' => '2013-06-06',
       'DefaultOptions' => { 'PrependFork' => true },
       'DefaultTarget' => 0
     )

--- a/modules/exploits/linux/misc/zabbix_server_exec.rb
+++ b/modules/exploits/linux/misc/zabbix_server_exec.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'Zabbix 1.6.7', {} ]
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => 'Sep 10 2009',
+        'DisclosureDate' => '2009-09-10',
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
           'Stability' => UNKNOWN_STABILITY,

--- a/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
+++ b/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ],
         ],
         'DefaultTarget' => 0,
-        'DisclosureDate' => 'Jun 22 2000',
+        'DisclosureDate' => '2000-06-22',
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
           'Stability' => UNKNOWN_STABILITY,

--- a/modules/exploits/multi/misc/java_jdwp_debugger.rb
+++ b/modules/exploits/multi/misc/java_jdwp_debugger.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'License' => MSF_LICENSE,
-      'DisclosureDate' => 'Mar 12 2010'
+      'DisclosureDate' => '2010-03-12'
     )
 
     register_options(

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [ 'OSVDB', '93537' ],
         [ 'URL', 'https://labs.f-secure.com/tools/sap-metasploit-modules/' ]
       ],
-      'DisclosureDate' => 'Mar 26 2013',
+      'DisclosureDate' => '2013-03-26',
       'Targets' => [
         [
           'Linux',

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [ 'URL', 'https://service.sap.com/sap/support/notes/1764994' ],
         [ 'URL', 'https://service.sap.com/sap/support/notes/1341333' ]
       ],
-      'DisclosureDate' => 'May 8 2012',
+      'DisclosureDate' => '2012-05-08',
       'Targets' => [
         [
           'Linux',

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -151,7 +151,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       # For the CVE
-      'DisclosureDate' => 'Jan 01 1999',
+      'DisclosureDate' => '1999-01-01',
       'Notes' => {
         'Stability' => [ CRASH_SAFE, ],
         'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'Privileged' => false,
-        'DisclosureDate' => "May 23 2013",
+        'DisclosureDate' => '2013-05-23',
         'DefaultTarget' => 1,
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,

--- a/modules/exploits/windows/http/avaya_ccr_imageupload_exec.rb
+++ b/modules/exploits/windows/http/avaya_ccr_imageupload_exec.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'Privileged' => false,
-      'DisclosureDate' => 'Jun 28 2012'
+      'DisclosureDate' => '2012-06-28'
     )
 
     register_options(

--- a/modules/exploits/windows/http/cogent_datahub_command.rb
+++ b/modules/exploits/windows/http/cogent_datahub_command.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [ 'Cogent DataHub < 7.3.5', {} ],
       ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => 'Apr 29 2014'
+      'DisclosureDate' => '2014-04-29'
     )
     register_options(
       [

--- a/modules/exploits/windows/http/hp_mpa_job_acct.rb
+++ b/modules/exploits/windows/http/hp_mpa_job_acct.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'Privileged' => false,
-      'DisclosureDate' => 'Dec 21 2011'
+      'DisclosureDate' => '2011-12-21'
     )
 
     register_options(

--- a/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
+++ b/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
@@ -44,7 +44,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'Privileged' => false,
-      'DisclosureDate' => 'Feb 15 2012'
+      'DisclosureDate' => '2012-02-15'
     )
 
     register_options(

--- a/modules/exploits/windows/http/manageengine_apps_mngr.rb
+++ b/modules/exploits/windows/http/manageengine_apps_mngr.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
           payload to the file system and a batch script that executes the payload. },
       'Author' => 'Jacob Giannantonio <JGiannan[at]gmail.com>',
       'Platform' => 'win',
-      'DisclosureDate' => 'Apr 08 2011',
+      'DisclosureDate' => '2011-04-08',
       'References' => [
         [ 'EDB', '17152' ],
       ],

--- a/modules/exploits/windows/http/novell_mdm_lfi.rb
+++ b/modules/exploits/windows/http/novell_mdm_lfi.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ['ZDI', '13-087'],
         ['URL', 'http://www.novell.com/support/kb/doc.php?id=7011895']
       ],
-      'DisclosureDate' => "Mar 13 2013",
+      'DisclosureDate' => '2013-03-13',
       'License' => MSF_LICENSE
     )
 

--- a/modules/exploits/windows/http/oracle_endeca_exec.rb
+++ b/modules/exploits/windows/http/oracle_endeca_exec.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'Privileged' => false,
-      'DisclosureDate' => 'Jul 16 2013'
+      'DisclosureDate' => '2013-07-16'
     )
 
     register_options(

--- a/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
+++ b/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'Privileged' => true,
-      'DisclosureDate' => 'Aug 14 2012'
+      'DisclosureDate' => '2012-08-14'
     )
     register_options(
       [

--- a/modules/exploits/windows/http/umbraco_upload_aspx.rb
+++ b/modules/exploits/windows/http/umbraco_upload_aspx.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'Privileged' => false,
-      'DisclosureDate' => 'Jun 28 2012'
+      'DisclosureDate' => '2012-06-28'
     )
 
     register_options(

--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -31,7 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         [ 'Automatic', {} ],
       ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => 'Dec 31 2004'
+      'DisclosureDate' => '2004-12-31'
     )
 
     register_options(

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -48,7 +48,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'CmdStagerFlavor' => 'tftp',
       'DefaultTarget' => 0,
-      'DisclosureDate' => 'Jul 17 1998',
+      'DisclosureDate' => '1998-07-17',
       'Compat' => {
         'Meterpreter' => {
           'Commands' => %w[

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -33,7 +33,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisableNops' => true,
       },
       'Platform' => 'win',
-      'DisclosureDate' => 'Aug 05 2011',
+      'DisclosureDate' => '2011-08-05',
       'Targets' => [
         [
           'Windows Universal',

--- a/modules/exploits/windows/misc/fb_cnct_group.rb
+++ b/modules/exploits/windows/misc/fb_cnct_group.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'Privileged' => true,
-      'DisclosureDate' => 'Jan 31 2013',
+      'DisclosureDate' => '2013-01-31',
       'Notes' => {
         'Stability' => [ CRASH_SERVICE_RESTARTS ],
       },

--- a/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 1,
       'Privileged' => true,
-      'DisclosureDate' => 'Jul 09 2012'
+      'DisclosureDate' => '2012-07-09'
     )
   end
 

--- a/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 1,
       'Privileged' => true,
-      'DisclosureDate' => 'Jul 09 2012'
+      'DisclosureDate' => '2012-07-09'
     )
   end
 

--- a/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
+++ b/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
@@ -42,7 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'Privileged' => true,
-      'DisclosureDate' => 'Mar 10 2009'
+      'DisclosureDate' => '2009-03-10'
     )
     register_options(
       [

--- a/modules/exploits/windows/misc/ms10_104_sharepoint.rb
+++ b/modules/exploits/windows/misc/ms10_104_sharepoint.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'Privileged' => true,
-      'DisclosureDate' => 'Dec 14 2010'
+      'DisclosureDate' => '2010-12-14'
     )
 
     register_options(

--- a/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
+++ b/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
       ],
       'DefaultTarget' => 0,
       'Privileged' => true,
-      'DisclosureDate' => 'Jan 23 2014'
+      'DisclosureDate' => '2014-01-23'
     )
     register_options(
       [

--- a/spec/lib/msf/core/exploit/browser_autopwn2_spec.rb
+++ b/spec/lib/msf/core/exploit/browser_autopwn2_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
     full_name         = opts[:full_name]
     short_name        = opts[:short_name]
     rank              = opts[:rank]            || 400
-    disclosure_date   = opts[:disclosure_date] || 'Dec 21 2014'
+    disclosure_date   = opts[:disclosure_date] || '2014-12-21'
     compat_payloads   = opts[:compat_payloads] || []
     datastore_options = opts[:datastore_options] || {}
     job_id            = opts[:job_id] || 0
@@ -108,7 +108,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
       full_name: 'windows/browser/ms14_064_ole_code_execution',
       short_name: 'ms14_064_ole_code_execution',
       rank: 600,
-      disclosure_date: 'Nov 13 2014',
+      disclosure_date: '2014-11-13',
       compat_payloads: compat_payloads,
       datastore_options: {'URIPATH'=>'/ms14_64'},
       job_id: 0,
@@ -126,7 +126,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
       full_name: 'multi/browser/adobe_flash_net_connection_confusion',
       short_name: 'adobe_flash_net_connection_confusion',
       rank: 500,
-      disclosure_date: 'Mar 12 2015',
+      disclosure_date: '2015-03-12',
       compat_payloads: compat_payloads,
       datastore_options: {'URIPATH'=>'/flash1'},
       job_id: 1,
@@ -141,7 +141,7 @@ RSpec.describe Msf::Exploit::Remote::BrowserAutopwn2 do
       full_name: 'multi/browser/adobe_flash_uncompress_zlib_uaf',
       short_name: 'adobe_flash_uncompress_zlib_uaf',
       rank: 500,
-      disclosure_date: 'Apr 28 2014',
+      disclosure_date: '2014-04-28',
       compat_payloads: compat_payloads,
       datastore_options: {'URIPATH'=>'/flash2'},
       job_id: 2,

--- a/spec/rubocop/cop/lint/module_disclosure_date_format_spec.rb
+++ b/spec/rubocop/cop/lint/module_disclosure_date_format_spec.rb
@@ -81,6 +81,37 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDisclosureDateFormat do
     expect_no_corrections
   end
 
+  it 'rejects invalid DisclosureDate values when super is called with a hash directly' do
+    expect_offense(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'DisclosureDate' => 'Nov 12 2013'
+                                ^^^^^^^^^^^^^ Modules should specify a DisclosureDate with the required format '%Y-%m-%d', for example '2020-10-02'
+          )
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class DummyModule
+        def initialize
+          super(
+            'Name' => 'Simple module name',
+            'Description' => 'Lorem ipsum dolor sit amet',
+            'Author' => [ 'example1', 'example2' ],
+            'License' => MSF_LICENSE,
+            'DisclosureDate' => '2013-11-12'
+          )
+        end
+      end
+    RUBY
+  end
+
   it 'provides an autocorrection when the DisclosureDate can safely be converted to the required format' do
     expect_offense(<<~RUBY)
       class DummyModule

--- a/tools/dev/msftidy.rb
+++ b/tools/dev/msftidy.rb
@@ -561,25 +561,15 @@ class MsftidyRunner
     # Check disclosure date format
     if @source =~ /["']DisclosureDate["'].*\=\>[\x0d\x20]*['\"](.+?)['\"]/
       d = $1  #Captured date
-      # Flag if overall format is wrong
-      if d =~ /^... (?:\d{1,2},? )?\d{4}$/
-        # Flag if month format is wrong
-        m = d.split[0]
-        months = [
-          'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-          'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
-        ]
-
-        error('Incorrect disclosure month format') if months.index(m).nil?
       # XXX: yyyy-mm is interpreted as yyyy-01-mm by Date::iso8601
-      elsif d =~ /^\d{4}-\d{2}-\d{2}$/
+      if d =~ /^\d{4}-\d{2}-\d{2}$/
         begin
           Date.iso8601(d)
         rescue ArgumentError
           error('Incorrect ISO 8601 disclosure date format')
         end
       else
-        error('Incorrect disclosure date format')
+        error('Incorrect disclosure date format, expected YYYY-MM-DD')
       end
     else
       error('Exploit is missing a disclosure date') if is_exploit_module?


### PR DESCRIPTION
YYYY-MM-DD is the current module disclosuredate format. Many older modules use a (previously accepted) Mon DD YYYY format. To prevent future module confusion, and simplify date processing, convert all dates to the new format

## Verification

make sure modules load and msftidy passes