### PR TITLE
Add Authentication to the MCP server's HTTP transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ Gemfile.local.lock
 .solargraph.yml
 # database config for testing
 config/database.yml
+# mcp config for mcping
+config/mcp_config.yaml
+config/mcp_config.yml
 # target config file for testing
 features/support/targets.yml
 # Generated test files

--- a/config/mcp_config.yaml.example
+++ b/config/mcp_config.yaml.example
@@ -15,6 +15,7 @@ mcp:
   # MCP server network configuration (for HTTP transport only)
   host: 127.0.0.1  # Host to bind to (default: localhost)
   port: 3000       # Port to listen on (default: 3000)
+  # auth_token: ... # Bearer token for authentication (default: randomly generated, one-time token)
   # Puma server tuning (for HTTP transport only)
   # min_threads: 0   # Minimum thread pool size (default: 0)
   # max_threads: 5   # Maximum thread pool size (default: 5)

--- a/docs/metasploit-framework.wiki/How-to-use-Metasploit-MCP-Server.md
+++ b/docs/metasploit-framework.wiki/How-to-use-Metasploit-MCP-Server.md
@@ -117,6 +117,7 @@ All configuration settings can be overridden by environment variables:
 | `MSF_MCP_TRANSPORT` | MCP transport type (`stdio` or `http`) |
 | `MSF_MCP_HOST` | MCP server host (for HTTP transport) |
 | `MSF_MCP_PORT` | MCP server port (for HTTP transport) |
+| `MSF_MCP_AUTH_TOKEN` | MCP server Bearer token for authentication (for HTTP transport) |
 
 Example using environment variables:
 
@@ -174,6 +175,53 @@ When auto-start is disabled and no RPC server is running, you must start `msfrpc
 ```
 msfrpcd -U your_username -P your_password -p 55553
 ```
+
+## Authentication
+
+The HTTP transport supports authentication through a Bearer token as set in the Authorization header (e.g.
+`Authorization: Bearer ...`). By default, if the token is not set, a random token will be generated automatically and
+printed when the MCP server starts.
+
+For example:
+
+```
+Initializing MCP server...
+Starting MCP server on HTTP transport...
+Server listening on http://localhost:3000/
+Authentication: Bearer token (auto-generated)
+  Configure your MCP client with: Authorization: Bearer 2fc41c38eccfe505b44cde1bc96dc4bf72e4abe163a689a3e25bd05e8c081cbd
+Press Ctrl+C to shutdown
+```
+
+Using the automatically generated token means the MCP client's configuration will need to be updated each time the
+server is restarted. A persistent token can be defined in two ways:
+
+1. In the configuration file, by defining `auth_token` to a non-empty string under the `mcp` key, e.g.:
+
+```yaml
+mcp:
+  transport: http
+  # ... other config keys
+  auth_token: MY-SUPER-SECURE-TOKEN
+```
+
+2. By setting the `MSF_MCP_AUTH_TOKEN` environment variable. As with other configuration options, the environment
+  variable takes precedence over the configuration.
+
+### Disabling Authentication
+
+While not advisable, authentication can be disabled by setting the configuration to null or an empty string. In this
+case the server will respond to HTTP requests from any client that can connect to it. Use caution when disabling 
+authentication.
+
+```yaml
+mcp:
+  transport: http
+  # ... other config keys
+  auth_token: null # DISABLE HTTP AUTHENTICATION
+```
+
+The same can be achieved through the environment variable, e.g. `MSF_MCP_AUTH_TOKEN="" ./msfmcpd --mcp-transport http`.
 
 ## MCP Tools
 

--- a/lib/msf/core/mcp.rb
+++ b/lib/msf/core/mcp.rb
@@ -33,6 +33,7 @@ require_relative 'mcp/logging/sinks/json_stream'
 require_relative 'mcp/logging/sinks/json_flatfile'
 require_relative 'mcp/logging/sinks/sanitizing'
 require_relative 'mcp/middleware/request_logger'
+require_relative 'mcp/middleware/bearer_auth'
 
 # Error classes
 require_relative 'mcp/errors'

--- a/lib/msf/core/mcp/application.rb
+++ b/lib/msf/core/mcp/application.rb
@@ -2,6 +2,7 @@
 
 require 'msf/core/mcp'
 require 'optparse'
+require 'securerandom'
 
 module Msf::MCP
   # Main application class that orchestrates the MCP server startup and lifecycle
@@ -280,19 +281,59 @@ module Msf::MCP
       port = @config.dig(:mcp, :port) || 3000
 
       if transport == :http
+        @output.puts "Starting MCP server on HTTP transport..."
+        @output.puts "Server listening on http://#{Rex::Socket.to_authority(host, port)}/"
+        auth_token = resolve_auth_token
+        case auth_token
+        when :disabled
+          @output.puts "Authentication: disabled"
+          auth_token = nil
+        when :enabled
+          @output.puts "Authentication: enabled"
+          auth_token = @config.dig(:mcp, :auth_token)
+        when :generated
+          auth_token = SecureRandom.hex(32)
+          @output.puts "Authentication: Bearer token (auto-generated)"
+          @output.puts "  Token: #{auth_token}"
+          @output.puts "  Configure your MCP client with: Authorization: Bearer #{auth_token}"
+        else
+          raise RuntimeError, 'auth_token did not resolve to a supported value.'
+        end
+        @output.puts "Press Ctrl+C to shutdown"
+
         min_threads = @config.dig(:mcp, :min_threads) || Msf::MCP::Server::PUMA_MIN_THREADS
         max_threads = @config.dig(:mcp, :max_threads) || Msf::MCP::Server::PUMA_MAX_THREADS
         workers = @config.dig(:mcp, :workers) || Msf::MCP::Server::PUMA_WORKERS
 
-        @output.puts "Starting MCP server on HTTP transport..."
-        @output.puts "Server listening on http://#{host}:#{port}"
-        @output.puts "Press Ctrl+C to shutdown"
-        @mcp_server.start(transport: :http, host: host, port: port, min_threads: min_threads, max_threads: max_threads, workers: workers)
+        @mcp_server.start(
+          transport: :http,
+          host: host,
+          port: port,
+          auth_token: auth_token,
+          min_threads: min_threads,
+          max_threads: max_threads,
+          workers: workers
+        )
       else
         @output.puts "Starting MCP server on stdio transport..."
         @output.puts "Server ready - waiting for MCP requests"
         @output.puts "Press Ctrl+C to shutdown"
         @mcp_server.start(transport: :stdio)
+      end
+    end
+
+    # Determine the auth token state for the HTTP transport startup message.
+    #
+    # Returns one of three values:
+    #   :disabled  -- explicitly set to nil/empty; authentication is off
+    #   :enabled   -- set via config file or env var; caller should fetch from config
+    #   :generated -- not configured; caller should generate and display a token
+    #
+    def resolve_auth_token
+      if @config[:mcp].key?(:auth_token)
+        @config[:mcp][:auth_token] ? :enabled : :disabled
+      else
+        :generated
       end
     end
 

--- a/lib/msf/core/mcp/application.rb
+++ b/lib/msf/core/mcp/application.rb
@@ -294,7 +294,6 @@ module Msf::MCP
         when :generated
           auth_token = SecureRandom.hex(32)
           @output.puts "Authentication: Bearer token (auto-generated)"
-          @output.puts "  Token: #{auth_token}"
           @output.puts "  Configure your MCP client with: Authorization: Bearer #{auth_token}"
         else
           raise RuntimeError, 'auth_token did not resolve to a supported value.'

--- a/lib/msf/core/mcp/config/loader.rb
+++ b/lib/msf/core/mcp/config/loader.rb
@@ -77,6 +77,15 @@ module Msf::MCP
           config[:mcp][:workers] ||= Msf::MCP::Server::PUMA_WORKERS
         end
 
+        # auth_token: only normalize if the key was explicitly provided.
+        # Absent key means "not configured" -- the application layer generates
+        # a token at startup so it can decide whether to print it.
+        # nil or "" becomes nil (authentication disabled); non-empty string is used as-is.
+        if config[:mcp].key?(:auth_token)
+          val = config[:mcp][:auth_token]
+          config[:mcp][:auth_token] = nil if val.nil? || (val.is_a?(String) && val.empty?)
+        end
+
         config[:rate_limit][:enabled] = config[:rate_limit].fetch(:enabled, true)
         config[:rate_limit][:requests_per_minute] ||= Defaults::RATE_LIMIT_REQUESTS_PER_MINUTE
         config[:rate_limit][:burst_size] ||= 10
@@ -113,6 +122,15 @@ module Msf::MCP
         config[:mcp][:host] = ENV['MSF_MCP_HOST'] if ENV['MSF_MCP_HOST']
         config[:mcp][:port] = ENV['MSF_MCP_PORT'].to_i if ENV['MSF_MCP_PORT']
 
+        # MCP authentication -- env var overrides config/default
+        #   unset            -- leave whatever apply_defaults established
+        #   set to ""        -- nil (disable authentication)
+        #   set to non-empty -- use as the bearer token
+        if ENV.key?('MSF_MCP_AUTH_TOKEN')
+          mcp_token = ENV['MSF_MCP_AUTH_TOKEN']
+          config[:mcp][:auth_token] = mcp_token.empty? ? nil : mcp_token
+        end
+
         # MCP Puma server tuning overrides
         config[:mcp][:min_threads] = ENV['MSF_MCP_MIN_THREADS'].to_i if ENV['MSF_MCP_MIN_THREADS']
         config[:mcp][:max_threads] = ENV['MSF_MCP_MAX_THREADS'].to_i if ENV['MSF_MCP_MAX_THREADS']
@@ -121,7 +139,7 @@ module Msf::MCP
 
       # Parse a string value into a boolean
       #
-      # @param value [String] String to parse ('true', '1', 'yes' → true; anything else → false)
+      # @param value [String] String to parse ('true', '1', 'yes' -> true; anything else -> false)
       # @return [Boolean]
       def self.parse_boolean(value)
         %w[true 1 yes].include?(value.to_s.downcase)

--- a/lib/msf/core/mcp/middleware/bearer_auth.rb
+++ b/lib/msf/core/mcp/middleware/bearer_auth.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Msf::MCP
+  module Middleware
+    ##
+    # Rack middleware that enforces Bearer token authentication on every request.
+    #
+    # Skipped (pass-through) when no token is configured -- the token is always
+    # present when this middleware is mounted because {Server#start_http} only
+    # adds it to the stack when +auth_token+ is non-nil.
+    #
+    # Clients must send:
+    #   Authorization: Bearer <token>
+    #
+    # Returns 401 with a WWW-Authenticate challenge on any mismatch.
+    # Comparison is constant-time via +Rack::Utils.secure_compare+ to prevent
+    # timing-based token enumeration.
+    #
+    class BearerAuth
+      UNAUTHORIZED = [
+        401,
+        {
+          'Content-Type'    => 'application/json',
+          'WWW-Authenticate' => 'Bearer realm="msfmcp"'
+        },
+        ['{"error":"Unauthorized"}']
+      ].freeze
+
+      def initialize(app, auth_token:)
+        @app        = app
+        @auth_token = auth_token
+      end
+
+      def call(env)
+        expected = "Bearer #{@auth_token}"
+        provided = env['HTTP_AUTHORIZATION'].to_s
+        return UNAUTHORIZED unless Rack::Utils.secure_compare(expected, provided)
+
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/msf/core/mcp/server.rb
+++ b/lib/msf/core/mcp/server.rb
@@ -72,12 +72,12 @@ module Msf::MCP
     # @return [MCP::Server] The MCP server instance (for testing purposes)
     # @raise [ArgumentError] If an unknown transport is specified
     #
-    def start(transport: :stdio, host: 'localhost', port: 3000, min_threads: PUMA_MIN_THREADS, max_threads: PUMA_MAX_THREADS, workers: PUMA_WORKERS)
+    def start(transport: :stdio, host: 'localhost', port: 3000, auth_token: nil, min_threads: PUMA_MIN_THREADS, max_threads: PUMA_MAX_THREADS, workers: PUMA_WORKERS)
       case transport
       when :stdio
         start_stdio
       when :http
-        start_http(host, port, min_threads: min_threads, max_threads: max_threads, workers: workers)
+        start_http(host, port, auth_token, min_threads: min_threads, max_threads: max_threads, workers: workers)
       else
         raise ArgumentError, "Unknown transport: #{transport}. Use :stdio or :http"
       end
@@ -120,13 +120,14 @@ module Msf::MCP
     #
     # @param host [String] Host address to bind to
     # @param port [Integer] Port to listen on
+    # @param auth_token [String] An authentication token to require
     # @param min_threads [Integer] Minimum number of Puma threads
     # @param max_threads [Integer] Maximum number of Puma threads
     # @param workers [Integer] Number of Puma worker processes
     #
     # @return [MCP::Server] The MCP server instance (for testing purposes)
     #
-    def start_http(host, port, min_threads: PUMA_MIN_THREADS, max_threads: PUMA_MAX_THREADS, workers: PUMA_WORKERS)
+    def start_http(host, port, auth_token, min_threads: PUMA_MIN_THREADS, max_threads: PUMA_MAX_THREADS, workers: PUMA_WORKERS)
       require 'rack'
       require 'puma'
       require 'puma/configuration'
@@ -139,6 +140,7 @@ module Msf::MCP
       # The transport itself is a Rack app (implements #call).
       rack_app = Rack::Builder.new do
         use Msf::MCP::Middleware::RequestLogger
+        use Msf::MCP::Middleware::BearerAuth, auth_token: auth_token if auth_token
         run transport
       end
 

--- a/lib/msf/core/mcp/server.rb
+++ b/lib/msf/core/mcp/server.rb
@@ -140,7 +140,7 @@ module Msf::MCP
       # The transport itself is a Rack app (implements #call).
       rack_app = Rack::Builder.new do
         use Msf::MCP::Middleware::RequestLogger
-        use Msf::MCP::Middleware::BearerAuth, auth_token: auth_token if auth_token
+        use Msf::MCP::Middleware::BearerAuth, auth_token: auth_token.to_s if auth_token && !auth_token.to_s.empty?
         run transport
       end
 

--- a/spec/lib/msf/core/mcp/application_spec.rb
+++ b/spec/lib/msf/core/mcp/application_spec.rb
@@ -406,6 +406,7 @@ RSpec.describe Msf::MCP::Application do
 
       expect(mock_mcp_server).to receive(:start).with(
         transport: :http, host: '0.0.0.0', port: 3000,
+        auth_token: a_string_matching(/\A[0-9a-f]{64}\z/),
         min_threads: 0, max_threads: 5, workers: 0
       )
 
@@ -425,6 +426,7 @@ RSpec.describe Msf::MCP::Application do
 
       expect(mock_mcp_server).to receive(:start).with(
         transport: :http, host: 'localhost', port: 3000,
+        auth_token: a_string_matching(/\A[0-9a-f]{64}\z/),
         min_threads: Msf::MCP::Server::PUMA_MIN_THREADS,
         max_threads: Msf::MCP::Server::PUMA_MAX_THREADS,
         workers: Msf::MCP::Server::PUMA_WORKERS

--- a/spec/lib/msf/core/mcp/middleware/bearer_auth_spec.rb
+++ b/spec/lib/msf/core/mcp/middleware/bearer_auth_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'msf/core/mcp'
+require 'rack'
+
+RSpec.describe Msf::MCP::Middleware::BearerAuth do
+  let(:token) { 's3cr3t' }
+  let(:inner_app) { ->(_env) { [200, { 'Content-Type' => 'application/json' }, ['OK']] } }
+  let(:middleware) { described_class.new(inner_app, auth_token: token) }
+
+  def rack_env_for(authorization: nil)
+    env = Rack::MockRequest.env_for('http://localhost:3000/mcp', method: 'POST')
+    env['HTTP_AUTHORIZATION'] = authorization if authorization
+    env
+  end
+
+  describe 'UNAUTHORIZED' do
+    subject { described_class::UNAUTHORIZED }
+
+    it 'has status 401' do
+      expect(subject[0]).to eq(401)
+    end
+
+    it 'includes Content-Type application/json' do
+      expect(subject[1]['Content-Type']).to eq('application/json')
+    end
+
+    it 'includes a WWW-Authenticate Bearer challenge' do
+      expect(subject[1]['WWW-Authenticate']).to eq('Bearer realm="msfmcp"')
+    end
+
+    it 'has a JSON error body' do
+      expect(subject[2]).to eq(['{"error":"Unauthorized"}'])
+    end
+
+    it 'is frozen' do
+      expect(subject).to be_frozen
+    end
+  end
+
+  describe '#call' do
+    context 'with the correct Bearer token' do
+      it 'delegates to the inner app and returns its response' do
+        env = rack_env_for(authorization: "Bearer #{token}")
+        status, _headers, body = middleware.call(env)
+
+        expect(status).to eq(200)
+        expect(body).to eq(['OK'])
+      end
+    end
+
+    context 'with a wrong token value' do
+      it 'returns 401' do
+        env = rack_env_for(authorization: 'Bearer wrongtoken')
+        status, headers, body = middleware.call(env)
+
+        expect(status).to eq(401)
+        expect(headers['WWW-Authenticate']).to eq('Bearer realm="msfmcp"')
+        expect(body).to eq(['{"error":"Unauthorized"}'])
+      end
+    end
+
+    context 'with no Authorization header' do
+      it 'returns 401' do
+        env = rack_env_for
+        status, _headers, _body = middleware.call(env)
+
+        expect(status).to eq(401)
+      end
+    end
+
+    context 'with the wrong scheme' do
+      it 'returns 401' do
+        env = rack_env_for(authorization: "Basic #{token}")
+        status, _headers, _body = middleware.call(env)
+
+        expect(status).to eq(401)
+      end
+    end
+
+    context 'with the correct token but wrong case for the scheme' do
+      it 'returns 401' do
+        env = rack_env_for(authorization: "bearer #{token}")
+        status, _headers, _body = middleware.call(env)
+
+        expect(status).to eq(401)
+      end
+    end
+
+    context 'with trailing whitespace on the token' do
+      it 'returns 401' do
+        env = rack_env_for(authorization: "Bearer #{token} ")
+        status, _headers, _body = middleware.call(env)
+
+        expect(status).to eq(401)
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/mcp/server_spec.rb
+++ b/spec/lib/msf/core/mcp/server_spec.rb
@@ -594,4 +594,91 @@ RSpec.describe Msf::MCP::Server do
       end
     end
   end
+
+  describe 'HTTP auth_token wiring' do
+    let(:auth_token) { 'integration_test_token_abc123' }
+
+    let(:mock_http_transport) do
+      instance_double(::MCP::Server::Transports::StreamableHTTPTransport).tap do |t|
+        allow(t).to receive(:call).and_return([200, { 'Content-Type' => 'text/plain' }, ['OK']])
+      end
+    end
+
+    let(:server) do
+      allow(::MCP::Server).to receive(:new).and_return(mock_mcp_server)
+      described_class.new(msf_client: mock_msf_client, rate_limiter: rate_limiter)
+    end
+
+    before do
+      require 'rack'
+      require 'puma'
+      require 'puma/configuration'
+      require 'puma/dsl'
+      require 'puma/launcher'
+      require 'puma/log_writer'
+
+      allow(::MCP::Server::Transports::StreamableHTTPTransport).to receive(:new).and_return(mock_http_transport)
+      allow(Puma::Launcher).to receive(:new).and_return(instance_double(Puma::Launcher, run: nil, stop: nil))
+      allow_any_instance_of(Puma::DSL).to receive(:app).and_wrap_original do |method, rack_app = nil|
+        @rack_app = rack_app if rack_app
+        method.call(rack_app)
+      end
+    end
+
+    after do
+      server.shutdown
+    end
+
+    def call_rack(authorization: nil)
+      env = Rack::MockRequest.env_for(
+        'http://localhost:3000/mcp',
+        method: 'POST',
+        input: StringIO.new('{"jsonrpc":"2.0","method":"ping","id":1}')
+      )
+      env['HTTP_AUTHORIZATION'] = authorization if authorization
+      @rack_app.to_app.call(env)
+    end
+
+    context 'when auth_token is provided' do
+      before { server.start(transport: :http, auth_token: auth_token) }
+
+      it 'rejects requests that have no Authorization header' do
+        status, _headers, _body = call_rack
+        expect(status).to eq(401)
+      end
+
+      it 'rejects requests with an incorrect token' do
+        status, _headers, _body = call_rack(authorization: 'Bearer wrongtoken')
+        expect(status).to eq(401)
+      end
+
+      it 'allows requests with the correct Bearer token' do
+        status, _headers, _body = call_rack(authorization: "Bearer #{auth_token}")
+        expect(status).to eq(200)
+      end
+
+      it 'includes a WWW-Authenticate header in the 401 response' do
+        _status, headers, _body = call_rack
+        expect(headers['WWW-Authenticate']).to eq('Bearer realm="msfmcp"')
+      end
+    end
+
+    context 'when auth_token is nil' do
+      before { server.start(transport: :http, auth_token: nil) }
+
+      it 'passes all requests through without authentication' do
+        status, _headers, _body = call_rack
+        expect(status).to eq(200)
+      end
+    end
+
+    context 'when auth_token is an empty string' do
+      before { server.start(transport: :http, auth_token: '') }
+
+      it 'passes all requests through without authentication' do
+        status, _headers, _body = call_rack
+        expect(status).to eq(200)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds authentication support to the MCP server's HTTP transport by default. The docs have been updated to reflect what this is and how it works.

## Verification

List the steps needed to make sure this thing works

- [ ] Run `./msfmcpd --mcp-transport http` and see it print a random token
- [ ] Run `MSF_MCP_AUTH_TOKEN="" ./msfmcpd --mcp-transport http` and see that it does not print a token and that authentication is disabled
- [ ] Run `MSF_MCP_AUTH_TOKEN="whatever" ./msfmcpd --mcp-transport http` and see that authentication is enabled, it's set to "whatever" but should not be displayed
- [ ] Add a token to the configuration file per the docs and load it with `./msfmcpd --config path/to/config.yaml` see that authentication is enabled
- [ ] Run `MSF_MCP_AUTH_TOKEN="" ./msfmcpd --mcp-transport http` again and see that authentication is disabled because the environment takes priority over the config

The token should only be printed when it's randomly generated; if it's set via the config or environment variable, the server should only print that authentication is enabled. Additionally, when authentication is disabled, that should be printed too so the user always knows the status, and the token is only printed when necessary.

## Demo
Start it for a random token.

```
./msfmcpd --mcp-transport http                                                                                                                
[DEPRECATION NOTICE] json-schema support for MultiJSON is deprecated and will be removed in a future version. To stop using MultiJSON, add `JSON::Validator.use_multi_json = false` to your application's initialization code.
No configuration file specified, using defaults
Validating configuration...
Configuration valid
Generated random credentials for auto-started RPC server
Starting Metasploit RPC server...
RPC server started via msfrpcd (PID: 98530)
Waiting for RPC server to become available...
Waiting for RPC server to become available...
Waiting for RPC server to become available...
RPC server is ready
Connecting to Metasploit RPC at localhost:55553
Authenticating with Metasploit...
Authentication successful
Initializing MCP server...
Starting MCP server on HTTP transport...
Server listening on http://localhost:3000/
Authentication: Bearer token (auto-generated)
  Configure your MCP client with: Authorization: Bearer 6f8fe7274096253e82dc90ab0bc6be10d859a9088d5053dbe177125e2d45793c
Press Ctrl+C to shutdown
```

Configure Claude Code using the `--header` option:

```
claude mcp add --transport http metasploit http://localhost:3000/  --header 'Authorization: Bearer 6f8fe7274096253e82dc90ab0bc6be10d859a9088d5053dbe177125e2d45793c'
```