### PR TITLE
Default to the most recent session

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1562,6 +1562,11 @@ class Core
         print_error('Please specify valid session identifier(s)')
         return false
       end
+      # Resolve any negative session ids (e.g. -1 = most recent) to
+      # concrete ids. Unresolvable negatives fall through unchanged so
+      # the existing "Invalid session identifier" error path fires with
+      # a meaningful value.
+      session_list = session_list.map { |id| resolve_session_id(id) || id }
     end
 
     if show_inactive && !framework.db.active
@@ -2797,6 +2802,7 @@ class Core
   # @return [false] if the given session_id is valid, but not interactive
   # @return [nil] if the given session_id is not valid at all
   def verify_session(session_id, quiet = false)
+    session_id = resolve_session_id(session_id)
     session = framework.sessions.get(session_id)
     if session
       if session.interactive?
@@ -2809,6 +2815,24 @@ class Core
       print_error("Invalid session identifier: #{session_id}") unless quiet
       nil
     end
+  end
+
+  #
+  # Resolve a session id of -1 to the most recently opened session id.
+  #
+  # Only -1 is special; other negative ids are passed through unchanged
+  # so the existing "Invalid session identifier" error path fires with
+  # a meaningful value.
+  #
+  # @param session_id [Integer, String, nil] The id to resolve.
+  # @return [Integer, String, nil] The most recent session id if input
+  #   was -1, the input unchanged for any other value, or nil when no
+  #   sessions are active.
+  #
+  def resolve_session_id(session_id)
+    return session_id if session_id.nil?
+    return session_id unless session_id.to_i == -1
+    framework.sessions.keys.sort.last
   end
 
   #

--- a/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
@@ -780,4 +780,64 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
       end
     end
   end
+
+  describe '#resolve_session_id' do
+    before(:each) do
+      allow(framework).to receive(:sessions).and_return(sessions)
+    end
+
+    context 'with no active sessions' do
+      let(:sessions) { {} }
+
+      it 'returns positive ids unchanged' do
+        expect(core.send(:resolve_session_id, 1)).to eq(1)
+      end
+
+      it 'returns nil for -1 since there is no session to resolve to' do
+        expect(core.send(:resolve_session_id, -1)).to be_nil
+      end
+
+      it 'returns nil for nil input' do
+        expect(core.send(:resolve_session_id, nil)).to be_nil
+      end
+    end
+
+    context 'with multiple active sessions' do
+      let(:sessions) do
+        {
+          1 => double('session1'),
+          2 => double('session2'),
+          5 => double('session5')
+        }
+      end
+
+      it 'returns positive ids unchanged' do
+        expect(core.send(:resolve_session_id, 2)).to eq(2)
+      end
+
+      it 'returns non-existent positive ids unchanged so the downstream error path fires' do
+        expect(core.send(:resolve_session_id, 99)).to eq(99)
+      end
+
+      it 'resolves -1 to the highest (most recent) session id' do
+        expect(core.send(:resolve_session_id, -1)).to eq(5)
+      end
+
+      it 'accepts the string "-1"' do
+        expect(core.send(:resolve_session_id, '-1')).to eq(5)
+      end
+
+      it 'returns -2 unchanged so the downstream error path fires' do
+        expect(core.send(:resolve_session_id, -2)).to eq(-2)
+      end
+
+      it 'returns other negative ids unchanged so the downstream error path fires' do
+        expect(core.send(:resolve_session_id, -99)).to eq(-99)
+      end
+
+      it 'returns nil for nil input' do
+        expect(core.send(:resolve_session_id, nil)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

Resolves #21412.

Adds a single special case to the `sessions` command: `-1` resolves to the most recently opened session. Works uniformly across every subcommand that takes a session id (`-i`, `-k`, `-u`, `-c`, `-C`, `-s`, `-n`, and the bare `sessions <id>` shortcut).

Other negative ids are intentionally passed through unchanged so the existing "Invalid session identifier" error path fires. This narrow scope matches the issue title strictly and addresses prior concerns (see #2952, h/t @zeroSteiner) about generalised negative indexing being too unwieldy.

## Implementation

A small `resolve_session_id` helper lives next to `verify_session` in `lib/msf/ui/console/command_dispatcher/core.rb` (same `protected` visibility, since it is an internal helper). It is called from `verify_session` (covers `-i`, `-c`, `-C`, `-s`, and the bare shortcut) and applied via `map` to `session_list` after `build_range_array` (covers `-k`, `-u`, `-n`, and the multi-id forms).

`build_range_array` already preserves negative integers as-is, so no change was needed there.

## Verification steps

1. Start `msfconsole` and open two or three sessions.
2. `sessions -1` drops into the highest-id session (most recently opened).
3. `sessions -k -1` terminates it.
4. `sessions -i -2` or `sessions -i -99` prints `Invalid session identifier`, matching the existing behaviour for unknown ids.

Unit specs for `resolve_session_id` are included.

## Release notes

```
enhancement: `sessions -1` now resolves to the most recently opened session, including with `-i`, `-k`, `-u`, `-c`, `-C`, `-s`, and `-n`. Acts on the session you just popped without typing its id.
```