### PR TITLE
Fixes de-registering datastore options validation

### DIFF
--- a/lib/msf/core/exploit/remote/smtp_deliver.rb
+++ b/lib/msf/core/exploit/remote/smtp_deliver.rb
@@ -158,19 +158,14 @@ module Exploit::Remote::SMTPDeliver
   # Sends an email message, connecting to the server first if a connection is
   # not already established.
   #
-  # @param data [String] The message body to send.
-  # @param mailfrom [String, nil] Override the MAILFROM datastore option for this send only.
-  # @param mailto [String, nil] Override the MAILTO datastore option for this send only.
-  # @param subject [String, nil] Override the SUBJECT datastore option for this send only.
-  #
-  def send_message(data, mailfrom: nil, mailto: nil, subject: nil)
-    mailfrom = (mailfrom || datastore['MAILFROM']).to_s.strip
+  def send_message(data)
+    mailfrom = datastore['MAILFROM'].strip
     if bad_address(mailfrom)
       print_error "Bad from address, not sending: #{mailfrom}"
       return nil
     end
 
-    mailto = (mailto || datastore['MAILTO']).to_s.strip
+    mailto = datastore['MAILTO'].strip
     if bad_address(mailto)
       print_error "Bad to address, not sending: #{mailto}"
       return nil
@@ -200,10 +195,9 @@ module Exploit::Remote::SMTPDeliver
       end
 
       # If the user supplied a Subject field, use that
-      subject_header = nil
-      resolved_subject = subject || datastore['SUBJECT']
-      if resolved_subject.present?
-        subject_header = "Subject: #{resolved_subject}\r\n"
+      subject = nil
+      if datastore['SUBJECT'].present?
+        subject = "Subject: #{datastore['SUBJECT']}\r\n"
       end
 
       # Avoid sending tons of data and killing the connection if the server
@@ -213,7 +207,7 @@ module Exploit::Remote::SMTPDeliver
       else
         full_msg = ''
         full_msg << date unless data =~ /date: /i
-        full_msg << subject_header unless subject_header.nil? || data =~ /subject: /i
+        full_msg << subject unless subject.nil? || data =~ /subject: /i
         full_msg << data
         # Escape leading dots in the mail messages so there are no false EOF
         full_msg.gsub!(/(?m)^\./, '..')

--- a/lib/msf/core/exploit/remote/smtp_deliver.rb
+++ b/lib/msf/core/exploit/remote/smtp_deliver.rb
@@ -158,14 +158,19 @@ module Exploit::Remote::SMTPDeliver
   # Sends an email message, connecting to the server first if a connection is
   # not already established.
   #
-  def send_message(data)
-    mailfrom = datastore['MAILFROM'].strip
+  # @param data [String] The message body to send.
+  # @param mailfrom [String, nil] Override the MAILFROM datastore option for this send only.
+  # @param mailto [String, nil] Override the MAILTO datastore option for this send only.
+  # @param subject [String, nil] Override the SUBJECT datastore option for this send only.
+  #
+  def send_message(data, mailfrom: nil, mailto: nil, subject: nil)
+    mailfrom = (mailfrom || datastore['MAILFROM']).to_s.strip
     if bad_address(mailfrom)
       print_error "Bad from address, not sending: #{mailfrom}"
       return nil
     end
 
-    mailto = datastore['MAILTO'].strip
+    mailto = (mailto || datastore['MAILTO']).to_s.strip
     if bad_address(mailto)
       print_error "Bad to address, not sending: #{mailto}"
       return nil
@@ -195,9 +200,10 @@ module Exploit::Remote::SMTPDeliver
       end
 
       # If the user supplied a Subject field, use that
-      subject = nil
-      if datastore['SUBJECT'].present?
-        subject = "Subject: #{datastore['SUBJECT']}\r\n"
+      subject_header = nil
+      resolved_subject = subject || datastore['SUBJECT']
+      if resolved_subject.present?
+        subject_header = "Subject: #{resolved_subject}\r\n"
       end
 
       # Avoid sending tons of data and killing the connection if the server
@@ -207,7 +213,7 @@ module Exploit::Remote::SMTPDeliver
       else
         full_msg = ''
         full_msg << date unless data =~ /date: /i
-        full_msg << subject unless subject.nil? || data =~ /subject: /i
+        full_msg << subject_header unless subject_header.nil? || data =~ /subject: /i
         full_msg << data
         # Escape leading dots in the mail messages so there are no false EOF
         full_msg.gsub!(/(?m)^\./, '..')

--- a/lib/msf/core/module_data_store.rb
+++ b/lib/msf/core/module_data_store.rb
@@ -15,6 +15,7 @@ module Msf
       super()
 
       @_module = m
+      @deregistered_keys = []
     end
 
     #
@@ -27,6 +28,60 @@ module Msf
       new_instance
     end
 
+  # Grab any available deregistered_keys, otherwise return a blank array
+  #
+  # @param [Msf::DataStore] other The other datastore to copy state from
+  # @return [Msf::DataStore] the current datastore instance
+    def copy_state(other)
+      super
+      incoming = other.respond_to?(:deregistered_keys, true) ? other.deregistered_keys : []
+      incoming.each do |key|
+        @deregistered_keys << key unless @deregistered_keys.any? { |k| k.casecmp?(key) }
+      end
+
+      # Strip any deregistered keys that may have been written into @user_defined
+      # by the parent's copy_state (e.g. during reverse_merge! which calls
+      # copy_state with a plain DataStore result that contains all merged values).
+      @deregistered_keys.each do |key|
+        k = find_key_case(key)
+        @user_defined.delete(k)
+      end
+
+      # Need self here to return datastore instance from parent
+      self
+    end
+
+    # Track deregistered keys
+    #
+    # @param [String] name
+    # @return [nil]
+    def remove_option(name)
+      super
+      # Resolve to the canonical cased key that the datastore actually uses so
+      # that filtering later works correctly regardless of what case or alias the
+      # caller passed to deregister_options.
+      canonical = find_key_case(name)
+      @deregistered_keys << canonical unless @deregistered_keys.any? { |k| k.casecmp?(canonical) }
+
+      # Need nil here to return original nil value from parent
+      nil
+    end
+
+    # Imports options and clears any matching keys from the deregistered list.
+    # This allows a module to call deregister_options followed by register_options
+    # for the same key and ensure we remove the re-registered option from the
+    # tracked @deregistered_keys
+    #
+    # @param [Msf::OptionContainer] options
+    # @param [String, nil] imported_by
+    # @param [Boolean] overwrite
+    def import_options(options, imported_by = nil, overwrite = true)
+      options.each_option do |name, _option|
+        @deregistered_keys.delete_if { |k| k.casecmp?(name) }
+      end
+      super
+    end
+
     # Search for a value within the current datastore, taking into consideration any registered aliases, fallbacks, etc.
     # If a value is not present in the current datastore, the global parent store will be referenced instead
     #
@@ -35,6 +90,9 @@ module Msf
     def search_for(key)
       k = find_key_case(key)
       return search_result(:user_defined, @user_defined[k]) if @user_defined.key?(k)
+
+      # If the module has not registered the key then return early as it has been deregistered
+      return search_result(:not_found, nil) if should_filter_key?(key)
 
       # Preference globally set values over a module's option default
       framework_datastore_search = search_framework_datastore(key)
@@ -61,7 +119,59 @@ module Msf
       search_framework_datastore(k)
     end
 
+    # Override the write path so that keys which were explicitly deregistered on
+    # the owning module are dropped.
+    #
+    # Compatible and functions as normal when:
+    #   - the key has never been deregistered via deregister_options
+    #   - there is no associated module (@_module is nil)
+    #
+    # @param [String] key
+    # @param [Object] value
+    def []=(key, value)
+      return if should_filter_key?(key)
+
+      super
+    end
+
+    # Override merge! so that when merging a DataStore (which writes directly to
+    # @user_defined, bypassing []=), any deregistered keys are stripped out
+    # afterward. This prevents a caller from injecting a deregistered option's
+    # value by merging a datastore that contains it.
+    #
+    # When merging a plain Hash the parent's merge! already routes through []=,
+    # so deregistered keys are filtered at that point and no extra work is needed.
+    #
+    # @param [Msf::DataStore, Hash] other
+    # @return [Msf::ModuleDataStore]
+    def merge!(other)
+      super
+      if other.is_a?(DataStore)
+        @deregistered_keys.each do |key|
+          k = find_key_case(key)
+          @user_defined.delete(k)
+          @options.delete_if { |opt_name, _| opt_name.casecmp?(k) }
+          @aliases.delete_if { |_, v| v.casecmp?(k) }
+        end
+      end
+      self
+    end
+
     protected
+
+    attr_reader :deregistered_keys
+
+    # Returns true when the write should be silently dropped because the key
+    # was explicitly deregistered via deregister_options.
+    # Normalises the incoming key via find_key_case so that differently-cased
+    # references to the same key are correctly matched against @deregistered_keys.
+    #
+    # @param [String] key
+    # @return [Boolean]
+    def should_filter_key?(key)
+      canonical = find_key_case(key)
+      @deregistered_keys.any? { |deregistered| deregistered.casecmp?(canonical) }
+    end
 
     # Search the framework datastore
     #

--- a/lib/msf/core/module_data_store.rb
+++ b/lib/msf/core/module_data_store.rb
@@ -39,9 +39,9 @@ module Msf
         @deregistered_keys << key unless @deregistered_keys.any? { |k| k.casecmp?(key) }
       end
 
-      # Strip any deregistered keys that may have been written into @user_defined
-      # by the parent's copy_state (e.g. during reverse_merge! which calls
-      # copy_state with a plain DataStore result that contains all merged values).
+      # Strip deregistered keys from @user_defined in case the parent's copy_state
+      # wrote them in (e.g. reverse_merge! calls copy_state with a merged DataStore
+      # that may contain values for deregistered keys).
       @deregistered_keys.each do |key|
         k = find_key_case(key)
         @user_defined.delete(k)
@@ -119,40 +119,19 @@ module Msf
       search_framework_datastore(k)
     end
 
-    # Override the write path so that keys which were explicitly deregistered on
-    # the owning module are dropped.
-    #
-    # Compatible and functions as normal when:
-    #   - the key has never been deregistered via deregister_options
-    #   - there is no associated module (@_module is nil)
-    #
-    # @param [String] key
-    # @param [Object] value
-    def []=(key, value)
-      return if should_filter_key?(key)
-
-      super
-    end
-
-    # Override merge! so that when merging a DataStore (which writes directly to
-    # @user_defined, bypassing []=), any deregistered keys are stripped out
-    # afterward. This prevents a caller from injecting a deregistered option's
-    # value by merging a datastore that contains it.
-    #
-    # When merging a plain Hash the parent's merge! already routes through []=,
-    # so deregistered keys are filtered at that point and no extra work is needed.
+    # Override merge! to strip deregistered keys from both DataStore and Hash
+    # merges. This is the primary guard against external callers injecting values
+    # for options the module has explicitly removed.
     #
     # @param [Msf::DataStore, Hash] other
     # @return [Msf::ModuleDataStore]
     def merge!(other)
       super
-      if other.is_a?(DataStore)
-        @deregistered_keys.each do |key|
-          k = find_key_case(key)
-          @user_defined.delete(k)
-          @options.delete_if { |opt_name, _| opt_name.casecmp?(k) }
-          @aliases.delete_if { |_, v| v.casecmp?(k) }
-        end
+      @deregistered_keys.each do |key|
+        k = find_key_case(key)
+        @user_defined.delete(k)
+        @options.delete_if { |opt_name, _| opt_name.casecmp?(k) }
+        @aliases.delete_if { |_, v| v.casecmp?(k) }
       end
       self
     end

--- a/lib/msf/core/module_data_store.rb
+++ b/lib/msf/core/module_data_store.rb
@@ -70,14 +70,18 @@ module Msf
     # Imports options and clears any matching keys from the deregistered list.
     # This allows a module to call deregister_options followed by register_options
     # for the same key and ensure we remove the re-registered option from the
-    # tracked @deregistered_keys
+    # tracked @deregistered_keys. Also clears aliases so that a deregistered
+    # key re-introduced as an alias of a new option is not incorrectly filtered.
     #
     # @param [Msf::OptionContainer] options
     # @param [String, nil] imported_by
     # @param [Boolean] overwrite
     def import_options(options, imported_by = nil, overwrite = true)
-      options.each_option do |name, _option|
+      options.each_option do |name, option|
         @deregistered_keys.delete_if { |k| k.casecmp?(name) }
+        option.aliases.each do |alias_name|
+          @deregistered_keys.delete_if { |k| k.casecmp?(alias_name) }
+        end
       end
       super
     end

--- a/spec/lib/msf/core/module_data_store_filter_spec.rb
+++ b/spec/lib/msf/core/module_data_store_filter_spec.rb
@@ -39,81 +39,34 @@ RSpec.describe Msf::ModuleDataStore do
 
   subject(:mod) { build_mod_with_framework(mod_class, framework) }
 
-  describe '#[]=' do
-    context 'when the key has been deregistered' do
-      it 'silently drops a direct assignment' do
-        mod.datastore['RHOST'] = '192.0.2.1'
-        expect(mod.datastore['RHOST']).to be_nil
-      end
-
-      it 'silently drops a value passed via _import_extra_options' do
-        mod._import_extra_options('Options' => { 'RHOST' => '192.0.2.1' })
-        expect(mod.datastore['RHOST']).to be_nil
-      end
-
-      it 'silently drops values copied from a parent datastore in bulk' do
-        { 'RHOST' => '192.0.2.1', 'LHOST' => '192.0.2.2' }.each do |k, v|
-          mod.datastore[k] = v
-        end
-
-        expect(mod.datastore['RHOST']).to be_nil
-      end
-    end
-
-    context 'when the key is registered' do
-      it 'stores and returns the value' do
-        mod.datastore['LHOST'] = '192.0.2.2'
-        expect(mod.datastore['LHOST']).to eq('192.0.2.2')
-      end
-
-      it 'stores values passed via _import_extra_options' do
-        mod._import_extra_options('Options' => { 'LHOST' => '192.0.2.2' })
-        expect(mod.datastore['LHOST']).to eq('192.0.2.2')
-      end
-
-      it 'preserves registered keys when copying alongside deregistered keys' do
-        { 'RHOST' => '192.0.2.1', 'LHOST' => '192.0.2.2' }.each do |k, v|
-          mod.datastore[k] = v
-        end
-
-        expect(mod.datastore['LHOST']).to eq('192.0.2.2')
-      end
-    end
-  end
-
   describe '#merge!' do
     context 'when merging a DataStore containing a deregistered key' do
-      it 'does not expose the deregistered key after merge' do
-        source = Msf::DataStore.new
-        source['RHOST'] = '192.0.2.1'
-        source['LHOST'] = '192.0.2.2'
+      let(:source) do
+        ds = Msf::DataStore.new
+        ds['RHOST'] = '192.0.2.1'
+        ds['LHOST'] = '192.0.2.2'
+        ds
+      end
 
+      it 'strips the deregistered key' do
         mod.datastore.merge!(source)
-
         expect(mod.datastore['RHOST']).to be_nil
       end
 
-      it 'preserves registered keys from the merged datastore' do
-        source = Msf::DataStore.new
-        source['RHOST'] = '192.0.2.1'
-        source['LHOST'] = '192.0.2.2'
-
+      it 'preserves registered keys' do
         mod.datastore.merge!(source)
-
         expect(mod.datastore['LHOST']).to eq('192.0.2.2')
       end
     end
 
     context 'when merging a plain Hash containing a deregistered key' do
-      it 'does not expose the deregistered key after merge' do
+      it 'strips the deregistered key' do
         mod.datastore.merge!('RHOST' => '192.0.2.1', 'LHOST' => '192.0.2.2')
-
         expect(mod.datastore['RHOST']).to be_nil
       end
 
-      it 'preserves registered keys from the merged hash' do
+      it 'preserves registered keys' do
         mod.datastore.merge!('RHOST' => '192.0.2.1', 'LHOST' => '192.0.2.2')
-
         expect(mod.datastore['LHOST']).to eq('192.0.2.2')
       end
     end
@@ -121,28 +74,25 @@ RSpec.describe Msf::ModuleDataStore do
 
   describe '#reverse_merge!' do
     context 'when reverse-merging a DataStore containing a deregistered key' do
-      it 'does not expose the deregistered key after reverse_merge!' do
-        source = Msf::DataStore.new
-        source['RHOST'] = '192.0.2.1'
-        source['LHOST'] = '192.0.2.2'
+      let(:source) do
+        ds = Msf::DataStore.new
+        ds['RHOST'] = '192.0.2.1'
+        ds['LHOST'] = '192.0.2.2'
+        ds
+      end
 
+      it 'strips the deregistered key' do
         mod.datastore.reverse_merge!(source)
-
         expect(mod.datastore['RHOST']).to be_nil
       end
 
-      it 'preserves registered keys from the reverse-merged datastore' do
-        source = Msf::DataStore.new
-        source['RHOST'] = '192.0.2.1'
-        source['LHOST'] = '192.0.2.2'
-
+      it 'preserves registered keys' do
         mod.datastore.reverse_merge!(source)
-
         expect(mod.datastore['LHOST']).to eq('192.0.2.2')
       end
     end
   end
-  
+
   describe '#search_for' do
     context 'when the key has been deregistered' do
       it 'does not expose a value set in the global framework datastore' do
@@ -190,31 +140,9 @@ RSpec.describe Msf::ModuleDataStore do
       expect(full_mod.datastore['RHOST']).to eq('192.0.2.1')
       expect(full_mod.datastore['LHOST']).to eq('192.0.2.2')
     end
-
-    it 'stores all registered OptAddress options' do
-      full_mod.options.each do |key, opt|
-        next unless opt.is_a?(Msf::OptAddress)
-
-        full_mod.datastore[key] = '192.0.2.1'
-        expect(full_mod.datastore[key]).to eq('192.0.2.1'),
-          "Expected #{key} to round-trip as '192.0.2.1'"
-      end
-    end
   end
 
-  context 'when used as a plain DataStore without an associated module' do
-    subject(:ds) { Msf::DataStore.new }
-
-    it 'accepts writes for any key' do
-      ds['FOO']      = 'bar'
-      ds['ANYTHING'] = 'value'
-
-      expect(ds['FOO']).to eq('bar')
-      expect(ds['ANYTHING']).to eq('value')
-    end
-  end
-
-  context 'when a mixin registers options that the including module deregisters (HttpClient scenario)' do
+  context 'when a mixin registers options that the including module deregisters' do
     let(:parent_mod_class) do
       Class.new(Msf::Auxiliary) do
         include Msf::Simple::Auxiliary
@@ -261,29 +189,19 @@ RSpec.describe Msf::ModuleDataStore do
     let(:parent_mod) { build_mod_with_framework(parent_mod_class, framework) }
     let(:child_mod)  { build_mod_with_framework(child_mod_class,  framework) }
 
-    context 'when the parent copies its own options to the child' do
+    context 'when the parent merges its datastore into the child' do
       before do
-        parent_mod.datastore['HttpUsername'] = 'spencer'
+        parent_mod.datastore['HttpUsername'] = 'foo'
         parent_mod.datastore['HttpPassword'] = 'Password1!'
       end
 
-      it 'does not set HttpUsername on the child' do
-        parent_mod.options.each_pair do |name, _opt|
-          next if parent_mod.datastore[name].nil?
-
-          child_mod.datastore[name] = parent_mod.datastore[name]
-        end
-
+      it 'strips HttpUsername from the child' do
+        child_mod.datastore.merge!(parent_mod.datastore)
         expect(child_mod.datastore['HttpUsername']).to be_blank
       end
 
-      it 'does not set HttpPassword on the child' do
-        parent_mod.options.each_pair do |name, _opt|
-          next if parent_mod.datastore[name].nil?
-
-          child_mod.datastore[name] = parent_mod.datastore[name]
-        end
-
+      it 'strips HttpPassword from the child' do
+        child_mod.datastore.merge!(parent_mod.datastore)
         expect(child_mod.datastore['HttpPassword']).to be_blank
       end
     end
@@ -303,7 +221,7 @@ RSpec.describe Msf::ModuleDataStore do
       end
     end
 
-    context 'when neither the parent nor the global datastore has set the options' do
+    context 'when no values have been set externally' do
       it 'returns blank for HttpUsername' do
         expect(child_mod.datastore['HttpUsername']).to be_blank
       end
@@ -314,7 +232,7 @@ RSpec.describe Msf::ModuleDataStore do
     end
   end
 
-  context 'when share_datastore is used (shell-to-meterpreter upgrade pattern)' do
+  context 'when share_datastore is used' do
     # Simulates the create_multihandler sequence in post/multi/manage/shell_to_meterpreter:
     #   pay.datastore['LHOST'] = lhost
     #   pay.datastore['LPORT'] = lport
@@ -403,8 +321,6 @@ RSpec.describe Msf::ModuleDataStore do
   end
 
   context 'when an option is deregistered and then re-registered with a new definition' do
-    # This pattern is used by payload adapters such as cmd/windows/https/x86 and
-    # cmd/windows/https/x64
     let(:mod_class) do
       Class.new(Msf::Auxiliary) do
         include Msf::Simple::Auxiliary
@@ -412,7 +328,7 @@ RSpec.describe Msf::ModuleDataStore do
         def initialize
           super(
             'Name'        => 'Test Module (deregister then re-register)',
-            'Description' => 'Verifies that re-registering a deregistered option restores normal write behaviour',
+            'Description' => 'Re-registers a previously deregistered option',
             'Author'      => ['spec'],
             'License'     => MSF_LICENSE
           )
@@ -433,7 +349,7 @@ RSpec.describe Msf::ModuleDataStore do
 
     subject(:mod) { build_mod_with_framework(mod_class, framework) }
 
-    it 'returns the new default for the re-registered option' do
+    it 'returns the new default' do
       expect(mod.datastore['FETCH_COMMAND']).to eq('CURL')
     end
 
@@ -442,7 +358,7 @@ RSpec.describe Msf::ModuleDataStore do
       expect(mod.datastore['FETCH_COMMAND']).to eq('CURL')
     end
 
-    it 'does not accept the old deregistered default' do
+    it 'does not use the old deregistered default' do
       expect(mod.datastore['FETCH_COMMAND']).not_to eq('CERTUTIL')
     end
   end

--- a/spec/lib/msf/core/module_data_store_filter_spec.rb
+++ b/spec/lib/msf/core/module_data_store_filter_spec.rb
@@ -1,0 +1,449 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+
+# Builds a module instance with a stubbed framework, matching the construction
+# pattern used elsewhere in this project's specs. The datastore wired up
+# during initialize is left intact so deregistered_keys state is preserved.
+def build_mod_with_framework(klass, framework)
+  mod = klass.new
+  allow(mod).to receive(:framework).and_return(framework)
+  mod
+end
+
+RSpec.describe Msf::ModuleDataStore do
+  let(:framework_datastore) { Msf::DataStore.new }
+  let(:framework) { instance_double(Msf::Framework, datastore: framework_datastore) }
+
+  let(:mod_class) do
+    Class.new(Msf::Auxiliary) do
+      include Msf::Simple::Auxiliary
+
+      def initialize
+        super(
+          'Name'        => 'Test Module',
+          'Description' => 'Test module with RHOST deregistered',
+          'Author'      => ['spec'],
+          'License'     => MSF_LICENSE
+        )
+        register_options(
+          [
+            Msf::OptAddress.new('RHOST', [true,  'The remote host', nil]),
+            Msf::OptAddress.new('LHOST', [false, 'The local host',  nil])
+          ]
+        )
+        deregister_options('RHOST')
+      end
+    end
+  end
+
+  subject(:mod) { build_mod_with_framework(mod_class, framework) }
+
+  describe '#[]=' do
+    context 'when the key has been deregistered' do
+      it 'silently drops a direct assignment' do
+        mod.datastore['RHOST'] = '192.0.2.1'
+        expect(mod.datastore['RHOST']).to be_nil
+      end
+
+      it 'silently drops a value passed via _import_extra_options' do
+        mod._import_extra_options('Options' => { 'RHOST' => '192.0.2.1' })
+        expect(mod.datastore['RHOST']).to be_nil
+      end
+
+      it 'silently drops values copied from a parent datastore in bulk' do
+        { 'RHOST' => '192.0.2.1', 'LHOST' => '192.0.2.2' }.each do |k, v|
+          mod.datastore[k] = v
+        end
+
+        expect(mod.datastore['RHOST']).to be_nil
+      end
+    end
+
+    context 'when the key is registered' do
+      it 'stores and returns the value' do
+        mod.datastore['LHOST'] = '192.0.2.2'
+        expect(mod.datastore['LHOST']).to eq('192.0.2.2')
+      end
+
+      it 'stores values passed via _import_extra_options' do
+        mod._import_extra_options('Options' => { 'LHOST' => '192.0.2.2' })
+        expect(mod.datastore['LHOST']).to eq('192.0.2.2')
+      end
+
+      it 'preserves registered keys when copying alongside deregistered keys' do
+        { 'RHOST' => '192.0.2.1', 'LHOST' => '192.0.2.2' }.each do |k, v|
+          mod.datastore[k] = v
+        end
+
+        expect(mod.datastore['LHOST']).to eq('192.0.2.2')
+      end
+    end
+  end
+
+  describe '#merge!' do
+    context 'when merging a DataStore containing a deregistered key' do
+      it 'does not expose the deregistered key after merge' do
+        source = Msf::DataStore.new
+        source['RHOST'] = '192.0.2.1'
+        source['LHOST'] = '192.0.2.2'
+
+        mod.datastore.merge!(source)
+
+        expect(mod.datastore['RHOST']).to be_nil
+      end
+
+      it 'preserves registered keys from the merged datastore' do
+        source = Msf::DataStore.new
+        source['RHOST'] = '192.0.2.1'
+        source['LHOST'] = '192.0.2.2'
+
+        mod.datastore.merge!(source)
+
+        expect(mod.datastore['LHOST']).to eq('192.0.2.2')
+      end
+    end
+
+    context 'when merging a plain Hash containing a deregistered key' do
+      it 'does not expose the deregistered key after merge' do
+        mod.datastore.merge!('RHOST' => '192.0.2.1', 'LHOST' => '192.0.2.2')
+
+        expect(mod.datastore['RHOST']).to be_nil
+      end
+
+      it 'preserves registered keys from the merged hash' do
+        mod.datastore.merge!('RHOST' => '192.0.2.1', 'LHOST' => '192.0.2.2')
+
+        expect(mod.datastore['LHOST']).to eq('192.0.2.2')
+      end
+    end
+  end
+
+  describe '#reverse_merge!' do
+    context 'when reverse-merging a DataStore containing a deregistered key' do
+      it 'does not expose the deregistered key after reverse_merge!' do
+        source = Msf::DataStore.new
+        source['RHOST'] = '192.0.2.1'
+        source['LHOST'] = '192.0.2.2'
+
+        mod.datastore.reverse_merge!(source)
+
+        expect(mod.datastore['RHOST']).to be_nil
+      end
+
+      it 'preserves registered keys from the reverse-merged datastore' do
+        source = Msf::DataStore.new
+        source['RHOST'] = '192.0.2.1'
+        source['LHOST'] = '192.0.2.2'
+
+        mod.datastore.reverse_merge!(source)
+
+        expect(mod.datastore['LHOST']).to eq('192.0.2.2')
+      end
+    end
+  end
+  
+  describe '#search_for' do
+    context 'when the key has been deregistered' do
+      it 'does not expose a value set in the global framework datastore' do
+        framework_datastore['RHOST'] = '192.0.2.1'
+        expect(mod.datastore['RHOST']).to be_nil
+      end
+    end
+  end
+
+  context 'when no options have been deregistered' do
+    let(:full_mod_class) do
+      Class.new(Msf::Auxiliary) do
+        include Msf::Simple::Auxiliary
+
+        def initialize
+          super(
+            'Name'        => 'Test Module (all options registered)',
+            'Description' => 'Test module with no deregistered options',
+            'Author'      => ['spec'],
+            'License'     => MSF_LICENSE
+          )
+          register_options(
+            [
+              Msf::OptAddress.new('RHOST', [true,  'The remote host', nil]),
+              Msf::OptAddress.new('LHOST', [false, 'The local host',  nil])
+            ]
+          )
+        end
+      end
+    end
+
+    subject(:full_mod) { build_mod_with_framework(full_mod_class, framework) }
+
+    it 'stores and returns all assigned options' do
+      full_mod.datastore['RHOST'] = '192.0.2.1'
+      full_mod.datastore['LHOST'] = '192.0.2.2'
+
+      expect(full_mod.datastore['RHOST']).to eq('192.0.2.1')
+      expect(full_mod.datastore['LHOST']).to eq('192.0.2.2')
+    end
+
+    it 'stores all options passed via _import_extra_options' do
+      full_mod._import_extra_options('Options' => { 'RHOST' => '192.0.2.1', 'LHOST' => '192.0.2.2' })
+
+      expect(full_mod.datastore['RHOST']).to eq('192.0.2.1')
+      expect(full_mod.datastore['LHOST']).to eq('192.0.2.2')
+    end
+
+    it 'stores all registered OptAddress options' do
+      full_mod.options.each do |key, opt|
+        next unless opt.is_a?(Msf::OptAddress)
+
+        full_mod.datastore[key] = '192.0.2.1'
+        expect(full_mod.datastore[key]).to eq('192.0.2.1'),
+          "Expected #{key} to round-trip as '192.0.2.1'"
+      end
+    end
+  end
+
+  context 'when used as a plain DataStore without an associated module' do
+    subject(:ds) { Msf::DataStore.new }
+
+    it 'accepts writes for any key' do
+      ds['FOO']      = 'bar'
+      ds['ANYTHING'] = 'value'
+
+      expect(ds['FOO']).to eq('bar')
+      expect(ds['ANYTHING']).to eq('value')
+    end
+  end
+
+  context 'when a mixin registers options that the including module deregisters (HttpClient scenario)' do
+    let(:parent_mod_class) do
+      Class.new(Msf::Auxiliary) do
+        include Msf::Simple::Auxiliary
+
+        def initialize
+          super(
+            'Name'        => 'Parent HTTP Module',
+            'Description' => 'Registers HttpUsername/HttpPassword',
+            'Author'      => ['spec'],
+            'License'     => MSF_LICENSE
+          )
+          register_options(
+            [
+              Msf::OptString.new('HttpUsername', [false, 'The HTTP username', '']),
+              Msf::OptString.new('HttpPassword', [false, 'The HTTP password', ''])
+            ]
+          )
+        end
+      end
+    end
+
+    let(:child_mod_class) do
+      Class.new(Msf::Auxiliary) do
+        include Msf::Simple::Auxiliary
+
+        def initialize
+          super(
+            'Name'        => 'Child HTTP Module',
+            'Description' => 'Deregisters HttpUsername/HttpPassword',
+            'Author'      => ['spec'],
+            'License'     => MSF_LICENSE
+          )
+          register_options(
+            [
+              Msf::OptString.new('HttpUsername', [false, 'The HTTP username', '']),
+              Msf::OptString.new('HttpPassword', [false, 'The HTTP password', ''])
+            ]
+          )
+          deregister_options('HttpUsername', 'HttpPassword')
+        end
+      end
+    end
+
+    let(:parent_mod) { build_mod_with_framework(parent_mod_class, framework) }
+    let(:child_mod)  { build_mod_with_framework(child_mod_class,  framework) }
+
+    context 'when the parent copies its own options to the child' do
+      before do
+        parent_mod.datastore['HttpUsername'] = 'spencer'
+        parent_mod.datastore['HttpPassword'] = 'Password1!'
+      end
+
+      it 'does not set HttpUsername on the child' do
+        parent_mod.options.each_pair do |name, _opt|
+          next if parent_mod.datastore[name].nil?
+
+          child_mod.datastore[name] = parent_mod.datastore[name]
+        end
+
+        expect(child_mod.datastore['HttpUsername']).to be_blank
+      end
+
+      it 'does not set HttpPassword on the child' do
+        parent_mod.options.each_pair do |name, _opt|
+          next if parent_mod.datastore[name].nil?
+
+          child_mod.datastore[name] = parent_mod.datastore[name]
+        end
+
+        expect(child_mod.datastore['HttpPassword']).to be_blank
+      end
+    end
+
+    context 'when the global framework datastore has values for the deregistered options' do
+      before do
+        framework_datastore['HttpUsername'] = 'global_admin'
+        framework_datastore['HttpPassword'] = 'global_secret'
+      end
+
+      it 'does not expose HttpUsername on the child' do
+        expect(child_mod.datastore['HttpUsername']).to be_blank
+      end
+
+      it 'does not expose HttpPassword on the child' do
+        expect(child_mod.datastore['HttpPassword']).to be_blank
+      end
+    end
+
+    context 'when neither the parent nor the global datastore has set the options' do
+      it 'returns blank for HttpUsername' do
+        expect(child_mod.datastore['HttpUsername']).to be_blank
+      end
+
+      it 'returns blank for HttpPassword' do
+        expect(child_mod.datastore['HttpPassword']).to be_blank
+      end
+    end
+  end
+
+  context 'when share_datastore is used (shell-to-meterpreter upgrade pattern)' do
+    # Simulates the create_multihandler sequence in post/multi/manage/shell_to_meterpreter:
+    #   pay.datastore['LHOST'] = lhost
+    #   pay.datastore['LPORT'] = lport
+    #   mh.share_datastore(pay.datastore)
+    #   mh.datastore['PAYLOAD']   = payload_name
+    #   mh.datastore['EXITFUNC']  = 'thread'
+    #   mh.datastore['WORKSPACE'] = workspace
+    let(:handler_mod_class) do
+      Class.new(Msf::Exploit) do
+        include Msf::Simple::Exploit
+
+        def initialize
+          super(
+            'Name'           => 'Mock Multi Handler',
+            'Description'    => 'Simulates exploit/multi/handler',
+            'Author'         => ['spec'],
+            'License'        => MSF_LICENSE,
+            'DisclosureDate' => '2024-01-01',
+            'Notes'          => { 'Stability' => [], 'Reliability' => [], 'SideEffects' => [] }
+          )
+          register_options(
+            [
+              Msf::OptString.new('PAYLOAD',   [true,  'Payload to use']),
+              Msf::OptString.new('EXITFUNC',  [false, 'Exit technique', 'thread']),
+              Msf::OptString.new('WORKSPACE', [false, 'Workspace']),
+              Msf::OptAddressLocal.new('LHOST', [false, 'Local host']),
+              Msf::OptPort.new('LPORT',         [true,  'Local port', 4444])
+            ]
+          )
+        end
+      end
+    end
+
+    let(:payload_mod_class) do
+      Class.new(Msf::Auxiliary) do
+        def initialize
+          super(
+            'Name'        => 'Mock Payload',
+            'Description' => 'Simulates a payload module datastore',
+            'Author'      => ['spec'],
+            'License'     => MSF_LICENSE
+          )
+          register_options(
+            [
+              Msf::OptAddressLocal.new('LHOST', [false, 'Local host']),
+              Msf::OptPort.new('LPORT',         [true,  'Local port', 4444])
+            ]
+          )
+        end
+      end
+    end
+
+    let(:handler_mod) { build_mod_with_framework(handler_mod_class, framework) }
+    let(:payload_mod) { build_mod_with_framework(payload_mod_class, framework) }
+
+    before do
+      payload_mod.datastore['LHOST'] = '192.0.2.1'
+      payload_mod.datastore['LPORT'] = 4433
+
+      handler_mod.share_datastore(payload_mod.datastore)
+
+      handler_mod.datastore['PAYLOAD']   = 'windows/x64/meterpreter/reverse_tcp'
+      handler_mod.datastore['EXITFUNC']  = 'thread'
+      handler_mod.datastore['WORKSPACE'] = 'default'
+    end
+
+    it 'preserves LHOST' do
+      expect(handler_mod.datastore['LHOST']).to eq('192.0.2.1')
+    end
+
+    it 'preserves LPORT' do
+      expect(handler_mod.datastore['LPORT']).to eq(4433)
+    end
+
+    it 'preserves PAYLOAD' do
+      expect(handler_mod.datastore['PAYLOAD']).to eq('windows/x64/meterpreter/reverse_tcp')
+    end
+
+    it 'preserves EXITFUNC' do
+      expect(handler_mod.datastore['EXITFUNC']).to eq('thread')
+    end
+
+    it 'preserves WORKSPACE' do
+      expect(handler_mod.datastore['WORKSPACE']).to eq('default')
+    end
+  end
+
+  context 'when an option is deregistered and then re-registered with a new definition' do
+    # This pattern is used by payload adapters such as cmd/windows/https/x86 and
+    # cmd/windows/https/x64
+    let(:mod_class) do
+      Class.new(Msf::Auxiliary) do
+        include Msf::Simple::Auxiliary
+
+        def initialize
+          super(
+            'Name'        => 'Test Module (deregister then re-register)',
+            'Description' => 'Verifies that re-registering a deregistered option restores normal write behaviour',
+            'Author'      => ['spec'],
+            'License'     => MSF_LICENSE
+          )
+          register_options(
+            [
+              Msf::OptEnum.new('FETCH_COMMAND', [true, 'Fetch command', 'CERTUTIL', %w[CURL TFTP CERTUTIL]])
+            ]
+          )
+          deregister_options('FETCH_COMMAND')
+          register_options(
+            [
+              Msf::OptEnum.new('FETCH_COMMAND', [true, 'Fetch command', 'CURL', %w[CURL]])
+            ]
+          )
+        end
+      end
+    end
+
+    subject(:mod) { build_mod_with_framework(mod_class, framework) }
+
+    it 'returns the new default for the re-registered option' do
+      expect(mod.datastore['FETCH_COMMAND']).to eq('CURL')
+    end
+
+    it 'accepts writes to the re-registered option' do
+      mod.datastore['FETCH_COMMAND'] = 'CURL'
+      expect(mod.datastore['FETCH_COMMAND']).to eq('CURL')
+    end
+
+    it 'does not accept the old deregistered default' do
+      expect(mod.datastore['FETCH_COMMAND']).not_to eq('CERTUTIL')
+    end
+  end
+end

--- a/spec/lib/msf/core/module_data_store_filter_spec.rb
+++ b/spec/lib/msf/core/module_data_store_filter_spec.rb
@@ -362,4 +362,44 @@ RSpec.describe Msf::ModuleDataStore do
       expect(mod.datastore['FETCH_COMMAND']).not_to eq('CERTUTIL')
     end
   end
+
+  context 'when a deregistered key is re-introduced as an alias on a new option' do
+    let(:mod_class) do
+      Class.new(Msf::Auxiliary) do
+        include Msf::Simple::Auxiliary
+
+        def initialize
+          super(
+            'Name'        => 'Test Module (alias re-registration)',
+            'Description' => 'Deregisters SMBUser, re-introduces it as an alias',
+            'Author'      => ['spec'],
+            'License'     => MSF_LICENSE
+          )
+          register_options(
+            [
+              Msf::OptString.new('SMBUser', [false, 'SMB username', ''])
+            ]
+          )
+          deregister_options('SMBUser')
+          register_options(
+            [
+              Msf::OptString.new('TARGET_USERNAME', [true, 'Target username'], aliases: ['SMBUser'])
+            ]
+          )
+        end
+      end
+    end
+
+    subject(:mod) { build_mod_with_framework(mod_class, framework) }
+
+    it 'preserves TARGET_USERNAME when merged in' do
+      mod.datastore.merge!('TARGET_USERNAME' => 'esc_user_2')
+      expect(mod.datastore['TARGET_USERNAME']).to eq('esc_user_2')
+    end
+
+    it 'preserves TARGET_USERNAME when accessed via its SMBUser alias' do
+      mod.datastore.merge!('TARGET_USERNAME' => 'esc_user_2')
+      expect(mod.datastore['SMBUser']).to eq('esc_user_2')
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses https://github.com/rapid7/metasploit-framework/issues/21319.

The goal here was to address:
> When a module deregisters an option, the validation process should ensure that it is not present when the module runs. It datastore['DEREGISTERED_OPTION'] should probably be nil but at the very least it should be #blank?.
> Allowing the caller to pass datastore options that the module explicitly deregistered can break the module authors assumption of how library methods will behave.


This [comment](https://github.com/rapid7/metasploit-framework/issues/21313#issuecomment-4261869346) calls out some example modules that replicates the issue (thanks for writing those up @zeroSteiner, they were super helpful).

## Before
<img width="2198" height="1716" alt="image" src="https://github.com/user-attachments/assets/6b1b9781-b41a-49f3-a493-d6102e8fe453" />

## After
<img width="2198" height="1716" alt="image" src="https://github.com/user-attachments/assets/5869a696-fff2-4c61-9f57-effffecf46cd" />

## Shell to Meterpreter
Tested this locally and still works with the new changes:
```
msf payload(python/shell_reverse_tcp) > sessions

Active sessions
===============

  Id  Name  Type                 Information  Connection
  --  ----  ----                 -----------  ----------
  1         shell python/python               xxx.xxx.xxx.xxx:4444 -> xxx.xxx.xxx.xxx:57164 (xxx.xxx.xxx.xxx)

msf payload(python/shell_reverse_tcp) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session(s): [1]
[!] SESSION may not be compatible with this module:
[!]  * incompatible session platform: python. This module works with: Linux, OSX, Unix, Solaris, BSD, Windows.
[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on xxx.xxx.xxx.xxx:4433
[*] Sending stage (23408 bytes) to xxx.xxx.xxx.xxx
[*] Meterpreter session 2 opened (xxx.xxx.xxx.xxx:4433 -> xxx.xxx.xxx.xxx:57176) at 2026-06-08 10:15:06 +0100

msf payload(python/shell_reverse_tcp) >
msf payload(python/shell_reverse_tcp) > sessions

Active sessions
===============

  Id  Name  Type                      Information  Connection
  --  ----  ----                      -----------  ----------
  1         shell python/python                    xxx.xxx.xxx.xxx:4444 -> xxx.xxx.xxx.xxx:57164 (xxx.xxx.xxx.xxx)
  2         meterpreter python/linux  kali @ kali  xxx.xxx.xxx.xxx:4433 -> xxx.xxx.xxx.xxx:57176 (xxx.xxx.xxx.xxx)

msf payload(python/shell_reverse_tcp) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > ls
Listing: /home/kali/Desktop
===========================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100755/rwxr-xr-x  416   fil   2026-06-08 10:13:44 +0100  python_payload.py

meterpreter > pwd
/home/kali/Desktop
meterpreter >
```

## Shell to Meterpreter with override options
```
msf post(multi/manage/shell_to_meterpreter) > run session=-1 payload_override=python/meterpreter/reverse_tcp platform_override=python lhost=xxx.xxx.xxx.xxx
[!] SESSION may not be compatible with this module:
[!]  * incompatible session platform: python. This module works with: Linux, OSX, Unix, Solaris, BSD, Windows.
[*] Upgrading session ID: -1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on xxx.xxx.xxx.xxx:4433
[*] Sending stage (23408 bytes) to xxx.xxx.xxx.xxx
[*] Meterpreter session 2 opened (xxx.xxx.xxx.xxx:4433 -> xxx.xxx.xxx.xxx:51960) at 2026-06-15 10:44:16 +0100
[*] Post module execution completed
msf post(multi/manage/shell_to_meterpreter) > sessions

Active sessions
===============

  Id  Name  Type                      Information  Connection
  --  ----  ----                      -----------  ----------
  1         shell python/python                    xxx.xxx.xxx.xxx:4444 -> xxx.xxx.xxx.xxx:51918 (xxx.xxx.xxx.xxx)
  2         meterpreter python/linux  kali @ kali  xxx.xxx.xxx.xxx:4433 -> xxx.xxx.xxx.xxx:51960 (xxx.xxx.xxx.xxx)

msf payload(python/shell_reverse_tcp) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > ls
Listing: /home/kali/Desktop
===========================

Mode              Size  Type  Last modified              Name
----              ----  ----  -------------              ----
100755/rwxr-xr-x  416   fil   2026-06-08 10:13:44 +0100  python_payload.py

meterpreter > pwd
/home/kali/Desktop
meterpreter > exit
```

## Notes
Specs were added so we if the implementation is changed in the future we will know if options start leaking back in. I also added a spec to cover the shell to Meterpreter workflows. 

# TODO LIST

- [ ] Run Pros test suite and fix any issues

## Verification

- [ ] Manually test the shell to Meterpreter workflows
- [ ] Pro test suite goes green
- [ ] Test modules work as expected
- [ ] Code changes are sane 