### PR TITLE
Update the Attic label definition

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -51,7 +51,7 @@ jobs:
                       - We may not have the proper access or equipment to test this pull request, or the contributor doesn't have time to work on it right now.
                       - Sometimes the implementation isn't quite right and a different approach is necessary.
 
-                    Pull requests in the attic are open for community pickup — if you're a community member looking for something to work on, feel free to pick this up and carry it across the finish line. The original may or may not return, if they do and want to continue the work, we'd welcome that too.
+                    Pull requests in the attic are open for community pickup — if you're a community member looking for something to work on, feel free to pick this up and carry it across the finish line. The original author may or may not return, if they do and want to continue the work, we'd welcome that too.
                     If you'd like to revive this PR, please comment below expressing your interest, then open a new pull request that references this one, and we'll be happy to review it.
                   `
                 },

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -47,11 +47,12 @@ jobs:
 
                     What does this generally mean? It could be one or more of several things:
 
-                      - It doesn't look like there has been any activity on this pull request in a while
+                      - It doesn't look like there has been any activity on this pull request in a while (60 days or more).
                       - We may not have the proper access or equipment to test this pull request, or the contributor doesn't have time to work on it right now.
                       - Sometimes the implementation isn't quite right and a different approach is necessary.
 
-                    We would love to land this pull request when it's ready. If you have a chance to address all comments, we would be happy to reopen and discuss how to merge this!
+                    Pull requests in the attic are open for community pickup — if you're a community member looking for something to work on, feel free to pick this up and carry it across the finish line. The original may or may not return, if they do and want to continue the work, we'd welcome that too.
+                    If you'd like to revive this PR, please comment below expressing your interest, then open a new pull request that references this one, and we'll be happy to review it.
                   `
                 },
                 'needs-docs': {

--- a/docs/metasploit-framework.wiki/Assigning-Labels.md
+++ b/docs/metasploit-framework.wiki/Assigning-Labels.md
@@ -2,7 +2,15 @@ Maintainers can assign labels to both issues and pull requests.
 
 ### Attic
 
-When we move something to the attic it means that what you submitted is a thing that we want but the circumstances were not quite right for landing it. Sometimes this is on us, and sometimes the contribution needs more work. We recognize that contributors work on the PRs they submit at their own pace. Take a look at the comments and review suggestions on your PR, and feel free to re-open it if and when you have time to work on it again. Don't think you'll be able to get it across the finish line? Find a community champion to do it for you.
+When we move something to the attic, it means what you submitted is something we want, but the circumstances
+weren't right for landing it as-is — sometimes that's on us, sometimes the contribution needs more work to meet our
+standards. Attic'd PRs remain open contributions: the original author is welcome to pick the work back up whenever they
+have time, and anyone in the community is equally welcome to carry it across the finish line, whether by collaborating
+with the original author or opening a fresh PR that builds on the work. If you'd like to take over an attic'd PR,
+comment on it so others know it's being worked on.
+
+After 60 days of inactivity, we'll close and attic PRs to keep the active queue manageable. Closing doesn't mean the
+work is rejected - the PR and its history stay available, and it can be revisited at any time.
 
 ### Bug
 


### PR DESCRIPTION
This updates the attic label definition. This more clearly informs contributors of how we plan on using the label. Most importantly - if we assign the attic label to your PR we're not rejecting the work, we're marking it as inactive to try to maintain a manageable PR queue. It also clarifies that any contributor is welcome to pick up attic'd PRs by commenting on the originally closed PR. Lastly, it specifies that PRs with no activity for 60 days are subject to being attic'd.