### PR TITLE
IPMI Scanner Bug Fixes

### DIFF
--- a/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
@@ -49,7 +49,17 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def scanner_process(data, shost, sport)
-    info = Rex::Proto::IPMI::Open_Session_Reply.new.read(data) #  rescue nil
+    info = nil
+
+    begin
+      info = Rex::Proto::IPMI::Open_Session_Reply.new.read(data)
+    rescue IOError, BinData::ValidityError => e
+      # Truncated replies raise IOError ("data truncated") or EOFError (a subclass
+      # of IOError); replies that fail a BinData assertion raise ValidityError.
+      vprint_error("#{Rex::Socket.to_authority(shost, sport)} - IPMI - Malformed open session reply: #{e.class}: #{e.message}")
+      return nil
+    end
+
     return unless info && info.session_payload_type == Rex::Proto::IPMI::PAYLOAD_RMCPPLUSOPEN_REP
 
     # Ignore duplicate replies
@@ -58,7 +68,7 @@ class MetasploitModule < Msf::Auxiliary
     @res[shost] ||= info
 
     if info.error_code == 0
-      print_good("#{shost}:#{sport} - IPMI - VULNERABLE: Accepted a session open request for cipher zero")
+      print_good("#{Rex::Socket.to_authority(shost, sport)} - IPMI - VULNERABLE: Accepted a session open request for cipher zero")
       report_vuln(
         :host => shost,
         :port => datastore['RPORT'].to_i,
@@ -69,7 +79,7 @@ class MetasploitModule < Msf::Auxiliary
         :refs => self.references
       )
     else
-      vprint_status("#{shost}:#{sport} - IPMI - NOT VULNERABLE: Rejected cipher zero with error code #{info.error_code}")
+      vprint_status("#{Rex::Socket.to_authority(shost, sport)} - IPMI - NOT VULNERABLE: Rejected cipher zero with error code #{info.error_code}")
     end
   end
 end

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -53,15 +53,15 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def ipmi_status(msg)
-    vprint_status("#{rhost}:#{rport} - IPMI - #{msg}")
+    vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - IPMI - #{msg}")
   end
 
   def ipmi_error(msg)
-    vprint_error("#{rhost}:#{rport} - IPMI - #{msg}")
+    vprint_error("#{Rex::Socket.to_authority(rhost, rport)} - IPMI - #{msg}")
   end
 
   def ipmi_good(msg)
-    print_good("#{rhost}:#{rport} - IPMI - #{msg}")
+    print_good("#{Rex::Socket.to_authority(rhost, rport)} - IPMI - #{msg}")
   end
 
   def run_host(ip)
@@ -96,6 +96,8 @@ class MetasploitModule < Msf::Auxiliary
 
     reported_vuln = false
     session_succeeded = false
+    seen_valid_open_session = false
+    stop_username_enumeration = false
 
     usernames.each do |username|
       console_session_id = Rex::Text.rand_text(4)
@@ -117,7 +119,15 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         unless r
-          ipmi_status("No response to IPMI open session request")
+          if seen_valid_open_session
+            # Target has previously responded to an open session request, so treat
+            # this non-response as transient (rate limiting, session exhaustion, etc.)
+            # rather than aborting so we don't miss hashes on a flaky target.
+            ipmi_status("No response to IPMI open session request for username #{username}")
+          else
+            ipmi_error("No response to IPMI open session request; stopping username enumeration")
+            stop_username_enumeration = true
+          end
           rakp = nil
           break
         end
@@ -137,6 +147,7 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         session_succeeded = true
+        seen_valid_open_session = true
 
         sess_data = Rex::Proto::IPMI::Session_Data.new.read(sess.data)
 
@@ -148,7 +159,12 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         unless r
-          ipmi_status("No response to RAKP1 message")
+          if seen_valid_open_session
+            ipmi_status("No response to RAKP1 message for username #{username}")
+          else
+            ipmi_error("No response to RAKP1 message; stopping username enumeration")
+            stop_username_enumeration = true
+          end
           next
         end
 
@@ -188,6 +204,8 @@ class MetasploitModule < Msf::Auxiliary
         # Break out of the session retry code if we make it here
         break
       end
+
+      break if stop_username_enumeration
 
       # Skip to the next user if we didnt get a valid response
       next if !rakp

--- a/modules/auxiliary/scanner/ipmi/ipmi_version.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_version.rb
@@ -35,7 +35,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def scan_host(ip)
-    vprint_status "#{ip}:#{rport} - IPMI - Probe sent"
+    vprint_status "#{Rex::Socket.to_authority(ip, rport)} - IPMI - Probe sent"
     scanner_send(Rex::Proto::IPMI::Utils.create_ipmi_getchannel_probe, ip, rport)
   end
 
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Auxiliary
     return unless info
 
     unless info.ipmi_command == 56
-      vprint_error "#{shost}:#{rport} - IPMI - Invalid response"
+      vprint_error "#{Rex::Socket.to_authority(shost, rport)} - IPMI - Invalid response"
       return
     end
 
@@ -57,7 +57,7 @@ class MetasploitModule < Msf::Auxiliary
 
     banner = info.to_banner
 
-    print_good("#{shost}:#{rport} - IPMI - #{banner}")
+    print_good("#{Rex::Socket.to_authority(shost, rport)} - IPMI - #{banner}")
 
     report_service(
       :host => shost,

--- a/spec/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero_spec.rb
+++ b/spec/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero_spec.rb
@@ -1,0 +1,49 @@
+require 'rspec'
+
+RSpec.describe 'IPMI Cipher Zero Scanner' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  subject do
+    load_and_create_module(
+      module_type: 'auxiliary',
+      reference_name: 'scanner/ipmi/ipmi_cipher_zero'
+    )
+  end
+
+  describe '#scanner_process' do
+    # A complete, valid cipher-zero "session open" reply with error_code == 0.
+    let(:valid_reply) do
+      [0x06, 0x00, 0xff, 0x07, 0x06, Rex::Proto::IPMI::PAYLOAD_RMCPPLUSOPEN_REP & 0x3f].pack('C*') +
+        [0x11111111].pack('V') +    # session id
+        [0x22222222].pack('V') +    # session sequence
+        [0x10].pack('v') +          # message length
+        [0x00, 0x00].pack('C*') +   # ignored1, error_code (0 == vulnerable)
+        [0x0000].pack('v') +        # ignored2
+        ('CON1' + 'BMC1').b         # session data
+    end
+
+    # The various ways a real BMC can return something we can't parse. The 8-byte
+    # and 12-byte truncations raise IOError ("data truncated"); the 1-byte case
+    # raises EOFError, which is a subclass of IOError.
+    [
+      ['a 1-byte reply (EOFError)', "\x01".b],
+      ['8 random bytes (IOError)', "\xde\xad\xbe\xef\x01\x02\x03\x04".b],
+      ['a 12-byte truncated reply (IOError)', "\x06\x00\xff\x07\x06\x44\x11\x11\x11\x11\x22\x22".b]
+    ].each do |label, data|
+      it "ignores #{label} without raising" do
+        expect { subject.scanner_process(data, '192.0.2.1', 623) }.not_to raise_error
+      end
+    end
+
+    it 'still reports a valid reply that arrives after a malformed one' do
+      subject.scanner_prescan(['192.0.2.1'])
+      allow(subject).to receive(:report_vuln)
+
+      expect(subject).to receive(:print_good).with(/VULNERABLE/)
+
+      # A malformed straggler must not abort processing of the legitimate reply.
+      subject.scanner_process("\xde\xad\xbe\xef\x01\x02\x03\x04".b, '192.0.2.1', 623)
+      subject.scanner_process(valid_reply, '192.0.2.1', 623)
+    end
+  end
+end

--- a/spec/modules/auxiliary/scanner/ipmi/ipmi_dumphashes_spec.rb
+++ b/spec/modules/auxiliary/scanner/ipmi/ipmi_dumphashes_spec.rb
@@ -1,0 +1,52 @@
+require 'rspec'
+require 'stringio'
+
+RSpec.describe 'IPMI Dump Hashes Scanner' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  subject do
+    load_and_create_module(
+      module_type: 'auxiliary',
+      reference_name: 'scanner/ipmi/ipmi_dumphashes'
+    )
+  end
+
+  let(:udp_sock) do
+    instance_double(Rex::Socket::Udp)
+  end
+
+  before do
+    subject.datastore['USER_FILE'] = 'users.txt'
+    subject.datastore['PASS_FILE'] = 'passwords.txt'
+    subject.datastore['CRACK_COMMON'] = false
+    subject.datastore['SESSION_MAX_ATTEMPTS'] = 1
+    subject.datastore['SESSION_RETRY_DELAY'] = 0
+    subject.datastore['RHOST'] = '192.0.2.1'
+    subject.datastore['RPORT'] = 623
+
+    allow(File).to receive(:open).with('users.txt', 'rb').and_yield(StringIO.new("admin\nroot\n"))
+    allow(File).to receive(:open).with('passwords.txt', 'rb').and_yield(StringIO.new("password\n"))
+    allow(Rex::Socket::Udp).to receive(:create).and_return(udp_sock)
+    allow(subject).to receive(:add_socket)
+    allow(subject).to receive(:ipmi_status)
+    allow(subject).to receive(:ipmi_error)
+    allow(subject).to receive(:ipmi_good)
+    allow(subject).to receive(:report_hash).and_return(1)
+    allow(subject).to receive(:report_vuln)
+    allow(subject).to receive(:report_cracked_cred)
+    allow(subject).to receive(:write_output_files)
+    allow(subject).to receive(:sleep)
+    allow(Rex).to receive(:sleep)
+  end
+
+  describe '#run_host' do
+    it 'stops username enumeration when the host never answers the first open-session probe' do
+      allow(udp_sock).to receive(:sendto)
+      allow(udp_sock).to receive(:recvfrom).and_return([nil, nil, nil])
+
+      expect(udp_sock).to receive(:sendto).exactly(3).times
+
+      subject.run_host('192.0.2.1')
+    end
+  end
+end


### PR DESCRIPTION
This makes a few improvements to the IPMI scanner modules as described below.

## `auxiliary/scanner/ipmi/ipmi_cipher_zero`

This module had an issue where if a malformed reply was received it would abort the operation meaning that if a legitimate reply was received afterwards that it would not be processed.

- [ ] Use the `ipmi_udp_harness.py` script, `python tools/dev/ipmi_udp_harness.py --mode cipher_zero --profile malformed_then_valid --listen 127.0.0.1 --port 623`
- [ ] Use the `ipmi_cipher_zero` module and target the local harness
- [ ] See in the patched version that there's a malformed reply that's received followed by a successful reply

## `auxiliary/scanner/ipmi/ipmi_dumphashes`

This module would run against a target that is not an IPMI service. In that case, it can appear hung due to how long it takes to run as it makes repeated requests to a target it can't communicate with. The update here aborts the operation more quickly when there isn't evidence that the target is IPMI.

- [ ] Use the `ipmi_udp_harness.py` script, `python tools/dev/ipmi_udp_harness.py --mode dumphashes --profile silent --listen 127.0.0.1 --port 623`
- [ ] Use the `auxiliary/scanner/ipmi/ipmi_dumphashes` module and target the local harness
- [ ] Run the module and see it return in a matter of seconds, without this patch it would appear to be hung

## Multiple
Addresses use `Rex::Socket.to_authority` to report the host and port combination so when there is an IPv6 address, it's correctly encapsulated in brackets.

## Verification

List the steps needed to make sure this thing works

- [ ] Start `msfconsole`
- [ ] Run through the steps to demonstrate the original issue and the fix as outlined above

<details>
<summary>ipmi_udp_harness.py</summary>

```python
#!/usr/bin/env python3
"""Configurable UDP harness for stressing Metasploit IPMI scanners.

Examples:
  python tools/dev/ipmi_udp_harness.py --mode version --profile valid
  python tools/dev/ipmi_udp_harness.py --mode cipher_zero --profile malformed
  python tools/dev/ipmi_udp_harness.py --mode dumphashes --profile flappy
"""

from __future__ import annotations

import argparse
import random
import socketserver
import struct
import sys
import time
from dataclasses import dataclass
from typing import Dict, List

PAYLOAD_RMCPPLUSOPEN_REQ = 0x10
PAYLOAD_RMCPPLUSOPEN_REP = 0x11
PAYLOAD_RAKP1 = 0x12
PAYLOAD_RAKP2 = 0x13


@dataclass
class Reply:
    payload: bytes
    delay: float = 0.0


@dataclass
class ClientState:
    packet_count: int = 0
    stage: int = 0


def pack_u24(value: int) -> bytes:
    return struct.pack("<I", value & 0xFFFFFF)[:3]


def make_random_bytes(length: int) -> bytes:
    return bytes(random.getrandbits(8) for _ in range(length))


def build_version_reply() -> bytes:
    body = bytes(
        [
            0x20, 0x00, 0x00, 0x81, 0x00, 0x38, 0x00, 0x0E, 0xFF, 0x07, 0x03
        ]
    ) + pack_u24(0x01020304) + b"\x00\x00\x00\x00"

    header = bytes([0x06, 0x00, 0xFF, 0x07, 0x00])
    return header + struct.pack("<I", 0) + struct.pack("<I", 0) + bytes([len(body)]) + body


def build_open_session_reply(
    *,
    error_code: int = 0,
    payload_type: int = PAYLOAD_RMCPPLUSOPEN_REP,
    console_session_id: bytes = b"CON1",
    bmc_session_id: bytes = b"BMC1",
    data: bytes | None = None,
) -> bytes:
    if data is None:
        data = console_session_id + bmc_session_id

    header = bytes([0x06, 0x00, 0xFF, 0x07, 0x06, payload_type & 0x3F])
    header += struct.pack("<I", 0x11111111)
    header += struct.pack("<I", 0x22222222)

    body = bytes([0x00, error_code & 0xFF]) + struct.pack("<H", 0x0000) + data
    return header + struct.pack("<H", len(body)) + body


def build_rakp2_reply() -> bytes:
    data = (
        b"CON1"
        + b"RANDOM-RANDOM-01"
        + b"0123456789ABCDEF"
        + b"0123456789ABCDEF0123"
    )
    return build_open_session_reply(
        error_code=0,
        payload_type=PAYLOAD_RAKP2,
        data=data,
    )


class IPMIHarnessScenario:
    def __init__(self, mode: str, profile: str, delay: float, duplicate_count: int, truncate_length: int, error_code: int):
        self.mode = mode
        self.profile = profile
        self.delay = delay
        self.duplicate_count = max(1, duplicate_count)
        self.truncate_length = max(1, truncate_length)
        self.error_code = error_code

    def replies_for(self, state: ClientState) -> List[Reply]:
        state.packet_count += 1

        if self.profile == "silent":
            return []

        if self.profile == "flappy":
            slot = state.packet_count % 5
            if slot == 1:
                return []
            if slot == 2:
                return [Reply(self.truncated_payload())]
            if slot == 3:
                return [Reply(self.valid_payload())]
            if slot == 4:
                return [Reply(self.valid_payload()) for _ in range(self.duplicate_count)]
            return [Reply(self.valid_payload(), delay=self.delay)]

        if self.profile == "malformed":
            return [Reply(self.truncated_payload() if self.truncate_length else make_random_bytes(8))]

        if self.profile == "malformed_then_valid":
            # Emit a malformed straggler immediately followed by a legitimate
            # reply from the same host. A scanner that aborts on the malformed
            # packet will never process (and never report) the valid one.
            return [Reply(self.truncated_payload()), Reply(self.valid_payload())]

        if self.profile == "duplicate":
            return [Reply(self.valid_payload()) for _ in range(self.duplicate_count)]

        if self.profile == "delayed":
            return [Reply(self.valid_payload(), delay=self.delay)]

        if self.profile == "error":
            return [Reply(self.error_payload())]

        return [Reply(self.valid_payload())]

    def valid_payload(self) -> bytes:
        if self.mode == "version":
            return build_version_reply()
        if self.mode == "cipher_zero":
            return build_open_session_reply(error_code=0)
        return self.dumphashes_payload()

    def error_payload(self) -> bytes:
        if self.mode == "version":
            return build_version_reply()
        if self.mode == "cipher_zero":
            return build_open_session_reply(error_code=self.error_code)
        return build_open_session_reply(error_code=self.error_code)

    def truncated_payload(self) -> bytes:
        return self.valid_payload()[: self.truncate_length]

    def dumphashes_payload(self) -> bytes:
        if self.mode != "dumphashes":
            return build_open_session_reply(error_code=0)

        payload = build_open_session_reply(error_code=0) if self._next_stage_is_open_session() else build_rakp2_reply()
        return payload

    def _next_stage_is_open_session(self) -> bool:
        # Stage alternates per client: open session first, then RAKP2.
        return True


class IPMIUDPServer(socketserver.ThreadingMixIn, socketserver.UDPServer):
    allow_reuse_address = True
    daemon_threads = True

    def __init__(self, server_address, handler_class, scenario: IPMIHarnessScenario):
        super().__init__(server_address, handler_class)
        self.scenario = scenario
        self.client_states: Dict[tuple, ClientState] = {}

    def state_for(self, client_address) -> ClientState:
        state = self.client_states.get(client_address)
        if state is None:
            state = ClientState()
            self.client_states[client_address] = state
        return state


class HarnessHandler(socketserver.BaseRequestHandler):
    def handle(self) -> None:
        data, sock = self.request
        state = self.server.state_for(self.client_address)

        if self.server.scenario.mode == "dumphashes":
            replies = self._dumphashes_replies(data, state)
        else:
            replies = self.server.scenario.replies_for(state)

        for reply in replies:
            if reply.delay > 0:
                time.sleep(reply.delay)
            sock.sendto(reply.payload, self.client_address)

    def _dumphashes_replies(self, data: bytes, state: ClientState) -> List[Reply]:
        state.packet_count += 1

        if self.server.scenario.profile == "silent":
            return []

        if self.server.scenario.profile == "flappy":
            slot = state.packet_count % 5
            if slot == 1:
                return []
            if slot == 2:
                return [Reply(build_open_session_reply(error_code=0)[: self.server.scenario.truncate_length])]
            if slot == 3:
                return [Reply(build_open_session_reply(error_code=0))]
            if slot == 4:
                return [Reply(build_rakp2_reply()) for _ in range(self.server.scenario.duplicate_count)]
            return [Reply(build_rakp2_reply(), delay=self.server.scenario.delay)]

        if state.stage == 0:
            state.stage = 1
            if self.server.scenario.profile == "malformed":
                return [Reply(build_open_session_reply(error_code=0)[: self.server.scenario.truncate_length])]
            if self.server.scenario.profile == "delayed":
                return [Reply(build_open_session_reply(error_code=0), delay=self.server.scenario.delay)]
            if self.server.scenario.profile == "duplicate":
                return [Reply(build_open_session_reply(error_code=0)) for _ in range(self.server.scenario.duplicate_count)]
            if self.server.scenario.profile == "error":
                return [Reply(build_open_session_reply(error_code=self.server.scenario.error_code))]
            return [Reply(build_open_session_reply(error_code=0))]

        if state.stage == 1:
            state.stage = 2
            if self.server.scenario.profile == "malformed":
                return [Reply(build_rakp2_reply()[: self.server.scenario.truncate_length])]
            if self.server.scenario.profile == "delayed":
                return [Reply(build_rakp2_reply(), delay=self.server.scenario.delay)]
            if self.server.scenario.profile == "duplicate":
                return [Reply(build_rakp2_reply()) for _ in range(self.server.scenario.duplicate_count)]
            return [Reply(build_rakp2_reply())]

        return [Reply(build_rakp2_reply())]


def parse_args(argv: List[str]) -> argparse.Namespace:
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--listen", default="0.0.0.0", help="Address to bind")
    parser.add_argument("--port", type=int, default=623, help="UDP port to bind")
    parser.add_argument("--mode", choices=["version", "cipher_zero", "dumphashes"], required=True)
    parser.add_argument(
        "--profile",
        choices=["valid", "silent", "malformed", "malformed_then_valid", "delayed", "duplicate", "error", "flappy"],
        default="valid",
    )
    parser.add_argument("--delay", type=float, default=1.5, help="Delay for delayed replies")
    parser.add_argument("--duplicate-count", type=int, default=2, help="How many times to duplicate responses")
    parser.add_argument("--truncate-length", type=int, default=12, help="Length used for truncated replies")
    parser.add_argument("--error-code", type=int, default=0x11, help="Error code used by error replies")
    parser.add_argument("--seed", type=int, default=1, help="Random seed for malformed payloads")
    return parser.parse_args(argv)


def main(argv: List[str]) -> int:
    args = parse_args(argv)
    random.seed(args.seed)
    scenario = IPMIHarnessScenario(
        mode=args.mode,
        profile=args.profile,
        delay=args.delay,
        duplicate_count=args.duplicate_count,
        truncate_length=args.truncate_length,
        error_code=args.error_code,
    )

    with IPMIUDPServer((args.listen, args.port), HarnessHandler, scenario) as server:
        print(f"Listening on {args.listen}:{args.port} for mode={args.mode} profile={args.profile}")
        try:
            server.serve_forever()
        except KeyboardInterrupt:
            return 130
    return 0


if __name__ == "__main__":
    raise SystemExit(main(sys.argv[1:]))
```
</details>

## Demo

<img width="1549" height="561" alt="image" src="https://github.com/user-attachments/assets/3f171761-00b9-49be-b604-474a5b2da5a1" />

Ran through both tests, new on the left, old on the right.