### PR TITLE
Add a module for pivoting over a Quectel Modem

### DIFF
--- a/documentation/modules/auxiliary/server/quectel_modem.md
+++ b/documentation/modules/auxiliary/server/quectel_modem.md
@@ -51,3 +51,22 @@ Timeout controls for serial AT command operations.
 Startup probing and runtime health check controls.
 
 ## Scenarios
+
+Quectel LTE EG91 modem
+
+```
+msf auxiliary(server/quectel_modem) > run
+[*] Probing modem with AT until OK...
+[+] Modem is responding to AT commands.
+[*] Waiting briefly for RDY URC (best-effort)...
+[*] Closing any leftover modem socket connections...
+[+] Modem session 1 opened (12 sockets, 1024B chunks)
+[*] Auxiliary module execution completed
+msf auxiliary(server/quectel_modem) > route add 0 0 -1
+[*] Route added
+(reverse-i-search)`im': tInterrupt: use the 'exit' command to quit
+msf auxiliary(server/quectel_modem) > load request
+[*] Successfully loaded plugin: Request
+msf auxiliary(server/quectel_modem) > request http://ifconfig.me
+192.0.2.1
+```

--- a/documentation/modules/auxiliary/server/quectel_modem.md
+++ b/documentation/modules/auxiliary/server/quectel_modem.md
@@ -1,0 +1,53 @@
+## Vulnerable Application
+
+Opens a serial connection to a Quectel cellular modem and registers it as a 'modem' session capable of network
+pivoting. The Quectel modems have a limited number of sockets available, configurable using MODEM_SOCKETS. Once
+the session is established, it can be routed through using the `route` command.
+
+The Quectel modems do not support all socket operations that other session types such as Meterpreter support. Notable
+limitations include not being able to bind to a particular address for any socket and no TCP server support.
+
+This module requires local serial access to a Quectel modem. It has been tested with a Quectel EG91-NA.
+
+## Verification Steps
+
+1. Make a physical connection to the Quectel modem over an RS232 serial cable (optionally with a USB adapter).
+2. Identify the connection, e.g. `/dev/ttyUSB0`.
+3. Optionally `chmod` it to make it readable by the Metasploit user which will require read and write access to it.
+4. Start msfconsole
+5. Load the `request` plugin by running `load request`
+6. Use the `request` command to obtain the current, unpivoted IP address by running `request -A curl/ https://ifconfig.me`
+7. Do: `use auxiliary/server/quectel_modem`
+8. Do: `set SERIAL /dev/ttyUSB0` where `/dev/ttyUSB0` is the previously identified connection.
+9. Do: `run`, you should see a session opened
+10. Do: `route add 0 0 -1` to route all of the traffic through the session.
+11. Repeat the `request` to ifconfig.me step and see a different IP address.
+
+## Options
+
+### MODEM_SOCKETS
+
+Number of Quectel socket IDs (SID pool size). This is effectively the number of concurrent connections the modem
+supports. The default is `12`.
+
+### SERIAL
+
+Serial device for the Quectel modem. The default is `/dev/ttyUSB0`.
+
+### BAUD
+
+Serial baud rate. The default is `115200`.
+
+### MAX_CHUNK_SIZE
+
+Bytes per AT+QISEND chunk. The default is `1024`.
+
+### PROMPT_TIMEOUT_MS, ACK_TIMEOUT_MS, OPEN_TIMEOUT_MS, CMD_TIMEOUT_MS
+
+Timeout controls for serial AT command operations.
+
+### STARTUP_OK_TIMEOUT_S, STARTUP_OK_INTERVAL_MS, HEALTHCHECK_INTERVAL_S, HEALTHCHECK_TIMEOUT_MS, HEALTHCHECK_MAX_FAILS
+
+Startup probing and runtime health check controls.
+
+## Scenarios

--- a/lib/msf/base/sessions/modem.rb
+++ b/lib/msf/base/sessions/modem.rb
@@ -1,0 +1,470 @@
+# -*- coding: binary -*-
+
+require 'rex/post/channel'
+require 'rex/post/meterpreter/channels/socket_abstraction'
+require 'rex/io/datagram_abstraction'
+require 'rex/socket/udp'
+
+module Msf
+module Sessions
+
+###
+#
+# Abstract base class for modem-backed pivot sessions.
+#
+# A modem session implements Msf::Session::Comm so that the framework can
+# open arbitrary TCP connections through the modem natively (route add,
+# autoroute, etc.) without a SOCKS proxy in the middle.
+#
+# Subclasses implement the protected create_tcp_client_channel,
+# create_tcp_server_channel, and create_udp_channel hooks. The base raises
+# NotImplementedError for each so missing implementations surface clearly
+# during development.
+#
+# The generic TcpClientChannel inner class works with any connection object
+# that satisfies the duck-type interface:
+#
+#   recv      -> blocks until String data or nil EOF
+#   send(buf) -> sends buf to the remote host
+#   close     -> tears down the connection
+#
+###
+class Modem
+  include Msf::Session
+  include Msf::Session::Comm
+  include Rex::Post::Channel::Container
+  # Provides user_input= / user_output= attr_accessors required by
+  # Msf::Session#set_from_exploit. Interactive sessions get these via
+  # Session::Interactive -> Rex::Ui::Interactive -> Rex::Ui::Subscriber.
+  # Non-interactive sessions (like this one) must include it directly.
+  include Rex::Ui::Subscriber
+
+  # Shared socket name interface for modem channels.
+  #
+  # Rex::Post::Channel::SocketAbstraction::SocketInterface#getsockname
+  # traverses a Meterpreter-style channel chain via channel.client.sock,
+  # which doesn't apply here. Override it to return a synthetic local
+  # address from the channel params so callers (e.g. the SOCKS5 response
+  # builder) get a valid value rather than a NoMethodError. Both the TCP
+  # and UDP channel SocketInterfaces mix this in.
+  module ChannelSocketInterface
+    include Rex::Post::Channel::SocketAbstraction::SocketInterface
+
+    def close(*args)
+      current_channel = channel if respond_to?(:channel)
+      super
+    ensure
+      current_channel.close if current_channel && !current_channel.closed?
+    end
+
+    def getsockname
+      return super unless channel
+
+      [ ::Socket::AF_INET,
+        channel.params.localhost || '0.0.0.0',
+        channel.params.localport || 0 ]
+    end
+  end
+
+  class ChannelBase
+    def initialize(session, cid, conn, params)
+      @session = session
+      @cid = cid
+      @conn = conn
+      @params = params
+      @mutex = Mutex.new
+      @remote_closed = false
+    end
+
+    def closed?
+      @cid.nil?
+    end
+
+    def remote_closed?
+      @mutex.synchronize { @remote_closed }
+    end
+
+    def remote_closed
+      return unless mark_remote_closed
+
+      notify_remote_closed
+      close_connection
+    end
+
+    def close
+      cid = nil
+      should_close_connection = false
+      @mutex.synchronize do
+        return if closed?
+
+        cid = @cid
+        should_close_connection = !@remote_closed
+        @cid = nil
+        @remote_closed = true
+      end
+
+      close_connection if should_close_connection
+      stop_reader_thread
+      @session.remove_channel(cid)
+      cleanup_abstraction
+    end
+
+    attr_reader :cid, :params
+
+    private
+
+    def mark_remote_closed
+      @mutex.synchronize do
+        return false if closed? || @remote_closed
+
+        @remote_closed = true
+      end
+      true
+    end
+
+    def notify_remote_closed
+    end
+
+    def spawn_reader_thread(name, &block)
+      framework = @session.framework
+      thread_manager = framework.threads if framework.respond_to?(:threads)
+      unless thread_manager.respond_to?(:spawn)
+        raise 'Modem channels require a framework thread manager'
+      end
+
+      thread_manager.spawn(name, false, &block)
+    end
+
+    def start_reader_thread(name)
+      @reader_thread = spawn_reader_thread(name) do
+        while (data = @conn.recv)
+          break unless yield(data)
+        end
+        remote_closed if data.nil?
+      end
+    end
+
+    def send_to_connection(buf, length = nil)
+      raise IOError, 'Channel has been closed.' if closed? || remote_closed?
+
+      buf = buf[0, length] if length && buf.length >= length
+      @conn.send(buf)
+      buf.length
+    end
+
+    def stop_reader_thread
+      return unless @reader_thread
+      return if @reader_thread == ::Thread.current
+
+      @reader_thread.kill
+      @reader_thread.join
+    end
+
+    def close_connection
+      @conn.close
+    rescue ::StandardError
+      nil
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # Generic TCP client channel
+  #
+  # Uses Rex::Post::Channel::StreamAbstraction to create an lsock/rsock pair.
+  # A dedicated reader thread drains recv from the underlying modem
+  # connection and writes into rsock, making data visible to lsock readers.
+  # The framework writes outbound data via write(), which forwards to the
+  # connection's send() method.
+  # -----------------------------------------------------------------------
+  class TcpClientChannel < ChannelBase
+    include Rex::Post::Channel::StreamAbstraction
+
+    module SocketInterface
+      include ChannelSocketInterface
+
+      def type?
+        'tcp'
+      end
+    end
+
+    def monitor_rsock(name = 'ModemTcpClientRemote')
+      monitor_sock(rsock, sink: self, name: name, on_exit: method(:close))
+    end
+
+    #
+    # Create a new TcpClientChannel.
+    #
+    # @param session [Modem]           parent session
+    # @param cid     [Integer]         channel ID, unique within the session
+    # @param conn    [#recv]           modem connection object
+    # @param params  [Rex::Socket::Parameters]
+    #
+    def initialize(session, cid, conn, params)
+      initialize_abstraction
+      super
+
+      start_reader_thread('ModemTcpClientChannelReader') do |data|
+        rsock.syswrite(data)
+        true
+      rescue ::StandardError
+        false
+      end
+
+      lsock.extend(SocketInterface)
+      lsock.channel = self
+      rsock.extend(SocketInterface)
+      rsock.channel = self
+
+      lsock.synchronize_access { lsock.initsock(params) }
+      rsock.synchronize_access { rsock.initsock(params) }
+
+      session.add_channel(self)
+    end
+
+    #
+    # Send data toward the remote host through the modem connection.
+    #
+    def write(buf, length = nil)
+      send_to_connection(buf, length)
+    end
+
+    private
+
+    def notify_remote_closed
+      begin
+        rsock.shutdown(::Socket::SHUT_WR)
+      rescue ::StandardError
+        nil
+      end
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # Generic UDP channel
+  #
+  # Mirrors the Meterpreter UDP channel
+  # (Rex::Post::Meterpreter::Extensions::Stdapi::Net::SocketSubsystem::UdpChannel):
+  # it builds a real UDP socketpair via Rex::IO::DatagramAbstraction and hands
+  # the framework an lsock extended with Rex::Socket::Udp, so the returned
+  # object is a drop-in UDPSocket-alike (send/sendto/recv/recvfrom/read/write).
+  #
+  # Outbound datagrams are routed to the modem connection's send() via the
+  # DirectChannelWrite mixin; inbound datagrams drained from recv are
+  # written into rsock followed by the sender's sockaddr (the same two-write
+  # trick Meterpreter's Datagram#dio_write_handler uses) so recvfrom() can
+  # reconstruct [data, host, port].
+  # -----------------------------------------------------------------------
+  class UdpChannel < ChannelBase
+    include Rex::IO::DatagramAbstraction
+
+    #
+    # Routes lsock writes (Rex::Socket::Udp#write/#sendto -> syswrite) straight
+    # to the channel, which forwards them to the modem connection, instead of
+    # into the local socketpair. Mirrors Meterpreter's DirectChannelWrite.
+    #
+    module DirectChannelWrite
+      def syswrite(buf)
+        channel.dio_write(buf)
+      end
+
+      attr_accessor :channel
+    end
+
+    module SocketInterface
+      include ChannelSocketInterface
+
+      MAX_SOCKADDR_LENGTH = 128
+
+      def type?
+        'udp'
+      end
+
+      #
+      # The reader thread writes each datagram into rsock followed by its
+      # sockaddr, so a recvfrom() pulls the data datagram then the sockaddr
+      # datagram back off the pair. Mirrors Datagram::SocketInterface.
+      #
+      def recvfrom_nonblock(length, flags = 0)
+        data     = super(length, flags)[0]
+        sockaddr = super(MAX_SOCKADDR_LENGTH, flags)[0]
+        [data, sockaddr]
+      end
+
+      #
+      # UDPSocket#send-compatible signature. The modem connection is bound to a
+      # single peer (AT+QIOPEN "UDP","host",port), so the explicit host/port are
+      # accepted to satisfy the interface but the datagram always goes to that
+      # peer.
+      #
+      def send(buf, _flags = 0, _a = nil, _b = nil)
+        channel.dio_write(buf)
+        buf.length
+      end
+    end
+
+    #
+    # Create a new UdpChannel.
+    #
+    # @param session [Modem]           parent session
+    # @param cid     [Integer]         channel ID, unique within the session
+    # @param conn    [#recv]           modem connection object
+    # @param params  [Rex::Socket::Parameters]
+    #
+    def initialize(session, cid, conn, params)
+      initialize_abstraction
+      super
+
+      lsock.extend(Rex::Socket::Udp)
+      lsock.initsock
+      lsock.extend(SocketInterface)
+      lsock.extend(DirectChannelWrite)
+      lsock.channel = self
+
+      rsock.extend(SocketInterface)
+      rsock.channel = self
+
+      @sockaddr = Rex::Socket.to_sockaddr(@params.peerhost, @params.peerport)
+      start_reader_thread('ModemUdpChannelReader') do |data|
+        if data.is_a?(::String) && !data.empty?
+          rsock.syswrite(data)
+          rsock.syswrite(@sockaddr)
+        end
+        true
+      rescue ::StandardError
+        false
+      end
+
+      session.add_channel(self)
+    end
+
+    #
+    # Send a datagram toward the peer through the modem connection. Invoked by
+    # the lsock's DirectChannelWrite#syswrite and SocketInterface#send.
+    #
+    def dio_write(buf)
+      send_to_connection(buf)
+    end
+  end
+
+  # -----------------------------------------------------------------------
+  # Session identity - subclasses should override desc
+  # -----------------------------------------------------------------------
+
+  def self.type
+    'modem'
+  end
+
+  def type
+    self.class.type
+  end
+
+  def desc
+    'Modem'
+  end
+
+  def platform
+    'hardware'
+  end
+
+  def arch
+    ARCH_CMD
+  end
+
+  def self.can_cleanup_files
+    false
+  end
+
+  def alive?
+    self.alive
+  end
+
+  # Modem sessions are never interactively attached to a terminal.
+  def interacting
+    false
+  end
+
+  def interactive?
+    false
+  end
+
+  # Base implementation: modem sessions cannot natively tunnel UDP in the
+  # general case.
+  #
+  # Note: returning false here causes the framework's DNS resolver to fall
+  # back to TCP-DNS, which would route through the modem and add significant
+  # latency. Subclasses that override this to true must also implement
+  # create_udp_channel so DNS and UDP traffic route correctly.
+  def supports_udp?
+    false
+  end
+
+  # -----------------------------------------------------------------------
+  # Msf::Session::Comm - dispatches to subclass hooks
+  # -----------------------------------------------------------------------
+
+  #
+  # Called by Rex::Socket::SwitchBoard to open a new socket through this
+  # session. Dispatches to the appropriate protected hook method.
+  #
+  # @param params [Rex::Socket::Parameters]
+  # @return [Socket-like] the local socket end for the framework to use
+  # @raise [Rex::ConnectionError] on unsupported protocol or open failure
+  #
+  def create(params)
+    notify_before_socket_create(self, params)
+
+    sock = case params.proto
+    when 'udp'
+      create_udp_channel(params)
+    when 'tcp'
+      if params.server
+        create_tcp_server_channel(params)
+      else
+        create_tcp_client_channel(params)
+      end
+    else
+      raise ::Rex::ConnectionError.new(params.peerhost, params.peerport,
+        reason: "Unsupported socket protocol: #{params.proto}")
+    end
+
+    raise ::Rex::ConnectionError unless sock
+    notify_socket_created(self, sock, params)
+    sock
+  end
+
+  # -----------------------------------------------------------------------
+  # Lifecycle
+  # -----------------------------------------------------------------------
+
+  def initialize(opts = {})
+    super()              # Msf::Session#initialize: sets alive, uuid, routes
+    @channel_ticker = 0
+    initialize_channels  # Rex::Post::Channel::Container
+    self.alive = true
+  end
+
+  def cleanup
+    channels.dup.each_value(&:close)
+    super
+  end
+
+  protected
+
+  def create_tcp_client_channel(_params)
+    raise NotImplementedError, "#{self.class}#create_tcp_client_channel is not implemented"
+  end
+
+  def create_tcp_server_channel(_params)
+    raise NotImplementedError, "#{self.class}#create_tcp_server_channel is not implemented"
+  end
+
+  #
+  # Base UDP fallback: delegate to the local system comm.
+  #
+  def create_udp_channel(params)
+    raise NotImplementedError, "#{self.class}#create_udp_channel is not implemented"
+  end
+end
+
+end  # Sessions
+end  # Msf

--- a/lib/msf/base/sessions/modem/quectel.rb
+++ b/lib/msf/base/sessions/modem/quectel.rb
@@ -1,0 +1,867 @@
+# -*- coding: binary -*-
+
+require 'concurrent'
+
+module Msf
+module Sessions
+
+###
+#
+# Quectel modem session - concrete Msf::Sessions::Modem subclass backed by
+# the Driver / Connection AT-command serial driver defined here.
+#
+# Routing capability:
+#   TCP client - AT+QIOPEN "TCP"  (create_tcp_client_channel)
+#   UDP client - AT+QIOPEN "UDP"  (create_udp_channel)
+#   TCP server - not supported    (create_tcp_server_channel raises)
+#
+###
+class Modem
+  class Quectel < Modem
+
+    # Tracks one AT command until completion (OK/ERROR/SEND FAIL)
+    class CmdWaiter
+      attr_reader :cmd, :event, :buf
+      attr_accessor :ok
+
+      def initialize(cmd)
+        @cmd   = cmd
+        @event = Concurrent::Event.new
+        @buf   = []
+        @ok    = false
+      end
+    end
+
+    # Represents one opened modem socket (SID)
+    class Connection
+      attr_reader :sock_id, :recv_queue, :prompt_event, :ack_event
+      attr_accessor :ack_ok, :open_event, :open_ok, :open_err, :prompt_ok, :closed_flag
+
+      def initialize(modem, sock_id)
+        @modem        = modem
+        @sock_id      = sock_id
+        @recv_queue   = Queue.new      # payload chunks or nil EOF sentinel
+        @prompt_event = Concurrent::Event.new
+        @ack_event    = Concurrent::Event.new
+        @ack_ok       = false
+        @prompt_ok    = true
+        @closed_flag  = false
+        @close_mutex  = Mutex.new
+        @open_event   = Concurrent::Event.new
+        @open_ok      = false
+        @open_err     = nil
+      end
+
+      # Send data over this modem socket via AT+QISEND.
+      #
+      # Data is automatically broken into chunks no larger than
+      # @modem.cfg[:max_chunk_size] (default 1024 B). Quectel modems accept at
+      # most 1460 B per AT+QISEND invocation; TLS records can be up to 16 KB so
+      # chunking is required for HTTPS / any binary protocol.
+      def send(data)
+        raise_closed! if closed?
+
+        chunk_size = [@modem.cfg[:max_chunk_size], 1].max
+        offset = 0
+        while offset < data.bytesize
+          raise_closed! if closed?
+
+          chunk = data.byteslice(offset, chunk_size)
+          send_chunk(chunk)
+          offset += chunk.bytesize
+        end
+      end
+
+      private
+
+      # Send a single chunk (<= max_chunk_size bytes) via one AT+QISEND transaction.
+      def send_chunk(data)
+        @modem.at_lock.synchronize do
+          raise_closed! if closed?
+
+          at = "AT+QISEND=#{@sock_id},#{data.bytesize}\r"
+
+          begin
+            @modem.mutex.synchronize do
+              raise_closed! if closed?
+
+              @prompt_ok = true
+              @prompt_event.reset
+              @ack_event.reset
+              @modem.pending_send_sid = @sock_id
+              @modem.serial.write(at)
+            end
+
+            # Wait for '>' prompt (or early reject)
+            unless @prompt_event.wait(@modem.cfg[:prompt_timeout])
+              raise ::Rex::RuntimeError, "[SID #{@sock_id}] No '>' prompt for QISEND"
+            end
+            @prompt_event.reset
+            raise_closed! if closed?
+
+            unless @prompt_ok
+              raise ::Rex::RuntimeError, "[SID #{@sock_id}] QISEND rejected (no prompt)"
+            end
+
+            # Write payload + Ctrl-Z
+            @modem.mutex.synchronize do
+              raise_closed! if closed?
+
+              @modem.serial.write(data)
+              @modem.serial.write("\x1A")
+            end
+
+            # Wait for SEND OK/FAIL
+            unless @ack_event.wait(@modem.cfg[:ack_timeout])
+              raise ::Rex::RuntimeError, "[SID #{@sock_id}] No SEND OK/ERROR"
+            end
+            @ack_event.reset
+            raise_closed! if closed?
+
+            unless @ack_ok
+              raise ::Rex::RuntimeError, "[SID #{@sock_id}] SEND ERROR"
+            end
+          ensure
+            @modem.pending_send_sid = nil if @modem.pending_send_sid == @sock_id
+          end
+        end
+      end
+
+      public
+
+      # Blocking recv; returns:
+      #   - bytes (String) when payload available
+      #   - nil when modem closed socket
+      def recv
+        @recv_queue.pop(true)
+      rescue ::ThreadError
+        return nil if closed?
+
+        @recv_queue.pop
+      end
+
+      def push_payload(data)
+        return if closed?
+
+        @recv_queue << data
+      end
+
+      def closed?
+        @close_mutex.synchronize { @closed_flag }
+      end
+
+      def mark_closed
+        @modem.release_id(@sock_id) if transition_closed
+      end
+
+      def close
+        should_qiclose = transition_closed
+
+        if should_qiclose && !@modem.closed?
+          begin
+            @modem.send_at("AT+QICLOSE=#{@sock_id},0", @modem.cfg[:cmd_timeout])
+          rescue ::StandardError => e
+            @modem.log_debug("[SID #{@sock_id}] QICLOSE error: #{e.class} #{e.message}")
+          end
+        end
+        @modem.release_id(@sock_id) if should_qiclose
+      end
+
+      private
+
+      def raise_closed!
+        raise ::IOError, "[SID #{@sock_id}] Socket has been closed."
+      end
+
+      def transition_closed
+        notify_close = false
+        @close_mutex.synchronize do
+          unless @closed_flag
+            @closed_flag = true
+            notify_close = true
+          end
+          @prompt_ok = false
+          @ack_ok = false
+        end
+        @prompt_event.set
+        @ack_event.set
+        @recv_queue << nil if notify_close
+        notify_close
+      end
+    end
+
+    # Encapsulates serial I/O and URC parsing for the Quectel module.
+    #
+    # Initialization only opens the port, configures termios, and starts the
+    # background reader thread. The caller is responsible for the startup
+    # sequence (AT probe, ATE0, leftover-socket cleanup, health watchdog) so
+    # that it can interleave its own status output between steps.
+    class Driver
+      attr_reader :serial, :mutex, :cfg
+      attr_accessor :pending_send_sid
+      attr_reader :at_lock
+      attr_reader :open_lock
+
+      # Serial port configuration uses Linux-specific termios ioctls (TCGETS/TCSETSW).
+      def self.supported_platform?
+        RUBY_PLATFORM.include?('linux')
+      end
+
+      # -----------------------------------------------------------------------
+      # Linux termios constants for in-process serial port configuration.
+      # Source: asm-generic/ioctls.h and asm-generic/termbits.h (NCCS=19).
+      # Using ioctl avoids shelling out to stty.
+      # -----------------------------------------------------------------------
+      TCGETS        = 0x5401  # get termios struct
+      TCSETSW       = 0x5403  # drain then apply termios struct
+      TERMIOS_SIZE  = 36      # sizeof(struct termios): 4*uint32 + 1 + 19*uint8
+
+      # Baud-rate values encoded in c_cflag (B* constants)
+      BAUD_CONSTANTS = {
+         9_600 => 0x0000_000D,
+        19_200 => 0x0000_000E,
+        38_400 => 0x0000_000F,
+        57_600 => 0x0000_1001,
+       115_200 => 0x0000_1002,
+       230_400 => 0x0000_1003,
+       460_800 => 0x0000_1004,
+       921_600 => 0x0000_1007,
+      }.freeze
+
+      CBAUD   = 0x0000_100F  # baud-rate mask in c_cflag
+      CSIZE   = 0x0000_0030  # character-size mask
+      CS8     = 0x0000_0030  # 8-bit characters
+      CSTOPB  = 0x0000_0040  # 2 stop bits (clear = 1 stop bit)
+      CREAD   = 0x0000_0080  # enable receiver
+      PARENB  = 0x0000_0100  # parity enable
+      CRTSCTS = 0x8000_0000  # RTS/CTS hardware flow control
+
+      # c_iflag bits cleared by cfmakeraw
+      IFLAG_RAW_CLEAR = 0x0001 |  # IGNBRK
+                        0x0002 |  # BRKINT
+                        0x0008 |  # PARMRK
+                        0x0020 |  # ISTRIP
+                        0x0040 |  # INLCR
+                        0x0080 |  # IGNCR
+                        0x0100 |  # ICRNL
+                        0x0400 |  # IXON
+                        0x1000    # IXOFF
+      OPOST  = 0x0000_0001  # output processing (sole c_oflag bit we clear)
+
+      # c_lflag bits cleared by cfmakeraw
+      LFLAG_RAW_CLEAR = 0x0001 |  # ISIG  - no signal generation (no Ctrl-C etc.)
+                        0x0002 |  # ICANON - line-by-line processing off
+                        0x0008 |  # ECHO
+                        0x0010 |  # ECHOE
+                        0x0020 |  # ECHOK
+                        0x0040 |  # ECHONL
+                        0x8000    # IEXTEN
+
+      VTIME_IDX = 5   # c_cc index: read timeout (tenths of a second)
+      VMIN_IDX  = 6   # c_cc index: minimum bytes before read returns
+
+      def initialize(port, baud, framework, cfg)
+        @framework = framework
+        @serial = ::File.open(port, 'r+b')
+        @serial.sync = true
+
+        configure_serial_port(@serial, baud)
+
+        @cfg = cfg
+
+        @mutex        = Mutex.new    # serialize direct writes/reads as needed
+        @cmd_mutex    = Mutex.new
+        @at_lock      = Mutex.new    # serialize all AT commands (prevents interleaving)
+        @pending_cmds = []           # FIFO of CmdWaiter
+
+        @line_buf    = ''.b
+        @reader_stop = false
+        @rdy_event   = Concurrent::Event.new
+
+        # Serialize QIOPEN operations (one open in-flight at a time)
+        @open_lock        = Mutex.new
+        @pending_send_sid = nil
+
+        @id_mutex = Mutex.new
+        @free_ids = (0...@cfg[:modem_sockets]).to_a
+        @conns    = {}              # sid -> Connection
+
+        @modem_ready       = true
+        @ready_mutex       = Mutex.new
+        @health_fail_count = 0
+        @health_stop       = false
+        @closed = false
+
+        # Spawn dedicated reader thread
+        @reader_thread = @framework.threads.spawn('cellular_modem_reader', false) do
+          reader_loop
+        end
+
+      rescue ::Exception
+        # Stop background threads that may have been spawned before the failure.
+        close
+        raise
+      end
+
+      # === readiness/health helpers =====================================
+
+      def closed?
+        @closed
+      end
+
+      def modem_ready?
+        @ready_mutex.synchronize { @modem_ready }
+      end
+
+      def set_modem_ready(val, reason: nil)
+        changed = false
+        @ready_mutex.synchronize do
+          if @modem_ready != val
+            @modem_ready = val
+            changed = true
+          end
+        end
+        return unless changed
+
+        msg = val ? "[MODEM] READY#{reason ? " (#{reason})" : ''}" \
+                  : "[MODEM] NOT READY#{reason ? " (#{reason})" : ''}"
+        val ? ilog(msg, 'cellular_modem') : wlog(msg, 'cellular_modem')
+      end
+
+      # Poll AT until the modem responds with OK, up to total_timeout_s seconds
+      # (0 = no timeout). Raises Rex::TimeoutError if the deadline is exceeded.
+      def startup_wait_for_ok(total_timeout_s, interval_s, probe_timeout_s)
+        total_timeout_s = total_timeout_s.to_i
+        interval_s = interval_s.to_f
+        interval_s = 1.0 if interval_s <= 0
+
+        # total_timeout_s == 0 means "no timeout" (wait indefinitely until AT returns OK)
+        deadline = (total_timeout_s > 0) ? (::Time.now + total_timeout_s) : nil
+
+        loop do
+          if deadline && ::Time.now > deadline
+            set_modem_ready(false, reason: 'startup probe timed out')
+            raise ::Rex::TimeoutError, "Startup AT probe timed out after #{total_timeout_s}s"
+          end
+
+          begin
+            send_at('AT', probe_timeout_s)
+            set_modem_ready(true, reason: 'startup probe OK')
+            return
+          rescue ::Rex::TimeoutError, ::Rex::RuntimeError
+            # modem not ready yet - keep polling
+          rescue ::StandardError => e
+            log_debug("startup AT probe error: #{e.class} #{e.message}")
+          end
+
+          ::Rex.sleep(interval_s)
+        end
+      end
+
+      # Wait up to +timeout+ seconds for the RDY URC. Best-effort; returns
+      # true if seen, false if the modem was already past the boot banner.
+      def wait_for_rdy(timeout)
+        @rdy_event.wait(timeout)
+      end
+
+      def start_health_watchdog
+        @health_stop = false
+        @health_thread = @framework.threads.spawn('cellular_modem_health_watchdog', false) do
+          loop do
+            break if @health_stop
+            begin
+              # Probe modem liveness
+              send_at('AT', @cfg[:healthcheck_timeout])
+              @health_fail_count = 0
+
+              # If we were previously NOT READY, run minimal re-init (echo off) after reboot
+              unless modem_ready?
+                reinitialize_after_reboot
+                set_modem_ready(true, reason: 'health probe OK')
+              end
+            rescue ::Rex::TimeoutError, ::Rex::RuntimeError
+              @health_fail_count += 1
+              if @health_fail_count >= @cfg[:healthcheck_max_fails]
+                set_modem_ready(false, reason: "health probe failed #{@health_fail_count}x")
+              end
+            rescue ::StandardError => e
+              @health_fail_count += 1
+              log_debug("health probe exception: #{e.class} #{e.message}")
+              if @health_fail_count >= @cfg[:healthcheck_max_fails]
+                set_modem_ready(false, reason: "health probe exception #{@health_fail_count}x")
+              end
+            end
+            ::Rex.sleep(@cfg[:healthcheck_interval])
+          end
+        end
+      end
+
+      def reinitialize_after_reboot
+        # After a power cycle, the module often resets settings like echo.
+        # If echo is enabled, the modem will echo QISEND payload bytes back on the AT port,
+        # which can look like "binary URCs" in the console. Re-assert ATE0 once we're back.
+        begin
+          send_at('ATE0', @cfg[:cmd_timeout])
+        rescue ::StandardError => e
+          log_debug("reinitialize_after_reboot: ATE0 failed: #{e.class} #{e.message}")
+        end
+
+        # Best-effort drain any buffered garbage that may have accumulated during reboot.
+        begin
+          loop do
+            r, _w, _e = ::IO.select([@serial], nil, nil, 0)
+            break unless r && r.include?(@serial)
+            @serial.read_nonblock(4096)
+          end
+        rescue ::IO::WaitReadable, ::EOFError, ::IOError
+        end
+      end
+
+      def close
+        return if @closed
+
+        @closed = true
+        @health_stop = true
+        @reader_stop = true
+        conns = []
+        if @id_mutex && @conns
+          @id_mutex.synchronize do
+            conns = @conns.values
+            @conns.clear
+            @free_ids = (0...@cfg[:modem_sockets]).to_a if @free_ids && @cfg
+          end
+        else
+          conns = @conns&.values || []
+          @conns&.clear
+        end
+        conns.each(&:mark_closed)
+
+        begin
+          @serial.close if @serial
+        rescue ::IOError
+        end
+
+        stop_thread(@health_thread)
+        stop_thread(@reader_thread)
+      end
+
+      def log_debug(msg)
+        dlog(msg, 'cellular_modem')
+      end
+
+      private
+
+      def stop_thread(thread)
+        return unless thread
+        return if thread == ::Thread.current
+
+        thread.join(1)
+        return unless thread.alive?
+
+        thread.kill
+        thread.join
+      end
+
+      # Configure the serial port in-process using termios ioctls.
+      # Equivalent to: stty raw -echo -crtscts -ixon -ixoff cs8 <baud>
+      #
+      # Raises Errno::ENOTTY if +io+ is not a serial device.
+      def configure_serial_port(io, baud)
+        baud_bits = BAUD_CONSTANTS[baud] or
+          raise ::ArgumentError, "Unsupported baud rate: #{baud}. " \
+                "Valid rates: #{BAUD_CONSTANTS.keys.join(', ')}"
+
+        buf = ("\x00" * TERMIOS_SIZE).b
+        io.ioctl(TCGETS, buf)
+
+        c_iflag, c_oflag, c_cflag, c_lflag = buf.unpack('LLLL')
+        c_cc = buf[17, 19].bytes
+
+        # cfmakeraw: disable all special character and line-discipline processing
+        c_iflag  = (c_iflag  & ~IFLAG_RAW_CLEAR) & 0xFFFF_FFFF
+        c_oflag  = (c_oflag  & ~OPOST)           & 0xFFFF_FFFF
+        c_lflag  = (c_lflag  & ~LFLAG_RAW_CLEAR) & 0xFFFF_FFFF
+        c_cflag  = (c_cflag  & ~(CSIZE | PARENB | CRTSCTS | CSTOPB)) & 0xFFFF_FFFF
+        c_cflag |= (CS8 | CREAD)
+
+        # Set baud rate (encoded in c_cflag for the old-style termios ABI)
+        c_cflag = (c_cflag & (~CBAUD & 0xFFFF_FFFF)) | baud_bits
+
+        # VMIN=1, VTIME=0: reads block until at least one byte arrives
+        c_cc[VMIN_IDX]  = 1
+        c_cc[VTIME_IDX] = 0
+
+        buf[0, 16]  = [c_iflag, c_oflag, c_cflag, c_lflag].pack('LLLL')
+        buf[17, 19] = c_cc.pack('C*')
+
+        io.ioctl(TCSETSW, buf)
+      end
+
+      public
+
+      # --- SID pool management ---
+
+      def allocate_id
+        @id_mutex.synchronize do
+          sid = @free_ids.shift
+          raise ::RuntimeError, 'No socket IDs available' unless sid
+
+          sid
+        end
+      end
+
+      def release_id(sid)
+        return unless sid
+
+        @id_mutex.synchronize do
+          @conns.delete(sid)
+          @free_ids << sid unless @free_ids.include?(sid)
+        end
+      end
+
+      def register_connection(sid, conn)
+        @id_mutex.synchronize do
+          @conns[sid] = conn
+        end
+      end
+
+      def connection_for_id(sid)
+        @id_mutex.synchronize do
+          @conns[sid]
+        end
+      end
+
+      #
+      # Open an outbound TCP socket through the Quectel modem.
+      #
+      # @param host [String] remote IP address or hostname
+      # @param port [Integer] remote TCP port
+      # @return [Connection, nil] nil on timeout or error
+      def open_tcp_client_socket(host, port)
+        open_socket('TCP', host, port, 'open_tcp_connection')
+      end
+
+      #
+      # Open an outbound UDP socket through the Quectel modem.
+      #
+      # @param host [String] remote IP address or hostname
+      # @param port [Integer] remote UDP port
+      # @return [Connection, nil] nil on timeout or error
+      def open_udp_socket(host, port)
+        open_socket('UDP', host, port, 'open_udp_connection')
+      end
+
+      def open_socket(protocol, host, port, error_method)
+        @open_lock.synchronize do
+          sid = allocate_id
+          conn = Connection.new(self, sid)
+          register_connection(sid, conn)
+
+          begin
+            cmd = %Q{AT+QIOPEN=1,#{sid},"#{protocol}","#{host}",#{port},0,1}
+            send_at(cmd, @cfg[:cmd_timeout])
+
+            unless conn.open_event.wait(@cfg[:open_timeout])
+              wlog("[SID #{sid}] #{protocol} QIOPEN timeout", 'cellular_modem')
+              release_id(sid)
+              return nil
+            end
+
+            unless conn.open_ok
+              wlog("[SID #{sid}] #{protocol} QIOPEN failed err=#{conn.open_err}", 'cellular_modem')
+              release_id(sid)
+              return nil
+            end
+
+            conn
+          rescue ::StandardError => e
+            elog("#{error_method} error (sid=#{sid}): #{e.class} #{e.message}", 'cellular_modem')
+            release_id(sid)
+            nil
+          end
+        end
+      end
+      private :open_socket
+
+      # --- AT helper with CmdWaiter ---
+
+      def send_at(cmd, timeout = nil)
+        timeout ||= @cfg[:cmd_timeout]
+        @at_lock.synchronize do
+          waiter = CmdWaiter.new(cmd)
+          @cmd_mutex.synchronize do
+            @pending_cmds << waiter
+          end
+
+          log_debug("-> AT #{cmd}")
+          @mutex.synchronize do
+            @serial.write("#{cmd}\r")
+          end
+
+          unless waiter.event.wait(timeout)
+            @cmd_mutex.synchronize do
+              @pending_cmds.delete(waiter)
+            end
+            raise ::Rex::TimeoutError, "AT cmd timeout: #{cmd}"
+          end
+
+          waiter.buf.each do |l|
+            log_debug("<- #{l}")
+          end
+
+          unless waiter.ok
+            raise ::Rex::RuntimeError, "AT cmd error: #{cmd}"
+          end
+
+          waiter.buf.join("\n")
+        end
+      end
+
+      # --- Reader loop and line handler ---
+
+      def reader_loop
+        loop do
+          break if @reader_stop
+          ch = nil
+          begin
+            ch = @serial.read(1)
+          rescue ::EOFError, ::IOError => e
+            elog("serial read error: #{e.class} #{e.message}", 'cellular_modem')
+            break
+          end
+          next unless ch
+          # QISEND '>' prompt (single char, no CRLF)
+          if ch == '>'
+            sid = @pending_send_sid
+            if sid
+              conn = connection_for_id(sid)
+              if conn
+                conn.prompt_ok = true
+                conn.prompt_event.set
+              end
+            end
+            next
+          end
+          @line_buf << ch
+          if @line_buf.end_with?("\r\n")
+            line = @line_buf.strip
+            @line_buf.clear
+            handle_line(line)
+          end
+        end
+      end
+
+      def handle_line(line)
+        # Avoid spewing raw binary to the console (can happen if echo is re-enabled after reboot)
+        if line.bytes.any? { |b| b < 0x09 || (b > 0x0D && b < 0x20) || b == 0x7F }
+          hex = line.bytes.first(32).map { |b| format('%02X', b) }.join(' ')
+          log_debug("URC: [binary #{line.bytesize} bytes] #{hex}#{line.bytesize > 32 ? ' ...' : ''}")
+        else
+          log_debug("URC: #{line}")
+        end
+
+        # Boot ready
+        if line == 'RDY'
+          dlog('[URC] RDY', 'cellular_modem')
+          @rdy_event.set
+          return
+        end
+
+        if line =~ /(POWERED DOWN|POWER DOWN|NORMAL POWER DOWN)/i
+          wlog("[URC] #{line}", 'cellular_modem')
+          set_modem_ready(false, reason: line)
+          return
+        end
+
+        # First, feed pending command waiter if any
+        @cmd_mutex.synchronize do
+          if (waiter = @pending_cmds.first)
+            case line
+            when 'OK'
+              waiter.buf << 'OK'
+              waiter.ok  = true
+              waiter.event.set
+              @pending_cmds.shift
+            when /^ERROR/, 'SEND FAIL'
+              waiter.buf << line
+              waiter.ok  = false
+              waiter.event.set
+              @pending_cmds.shift
+            else
+              waiter.buf << line
+            end
+          end
+        end
+
+        # +QIOPEN: sid,err
+        if line.start_with?('+QIOPEN:')
+          begin
+            rest = line.split(':', 2)[1].strip
+            parts = rest.split(',').map(&:strip)
+            sid  = parts[0].to_i
+            err  = parts[1].to_i
+            if (conn = connection_for_id(sid))
+              conn.open_ok  = (err == 0)
+              conn.open_err = err
+              conn.open_event.set
+            end
+          rescue ::StandardError
+          end
+          return
+        end
+
+        # +QIURC: "recv",sid,len
+        if line.start_with?('+QIURC: "recv"')
+          begin
+            parts = line.split(',')
+            sid   = parts[1].to_i
+            len   = parts[2].to_i
+          rescue ::StandardError
+            return
+          end
+
+          payload = ''.b
+          while payload.bytesize < len
+            begin
+              chunk = @serial.read(len - payload.bytesize)
+            rescue ::EOFError, ::IOError
+              break
+            end
+            next unless chunk
+            payload << chunk
+          end
+
+          if (conn = connection_for_id(sid))
+            conn.push_payload(payload)
+          end
+          return
+        end
+
+        # +QIURC: "closed",sid
+        if line.start_with?('+QIURC: "closed"')
+          begin
+            sid = line.split(',')[1].to_i
+          rescue ::StandardError
+            return
+          end
+          if (conn = connection_for_id(sid))
+            conn.mark_closed
+          end
+          return
+        end
+
+        # QISEND results / early rejects mapped via pending_send_sid
+        if ['SEND OK', 'SEND FAIL', 'ERROR'].include?(line)
+          sid = @pending_send_sid
+          if sid && (conn = connection_for_id(sid))
+            ok = (line == 'SEND OK')
+            conn.ack_ok = ok
+            conn.ack_event.set
+
+            # If the modem rejects QISEND before issuing a '>' prompt, wake the sender
+            # that's blocked waiting on prompt_event.
+            if !ok && line == 'ERROR'
+              conn.prompt_ok = false
+              conn.prompt_event.set
+            end
+          end
+          return
+        end
+      end
+    end
+
+    def initialize(quectel_modem, opts = {})
+      super(opts)
+      @quectel_modem = quectel_modem
+      self.info = desc
+    end
+
+    def desc
+      'Quectel modem'
+    end
+
+    def tunnel_to_s
+      @quectel_modem.serial.path
+    end
+
+    def cleanup
+      super # closes all open channels (base Modem#cleanup)
+    ensure
+      begin
+        @quectel_modem&.close
+      rescue ::StandardError => e
+        elog("Quectel modem cleanup error: #{e.class} #{e.message}", 'cellular_modem')
+      end
+    end
+
+    # Quectel supports native UDP via AT+QIOPEN "UDP".
+    def supports_udp?
+      true
+    end
+
+    protected
+
+    #
+    # Open an outbound TCP connection through the Quectel modem.
+    #
+    # Sends AT+QIOPEN and waits for the +QIOPEN URC. The connection timeout
+    # is governed by the module's OPEN_TIMEOUT_MS datastore option (default
+    # 30 s), configured when Driver was constructed.
+    #
+    # @return [lsock] the local socket end for the framework
+    # @raise [Rex::ConnectionError] on open failure or timeout
+    #
+    def create_tcp_client_channel(params)
+      validate_unbound_socket!(params)
+
+      conn = @quectel_modem.open_tcp_client_socket(params.peerhost, params.peerport)
+      unless conn
+        raise ::Rex::ConnectionError.new(params.peerhost, params.peerport,
+          reason: 'Quectel modem failed to open AT connection (QIOPEN timeout or error).')
+      end
+
+      chan = TcpClientChannel.new(self, @channel_ticker += 1, conn, params)
+      chan.lsock
+    end
+
+    #
+    # Quectel AT commands do not support inbound TCP listeners.
+    #
+    def create_tcp_server_channel(params)
+      raise ::Rex::ConnectionError.new(params.localhost, params.localport,
+        reason: 'TCP server sockets are not supported by Quectel modem sessions.')
+    end
+
+    #
+    # Open an outbound UDP socket through the Quectel modem via AT+QIOPEN "UDP".
+    #
+    # @return [lsock] the local UDP socket end for the framework
+    # @raise [Rex::ConnectionError] on open failure or timeout
+    #
+    def create_udp_channel(params)
+      validate_unbound_socket!(params)
+
+      conn = @quectel_modem.open_udp_socket(params.peerhost, params.peerport)
+      unless conn
+        raise ::Rex::ConnectionError.new(params.peerhost, params.peerport,
+          reason: 'Quectel modem failed to open UDP AT connection (QIOPEN timeout or error).')
+      end
+
+      chan = UdpChannel.new(self, @channel_ticker += 1, conn, params)
+      chan.lsock
+    end
+
+    def validate_unbound_socket!(params)
+      local_addr = params.localhost
+      local_port = params.localport.to_i
+      bound_addr = local_addr.present? && (!Rex::Socket.is_ip_addr?(local_addr) || Rex::Socket.addr_atoi(local_addr) != 0)
+      return unless bound_addr || local_port != 0
+
+      raise ::Rex::BindFailed.new(local_addr, local_port,
+        reason: 'Quectel modem sockets do not support binding to a particular address.')
+    end
+  end
+end
+
+end  # Sessions
+end  # Msf

--- a/lib/msf/core/db_manager/route.rb
+++ b/lib/msf/core/db_manager/route.rb
@@ -12,6 +12,9 @@ module Msf::DBManager::Route
     else
       s = session
     end
+    # Session was never persisted to the database (e.g. hardware sessions with
+    # no associated host). Skip route recording rather than raising.
+    return if s.nil?
     unless s.respond_to?(:routes)
       raise ArgumentError.new("Invalid :session, expected Session object got #{session.class}")
     end
@@ -34,6 +37,7 @@ module Msf::DBManager::Route
     else
       s = session
     end
+    return if s.nil?
     unless s.respond_to?(:routes)
       raise ArgumentError.new("Invalid :session, expected Session object got #{session.class}")
     end

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -313,6 +313,7 @@ module DNS
     def send_udp(packet,packet_data, nameservers)
       ans = nil
       nameservers.each do |ns, socket_options|
+        socket = nil
         begin
           config = {
             'PeerHost' => ns.to_s,
@@ -346,6 +347,8 @@ module DNS
       rescue Timeout::Error
         @logger.warn "Nameserver #{ns} not responding within UDP timeout, trying next one"
         next
+      ensure
+        socket.close if socket && !socket.closed?
       end
       ans
     end

--- a/modules/auxiliary/server/quectel_modem.rb
+++ b/modules/auxiliary/server/quectel_modem.rb
@@ -1,0 +1,174 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/base/sessions/modem'
+require 'msf/base/sessions/modem/quectel'
+
+class MetasploitModule < Msf::Auxiliary
+  DEFAULT_MAX_CHUNK_SIZE = 1024 # bytes per QISEND chunk
+  DEFAULT_PROMPT_TIMEOUT_MS = 5000 # wait for '>' after QISEND (ms)
+  DEFAULT_ACK_TIMEOUT_MS = 8000 # wait for SEND OK/FAIL (ms)
+  DEFAULT_OPEN_TIMEOUT_MS = 30000 # wait for +QIOPEN URC (ms)
+  DEFAULT_CMD_TIMEOUT_MS = 6000 # wait for AT command OK/ERROR (ms)
+
+  # === v0.06.4 modem health / readiness defaults ===============================
+  DEFAULT_STARTUP_OK_TIMEOUT_S = 0 # total seconds to wait for first AT OK (0 = no timeout)
+  DEFAULT_STARTUP_OK_INTERVAL_MS = 1000  # delay between AT probes at startup (ms)
+  DEFAULT_HEALTHCHECK_INTERVAL_S = 3     # seconds between AT probes at runtime
+  DEFAULT_HEALTHCHECK_TIMEOUT_MS = 2000  # per-probe AT timeout (ms)
+  DEFAULT_HEALTHCHECK_MAX_FAILS = 3 # consecutive failures before marking NOT READY
+
+  DEFAULT_MODEM_SOCKETS = 12 # SID pool size (0..N-1); Quectel Cell Module supports up to 12
+
+  # === Metasploit module proper ============================================
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Quectel Cellular Modem Pivot (Serial AT)',
+        'Description' => %q{
+          Opens a serial connection to a Quectel cellular modem and registers it as a 'modem' session capable of network
+          pivoting. The Quectel modems have a limited number of sockets available, configurable using MODEM_SOCKETS. Once
+          the session is established, it can be routed through using the `route` command.
+        },
+        'Author' => [
+          'Deral Heiland',       # original SOCKS5 proxy module
+          'Spencer McIntyre'     # native session refactor
+        ],
+        'License' => MSF_LICENSE,
+        'Notes' => { 'Stability' => [], 'Reliability' => [], 'SideEffects' => [] }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('SERIAL', [ true, 'Serial device for Quectel modem', '/dev/ttyUSB0' ]),
+        OptInt.new('BAUD', [ true, 'Serial baud rate', 115200 ]),
+
+        # Advanced performance knobs (tune as needed)
+        OptInt.new('MODEM_SOCKETS', [ true, 'Number of Quectel socket IDs (SID pool size)', DEFAULT_MODEM_SOCKETS ]),
+        OptInt.new('MAX_CHUNK_SIZE', [ true, 'Bytes per AT+QISEND chunk', DEFAULT_MAX_CHUNK_SIZE ]),
+        OptInt.new('PROMPT_TIMEOUT_MS', [ true, "Timeout waiting for QISEND '>' prompt (ms)", DEFAULT_PROMPT_TIMEOUT_MS ]),
+        OptInt.new('ACK_TIMEOUT_MS', [ true, 'Timeout waiting for SEND OK/FAIL (ms)', DEFAULT_ACK_TIMEOUT_MS ]),
+        OptInt.new('OPEN_TIMEOUT_MS', [ true, 'Timeout waiting for +QIOPEN URC (ms)', DEFAULT_OPEN_TIMEOUT_MS ]),
+        OptInt.new('CMD_TIMEOUT_MS', [ true, 'Timeout waiting for AT command OK/ERROR (ms)', DEFAULT_CMD_TIMEOUT_MS ]),
+
+        # modem readiness / health watchdog
+        OptInt.new('STARTUP_OK_TIMEOUT_S', [ true, 'Startup: total seconds to wait for first AT OK (0 = no timeout)', DEFAULT_STARTUP_OK_TIMEOUT_S ]),
+        OptInt.new('STARTUP_OK_INTERVAL_MS', [ true, 'Startup: delay between AT probes (ms)', DEFAULT_STARTUP_OK_INTERVAL_MS ]),
+        OptInt.new('HEALTHCHECK_INTERVAL_S', [ true, 'Runtime: seconds between modem AT health probes', DEFAULT_HEALTHCHECK_INTERVAL_S ]),
+        OptInt.new('HEALTHCHECK_TIMEOUT_MS', [ true, 'Runtime: AT health probe timeout (ms)', DEFAULT_HEALTHCHECK_TIMEOUT_MS ]),
+        OptInt.new('HEALTHCHECK_MAX_FAILS', [ true, 'Runtime: consecutive AT probe failures before marking modem NOT READY', DEFAULT_HEALTHCHECK_MAX_FAILS ])
+      ]
+    )
+
+    @modem = nil
+    @cfg = {}
+    @session_registered = false
+  end
+
+  def setup
+    super
+    unless Msf::Sessions::Modem::Quectel::Driver.supported_platform?
+      fail_with(Failure::BadConfig,
+                "This module uses Linux-specific termios ioctls and cannot run on #{RUBY_PLATFORM}")
+    end
+
+    dev = datastore['SERIAL']
+    baud = datastore['BAUD'].to_i
+
+    # Build runtime config from datastore (keep everything in seconds/bytes internally)
+    @cfg = {
+      modem_sockets: [datastore['MODEM_SOCKETS'].to_i, 1].max,
+      max_chunk_size: [datastore['MAX_CHUNK_SIZE'].to_i, 1].max,
+      prompt_timeout: [datastore['PROMPT_TIMEOUT_MS'].to_i, 0].max / 1000.0,
+      ack_timeout: [datastore['ACK_TIMEOUT_MS'].to_i, 0].max / 1000.0,
+      open_timeout: [datastore['OPEN_TIMEOUT_MS'].to_i, 0].max / 1000.0,
+      cmd_timeout: [datastore['CMD_TIMEOUT_MS'].to_i, 0].max / 1000.0,
+      startup_ok_timeout: [datastore['STARTUP_OK_TIMEOUT_S'].to_i, 0].max,
+      startup_ok_interval: [datastore['STARTUP_OK_INTERVAL_MS'].to_i, 0].max / 1000.0,
+      healthcheck_interval: [datastore['HEALTHCHECK_INTERVAL_S'].to_i, 0].max,
+      healthcheck_timeout: [datastore['HEALTHCHECK_TIMEOUT_MS'].to_i, 0].max / 1000.0,
+      healthcheck_max_fails: [datastore['HEALTHCHECK_MAX_FAILS'].to_i, 1].max
+    }
+
+    # Open the serial port and start the background reader thread.
+    begin
+      @modem = Msf::Sessions::Modem::Quectel::Driver.new(dev, baud, framework, @cfg)
+    rescue ::Errno::ENOENT
+      fail_with(Failure::BadConfig, "Serial device not found: #{dev}")
+    rescue ::Errno::EACCES
+      fail_with(Failure::BadConfig, "Permission denied opening #{dev} - check that your user is in the 'dialout' group")
+    rescue ::Errno::EBUSY
+      fail_with(Failure::BadConfig, "#{dev} is busy - another process may have it open")
+    rescue ::Errno::EIO, ::Errno::ENXIO
+      fail_with(Failure::Unreachable, "I/O error on #{dev} - check the USB cable and modem power")
+    rescue ::Errno::ENOTTY
+      fail_with(Failure::BadConfig, "#{dev} is not a serial port (ioctl TCGETS failed)")
+    rescue ::StandardError => e
+      fail_with(Failure::Unknown, "Failed to open serial port on #{dev}: #{e.class} #{e.message}")
+    end
+
+    # Poll AT until the modem is responsive.
+    print_status('Probing modem with AT until OK...')
+    begin
+      @modem.startup_wait_for_ok(@cfg[:startup_ok_timeout], @cfg[:startup_ok_interval], @cfg[:healthcheck_timeout])
+    rescue ::Rex::TimeoutError => e
+      fail_with(Failure::TimeoutExpired, e.message)
+    rescue ::StandardError => e
+      fail_with(Failure::Unknown, "Modem startup probe failed: #{e.class} #{e.message}")
+    end
+    print_good('Modem is responding to AT commands.')
+
+    # Best-effort wait for the RDY banner (already past it on a warm start).
+    print_status('Waiting briefly for RDY URC (best-effort)...')
+    @modem.wait_for_rdy(5)
+
+    # Disable echo so URC parsing is not confused by command echoes.
+    begin
+      @modem.send_at('ATE0', @cfg[:cmd_timeout])
+    rescue ::StandardError => e
+      fail_with(Failure::Unknown, "Failed to disable echo (ATE0): #{e.class} #{e.message}")
+    end
+
+    # Close any leftover socket connections from a previous session (e.g. MSF
+    # crashed without sending AT+QICLOSE). Errors are silently ignored - a SID
+    # that is not open will return ERROR, which is expected.
+    print_status('Closing any leftover modem socket connections...')
+    (0...@cfg[:modem_sockets]).each do |sid|
+      @modem.send_at("AT+QICLOSE=#{sid},0", @cfg[:cmd_timeout])
+    rescue ::StandardError => e
+      nil
+    end
+
+    # Start runtime health watchdog now that the modem is known-good.
+    @modem.start_health_watchdog
+  end
+
+  def cleanup
+    # Only close the modem if the session was never registered.
+    # Once the session takes ownership, it is responsible for
+    # closing the modem via Msf::Sessions::Modem::Quectel#cleanup.
+    @modem.close if @modem && !@session_registered
+    super
+  end
+
+  def run
+    unless @modem.modem_ready?
+      print_error('Modem is not ready - check serial connection and power')
+      return
+    end
+
+    sess = Msf::Sessions::Modem::Quectel.new(@modem)
+    sess.set_from_exploit(self)
+    framework.sessions.register(sess)
+    # Transfer modem ownership to the session; cleanup must not close it now.
+    @session_registered = true
+    print_good("Modem session #{sess.sid} opened (#{@cfg[:modem_sockets]} sockets, #{@cfg[:max_chunk_size]}B chunks)")
+    # Return immediately - the session runs independently of this module job.
+  end
+
+end

--- a/spec/lib/msf/base/sessions/modem/quectel_spec.rb
+++ b/spec/lib/msf/base/sessions/modem/quectel_spec.rb
@@ -1,0 +1,304 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'msf/base/sessions/modem'
+require 'msf/base/sessions/modem/quectel'
+require 'timeout'
+
+RSpec.describe Msf::Sessions::Modem::Quectel do
+  subject(:session) { described_class.new(modem) }
+
+  let(:serial) { double('serial', path: '/dev/ttyUSB0') }
+  let(:modem) do
+    double('QuectelModem', open_tcp_client_socket: nil, open_udp_socket: nil,
+                           close: nil, serial: serial)
+  end
+  let(:spawned_threads) { [] }
+  let(:thread_manager) do
+    double('thread_manager').tap do |manager|
+      allow(manager).to receive(:spawn) do |name, critical, *args, &block|
+        thread = ::Thread.new(*args) do |*thread_args|
+          ::Thread.current[:tm_name] = name
+          ::Thread.current[:tm_crit] = critical
+          block.call(*thread_args)
+        end
+        spawned_threads << thread
+        thread
+      end
+    end
+  end
+  let(:framework) { double('framework', threads: thread_manager) }
+  # Connection duck-type consumed by the channel/socket wrappers.
+  let(:recv_queue) { Queue.new }
+  let(:conn) do
+    double('conn', send: nil).tap do |connection|
+      allow(connection).to receive(:recv) { recv_queue.pop }
+      allow(connection).to receive(:close) { recv_queue << nil }
+    end
+  end
+
+  def params_double(peerhost:, peerport: 53, localhost: '0.0.0.0', localport: 0)
+    double('params', proto: 'udp', server: false, peerhost: peerhost, peerhostname: peerhost,
+                     peerport: peerport, localhost: localhost, localport: localport,
+                     sslkeylogfile: nil, context: nil, v6: false)
+  end
+
+  before do
+    @original_thread_factory_provider = Rex::ThreadFactory.class_variable_get(:@@provider)
+    Rex::ThreadFactory.provider = thread_manager
+    session.framework = framework
+  end
+
+  after do
+    Rex::ThreadFactory.provider = @original_thread_factory_provider
+
+    spawned_threads.each do |thread|
+      thread.kill if thread.alive?
+      thread.join
+    end
+  end
+
+  describe 'identity' do
+    it 'supports native UDP' do
+      expect(session.supports_udp?).to be(true)
+    end
+
+    it 'has a Quectel description' do
+      expect(session.desc).to eq('Quectel modem')
+    end
+
+    it 'populates info with the description' do
+      expect(session.info).to eq('Quectel modem')
+    end
+
+    it 'returns the serial device path from tunnel_to_s' do
+      expect(session.tunnel_to_s).to eq('/dev/ttyUSB0')
+    end
+  end
+
+  describe '#create_tcp_client_channel' do
+    let(:params) { params_double(peerhost: '192.0.2.10', peerport: 80) }
+
+    it 'raises ConnectionError when the modem cannot open the connection' do
+      allow(modem).to receive(:open_tcp_client_socket).and_return(nil)
+      expect { session.send(:create_tcp_client_channel, params) }
+        .to raise_error(::Rex::ConnectionError)
+    end
+
+    it 'returns the local socket end on success' do
+      allow(modem).to receive(:open_tcp_client_socket).and_return(conn)
+      sock = session.send(:create_tcp_client_channel, params)
+      expect(sock).to respond_to(:syswrite)
+      sock.channel.close
+    end
+  end
+
+  describe '#create_tcp_server_channel' do
+    it 'is not supported and raises ConnectionError' do
+      params = params_double(peerhost: '0.0.0.0', peerport: 4444)
+      expect { session.send(:create_tcp_server_channel, params) }
+        .to raise_error(::Rex::ConnectionError)
+    end
+  end
+
+  describe '#create_udp_channel' do
+    # No bypass to the local comm is permitted: loopback/link-local destinations
+    # must still be opened through the modem (or fail), never via Comm::Local.
+    %w[127.0.0.1 ::1 169.254.1.1 fe80::1 8.8.8.8].each do |addr|
+      it "opens #{addr} through the modem rather than bypassing to the local comm" do
+        params = params_double(peerhost: addr)
+        expect(::Rex::Socket::Comm::Local).not_to receive(:create)
+        expect(modem).to receive(:open_udp_socket).with(addr, 53).and_return(conn)
+        sock = session.send(:create_udp_channel, params)
+        expect(sock).to be_a(Rex::Socket::Udp)
+        sock.channel.close
+      end
+    end
+
+    it 'returns a real UDP local socket end on success' do
+      params = params_double(peerhost: '8.8.8.8')
+      allow(modem).to receive(:open_udp_socket).with('8.8.8.8', 53).and_return(conn)
+      sock = session.send(:create_udp_channel, params)
+      expect(sock).to be_a(Rex::Socket::Udp)
+      expect(sock).to respond_to(:sendto, :recvfrom)
+      sock.channel.close
+    end
+
+    it 'raises ConnectionError (no local-comm fallback) when the modem refuses the UDP open' do
+      params = params_double(peerhost: '8.8.8.8')
+      allow(modem).to receive(:open_udp_socket).and_return(nil)
+      expect(::Rex::Socket::Comm::Local).not_to receive(:create)
+      expect { session.send(:create_udp_channel, params) }
+        .to raise_error(::Rex::ConnectionError)
+    end
+  end
+
+  describe '#cleanup' do
+    it 'closes the underlying modem' do
+      expect(modem).to receive(:close)
+      session.cleanup
+    end
+
+    it 'closes the underlying modem when channel cleanup raises' do
+      chan = double('channel')
+      allow(chan).to receive(:cid).and_return(1)
+      allow(chan).to receive(:close).and_raise(::RuntimeError, 'channel cleanup failed')
+      session.add_channel(chan)
+
+      expect(modem).to receive(:close)
+      expect { session.cleanup }.to raise_error(::RuntimeError, 'channel cleanup failed')
+    end
+  end
+end
+
+RSpec.describe Msf::Sessions::Modem::Quectel::Connection do
+  subject(:connection) { described_class.new(modem, 4) }
+
+  let(:cfg) do
+    {
+      max_chunk_size: 1024,
+      cmd_timeout: 1,
+      prompt_timeout: 1,
+      ack_timeout: 1
+    }
+  end
+  let(:serial) { double('serial') }
+  let(:modem) do
+    double(
+      'QuectelDriver',
+      at_lock: Mutex.new,
+      cfg: cfg,
+      closed?: false,
+      log_debug: nil,
+      mutex: Mutex.new,
+      pending_send_sid: nil,
+      serial: serial
+    )
+  end
+
+  before do
+    allow(modem).to receive(:pending_send_sid=)
+  end
+
+  describe '#close' do
+    it 'sends QICLOSE and releases the SID once' do
+      expect(modem).to receive(:send_at).with('AT+QICLOSE=4,0', 1).once
+      expect(modem).to receive(:release_id).with(4).once
+
+      connection.close
+      connection.close
+
+      expect(connection).to be_closed
+    end
+
+    it 'does not send QICLOSE after a remote close has already released the SID' do
+      expect(modem).to receive(:release_id).with(4).once
+      expect(modem).not_to receive(:send_at)
+
+      connection.mark_closed
+      connection.close
+
+      expect(connection.recv).to be_nil
+    end
+  end
+
+  describe '#recv' do
+    it 'returns nil without blocking after the close sentinel has been drained' do
+      expect(modem).to receive(:release_id).with(4).once
+
+      connection.mark_closed
+
+      expect(connection.recv).to be_nil
+      expect(::Timeout.timeout(0.1) { connection.recv }).to be_nil
+    end
+  end
+
+  describe '#send' do
+    it 'fails before QISEND when the connection is already remote-closed' do
+      allow(modem).to receive(:release_id)
+      expect(serial).not_to receive(:write)
+
+      connection.mark_closed
+
+      expect { connection.send('payload') }.to raise_error(IOError)
+    end
+  end
+end
+
+RSpec.describe Msf::Sessions::Modem::Quectel::Driver do
+  subject(:driver) { described_class.allocate }
+
+  let(:conn) { double('conn') }
+  let(:health_thread) { instance_double(::Thread) }
+  let(:reader_thread) { instance_double(::Thread) }
+  let(:serial) { double('serial') }
+
+  before do
+    driver.instance_variable_set(:@closed, false)
+    driver.instance_variable_set(:@conns, { 0 => conn })
+    driver.instance_variable_set(:@health_stop, false)
+    driver.instance_variable_set(:@health_thread, health_thread)
+    driver.instance_variable_set(:@reader_stop, false)
+    driver.instance_variable_set(:@reader_thread, reader_thread)
+    driver.instance_variable_set(:@serial, serial)
+  end
+
+  describe '#close' do
+    it 'closes the serial device and stops background threads' do
+      expect(conn).to receive(:mark_closed)
+      expect(serial).to receive(:close)
+
+      expect(health_thread).to receive(:join).with(1)
+      expect(health_thread).to receive(:alive?).and_return(true)
+      expect(health_thread).to receive(:kill)
+      expect(health_thread).to receive(:join).with(no_args)
+
+      expect(reader_thread).to receive(:join).with(1)
+      expect(reader_thread).to receive(:alive?).and_return(true)
+      expect(reader_thread).to receive(:kill)
+      expect(reader_thread).to receive(:join).with(no_args)
+
+      driver.close
+
+      expect(driver).to be_closed
+      expect(driver.instance_variable_get(:@health_stop)).to be(true)
+      expect(driver.instance_variable_get(:@reader_stop)).to be(true)
+      expect(driver.instance_variable_get(:@conns)).to be_empty
+    end
+
+    it 'does nothing when already closed' do
+      driver.instance_variable_set(:@closed, true)
+
+      expect(conn).not_to receive(:mark_closed)
+      expect(serial).not_to receive(:close)
+      expect(health_thread).not_to receive(:join)
+      expect(reader_thread).not_to receive(:join)
+
+      driver.close
+    end
+  end
+
+  describe '#handle_line' do
+    before do
+      driver.instance_variable_set(:@cfg, { modem_sockets: 12 })
+      driver.instance_variable_set(:@cmd_mutex, Mutex.new)
+      driver.instance_variable_set(:@pending_cmds, [])
+      driver.instance_variable_set(:@id_mutex, Mutex.new)
+      driver.instance_variable_set(:@free_ids, [])
+      driver.instance_variable_set(:@conns, {})
+      allow(driver).to receive(:log_debug)
+    end
+
+    it 'marks remote closed connections and releases their SID' do
+      conn = Msf::Sessions::Modem::Quectel::Connection.new(driver, 2)
+      driver.register_connection(2, conn)
+
+      driver.send(:handle_line, '+QIURC: "closed",2')
+
+      expect(conn).to be_closed
+      expect(conn.recv).to be_nil
+      expect(driver.connection_for_id(2)).to be_nil
+      expect(driver.instance_variable_get(:@free_ids)).to include(2)
+    end
+  end
+end

--- a/spec/lib/msf/base/sessions/modem_spec.rb
+++ b/spec/lib/msf/base/sessions/modem_spec.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'msf/base/sessions/modem'
+
+RSpec.describe Msf::Sessions::Modem do
+  subject(:session) { Msf::Sessions::Modem.new }
+
+  let(:spawned_threads) { [] }
+  let(:thread_manager) do
+    double('thread_manager').tap do |manager|
+      allow(manager).to receive(:spawn) do |name, critical, *args, &block|
+        thread = ::Thread.new(*args) do |*thread_args|
+          ::Thread.current[:tm_name] = name
+          ::Thread.current[:tm_crit] = critical
+          block.call(*thread_args)
+        end
+        spawned_threads << thread
+        thread
+      end
+    end
+  end
+  let(:framework) { double('framework', threads: thread_manager) }
+
+  # Minimal connection duck-type used by the channel/socket classes:
+  #   recv      -> blocks until String data or nil EOF
+  #   send(buf) -> bytes sent
+  #   close
+  let(:recv_queue) { Queue.new }
+  let(:conn) do
+    double('conn', send: nil).tap do |connection|
+      allow(connection).to receive(:recv) { recv_queue.pop }
+      allow(connection).to receive(:close) { recv_queue << nil }
+    end
+  end
+
+  def params_double(proto:, server: false, peerhost: '192.0.2.1', peerport: 80,
+                    localhost: '0.0.0.0', localport: 0)
+    double('params', proto: proto, server: server, peerhost: peerhost, peerhostname: peerhost,
+                     peerport: peerport, localhost: localhost, localport: localport,
+                     sslkeylogfile: nil, context: nil, v6: false)
+  end
+
+  before do
+    @original_thread_factory_provider = Rex::ThreadFactory.class_variable_get(:@@provider)
+    Rex::ThreadFactory.provider = thread_manager
+    session.framework = framework
+  end
+
+  after do
+    Rex::ThreadFactory.provider = @original_thread_factory_provider
+
+    spawned_threads.each do |thread|
+      thread.kill if thread.alive?
+      thread.join
+    end
+  end
+
+  def queue_pop(queue, timeout: 2)
+    deadline = Time.now + timeout
+    loop do
+      return queue.pop(true)
+    rescue ThreadError
+      raise 'Timed out waiting for queue item' if Time.now >= deadline
+
+      sleep 0.01
+    end
+  end
+
+  describe 'session identity' do
+    it 'reports the modem type' do
+      expect(described_class.type).to eq('modem')
+      expect(session.type).to eq('modem')
+    end
+
+    it 'reports a hardware platform and command arch' do
+      expect(session.platform).to eq('hardware')
+      expect(session.arch).to eq(ARCH_CMD)
+    end
+
+    it 'is non-interactive' do
+      expect(session.interactive?).to be(false)
+      expect(session.interacting).to be(false)
+    end
+
+    it 'does not support UDP at the base level' do
+      expect(session.supports_udp?).to be(false)
+    end
+
+    it 'cannot clean up files' do
+      expect(described_class.can_cleanup_files).to be(false)
+    end
+  end
+
+  describe '#create dispatch' do
+    it 'routes udp to create_udp_channel' do
+      params = params_double(proto: 'udp')
+      expect(session).to receive(:create_udp_channel).with(params).and_return(:udp_sock)
+      expect(session.create(params)).to eq(:udp_sock)
+    end
+
+    it 'routes tcp client to create_tcp_client_channel' do
+      params = params_double(proto: 'tcp', server: false)
+      expect(session).to receive(:create_tcp_client_channel).with(params).and_return(:tcp_sock)
+      expect(session.create(params)).to eq(:tcp_sock)
+    end
+
+    it 'routes tcp server to create_tcp_server_channel' do
+      params = params_double(proto: 'tcp', server: true)
+      expect(session).to receive(:create_tcp_server_channel).with(params).and_return(:srv_sock)
+      expect(session.create(params)).to eq(:srv_sock)
+    end
+
+    it 'raises ConnectionError on an unsupported protocol' do
+      params = params_double(proto: 'sctp')
+      expect { session.create(params) }.to raise_error(::Rex::ConnectionError)
+    end
+  end
+
+  describe 'base subclass hooks' do
+    it 'raises NotImplementedError for tcp client channels' do
+      expect { session.send(:create_tcp_client_channel, params_double(proto: 'tcp')) }
+        .to raise_error(NotImplementedError)
+    end
+
+    it 'raises NotImplementedError for tcp server channels' do
+      expect { session.send(:create_tcp_server_channel, params_double(proto: 'tcp', server: true)) }
+        .to raise_error(NotImplementedError)
+    end
+
+    it 'raises NotImplementedError for udp channels' do
+      expect { session.send(:create_udp_channel, params_double(proto: 'udp')) }
+        .to raise_error(NotImplementedError)
+    end
+  end
+
+  describe '#cleanup' do
+    it 'closes every open channel' do
+      chan = double('channel', close: nil)
+      allow(chan).to receive(:cid).and_return(1)
+      session.add_channel(chan)
+      expect(chan).to receive(:close)
+      session.cleanup
+    end
+
+    it 'allows channels to remove themselves while cleaning up' do
+      first_channel = double('first_channel')
+      second_channel = double('second_channel')
+      allow(first_channel).to receive(:cid).and_return(1)
+      allow(second_channel).to receive(:cid).and_return(2)
+      allow(first_channel).to receive(:close) { session.remove_channel(1) }
+      allow(second_channel).to receive(:close) { session.remove_channel(2) }
+
+      session.add_channel(first_channel)
+      session.add_channel(second_channel)
+
+      expect { session.cleanup }.not_to raise_error
+      expect(session.channels).to be_empty
+    end
+  end
+
+  describe Msf::Sessions::Modem::UdpChannel do
+    let(:params) { params_double(proto: 'udp', peerhost: '8.8.8.8', peerport: 53) }
+
+    it 'spawns the reader through the framework thread manager' do
+      chan = described_class.new(session, 1, conn, params)
+
+      expect(thread_manager).to have_received(:spawn).with('ModemUdpChannelReader', false)
+      chan.close
+    end
+
+    it 'hands back a real Rex::Socket::Udp lsock reporting the udp type' do
+      chan = described_class.new(session, 1, conn, params)
+      expect(chan.lsock).to be_a(Rex::Socket::Udp)
+      expect(chan.lsock.type?).to eq('udp')
+      chan.close
+    end
+
+    it 'forwards lsock writes to conn.send and returns the length' do
+      chan = described_class.new(session, 2, conn, params)
+      expect(conn).to receive(:send).with('query')
+      expect(chan.lsock.write('query')).to eq(5)
+      chan.close
+    end
+
+    it 'forwards lsock sendto to conn.send' do
+      chan = described_class.new(session, 3, conn, params)
+      expect(conn).to receive(:send).with('query')
+      chan.lsock.sendto('query', '8.8.8.8', 53)
+      chan.close
+    end
+
+    it 'drains an inbound datagram into the lsock as [data, host, port]' do
+      recv_queue << 'response'
+      recv_queue << nil
+      chan = described_class.new(session, 4, conn, params)
+
+      data, host, port = chan.lsock.recvfrom(65535, 2)
+      expect(data).to eq('response')
+      expect(host).to eq('8.8.8.8')
+      expect(port).to eq(53)
+      chan.close
+    end
+
+    it 'reads the synthetic sockaddr with its full length' do
+      recv_queue << 'response'
+      recv_queue << nil
+      chan = described_class.new(session, 4, conn, params)
+
+      data, host, port = chan.lsock.recvfrom(1, 2)
+      expect(data).to eq('r')
+      expect(host).to eq('8.8.8.8')
+      expect(port).to eq(53)
+      chan.close
+    end
+
+    it 'closes the connection once and is idempotent' do
+      chan = described_class.new(session, 5, conn, params)
+      expect(conn).to receive(:close).once do
+        recv_queue << nil
+      end
+      chan.close
+      chan.close
+      expect(chan.closed?).to be(true)
+    end
+
+    it 'closes the connection when the framework closes the local socket' do
+      closed = Queue.new
+      allow(conn).to receive(:close) do
+        recv_queue << nil
+        closed << true
+      end
+      chan = described_class.new(session, 6, conn, params)
+
+      chan.lsock.close
+
+      expect(queue_pop(closed)).to be(true)
+      expect(conn).to have_received(:close).once
+      expect(chan.closed?).to be(true)
+      expect(session.channels).to be_empty
+    end
+
+    it 'marks the channel remote-closed when the connection reports closed' do
+      recv_queue << nil
+      closed = Queue.new
+      allow(conn).to receive(:close) do
+        recv_queue << nil
+        closed << true
+      end
+      chan = described_class.new(session, 7, conn, params)
+
+      expect(queue_pop(closed)).to be(true)
+      expect(conn).to have_received(:close).once
+      expect(chan.remote_closed?).to be(true)
+      expect { chan.lsock.write('query') }.to raise_error(IOError)
+      chan.close
+    end
+  end
+
+  describe Msf::Sessions::Modem::TcpClientChannel do
+    let(:params) { params_double(proto: 'tcp') }
+
+    it 'spawns the reader through the framework thread manager' do
+      chan = described_class.new(session, 1, conn, params)
+
+      expect(thread_manager).to have_received(:spawn).with('ModemTcpClientChannelReader', false)
+      chan.close
+    end
+
+    it 'relays lsock writes to conn.send' do
+      sent = Queue.new
+      allow(conn).to receive(:send) { |data| sent << data }
+      chan = described_class.new(session, 1, conn, params)
+
+      expect(chan.lsock.write('payload')).to eq(7)
+      expect(queue_pop(sent)).to eq('payload')
+      chan.close
+    end
+
+    it 'forwards writes to conn.send and returns the length' do
+      chan = described_class.new(session, 2, conn, params)
+      expect(conn).to receive(:send).with('payload')
+      expect(chan.write('payload')).to eq(7)
+      chan.close
+    end
+
+    it 'drains incoming data from conn into the readable socket' do
+      recv_queue << 'hello'
+      recv_queue << nil
+      chan = described_class.new(session, 3, conn, params)
+
+      data = String.new
+      deadline = Time.now + 2
+      while Time.now < deadline
+        ready = IO.select([chan.lsock], nil, nil, 0.1)
+        next unless ready
+
+        begin
+          data << chan.lsock.recv(64)
+        rescue StandardError
+          break
+        end
+        break unless data.empty?
+      end
+
+      expect(data).to eq('hello')
+      chan.close
+    end
+
+    it 'reports closed after #close' do
+      chan = described_class.new(session, 4, conn, params)
+      expect(chan.closed?).to be(false)
+      chan.close
+      expect(chan.closed?).to be(true)
+    end
+
+    it 'closes the connection when the framework closes the local socket' do
+      closed = Queue.new
+      allow(conn).to receive(:close) do
+        recv_queue << nil
+        closed << true
+      end
+      chan = described_class.new(session, 5, conn, params)
+
+      chan.lsock.close
+
+      expect(queue_pop(closed)).to be(true)
+      expect(conn).to have_received(:close).once
+      expect(chan.closed?).to be(true)
+      expect(session.channels).to be_empty
+    end
+
+    it 'signals EOF and rejects writes when the connection reports closed' do
+      recv_queue << 'hello'
+      recv_queue << nil
+      closed = Queue.new
+      allow(conn).to receive(:close) do
+        recv_queue << nil
+        closed << true
+      end
+      chan = described_class.new(session, 6, conn, params)
+
+      expect(queue_pop(closed)).to be(true)
+      expect(conn).to have_received(:close).once
+      expect(chan.remote_closed?).to be(true)
+      expect(chan.lsock.read(5)).to eq('hello')
+      expect { chan.write('again') }.to raise_error(IOError)
+      chan.close
+    end
+  end
+end

--- a/spec/lib/rex/proto/dns/resolver_spec.rb
+++ b/spec/lib/rex/proto/dns/resolver_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rex/proto/dns/resolver'
+require 'rex/socket/udp'
+
+RSpec.describe Rex::Proto::DNS::Resolver do
+  subject(:resolver) { described_class.new(config_file: nil, nameservers: [], log_file: File::NULL) }
+
+  let(:socket) do
+    double(
+      'Rex::Socket::Udp',
+      close: nil,
+      closed?: false,
+      recvfrom: ['answer', '192.0.2.53', 53],
+      write: nil
+    )
+  end
+
+  describe '#send_udp' do
+    before do
+      allow(Rex::Socket::Udp).to receive(:create).and_return(socket)
+    end
+
+    it 'closes the UDP socket after receiving an answer' do
+      expect(socket).to receive(:close)
+
+      answer = resolver.send_udp(nil, 'query', [['192.0.2.53', {}]])
+
+      expect(answer).to eq(['answer', '192.0.2.53', 53])
+    end
+
+    it 'closes the UDP socket after a timeout' do
+      allow(socket).to receive(:recvfrom).and_raise(Timeout::Error)
+      expect(socket).to receive(:close)
+
+      expect(resolver.send_udp(nil, 'query', [['192.0.2.53', {}]])).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This adds a new "modem" session type that allows you to open a session to an arbitrary modem and pivot your network traffic over it as if it were a Meterpreter session. I have testing hardware but I've also had Claude create an emulator that can be used for testing.

## Verification

List the steps needed to make sure this thing works

- [x] Start the included emulator: `python modem_emulator.py --debug`
- [x] Use the new module, set SERIAL to `/tmp/ttyModem` from the emulator
- [x] Run the module and get a sessoin
- [x] Route your traffic through it and follow the debug lines to see it working

<details>
<summary>modem_emulator.py</summary>

```python
#!/usr/bin/env python3
"""
Quectel Modem Emulator

Creates a virtual serial port (pty) and emulates the Quectel AT command protocol
used by modules/auxiliary/server/quectel_modem.rb, forwarding traffic through real
OS sockets. Use this to test the module without physical hardware.

Usage:
    python3 tools/hardware/modem_emulator.py --serial /tmp/ttyModem --debug

Then in msfconsole:
    use auxiliary/server/quectel_modem
    set SERIAL /tmp/ttyModem
    set STARTUP_OK_TIMEOUT_S 5
    run
"""

import argparse
import os
import pty
import random
import re
import select
import signal
import socket
import sys
import termios
import threading
import time
import tty


def _log(msg, prefix='[EMU]', file=sys.stderr):
    print(f'{prefix} {msg}', file=file, flush=True)


def _jitter_sleep(mean_ms, stddev_ms):
    if mean_ms <= 0 and stddev_ms <= 0:
        return
    delay_ms = max(0.0, random.gauss(mean_ms, stddev_ms))
    time.sleep(delay_ms / 1000.0)


class SIDPool:
    _PENDING = object()

    def __init__(self, n=12):
        self._lock = threading.Lock()
        self._free = list(range(n))
        self._table = {}

    def allocate(self):
        with self._lock:
            if not self._free:
                return None
            sid = self._free.pop(0)
            self._table[sid] = self._PENDING
            return sid

    def register(self, sid, fwd):
        with self._lock:
            self._table[sid] = fwd

    def release(self, sid):
        with self._lock:
            self._table.pop(sid, None)
            if sid not in self._free:
                self._free.append(sid)

    def get(self, sid):
        with self._lock:
            v = self._table.get(sid)
            return None if (v is None or v is self._PENDING) else v

    def is_allocated(self, sid):
        with self._lock:
            return sid in self._table

    def all_forwarders(self):
        with self._lock:
            return [v for v in self._table.values() if v is not self._PENDING]


class SocketForwarder:
    def __init__(self, sid, sock, proto, emulator):
        self.sid = sid
        self.sock = sock
        self.proto = proto
        self._emulator = emulator
        self._stop = threading.Event()
        self._thread = threading.Thread(
            target=self._forward_loop,
            daemon=True,
            name=f'modem-fwd-{sid}',
        )

    def start(self):
        self._thread.start()

    def stop(self):
        self._stop.set()

    def _forward_loop(self):
        args = self._emulator.args
        debug = args.debug
        sid = self.sid
        while not self._stop.is_set():
            try:
                r, _, _ = select.select([self.sock], [], [], 0.1)
            except (OSError, ValueError):
                break
            if not r:
                continue
            try:
                data = self.sock.recv(65536)
            except OSError as e:
                if not self._stop.is_set() and debug:
                    _log(f'[SID {sid}] recv error: {e}')
                data = b''
            if not data:
                # Only emit closed URC for a genuine remote close, not a local QICLOSE.
                if not self._stop.is_set():
                    if debug:
                        _log(f'[SID {sid}] remote closed')
                    urc = f'+QIURC: "closed",{sid}\r\n'.encode()
                    self._emulator._write(urc)
                    self._emulator.sid_pool.release(sid)
                break
            _jitter_sleep(args.jitter_mean, args.jitter_stddev)
            if debug:
                _log(f'[SID {sid}] recv {len(data)} bytes → URC')
            # Emit header + payload atomically in one _write call
            urc_header = f'+QIURC: "recv",{sid},{len(data)}\r\n'.encode()
            self._emulator._write(urc_header + data)


class ModemEmulator:
    # AT+QIOPEN=1,SID,"TCP"|"UDP","HOST",PORT,0,1
    _RE_QIOPEN = re.compile(
        r'^AT\+QIOPEN=\d+,(\d+),"(TCP|UDP)","([^"]+)",(\d+),\d+,\d+$',
        re.IGNORECASE,
    )
    # AT+QICLOSE=SID,N
    _RE_QICLOSE = re.compile(r'^AT\+QICLOSE=(\d+),\d+$', re.IGNORECASE)
    # AT+QISEND=SID,N
    _RE_QISEND = re.compile(r'^AT\+QISEND=(\d+),(\d+)$', re.IGNORECASE)

    def __init__(self, args):
        self.args = args
        self.master_fd = None
        self.slave_fd = None
        self.slave_path = None
        self._write_lock = threading.Lock()
        self.sid_pool = SIDPool(args.sockets)
        self._stop = threading.Event()
        self._reader_thread = None

    def setup_pty(self):
        self.master_fd, self.slave_fd = pty.openpty()
        self.slave_path = os.ttyname(self.slave_fd)

        # Set raw mode on slave before Ruby opens it; prevents echo/line-discipline
        # translation during the window before Ruby calls configure_serial_port().
        tty.setraw(self.slave_fd)

        # Set baud rate cosmetically so Ruby's TCGETS reads something sensible.
        attrs = termios.tcgetattr(self.slave_fd)
        baud_const = _baud_to_termios(self.args.baud)
        if baud_const is not None:
            attrs[4] = baud_const
            attrs[5] = baud_const
            termios.tcsetattr(self.slave_fd, termios.TCSANOW, attrs)

        serial_path = self.args.serial
        if os.path.islink(serial_path) or os.path.exists(serial_path):
            os.unlink(serial_path)
        os.symlink(self.slave_path, serial_path)

        _log(f'Emulator ready at {serial_path} -> {self.slave_path}', prefix='[EMU]')

    def start(self):
        # Emit RDY URC so Ruby's best-effort wait_for_rdy() can catch it.
        self._write(b'RDY\r\n')
        self._reader_thread = threading.Thread(
            target=self._reader_loop, daemon=True, name='modem-reader'
        )
        self._reader_thread.start()

    def stop(self):
        self._stop.set()
        try:
            os.close(self.master_fd)
        except OSError:
            pass
        if self._reader_thread:
            self._reader_thread.join(timeout=2.0)
        for fwd in self.sid_pool.all_forwarders():
            fwd.stop()
            try:
                fwd.sock.close()
            except OSError:
                pass
        try:
            os.unlink(self.args.serial)
        except FileNotFoundError:
            pass
        try:
            os.close(self.slave_fd)
        except OSError:
            pass

    def _write(self, data: bytes):
        with self._write_lock:
            try:
                os.write(self.master_fd, data)
            except OSError:
                pass

    def _read_exactly(self, n: int) -> bytes:
        buf = b''
        while len(buf) < n:
            try:
                chunk = os.read(self.master_fd, n - len(buf))
            except OSError as e:
                raise EOFError(f'pty closed mid-read: {e}')
            if not chunk:
                raise EOFError('pty closed mid-read')
            buf += chunk
        return buf

    def _reader_loop(self):
        buf = bytearray()
        debug = self.args.debug
        while not self._stop.is_set():
            try:
                ch = os.read(self.master_fd, 1)
            except OSError:
                break
            if not ch:
                break
            if ch == b'\r':
                line = buf.decode('ascii', errors='replace').strip()
                buf.clear()
                if line:
                    if debug:
                        _log(f'→ {line!r}')
                    self._handle_cmd(line)
            elif ch != b'\n':
                buf.extend(ch)

    def _handle_cmd(self, line: str):
        debug = self.args.debug

        if line.upper() in ('AT', 'AT\r'):
            self._write(b'OK\r\n')
            return

        if line.upper() == 'ATE0':
            self._write(b'OK\r\n')
            return

        m = self._RE_QIOPEN.match(line)
        if m:
            self._cmd_qiopen(m)
            return

        m = self._RE_QICLOSE.match(line)
        if m:
            self._cmd_qiclose(m)
            return

        m = self._RE_QISEND.match(line)
        if m:
            self._cmd_qisend(m)
            return

        if debug:
            _log(f'unknown command: {line!r}')
        self._write(b'ERROR\r\n')

    def _cmd_qiopen(self, m):
        sid = int(m.group(1))
        proto = m.group(2).upper()
        host = m.group(3)
        port = int(m.group(4))
        debug = self.args.debug

        # Check if this exact SID is already in use
        if self.sid_pool.is_allocated(sid):
            if debug:
                _log(f'[SID {sid}] already allocated')
            self._write(b'ERROR\r\n')
            return

        # Allocate the specific SID requested by Ruby
        # The pool uses FIFO allocation; we need to honor the SID Ruby chose.
        # We'll allocate the next free SID and verify it matches, or skip if wrong.
        # Actually, Ruby allocates SIDs sequentially from its own free pool and
        # passes the chosen SID in the command — we must register that specific SID.
        with self.sid_pool._lock:
            if sid in self.sid_pool._free:
                self.sid_pool._free.remove(sid)
                self.sid_pool._table[sid] = SIDPool._PENDING
            elif sid not in self.sid_pool._table:
                # SID not in free list and not allocated — shouldn't happen with
                # a fresh pool but handle gracefully.
                self.sid_pool._table[sid] = SIDPool._PENDING
            else:
                pass  # already marked pending by a prior allocate() call

        # Respond OK immediately; URC arrives after the real socket connects.
        self._write(b'OK\r\n')

        def connect_and_emit():
            sock = None
            err = 3
            try:
                if proto == 'TCP':
                    sock = socket.create_connection((host, port), timeout=self.args.connect_timeout)
                else:
                    # UDP: create an unconnected UDP socket, then "connect" to set default peer
                    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
                    sock.connect((host, port))
                err = 0
            except OSError as e:
                if debug:
                    _log(f'[SID {sid}] connect failed: {e}')
                sock = None
                err = 3

            if err == 0 and sock:
                fwd = SocketForwarder(sid, sock, proto, self)
                self.sid_pool.register(sid, fwd)
                fwd.start()
                if debug:
                    _log(f'[SID {sid}] {proto} connected to {host}:{port}')
            else:
                self.sid_pool.release(sid)

            urc = f'+QIOPEN: {sid},{err}\r\n'.encode()
            self._write(urc)

        t = threading.Thread(target=connect_and_emit, daemon=True, name=f'modem-conn-{sid}')
        t.start()

    def _cmd_qiclose(self, m):
        sid = int(m.group(1))
        debug = self.args.debug

        if not self.sid_pool.is_allocated(sid):
            if debug:
                _log(f'[SID {sid}] QICLOSE on unallocated SID → ERROR')
            self._write(b'ERROR\r\n')
            return

        fwd = self.sid_pool.get(sid)
        self.sid_pool.release(sid)
        if fwd:
            fwd.stop()
            try:
                fwd.sock.close()
            except OSError:
                pass
        if debug:
            _log(f'[SID {sid}] closed')
        self._write(b'OK\r\n')

    def _cmd_qisend(self, m):
        sid = int(m.group(1))
        n = int(m.group(2))
        debug = self.args.debug

        fwd = self.sid_pool.get(sid)
        if fwd is None:
            if debug:
                _log(f'[SID {sid}] QISEND on unallocated/pending SID → ERROR')
            self._write(b'ERROR\r\n')
            return

        # Send prompt — single byte, no CRLF
        self._write(b'>')

        try:
            # Read exactly n payload bytes + 1 Ctrl-Z (0x1A)
            raw = self._read_exactly(n + 1)
        except EOFError as e:
            if debug:
                _log(f'[SID {sid}] QISEND read error: {e}')
            self._write(b'SEND FAIL\r\n')
            return

        payload = raw[:-1]  # strip Ctrl-Z

        if debug:
            _log(f'[SID {sid}] QISEND {len(payload)} bytes')

        try:
            fwd.sock.sendall(payload)
            self._write(b'SEND OK\r\n')
        except OSError as e:
            if debug:
                _log(f'[SID {sid}] send error: {e}')
            self._write(b'SEND FAIL\r\n')


def _baud_to_termios(baud):
    mapping = {
        9600:   termios.B9600,
        19200:  termios.B19200,
        38400:  termios.B38400,
        57600:  termios.B57600,
        115200: termios.B115200,
        230400: termios.B230400,
    }
    return mapping.get(baud)


def main():
    parser = argparse.ArgumentParser(
        description='Quectel modem emulator for testing modules/auxiliary/server/quectel_modem.rb'
    )
    parser.add_argument(
        '--serial', default='/tmp/ttyModem',
        help='Symlink path exposed as the serial device (default: /tmp/ttyModem)',
    )
    parser.add_argument(
        '--baud', type=int, default=115200,
        help='Baud rate (informational only; pty ignores it for throughput)',
    )
    parser.add_argument(
        '--sockets', type=int, default=12,
        help='SID pool size — must match MODEM_SOCKETS in msfconsole (default: 12)',
    )
    parser.add_argument(
        '--jitter-mean', type=float, default=0.0, dest='jitter_mean',
        help='Mean receive jitter in milliseconds (default: 0)',
    )
    parser.add_argument(
        '--jitter-stddev', type=float, default=0.0, dest='jitter_stddev',
        help='Jitter standard deviation in milliseconds (default: 0)',
    )
    parser.add_argument(
        '--connect-timeout', type=float, default=10.0, dest='connect_timeout',
        help='Real socket connect timeout in seconds (default: 10)',
    )
    parser.add_argument(
        '--debug', action='store_true',
        help='Verbose protocol logging to stderr',
    )
    args = parser.parse_args()

    stop_event = threading.Event()

    def _handle_signal(signum, frame):
        _log('Shutting down…')
        stop_event.set()

    signal.signal(signal.SIGINT, _handle_signal)
    signal.signal(signal.SIGTERM, _handle_signal)

    emulator = ModemEmulator(args)
    emulator.setup_pty()
    emulator.start()

    _log(
        f'Listening on {args.serial} -> {emulator.slave_path} '
        f'(sockets={args.sockets}, jitter={args.jitter_mean}±{args.jitter_stddev}ms). '
        f'Ctrl-C to stop.',
    )

    stop_event.wait()
    emulator.stop()
    _log('Done.')


if __name__ == '__main__':
    main()
```
</details>

## Demo
```
msf auxiliary(server/quectel_modem) > run
[*] Probing modem with AT until OK...
[+] Modem is responding to AT commands.
[*] Waiting briefly for RDY URC (best-effort)...
[*] Closing any leftover modem socket connections...
[+] Modem session 1 opened (12 sockets, 1024B chunks)
[*] Auxiliary module execution completed
msf auxiliary(server/quectel_modem) > route add 0 0 -1
[*] Route added
(reverse-i-search)`im': tInterrupt: use the 'exit' command to quit
msf auxiliary(server/quectel_modem) > load request
[*] Successfully loaded plugin: Request
msf auxiliary(server/quectel_modem) > request http://ifconfig.me
```