### PR TITLE
Add MCP module notes and comments for hosts

### DIFF
--- a/config/mcp_config.yaml.example
+++ b/config/mcp_config.yaml.example
@@ -1,7 +1,7 @@
 # Metasploit RPC API connection (MessagePack)
 msf_api:
   type: messagepack
-  host: localhost
+  host: 127.0.0.1
   port: 55553
   ssl: true
   endpoint: /api/
@@ -13,7 +13,7 @@ msf_api:
 mcp:
   transport: stdio  # stdio (default) or http
   # MCP server network configuration (for HTTP transport only)
-  host: localhost  # Host to bind to (default: localhost)
+  host: 127.0.0.1  # Host to bind to (default: localhost)
   port: 3000       # Port to listen on (default: 3000)
   # Puma server tuning (for HTTP transport only)
   # min_threads: 0   # Minimum thread pool size (default: 0)

--- a/docs/metasploit-framework.wiki/How-to-use-Metasploit-MCP-Server.md
+++ b/docs/metasploit-framework.wiki/How-to-use-Metasploit-MCP-Server.md
@@ -330,6 +330,9 @@ The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) is an int
 
 ```
 npx @modelcontextprotocol/inspector
+
+# stdio transport type usage:
+npx @modelcontextprotocol/inspector -- bundle exec ./msfmcpd
 ```
 
 ## Troubleshooting

--- a/lib/msf/core/mcp/metasploit/response_transformer.rb
+++ b/lib/msf/core/mcp/metasploit/response_transformer.rb
@@ -52,6 +52,7 @@ module Msf::MCP
           stance: info['stance'],
           actions: info['actions'],
           default_action: info['default_action'],
+          notes: info['notes'],
           # TODO: write transformer for options
           options: info['options']
         }.compact
@@ -76,7 +77,8 @@ module Msf::MCP
             os_language: host['os_lang'],
             updated_at: format_timestamp(host['updated_at']),
             purpose: host['purpose'],
-            info: host['info']
+            info: host['info'],
+            comments: host['comments']
           }.compact
         end
       end

--- a/lib/msf/core/mcp/rpc_manager.rb
+++ b/lib/msf/core/mcp/rpc_manager.rb
@@ -125,7 +125,7 @@ module Msf::MCP
                 "Timed out waiting for RPC server after #{timeout} seconds"
         end
 
-        @output.puts 'Waiting for RPC server to become available...'
+        @output.puts "Waiting for RPC server to become available at #{Rex::Socket.to_authority(@config[:msf_api][:host], @config[:msf_api][:port])}..."
         sleep(interval)
       end
     end

--- a/lib/msf/core/mcp/tools/host_info.rb
+++ b/lib/msf/core/mcp/tools/host_info.rb
@@ -72,7 +72,8 @@ module Msf::MCP
                 os_language: { type: 'string' },
                 updated_at: { type: 'string' },
                 purpose: { type: 'string' },
-                info: { type: 'string' }
+                info: { type: 'string' },
+                comments: { type: 'string' }
               }
             }
           }

--- a/lib/msf/core/mcp/tools/module_info.rb
+++ b/lib/msf/core/mcp/tools/module_info.rb
@@ -59,6 +59,7 @@ module Msf::MCP
               privileged: { type: 'boolean' },
               has_check_method: { type: 'boolean' },
               default_options: { type: 'object' },
+              notes: { type: 'object' },
               references: { type: 'array', items: { type: ['string', 'object'] } },
               targets: { type: 'object' },
               default_target: { type: 'integer' },

--- a/spec/lib/msf/core/mcp/metasploit/response_transformer_spec.rb
+++ b/spec/lib/msf/core/mcp/metasploit/response_transformer_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
         'privileged' => true,
         'check' => true,
         'default_options' => { 'Option1' => 'Value1' },
+        'notes' => { 'SideEffects' => ['IOC_IN_LOGS'], 'Stability' => ['CRASH_SAFE'] },
         'references' => [{'CVE' => '2017-0144'}, {'URL' => 'https://example.com'}],
         'targets' => { 0 => 'Windows 7', 1 => 'Windows 8' },
         'default_target' => 0,
@@ -99,6 +100,7 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
         privileged: true,
         has_check_method: true,
         default_options: { 'Option1' => 'Value1' },
+        notes: { 'SideEffects' => ['IOC_IN_LOGS'], 'Stability' => ['CRASH_SAFE'] },
         references: [{'CVE' => '2017-0144'}, {'URL' => 'https://example.com'}],
         targets: { 0 => 'Windows 7', 1 => 'Windows 8' },
         default_target: 0,
@@ -173,6 +175,7 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
             'os_lang' => 'English',
             'purpose' => 'server',
             'info' => 'Web server',
+            'comments' => 'Primary web server',
             'state' => 'alive',
             'created_at' => 1609459200,
             'updated_at' => 1640995200
@@ -192,7 +195,8 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
         hostname: 'testhost',
         os_name: 'Linux',
         os_flavor: 'Ubuntu',
-        state: 'alive'
+        state: 'alive',
+        comments: 'Primary web server'
       )
       expect(result[0][:created_at]).to eq('2021-01-01T00:00:00Z')
       expect(result[0][:updated_at]).to eq('2022-01-01T00:00:00Z')


### PR DESCRIPTION
Updates the Metasploit MCP tool to expose note information on Metasploit modules, as well as host comments.

## Verification

Running the inspector tool:

```
npx @modelcontextprotocol/inspector -- bundle exec ./msfmcpd
```

Veriftying module notes:

<img width="2553" height="1160" alt="image" src="https://github.com/user-attachments/assets/6083a739-94ad-49a9-828e-9be4a3c51d38" />

Verifying host comments:

<img width="2560" height="1162" alt="image" src="https://github.com/user-attachments/assets/94e68664-0fba-4a84-8de3-2691c3d9679c" />
