### PR TITLE
guard wsl startup_folder persistence

### DIFF
--- a/modules/exploits/linux/persistence/wsl/startup_folder.rb
+++ b/modules/exploits/linux/persistence/wsl/startup_folder.rb
@@ -78,7 +78,11 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    return CheckCode::Safe('Target is not WSL') unless wsl?
+    begin
+      return CheckCode::Safe('Target is not WSL') unless wsl?
+    rescue RuntimeError => e # [-] Exploit failed: RuntimeError Failed to run uname -r
+      return CheckCode::Safe(e.message)
+    end
 
     vprint_good('Inside WSL environment')
 


### PR DESCRIPTION
Get a shell on windows, run the persistence_suggester. You'll note the exploits/linux/persistence/wsl/startup_folder fails because it tries to run `uname -r` and can't on windows. 

```
[-] Exploit failed: RuntimeError Failed to run uname -r
```

This PR adds a guard clause to handle the bubbled up error and correctly return the check code.

## Verification

- [ ] Start `msfconsole`
- [ ] Get a shell on windows
- [ ] `use persistence_suggester`
- [ ] `run`
- [ ] **Verify** The module no longer crashes