### PR TITLE
Spike Windows version checks in exploit targets and payloads

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -492,13 +492,22 @@ class ReadableText
   def self.dump_payload_module(mod, indent = '')
     # General
     output  = "\n"
-    output << "       Name: #{mod.name}\n"
-    output << "     Module: #{mod.fullname}\n"
-    output << "   Platform: #{mod.platform_to_s}\n"
-    output << "       Arch: #{mod.arch_to_s}\n"
-    output << "Needs Admin: " + (mod.privileged? ? "Yes" : "No") + "\n"
-    output << " Total size: #{mod.size}\n"
-    output << "       Rank: #{mod.rank_to_s.capitalize}\n"
+    output << "             Name: #{mod.name}\n"
+    output << "           Module: #{mod.fullname}\n"
+    output << "         Platform: #{mod.platform_to_s}\n"
+    output << "             Arch: #{mod.arch_to_s}\n"
+    output << "      Needs Admin: " + (mod.privileged? ? "Yes" : "No") + "\n"
+    output << "       Total size: #{mod.size}\n"
+    output << "             Rank: #{mod.rank_to_s.capitalize}\n"
+
+    required_versions = mod.supported_versions
+    if required_versions && required_versions.any?
+      output << "Supported Versions:\n"
+      required_versions.each do |runtime, ranges|
+        ranges_desc = ranges.map { |r| r.max ? "#{r.min}..#{r.max}" : "#{r.min}+" }.join(', ')
+        output << "  #{runtime}: #{ranges_desc}\n"
+      end
+    end
     output << "\n"
 
     # Authors

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -58,6 +58,7 @@ module Msf
     include Msf::Module::Ranking
     include Msf::Module::Type
     include Msf::Module::UI
+    include Msf::Module::VersionCompatibility
     include Msf::Module::UUID
     include Msf::Module::SideEffects
     include Msf::Module::Stability

--- a/lib/msf/core/module/module_info.rb
+++ b/lib/msf/core/module/module_info.rb
@@ -42,6 +42,15 @@ module Msf::Module::ModuleInfo
     module_info['Name']
   end
 
+  #
+  # Return the module's supported software runtime versions.
+  # For example:
+  # - Windows -> XP_SP1
+  # - Python -> 3.4
+  #
+  def supported_versions
+    module_info['SupportedVersions']
+  end
 
   #
   # Return the module's notes (including AKA and NOCVE descriptors).

--- a/lib/msf/core/module/runtime_version_inference.rb
+++ b/lib/msf/core/module/runtime_version_inference.rb
@@ -1,0 +1,86 @@
+# -*- coding: binary -*-
+
+#
+# Infers runtime version metadata (the 'RuntimeVersions' target option) from a
+# human-readable exploit target name.
+#
+# The 'RuntimeVersions' hash is keyed by runtime name (e.g. 'Windows',
+# 'Python') and consumed by Msf::Module::VersionCompatibility to warn when a
+# payload's minimum supported version is newer than the version a target
+# provides.
+#
+# Only Windows inference is implemented today, but the registry below is the
+# single extension point: supporting a new runtime (macOS, Linux, ...) is a
+# matter of adding one Inferrer that knows its runtime key, which platforms it
+# applies to, and how to turn a target name into a Rex::Version.
+#
+module Msf::Module::RuntimeVersionInference
+  #
+  # Describes how to infer a single runtime's version from a target name.
+  #
+  # @!attribute runtime
+  #   @return [String] The 'RuntimeVersions' hash key this inferrer populates.
+  # @!attribute platform_pattern
+  #   @return [Regexp, nil] Matched against a target's declared platform names.
+  #     When it matches none of them the inferrer is skipped; nil means the
+  #     inferrer is not platform gated.
+  # @!attribute resolver
+  #   @return [#call] A callable taking the target name and returning a
+  #     Rex::Version or nil.
+  #
+  Inferrer = Struct.new(:runtime, :platform_pattern, :resolver) do
+    # Resolve the runtime version for the supplied target name.
+    #
+    # @param name [String] The exploit target name.
+    # @return [Rex::Version, nil]
+    def infer(name)
+      resolver.call(name)
+    end
+
+    # Whether this inferrer applies to a target declaring the given platform
+    # names. When the target declares no platform we fall back to name-based
+    # inference (return true), and an inferrer with no platform_pattern is
+    # always considered applicable.
+    #
+    # @param platform_names [Array<String>, nil] Lower-cased platform names.
+    # @return [Boolean]
+    def applicable_to_platforms?(platform_names)
+      return true if platform_names.nil? || platform_names.empty?
+      return true if platform_pattern.nil?
+
+      platform_names.any? { |platform_name| platform_pattern.match?(platform_name) }
+    end
+  end
+
+  # The ordered list of registered inferrers. Add new runtimes here.
+  INFERRERS = [
+    Inferrer.new('Windows', /win/i, ->(name) { Msf::WindowsVersion.from_target_name(name) })
+  ].freeze
+
+  module_function
+
+  # Infer runtime versions for a target name.
+  #
+  # @param name [String] The exploit target name.
+  # @param existing [Hash] Runtime versions already set (e.g. manually in module
+  #   metadata). Runtimes present here are never overwritten.
+  # @param platform_names [Array<String>, nil] The target's declared platform
+  #   names (lower-cased), used to skip inferrers for other platforms. Nil when
+  #   the target declares no platform.
+  # @return [Hash] A hash of runtime name => Rex::Version for the runtimes that
+  #   could be inferred. Empty when nothing could be inferred.
+  def infer(name, existing: {}, platform_names: nil)
+    inferred = {}
+
+    INFERRERS.each do |inferrer|
+      # Respect any explicitly supplied version for this runtime.
+      next if existing.key?(inferrer.runtime)
+      next unless inferrer.applicable_to_platforms?(platform_names)
+
+      version = inferrer.infer(name)
+      inferred[inferrer.runtime] = version unless version.nil?
+    end
+
+    inferred
+  end
+end

--- a/lib/msf/core/module/target.rb
+++ b/lib/msf/core/module/target.rb
@@ -153,6 +153,8 @@ class Msf::Module::Target
     if opts['Bruteforce']
       self.bruteforce = Bruteforce.new(opts['Bruteforce'])
     end
+
+    infer_runtime_versions
   end
 
   #
@@ -168,6 +170,17 @@ class Msf::Module::Target
   #
   def bruteforce?
     return (bruteforce != nil)
+  end
+
+  #
+  # Returns the runtime version requirements for this target, if any. This is
+  # the metadata consulted when checking whether a payload is compatible with
+  # the target (see Msf::Module::VersionCompatibility). It may be supplied
+  # explicitly via the target's 'RuntimeVersions' option, or inferred from the
+  # target name on creation.
+  #
+  def runtime_versions
+    opts['RuntimeVersions']
   end
 
   ##
@@ -324,6 +337,43 @@ class Msf::Module::Target
   attr_reader :default_options
 
 protected
+
+  #
+  # Attempt to automatically tag this target with runtime version metadata
+  # derived from its name (e.g. a target named "Windows 7 SP1" is tagged with
+  # 'RuntimeVersions' => { 'Windows' => Win7_SP1 }).
+  #
+  # This complements manual tagging: versions supplied explicitly in the
+  # target's 'RuntimeVersions' option are always preserved. Inference is
+  # delegated to Msf::Module::RuntimeVersionInference, which is the extension
+  # point for supporting additional runtimes (macOS, Linux, ...) in future.
+  # Generic or ambiguous names are left untagged.
+  #
+  def infer_runtime_versions
+    existing = opts['RuntimeVersions']
+    existing = {} unless existing.is_a?(Hash)
+
+    inferred = Msf::Module::RuntimeVersionInference.infer(
+      name,
+      existing: existing,
+      platform_names: declared_platform_names
+    )
+    return if inferred.empty?
+
+    self.opts = opts.merge('RuntimeVersions' => existing.merge(inferred))
+  end
+
+  #
+  # The lower-cased platform names declared directly on this target, or nil when
+  # the target declares no platform (in which case runtime inference falls back
+  # to the target name alone).
+  #
+  def declared_platform_names
+    platform_opt = opts['Platform']
+    return nil if platform_opt.nil?
+
+    Array(platform_opt).map { |entry| entry.to_s.downcase }
+  end
 
   attr_writer :name, :platform, :arch, :opts, :ret, :save_registers # :nodoc:
   attr_writer :bruteforce # :nodoc:

--- a/lib/msf/core/module/version_compatibility.rb
+++ b/lib/msf/core/module/version_compatibility.rb
@@ -17,7 +17,7 @@ module Msf::Module::VersionCompatibility
   def version_compatibility_warnings(payload_instance)
     warnings = []
 
-    target_versions = current_target_runtime_versions
+    target_versions = current_target_platform_versions
     return warnings unless target_versions.is_a?(Hash) && !target_versions.empty?
 
     supported = payload_instance.supported_versions
@@ -36,7 +36,7 @@ module Msf::Module::VersionCompatibility
       lowest_min = ranges.map(&:min).min
       required_name = human_readable_version_string(runtime, lowest_min)
       target_name = human_readable_version_string(runtime, target_ver)
-      warnings << "Payload requires #{runtime} version within a supported range (minimum #{required_name}), but the target provides #{target_name}"
+      warnings << "Payload requires #{platform_display_name(runtime)} version within a supported range (minimum #{required_name}), but the target provides #{target_name}"
     end
 
     warnings
@@ -52,20 +52,32 @@ module Msf::Module::VersionCompatibility
     value.is_a?(Rex::Version) ? value : Rex::Version.new(value.to_s)
   end
 
-  # Map a runtime (Windows, Python etc.) and a version to a human-readable string.
-  # For example 'Windows', '5.1.2600.2' would get mapped to 'Windows XP Service Pack 2 (5.1.2600.2)'
+  # Map a runtime (win, python etc.) and a version to a human-readable string.
+  # For example 'win', '5.1.2600.2' would get mapped to 'Windows XP Service Pack 2 (5.1.2600.2)'
   #
-  # @param runtime [String] The runtime key (e.g., 'Windows', 'Python').
+  # @param runtime [String] The runtime key (e.g., 'win', 'python').
   # @param version [Rex::Version] The version to look up.
   # @return [String] A human-readable string
   def human_readable_version_string(runtime, version)
     case runtime
-    when 'Windows'
+    when 'win'
       name = windows_version_name(version)
       return "#{name} (#{version})" if name
     end
 
-    "#{runtime} (#{version})"
+    "#{platform_display_name(runtime)} (#{version})"
+  end
+
+  # Map a platform key (matching the module Platform hash values) to a human-readable name.
+  # For example 'win' => 'Windows', 'python' => 'Python'. Falls back to the raw key when the
+  # platform is not recognized.
+  #
+  # @param runtime [String] The platform key (e.g., 'win', 'python').
+  # @return [String] A human-readable platform name.
+  def platform_display_name(runtime)
+    Msf::Module::Platform.find_platform(runtime).realname
+  rescue ArgumentError
+    runtime
   end
 
   # Look up a Windows version's human-readable name from the WindowsVersion mappings.
@@ -88,11 +100,11 @@ module Msf::Module::VersionCompatibility
   # Get the lowest runtime version requirements from an array of targets.
   #
   # @param targets [Array<Msf::Target>] The array of targets to query over.
-  # @return [Hash] The RuntimeVersions hash from the targets array.
-  def lowest_runtime_versions_from_targets(targets)
+  # @return [Hash] The PlatformVersions hash from the targets array.
+  def lowest_platform_versions_from_targets(targets)
     lowest_versions = {}
     targets.each do |t|
-      versions = t.opts['RuntimeVersions']
+      versions = t.opts['PlatformVersions']
       next unless versions.is_a?(Hash)
 
       versions.each do |runtime, version|
@@ -106,15 +118,15 @@ module Msf::Module::VersionCompatibility
     lowest_versions
   end
 
-  # Retrieve RuntimeVersions from the currently selected target.
+  # Retrieve PlatformVersions from the currently selected target.
   # When the Automatic target is selected, the lowest supported version of each defined
-  # runtime (Windows, Python, etc.) is returned instead.
+  # runtime (win, python, etc.) is returned instead.
   #
-  # @return [Hash, nil] The RuntimeVersions hash from the active target, or nil.
-  def current_target_runtime_versions
+  # @return [Hash, nil] The PlatformVersions hash from the active target, or nil.
+  def current_target_platform_versions
     return nil unless respond_to?(:target) && target
 
-    target_versions = target.opts['RuntimeVersions']
+    target_versions = target.opts['PlatformVersions']
     if target_versions.is_a?(Hash) && !target_versions.empty?
       return target_versions
     end
@@ -124,7 +136,7 @@ module Msf::Module::VersionCompatibility
 
     return nil unless respond_to?(:targets) && targets.is_a?(Array)
 
-    lowest_versions = lowest_runtime_versions_from_targets(targets)
+    lowest_versions = lowest_platform_versions_from_targets(targets)
     lowest_versions.any? ? lowest_versions : nil
   end
 end

--- a/lib/msf/core/module/version_compatibility.rb
+++ b/lib/msf/core/module/version_compatibility.rb
@@ -1,0 +1,130 @@
+# -*- coding: binary -*-
+
+require 'rex/version'
+
+#
+# Provides version compatibility checks between exploit targets and payloads.
+#
+module Msf::Module::VersionCompatibility
+  # Check version compatibility between a payload and the current exploit target.
+  #
+  # A payload declares its supported versions as a Hash of runtime name to an Array of
+  # VersionRange objects (SupportedVersions). A target version is considered compatible
+  # when it falls within at least one of the declared ranges for that runtime.
+  #
+  # @param payload_instance [Msf::Payload] A payload module instance.
+  # @return [Array<String>] An array of warning strings. Empty means the payload is compatible.
+  def version_compatibility_warnings(payload_instance)
+    warnings = []
+
+    target_versions = current_target_runtime_versions
+    return warnings unless target_versions.is_a?(Hash) && !target_versions.empty?
+
+    supported = payload_instance.supported_versions
+    return warnings unless supported.is_a?(Hash) && !supported.empty?
+
+    supported.each do |runtime, ranges|
+      next unless target_versions.key?(runtime)
+      next unless ranges.is_a?(Array) && !ranges.empty?
+
+      target_ver = to_version(target_versions[runtime])
+
+      # The target is compatible if it falls within any of the declared ranges.
+      next if ranges.any? { |range| range.contains?(target_ver) }
+
+      # No range matched - build a helpful warning using the lowest minimum across all ranges.
+      lowest_min = ranges.map(&:min).min
+      required_name = human_readable_version_string(runtime, lowest_min)
+      target_name = human_readable_version_string(runtime, target_ver)
+      warnings << "Payload requires #{runtime} version within a supported range (minimum #{required_name}), but the target provides #{target_name}"
+    end
+
+    warnings
+  end
+
+  private
+
+  # Normalize a value to Rex::Version
+  #
+  # @param value [String, Rex::Version] The version to normalize.
+  # @return [Rex::Version]
+  def to_version(value)
+    value.is_a?(Rex::Version) ? value : Rex::Version.new(value.to_s)
+  end
+
+  # Map a runtime (Windows, Python etc.) and a version to a human-readable string.
+  # For example 'Windows', '5.1.2600.2' would get mapped to 'Windows XP Service Pack 2 (5.1.2600.2)'
+  #
+  # @param runtime [String] The runtime key (e.g., 'Windows', 'Python').
+  # @param version [Rex::Version] The version to look up.
+  # @return [String] A human-readable string
+  def human_readable_version_string(runtime, version)
+    case runtime
+    when 'Windows'
+      name = windows_version_name(version)
+      return "#{name} (#{version})" if name
+    end
+
+    "#{runtime} (#{version})"
+  end
+
+  # Look up a Windows version's human-readable name from the WindowsVersion mappings.
+  #
+  # @param version [Rex::Version] The version to look up.
+  # @return [String, nil] The friendly name, or nil if not found.
+  def windows_version_name(version)
+    [
+      { klass: Msf::WindowsVersion::WorkstationSpecificVersions, mapping: Msf::WindowsVersion::WorkstationNameMapping },
+      { klass: Msf::WindowsVersion::ServerSpecificVersions, mapping: Msf::WindowsVersion::ServerNameMapping }
+    ].each do |h|
+      h[:klass].constants.each do |const|
+        return h[:mapping][const] if h[:klass].const_get(const) == version
+      end
+    end
+
+    nil
+  end
+
+  # Get the lowest runtime version requirements from an array of targets.
+  #
+  # @param targets [Array<Msf::Target>] The array of targets to query over.
+  # @return [Hash] The RuntimeVersions hash from the targets array.
+  def lowest_runtime_versions_from_targets(targets)
+    lowest_versions = {}
+    targets.each do |t|
+      versions = t.opts['RuntimeVersions']
+      next unless versions.is_a?(Hash)
+
+      versions.each do |runtime, version|
+        ver = to_version(version)
+        if lowest_versions[runtime].nil? || ver < lowest_versions[runtime]
+          lowest_versions[runtime] = ver
+        end
+      end
+    end
+
+    lowest_versions
+  end
+
+  # Retrieve RuntimeVersions from the currently selected target.
+  # When the Automatic target is selected, the lowest supported version of each defined
+  # runtime (Windows, Python, etc.) is returned instead.
+  #
+  # @return [Hash, nil] The RuntimeVersions hash from the active target, or nil.
+  def current_target_runtime_versions
+    return nil unless respond_to?(:target) && target
+
+    target_versions = target.opts['RuntimeVersions']
+    if target_versions.is_a?(Hash) && !target_versions.empty?
+      return target_versions
+    end
+
+    is_auto_target = target.opts['auto']
+    return nil unless is_auto_target
+
+    return nil unless respond_to?(:targets) && targets.is_a?(Array)
+
+    lowest_versions = lowest_runtime_versions_from_targets(targets)
+    lowest_versions.any? ? lowest_versions : nil
+  end
+end

--- a/lib/msf/core/module/version_range.rb
+++ b/lib/msf/core/module/version_range.rb
@@ -1,0 +1,90 @@
+# -*- coding: binary -*-
+
+require 'rex/version'
+
+#
+# Provides a wrapper around a minimum and maximum version range.
+# Both minimum and maximum are optional:
+# - When no maximum is set, all versions >= min are considered within range.
+# - When no minimum is set, all versions <= max are considered within range.
+# - At least one of min or max must be provided.
+#
+class Msf::Module::VersionRange
+
+  def initialize(min: nil, max: nil)
+    raise "Improper argument(s) supplied to #{self.class}" if min.nil? && max.nil?
+    raise "Improper argument(s) supplied to #{self.class}" unless min.nil? || valid_version_value?(min)
+    raise "Improper argument(s) supplied to #{self.class}" unless max.nil? || valid_version_value?(max)
+
+    self.min = min.nil? ? nil : to_version(min)
+    self.max = max.nil? ? nil : to_version(max)
+  end
+
+  # Check whether a value is acceptable as a version argument.
+  # Rex::Version is quite funky:
+  #   Rex::Version.new(nil).to_s -> "0"
+  #   Rex::Version.new('nil') raises ArgumentError
+  # So we must guard against nil and non-numeric strings before creating Rex::Version.
+  #
+  # @param value [String, Integer, Rex::Version, nil] The value to check.
+  # @return [Boolean]
+  def self.valid_version_value?(value)
+    return false if value.nil?
+    return true if value.is_a?(Rex::Version)
+    return true if value.is_a?(Integer)
+
+    return false unless value.is_a?(String)
+    return false if value.empty?
+
+    begin
+      Rex::Version.new(value)
+      true
+    rescue ArgumentError
+      false
+    end
+  end
+
+  # Does this version range contain the specified version?
+  # A version is contained if it is >= min and, if a max is defined, <= max.
+  #
+  # @param version [String, Integer, Rex::Version] The version to check.
+  # @return [Boolean, nil] true/false, or nil if the version value is invalid.
+  def contains?(version)
+    return nil unless valid_version_value?(version)
+
+    ver = to_version(version)
+
+    # If we don't have a minimum version defined, all versions <= max are affected.
+    return ver <= max if min.nil?
+
+    # If we don't have a maximum version defined, all versions >= min are OK.
+    return ver >= min if max.nil?
+
+    ver.between?(min, max)
+  end
+
+  # Normalize a value to Rex::Version.
+  #
+  # @param value [String, Integer, Rex::Version] The version to normalize.
+  # @return [Rex::Version]
+  def self.to_version(value)
+    value.is_a?(Rex::Version) ? value : Rex::Version.new(value.to_s)
+  end
+
+  # @return [Rex::Version, nil] The minimum version (inclusive), or nil for unbounded.
+  attr_accessor :min
+
+  # @return [Rex::Version, nil] The maximum version (inclusive), or nil for unbounded.
+  attr_accessor :max
+
+  private
+
+  def to_version(value)
+    self.class.to_version(value)
+  end
+
+  def valid_version_value?(value)
+    self.class.valid_version_value?(value)
+  end
+
+end

--- a/lib/msf/core/module/version_range.rb
+++ b/lib/msf/core/module/version_range.rb
@@ -1,0 +1,84 @@
+# -*- coding: binary -*-
+
+require 'rex/version'
+
+#
+# Provides a wrapper around a minimum and maximum version range.
+# A range has a required minimum version and an optional maximum version.
+# When no maximum is set, all versions >= min are considered within range.
+#
+class Msf::Module::VersionRange
+
+  def initialize(min: nil, max: nil)
+    raise "Improper argument(s) supplied to #{self.class}" unless valid_version_value?(min)
+    raise "Improper argument(s) supplied to #{self.class}" unless max.nil? || valid_version_value?(max)
+
+    self.min = to_version(min)
+    self.max = max.nil? ? nil : to_version(max)
+  end
+
+  # Check whether a value is acceptable as a version argument.
+  # Rex::Version is quite funky:
+  #   Rex::Version.new(nil).to_s -> "0"
+  #   Rex::Version.new('nil') raises ArgumentError
+  # So we must guard against nil and non-numeric strings before creating Rex::Version.
+  #
+  # @param value [String, Integer, Rex::Version, nil] The value to check.
+  # @return [Boolean]
+  def self.valid_version_value?(value)
+    return false if value.nil?
+    return true if value.is_a?(Rex::Version)
+    return true if value.is_a?(Integer)
+
+    return false unless value.is_a?(String)
+    return false if value.empty?
+
+    begin
+      Rex::Version.new(value)
+      true
+    rescue ArgumentError
+      false
+    end
+  end
+
+  # Does this version range contain the specified version?
+  # A version is contained if it is >= min and, if a max is defined, <= max.
+  #
+  # @param version [String, Integer, Rex::Version] The version to check.
+  # @return [Boolean, nil] true/false, or nil if the version value is invalid.
+  def contains?(version)
+    return nil unless valid_version_value?(version)
+
+    ver = to_version(version)
+
+    # If we don't have a maximum version defined, all versions >= min are OK.
+    return ver >= min if max.nil?
+
+    ver.between?(min, max)
+  end
+
+  # Normalize a value to Rex::Version.
+  #
+  # @param value [String, Integer, Rex::Version] The version to normalize.
+  # @return [Rex::Version]
+  def self.to_version(value)
+    value.is_a?(Rex::Version) ? value : Rex::Version.new(value.to_s)
+  end
+
+  # @return [Rex::Version] The minimum version (inclusive).
+  attr_accessor :min
+
+  # @return [Rex::Version, nil] The maximum version (inclusive), or nil for unbounded.
+  attr_accessor :max
+
+  private
+
+  def to_version(value)
+    self.class.to_version(value)
+  end
+
+  def valid_version_value?(value)
+    self.class.valid_version_value?(value)
+  end
+
+end

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -530,6 +530,13 @@ class Payload < Msf::Module
 
       next unless payload
 
+      # Skip payloads that don't meet the target's version requirements
+      payload_instance = mod.framework.payloads.create(payload)
+      if payload_instance
+        warnings = mod.version_compatibility_warnings(payload_instance)
+        next unless warnings.empty?
+      end
+
       return configure_payload.call(payload)
     end
 

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 
+require 'msf/core/payload/python/meterpreter_version'
 
 module Msf
 
@@ -25,7 +26,13 @@ module Payload::Python::MeterpreterLoader
       'Author'        => [ 'Spencer McIntyre' ],
       'Platform'      => 'python',
       'Arch'          => ARCH_PYTHON,
-      'Stager'        => {'Payload' => ""}
+      'Stager'        => {'Payload' => ""},
+      'SupportedVersions' => {
+        'Python' => [
+          Module::VersionRange.new(min: Msf::Payload::Python::MeterpreterVersion::MINIMUM_VERSION, max: '2.7'),
+          Module::VersionRange.new(min: '3.1')
+        ]
+      }
     ))
 
     register_advanced_options(

--- a/lib/msf/core/payload/python/meterpreter_loader.rb
+++ b/lib/msf/core/payload/python/meterpreter_loader.rb
@@ -28,7 +28,7 @@ module Payload::Python::MeterpreterLoader
       'Arch'          => ARCH_PYTHON,
       'Stager'        => {'Payload' => ""},
       'SupportedVersions' => {
-        'Python' => [
+        'python' => [
           Module::VersionRange.new(min: Msf::Payload::Python::MeterpreterVersion::MINIMUM_VERSION, max: '2.7'),
           Module::VersionRange.new(min: '3.1')
         ]

--- a/lib/msf/core/payload/python/meterpreter_version.rb
+++ b/lib/msf/core/payload/python/meterpreter_version.rb
@@ -1,0 +1,10 @@
+# -*- coding: binary -*-
+
+module Msf
+
+module Payload::Python::MeterpreterVersion
+  # The minimum version of Python that is able to run Meterpreter payloads. Versions below this are not supported.
+  MINIMUM_VERSION = '2.5'
+end
+
+end

--- a/lib/msf/core/payload/windows.rb
+++ b/lib/msf/core/payload/windows.rb
@@ -10,6 +10,7 @@
 ###
 module Msf::Payload::Windows
 
+  require 'msf/core/payload/windows/meterpreter_version'
 
   # Provides the #prepends method
   # XXX: For some unfathomable reason, the order of requires here is

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 
-
 module Msf
 
 ###
@@ -26,7 +25,12 @@ module Payload::Windows::MeterpreterLoader
       'Platform'      => 'win',
       'Arch'          => ARCH_X86,
       'PayloadCompat' => { 'Convention' => 'sockedi handleedi -https', },
-      'Stage'         => { 'Payload'   => "" }
+      'Stage'         => { 'Payload'   => "" },
+      'SupportedVersions' => {
+        'Windows' => [
+          Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
+        ]
+      }
       ))
   end
 

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -27,7 +27,7 @@ module Payload::Windows::MeterpreterLoader
       'PayloadCompat' => { 'Convention' => 'sockedi handleedi -https', },
       'Stage'         => { 'Payload'   => "" },
       'SupportedVersions' => {
-        'Windows' => [
+        'win' => [
           Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
         ]
       }

--- a/lib/msf/core/payload/windows/meterpreter_loader.rb
+++ b/lib/msf/core/payload/windows/meterpreter_loader.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 
-
 module Msf
 
 ###
@@ -27,7 +26,12 @@ module Payload::Windows::MeterpreterLoader
       'Platform'      => 'win',
       'Arch'          => ARCH_X86,
       'PayloadCompat' => { 'Convention' => 'sockedi handleedi -https', },
-      'Stage'         => { 'Payload'   => "" }
+      'Stage'         => { 'Payload'   => "" },
+      'SupportedVersions' => {
+        'Windows' => [
+          Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
+        ]
+      }
       ))
   end
 

--- a/lib/msf/core/payload/windows/meterpreter_version.rb
+++ b/lib/msf/core/payload/windows/meterpreter_version.rb
@@ -1,0 +1,10 @@
+# -*- coding: binary -*-
+
+module Msf
+
+module Payload::Windows::MeterpreterVersion
+  # The minimum version of Windows that is able to run Meterpreter payloads. Versions below this are not supported.
+  MINIMUM_VERSION = Msf::WindowsVersion::XP_SP2
+end
+
+end

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 
-
 module Msf
 
 ###
@@ -27,7 +26,12 @@ module Payload::Windows::MeterpreterLoader_x64
       'Platform'      => 'win',
       'Arch'          => ARCH_X64,
       'PayloadCompat' => { 'Convention' => 'sockrdi handlerdi -https' },
-      'Stage'         => { 'Payload'   => "" }
+      'Stage'         => { 'Payload'   => "" },
+      'SupportedVersions' => {
+        'Windows' => [
+          Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
+        ]
+      }
       ))
   end
 

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -28,7 +28,7 @@ module Payload::Windows::MeterpreterLoader_x64
       'PayloadCompat' => { 'Convention' => 'sockrdi handlerdi -https' },
       'Stage'         => { 'Payload'   => "" },
       'SupportedVersions' => {
-        'Windows' => [
+        'win' => [
           Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
         ]
       }

--- a/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
+++ b/lib/msf/core/payload/windows/x64/meterpreter_loader_x64.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 
-
 module Msf
 
 ###
@@ -28,7 +27,12 @@ module Payload::Windows::MeterpreterLoader_x64
       'Platform'      => 'win',
       'Arch'          => ARCH_X64,
       'PayloadCompat' => { 'Convention' => 'sockrdi handlerdi -https' },
-      'Stage'         => { 'Payload'   => "" }
+      'Stage'         => { 'Payload'   => "" },
+      'SupportedVersions' => {
+        'Windows' => [
+          Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
+        ]
+      }
       ))
   end
 

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -31,6 +31,8 @@ module Msf
 
     module WorkstationSpecificVersions
       Win2000 = Rex::Version.new('5.0.2195')
+      # The actual build number is 5.0.2195.6717 but .4 suffix is consistent with other service packs in this file
+      Win2000_SP4 = Rex::Version.new('5.0.2195.4')
       XP_SP0 = Rex::Version.new('5.1.2600.0')
       XP_SP1 = Rex::Version.new('5.1.2600.1')
       XP_SP2 = Rex::Version.new('5.1.2600.2')
@@ -86,6 +88,7 @@ module Msf
 
     WorkstationNameMapping = {
       :Win2000 => "Windows 2000",
+      :Win2000_SP4 => "Windows 2000 Service Pack 4",
       :XP_SP0 => "Windows XP",
       :XP_SP1 => "Windows XP Service Pack 1",
       :XP_SP2 => "Windows XP Service Pack 2",

--- a/lib/msf/core/windows_version.rb
+++ b/lib/msf/core/windows_version.rb
@@ -122,6 +122,103 @@ module Msf
 
     Win10_InitialRelease = Win10_1507
 
+    #
+    # Ordered mapping used to infer a Windows version from a human-readable
+    # exploit target name (see .from_target_name).
+    #
+    # Entries are ordered from most specific to least specific so that
+    # overlapping names resolve correctly (e.g. "8.1" is claimed before "8",
+    # "2008 R2" before "2008"). Each entry declares:
+    #   :pattern        - regex identifying the family within the target name
+    #   :base           - the oldest (baseline) version for the family, used
+    #                     when no service pack is specified
+    #   :service_packs  - optional map of service-pack number => version
+    #
+    # Year-named families (Server SKUs, Windows 2000) require the year to be
+    # directly preceded by "Windows"/"Server" so that unrelated years found in
+    # CVE identifiers, build numbers or product versions (e.g. "CVE-2019-1458")
+    # are not mistaken for an operating system version.
+    #
+    TARGET_NAME_FAMILIES = [
+      # --- Windows Server (always Server SKUs, must be prefixed with Windows/Server) ---
+      { pattern: /(?:windows|server)\s+2025\b/i, base: ServerSpecificVersions::Server2025 },
+      { pattern: /(?:windows|server)\s+2022\b/i, base: ServerSpecificVersions::Server2022 },
+      { pattern: /(?:windows|server)\s+2019\b/i, base: ServerSpecificVersions::Server2019 },
+      { pattern: /(?:windows|server)\s+2016\b/i, base: ServerSpecificVersions::Server2016 },
+      { pattern: /(?:windows|server)\s+2012\s*r2\b/i, base: ServerSpecificVersions::Server2012_R2 },
+      { pattern: /(?:windows|server)\s+2012\b/i, base: ServerSpecificVersions::Server2012 },
+      {
+        pattern: /(?:windows|server)\s+2008\s*r2\b/i,
+        base: ServerSpecificVersions::Server2008_R2_SP0,
+        service_packs: {
+          0 => ServerSpecificVersions::Server2008_R2_SP0,
+          1 => ServerSpecificVersions::Server2008_R2_SP1
+        }
+      },
+      {
+        pattern: /(?:windows|server)\s+2008\b/i,
+        base: ServerSpecificVersions::Server2008_SP0,
+        service_packs: {
+          0 => ServerSpecificVersions::Server2008_SP0,
+          1 => ServerSpecificVersions::Server2008_SP1,
+          2 => ServerSpecificVersions::Server2008_SP2
+        }
+      },
+      {
+        pattern: /(?:windows|server)\s+2003\b/i,
+        base: ServerSpecificVersions::Server2003_SP0,
+        service_packs: {
+          0 => ServerSpecificVersions::Server2003_SP0,
+          1 => ServerSpecificVersions::Server2003_SP1,
+          2 => ServerSpecificVersions::Server2003_SP2
+        }
+      },
+
+      # --- Windows workstation ---
+      { pattern: /\bwin(?:dows)?\s*11\b/i, base: WorkstationSpecificVersions::Win11_21H2 },
+      { pattern: /\bwin(?:dows)?\s*10\b/i, base: WorkstationSpecificVersions::Win10_1507 },
+      { pattern: /\bwin(?:dows)?\s*8\.1\b/i, base: WorkstationSpecificVersions::Win81 },
+      { pattern: /\bwin(?:dows)?\s*8\b/i, base: WorkstationSpecificVersions::Win8 },
+      {
+        pattern: /\bwin(?:dows)?\s*7\b/i,
+        base: WorkstationSpecificVersions::Win7_SP0,
+        service_packs: {
+          0 => WorkstationSpecificVersions::Win7_SP0,
+          1 => WorkstationSpecificVersions::Win7_SP1
+        }
+      },
+      {
+        pattern: /\bvista\b/i,
+        base: WorkstationSpecificVersions::Vista_SP0,
+        service_packs: {
+          0 => WorkstationSpecificVersions::Vista_SP0,
+          1 => WorkstationSpecificVersions::Vista_SP1,
+          2 => WorkstationSpecificVersions::Vista_SP2
+        }
+      },
+      {
+        pattern: /\bxp\b/i,
+        base: WorkstationSpecificVersions::XP_SP0,
+        service_packs: {
+          0 => WorkstationSpecificVersions::XP_SP0,
+          1 => WorkstationSpecificVersions::XP_SP1,
+          2 => WorkstationSpecificVersions::XP_SP2,
+          3 => WorkstationSpecificVersions::XP_SP3
+        }
+      },
+      {
+        pattern: /(?:windows|server)\s+2000\b/i,
+        base: WorkstationSpecificVersions::Win2000,
+        service_packs: {
+          0 => WorkstationSpecificVersions::Win2000,
+          1 => WorkstationSpecificVersions::Win2000,
+          2 => WorkstationSpecificVersions::Win2000,
+          3 => WorkstationSpecificVersions::Win2000,
+          4 => WorkstationSpecificVersions::Win2000_SP4
+        }
+      }
+    ].freeze
+
     module MajorRelease
       NT351 = 'Windows NT 3.51'.freeze
       Win95 = 'Windows 95'.freeze
@@ -247,6 +344,80 @@ module Msf
       else
         nil
       end
+    end
+
+    # Attempt to infer a specific Windows version from a human-readable exploit
+    # target name (for example "Windows 7 SP1 x64" resolves to Win7_SP1).
+    #
+    # The inference is deliberately conservative so it can be relied upon for
+    # automatic metadata tagging:
+    #   * Only names that reference exactly one Windows family are resolved.
+    #     Names referencing several different versions (e.g.
+    #     "Windows XP SP3 / Windows 7 SP1") are treated as ambiguous and return
+    #     nil, since no single version represents them reliably.
+    #   * Generic names such as "Windows", "Windows x64" or "Windows Universal"
+    #     return nil because they do not specify a version.
+    #   * Year-named families (Server SKUs, Windows 2000) are only considered
+    #     when the name also mentions "Windows"/"Server", so unrelated software
+    #     release years are not mistaken for an OS version.
+    #
+    # When a family is matched without a recognisable service pack, the oldest
+    # (baseline) release of that family is returned. This represents the minimum
+    # Windows version the target is expected to run on, which is the value that
+    # matters for payload version-compatibility checks.
+    #
+    # @param name [String] The exploit target name.
+    # @return [Rex::Version, nil] The inferred version, or nil when the name is
+    #   too generic or ambiguous to resolve reliably.
+    def self.from_target_name(name)
+      return nil unless name.is_a?(String) && !name.empty?
+
+      service_packs = service_packs_from_name(name)
+
+      matched = []
+      remaining = name.dup
+
+      TARGET_NAME_FAMILIES.each do |family|
+        # Consume each occurrence so a less specific pattern (e.g. "8") cannot
+        # re-match a substring already claimed by a more specific one ("8.1").
+        while remaining =~ family[:pattern]
+          matched << family unless matched.include?(family)
+          remaining = remaining.sub(family[:pattern], ' ')
+        end
+      end
+
+      # No version referenced, or the name is ambiguous (several distinct
+      # versions) - not safe to tag automatically.
+      return nil unless matched.length == 1
+
+      resolve_family_version(matched.first, service_packs)
+    end
+
+    # Resolve a matched family to a concrete version, honouring any service
+    # packs referenced in the name.
+    #
+    # @param family [Hash] An entry from TARGET_NAME_FAMILIES.
+    # @param service_packs [Array<Integer>] Service-pack numbers found in the name.
+    # @return [Rex::Version]
+    def self.resolve_family_version(family, service_packs)
+      sp_versions = family[:service_packs]
+      return family[:base] if sp_versions.nil? || service_packs.empty?
+
+      # Only consider service packs that are valid for this family. When several
+      # are present (e.g. "XP SP2/SP3") pick the oldest, as it is the lowest
+      # version the target could be running.
+      mapped = service_packs.filter_map { |sp| sp_versions[sp] }
+      mapped.min || family[:base]
+    end
+
+    # Extract every service-pack number referenced in a target name.
+    #
+    # @param name [String] The exploit target name.
+    # @return [Array<Integer>] The unique service-pack numbers found.
+    def self.service_packs_from_name(name)
+      matches = name.scan(/service\s*pack\s*(\d+)/i)
+      matches += name.scan(/\bsp\s?(\d+)\b/i)
+      matches.flatten.map(&:to_i).uniq
     end
 
     private

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2248,11 +2248,30 @@ class Core
     # Set PAYLOAD from TARGET
     if name.upcase == 'TARGET' && active_module && (active_module.exploit? || active_module.evasion?)
       active_module.import_target_defaults
+
+      # Warn if the currently configured payload is incompatible with the new target
+      current_payload = datastore['PAYLOAD']
+      if current_payload
+        payload_instance = framework.payloads.create(current_payload)
+        if payload_instance
+          warnings = active_module.version_compatibility_warnings(payload_instance)
+          warnings.each { |w| print_warning(w) }
+        end
+      end
     end
 
     # If the new SSL value already set in datastore[name] is different from the old value, warn the user
     if name.casecmp('SSL') == 0 && datastore[name] != old_value
       print_warning("Changing the SSL option's value may require changing RPORT!")
+    end
+
+    # Warn if payload version requirements may not be met by the current target
+    if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?) && !clear
+      payload_instance = framework.payloads.create(value)
+      if payload_instance
+        warnings = active_module.version_compatibility_warnings(payload_instance)
+        warnings.each { |w| print_warning(w) }
+      end
     end
 
     if name.casecmp?('SessionTlvLogging')

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2255,11 +2255,28 @@ class Core
           print_status("Payload not compatible with target, defaulting to #{chosen_payload}")
         end
       end
+
+      if current_payload
+        payload_instance = framework.payloads.create(current_payload)
+        if payload_instance
+          warnings = active_module.version_compatibility_warnings(payload_instance)
+          warnings.each { |w| print_warning(w) }
+        end
+      end
     end
 
     # If the new SSL value already set in datastore[name] is different from the old value, warn the user
     if name.casecmp('SSL') == 0 && datastore[name] != old_value
       print_warning("Changing the SSL option's value may require changing RPORT!")
+    end
+
+    # Warn if payload version requirements may not be met by the current target
+    if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?) && !clear
+      payload_instance = framework.payloads.create(value)
+      if payload_instance
+        warnings = active_module.version_compatibility_warnings(payload_instance)
+        warnings.each { |w| print_warning(w) }
+      end
     end
 
     if name.casecmp?('SessionTlvLogging')

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -923,9 +923,19 @@ module Msf
             # Choose a default payload when the module is used, not run
             if mod.datastore['PAYLOAD']
               print_status("Using configured payload #{mod.datastore['PAYLOAD']}")
+              pints = framework.payloads.create(mod.datastore['PAYLOAD'])
+              if pints
+                mod.version_compatibility_warnings(pints).each { |w| print_warning(w) }
+              end
             elsif dispatcher.respond_to?(:choose_payload)
               chosen_payload = dispatcher.choose_payload(mod)
-              print_status("No payload configured, defaulting to #{chosen_payload}") if chosen_payload
+              if chosen_payload
+                print_status("No payload configured, defaulting to #{chosen_payload}")
+                pinst = framework.payloads.create(chosen_payload)
+                if pinst
+                  mod.version_compatibility_warnings(pinst).each { |w| print_warning(w) }
+                end
+              end
             end
 
             if framework.features.enabled?(Msf::FeatureManager::DISPLAY_MODULE_ACTION) && mod.respond_to?(:actions) && mod.actions.size > 1
@@ -1762,7 +1772,12 @@ module Msf
                 next unless mod
 
                 count += 1
-                tbl << add_record(mod, count, true)
+                version_warning = nil
+                if active_module
+                  warnings = active_module.version_compatibility_warnings(mod)
+                  version_warning = warnings.first unless warnings.empty?
+                end
+                tbl << add_record(mod, count, true, version_warning: version_warning)
               end
             else
               results = Msf::Modules::Metadata::Cache.instance.find(
@@ -1781,22 +1796,27 @@ module Msf
           # @param [count] passes the count for each record
           # @param [compatible_mod] handles logic for if there is an active module when the
           # `show` command is run
+          # @param [version_warning] optional version compatibility warning string
           #
           # Adds a record for a table, also handle logic for whether the module is currently
           # handling compatible payloads/encoders
-          def add_record(mod, count, compatible_mod)
+          def add_record(mod, count, compatible_mod, version_warning: nil)
             if compatible_mod
               check = mod.has_check? ? 'Yes' : 'No'
             else
               check = mod.check ? 'Yes' : 'No'
             end
+
+            description = mod.name
+            description = "#{description} [!] #{version_warning}" if version_warning
+
             [
               count,
               mod.fullname,
               mod.disclosure_date.nil? ? '' : mod.disclosure_date.strftime('%Y-%m-%d'),
               mod.rank,
               check,
-              mod.name
+              description
             ]
           end
 

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -923,9 +923,19 @@ module Msf
             # Choose a default payload when the module is used, not run
             if mod.datastore['PAYLOAD']
               print_status("Using configured payload #{mod.datastore['PAYLOAD']}")
+              pints = framework.payloads.create(mod.datastore['PAYLOAD'])
+              if pints
+                mod.version_compatibility_warnings(pints).each { |w| print_warning(w) }
+              end
             elsif dispatcher.respond_to?(:choose_payload)
               chosen_payload = dispatcher.choose_payload(mod)
-              print_status("No payload configured, defaulting to #{chosen_payload}") if chosen_payload
+              if chosen_payload
+                print_status("No payload configured, defaulting to #{chosen_payload}")
+                pinst = framework.payloads.create(chosen_payload)
+                if pinst
+                  mod.version_compatibility_warnings(pinst).each { |w| print_warning(w) }
+                end
+              end
             end
 
             # Import payload options so validation applies immediately on set calls
@@ -1768,7 +1778,12 @@ module Msf
                 next unless mod
 
                 count += 1
-                tbl << add_record(mod, count, true)
+                version_warning = nil
+                if active_module
+                  warnings = active_module.version_compatibility_warnings(mod)
+                  version_warning = warnings.first unless warnings.empty?
+                end
+                tbl << add_record(mod, count, true, version_warning: version_warning)
               end
             else
               results = Msf::Modules::Metadata::Cache.instance.find(
@@ -1787,22 +1802,27 @@ module Msf
           # @param count [Integer] passes the count for each record
           # @param compatible_mod [Boolean] handles logic for whether the module is currently
           #   handling compatible payloads/encoders
+          # @param version_warning [String] optional version compatibility warning string
           #
           # Adds a record for a table, also handle logic for whether the module is currently
           # handling compatible payloads/encoders
-          def add_record(mod, count, compatible_mod)
+          def add_record(mod, count, compatible_mod, version_warning: nil)
             if compatible_mod
               check = mod.has_check? ? 'Yes' : 'No'
             else
               check = mod.check ? 'Yes' : 'No'
             end
+
+            description = mod.name
+            description = "#{description} [!] #{version_warning}" if version_warning
+
             [
               count,
               mod.fullname,
               mod.disclosure_date.nil? ? '' : mod.disclosure_date.strftime('%Y-%m-%d'),
               mod.rank,
               check,
-              mod.name
+              description
             ]
           end
 

--- a/modules/exploits/windows/smb/ms04_031_netdde.rb
+++ b/modules/exploits/windows/smb/ms04_031_netdde.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => 'win',
         'Targets' => [
-          [ 'Windows 2000 SP4', { 'Ret' => 0x77e56f43, 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000_SP4 } } ], # push esp, ret :)
+          [ 'Windows 2000 SP4', { 'Ret' => 0x77e56f43, 'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000_SP4 } } ], # push esp, ret :)
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2004-10-12',

--- a/modules/exploits/windows/smb/ms04_031_netdde.rb
+++ b/modules/exploits/windows/smb/ms04_031_netdde.rb
@@ -41,7 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => 'win',
         'Targets' => [
-          [ 'Windows 2000 SP4', { 'Ret' => 0x77e56f43 } ], # push esp, ret :)
+          [ 'Windows 2000 SP4', { 'Ret' => 0x77e56f43, 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000_SP4 } } ], # push esp, ret :)
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2004-10-12',

--- a/modules/exploits/windows/smb/ms05_039_pnp.rb
+++ b/modules/exploits/windows/smb/ms05_039_pnp.rb
@@ -44,20 +44,23 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Windows 2000 SP0-SP4', # Tested OK - 11/25/2005 hdm
             {
-              'Ret' => 0x767a38f6 # umpnpmgr.dll
+              'Ret' => 0x767a38f6, # umpnpmgr.dll
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 }
             },
           ],
           [
             'Windows 2000 SP4 French',
             {
               'Author' => 'ExaProbe <fmourron@exaprobe.com>',
-              'Ret' => 0x767438f6
+              'Ret' => 0x767438f6,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000_SP4 }
             },
           ],
           [
             'Windows 2000 SP4 Spanish',
             {
-              'Ret' => 0x767738f6 # umpnpmgr.dll
+              'Ret' => 0x767738f6, # umpnpmgr.dll
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000_SP4 }
             },
           ],
           [
@@ -65,21 +68,24 @@ class MetasploitModule < Msf::Exploit::Remote
             'Windows 2000 SP4 Universal',
             {
               'Author' => 'Pita Houmous <pita@mail.com>',
-              'Ret' => 0x01013C79
+              'Ret' => 0x01013C79,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000_SP4 }
             },
           ],
           [
             'Windows 2000 SP0-SP4 German',
             {
               'Author' => 'Michael Thumann <mthumann@ernw.de>',
-              'Ret' => 0x767338f6
+              'Ret' => 0x767338f6,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 }
             },
           ],
           [
             'Windows 2000 SP0-SP4 Italian',
             {
               'Author' => 'acaro <acaro@jervus.it>',
-              'Ret' => 0x7677366f
+              'Ret' => 0x7677366f,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 }
             },
           ],
           [
@@ -87,7 +93,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Ret' => 0x758c572a, # pop edi / pop ebx / ret in umpnpmgr.dll v5.1.2600.1106
               'Pipe' => 'ntsvcs',
-              'Offset' => 16
+              'Offset' => 16,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP1 }
             }
           ],
           # NOTE: XP SP2, Server 2003 (and SP1) require an Administrator account to access
@@ -102,6 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'PtrToZero' => 0x758c0170, # PE data of umpnpmgr.dll v5.1.2600.2180
               'Offset' => 72,
               'EspOffset' => 108,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 },
               'RopStack' =>
                 # All addresses are from umpnpmgr.dll v5.2.3790.1830
                 [
@@ -174,7 +182,8 @@ class MetasploitModule < Msf::Exploit::Remote
               'Ret' => 0x780df756, # push esp / ret in msvcp60.dll
               'Pipe' => 'ntsvcs',
               'PtrToZero' => 0x757702c0, # PE data of umpnpmgr.dll
-              'Offset' => 72
+              'Offset' => 72,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP0 }
             }
           ],
           [
@@ -188,6 +197,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'PtrToZero' => 0x757702c0, # PE data of umpnpmgr.dll
               'Offset' => 72, # offset to saved eip
               'EspOffset' => 108, # Offset to where esp ends up pointing
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP1 },
               'RopStack' =>              # NOTE: 0x41414141 will become random data
                 # All addresses are from umpnpmgr.dll v5.2.3790.1830
                 [

--- a/modules/exploits/windows/smb/ms05_039_pnp.rb
+++ b/modules/exploits/windows/smb/ms05_039_pnp.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Windows 2000 SP0-SP4', # Tested OK - 11/25/2005 hdm
             {
               'Ret' => 0x767a38f6, # umpnpmgr.dll
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000 }
             },
           ],
           [
@@ -53,14 +53,14 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Author' => 'ExaProbe <fmourron@exaprobe.com>',
               'Ret' => 0x767438f6,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000_SP4 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000_SP4 }
             },
           ],
           [
             'Windows 2000 SP4 Spanish',
             {
               'Ret' => 0x767738f6, # umpnpmgr.dll
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000_SP4 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000_SP4 }
             },
           ],
           [
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Author' => 'Pita Houmous <pita@mail.com>',
               'Ret' => 0x01013C79,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000_SP4 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000_SP4 }
             },
           ],
           [
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Author' => 'Michael Thumann <mthumann@ernw.de>',
               'Ret' => 0x767338f6,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000 }
             },
           ],
           [
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Author' => 'acaro <acaro@jervus.it>',
               'Ret' => 0x7677366f,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000 }
             },
           ],
           [
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Ret' => 0x758c572a, # pop edi / pop ebx / ret in umpnpmgr.dll v5.1.2600.1106
               'Pipe' => 'ntsvcs',
               'Offset' => 16,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP1 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::XP_SP1 }
             }
           ],
           # NOTE: XP SP2, Server 2003 (and SP1) require an Administrator account to access
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'PtrToZero' => 0x758c0170, # PE data of umpnpmgr.dll v5.1.2600.2180
               'Offset' => 72,
               'EspOffset' => 108,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 },
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::XP_SP2 },
               'RopStack' =>
                 # All addresses are from umpnpmgr.dll v5.2.3790.1830
                 [
@@ -183,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Pipe' => 'ntsvcs',
               'PtrToZero' => 0x757702c0, # PE data of umpnpmgr.dll
               'Offset' => 72,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP0 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Server2003_SP0 }
             }
           ],
           [
@@ -197,7 +197,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'PtrToZero' => 0x757702c0, # PE data of umpnpmgr.dll
               'Offset' => 72, # offset to saved eip
               'EspOffset' => 108, # Offset to where esp ends up pointing
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP1 },
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Server2003_SP1 },
               'RopStack' =>              # NOTE: 0x41414141 will become random data
                 # All addresses are from umpnpmgr.dll v5.2.3790.1830
                 [

--- a/modules/exploits/windows/smb/ms06_025_rasmans_reg.rb
+++ b/modules/exploits/windows/smb/ms06_025_rasmans_reg.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => 'win',
         'Targets' => [
-          [ 'Windows 2000 SP4', { 'Ret' => 0x750217ae } ], # call esi
+          [ 'Windows 2000 SP4', { 'Ret' => 0x750217ae, 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000_SP4 } } ], # call esi
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2006-06-13',

--- a/modules/exploits/windows/smb/ms06_025_rasmans_reg.rb
+++ b/modules/exploits/windows/smb/ms06_025_rasmans_reg.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => 'win',
         'Targets' => [
-          [ 'Windows 2000 SP4', { 'Ret' => 0x750217ae, 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000_SP4 } } ], # call esi
+          [ 'Windows 2000 SP4', { 'Ret' => 0x750217ae, 'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000_SP4 } } ], # call esi
         ],
         'DefaultTarget' => 0,
         'DisclosureDate' => '2006-06-13',

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Ret' => 0x001f1cb0,
               'Scratch' => 0x00020408,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000 }
             }
           ], # JMP EDI SVCHOST.EXE
 
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Ret' => 0x01001361,
               'Scratch' => 0x00020408,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP0 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::XP_SP0 }
             }
           ], # JMP ESI SVCHOST.EXE
 
@@ -99,7 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Ret' => 0x0100129e,
               'Scratch' => 0x00020408,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP0 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Server2003_SP0 }
             }
           ], # JMP ESI SVCHOST.EXE
 
@@ -114,7 +114,7 @@ class MetasploitModule < Msf::Exploit::Remote
               # No pivot is needed, we drop into our rop
               'Scratch' => 0x00020408,
               'UseROP' => '5.1.2600.2180',
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::XP_SP2 }
             }
           ],
 
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Ret' => 0x6f88f727,
               'DisableNX' => 0x6f8916e2,
               'Scratch' => 0x00020408,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::XP_SP2 }
             }
           ], # JMP ESI ACGENRAL.DLL, NX/NX BYPASS ACGENRAL.DLL
 
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
               # No pivot is needed, we drop into our rop
               'Scratch' => 0x00020408,
               'UseROP' => '5.1.2600.5512',
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP3 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::XP_SP3 }
             }
           ],
 
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Ret' => 0x6f88f807,
               'DisableNX' => 0x6f8917c2,
               'Scratch' => 0x00020408,
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP3 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::XP_SP3 }
             }
           ], # JMP ESI ACGENRAL.DLL, NX/NX BYPASS ACGENRAL.DLL
 

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -76,6 +76,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Ret' => 0x001f1cb0,
               'Scratch' => 0x00020408,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 }
             }
           ], # JMP EDI SVCHOST.EXE
 
@@ -88,6 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Ret' => 0x01001361,
               'Scratch' => 0x00020408,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP0 }
             }
           ], # JMP ESI SVCHOST.EXE
 
@@ -97,6 +99,7 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Ret' => 0x0100129e,
               'Scratch' => 0x00020408,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP0 }
             }
           ], # JMP ESI SVCHOST.EXE
 
@@ -110,7 +113,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               # No pivot is needed, we drop into our rop
               'Scratch' => 0x00020408,
-              'UseROP' => '5.1.2600.2180'
+              'UseROP' => '5.1.2600.2180',
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 }
             }
           ],
 
@@ -120,7 +124,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Ret' => 0x6f88f727,
               'DisableNX' => 0x6f8916e2,
-              'Scratch' => 0x00020408
+              'Scratch' => 0x00020408,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 }
             }
           ], # JMP ESI ACGENRAL.DLL, NX/NX BYPASS ACGENRAL.DLL
 
@@ -130,7 +135,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               # No pivot is needed, we drop into our rop
               'Scratch' => 0x00020408,
-              'UseROP' => '5.1.2600.5512'
+              'UseROP' => '5.1.2600.5512',
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP3 }
             }
           ],
 
@@ -140,7 +146,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Ret' => 0x6f88f807,
               'DisableNX' => 0x6f8917c2,
-              'Scratch' => 0x00020408
+              'Scratch' => 0x00020408,
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP3 }
             }
           ], # JMP ESI ACGENRAL.DLL, NX/NX BYPASS ACGENRAL.DLL
 

--- a/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
+++ b/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
@@ -61,6 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'ReadAddress' => 0xFFDF0D04, # A readable address from kernel space (no nulls in address).
               'ProcessIDHigh' => 0x0217, # srv2!SrvSnapShotScavengerTimer
               'MagicIndex' => 0x3FFFFFB4, # (DWORD)( MagicIndex*4 + 0x130 ) == 0
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Vista_SP0 }
             }
           ],
         ],

--- a/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
+++ b/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'ReadAddress' => 0xFFDF0D04, # A readable address from kernel space (no nulls in address).
               'ProcessIDHigh' => 0x0217, # srv2!SrvSnapShotScavengerTimer
               'MagicIndex' => 0x3FFFFFB4, # (DWORD)( MagicIndex*4 + 0x130 ) == 0
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Vista_SP0 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Vista_SP0 }
             }
           ],
         ],

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -104,56 +104,56 @@ class MetasploitModule < Msf::Exploit::Remote
             'Windows 7',
             {
               'os_patterns' => ['Windows 7'],
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win7_SP0 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win7_SP0 }
             }
           ],
           [
             'Windows Embedded Standard 7',
             {
               'os_patterns' => ['Windows Embedded Standard 7'],
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win7_SP0 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win7_SP0 }
             }
           ],
           [
             'Windows Server 2008 R2',
             {
               'os_patterns' => ['Windows Server 2008 R2'],
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2008_R2_SP0 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Server2008_R2_SP0 }
             }
           ],
           [
             'Windows 8',
             {
               'os_patterns' => ['Windows 8'],
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win8 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win8 }
             }
           ],
           [
             'Windows 8.1',
             {
               'os_patterns' => ['Windows 8.1'],
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win81 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win81 }
             }
           ],
           [
             'Windows Server 2012',
             {
               'os_patterns' => ['Windows Server 2012'],
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2012 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Server2012 }
             }
           ],
           [
             'Windows 10 Pro',
             {
               'os_patterns' => ['Windows Pro Build'],
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win10_1507 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win10_1507 }
             }
           ],
           [
             'Windows 10 Enterprise Evaluation',
             {
               'os_patterns' => ['Windows 10 Enterprise Evaluation Build'],
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win10_1507 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win10_1507 }
             }
           ]
         ],

--- a/modules/exploits/windows/smb/ms17_010_eternalblue.rb
+++ b/modules/exploits/windows/smb/ms17_010_eternalblue.rb
@@ -103,49 +103,57 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Windows 7',
             {
-              'os_patterns' => ['Windows 7']
+              'os_patterns' => ['Windows 7'],
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win7_SP0 }
             }
           ],
           [
             'Windows Embedded Standard 7',
             {
-              'os_patterns' => ['Windows Embedded Standard 7']
+              'os_patterns' => ['Windows Embedded Standard 7'],
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win7_SP0 }
             }
           ],
           [
             'Windows Server 2008 R2',
             {
-              'os_patterns' => ['Windows Server 2008 R2']
+              'os_patterns' => ['Windows Server 2008 R2'],
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2008_R2_SP0 }
             }
           ],
           [
             'Windows 8',
             {
-              'os_patterns' => ['Windows 8']
+              'os_patterns' => ['Windows 8'],
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win8 }
             }
           ],
           [
             'Windows 8.1',
             {
-              'os_patterns' => ['Windows 8.1']
+              'os_patterns' => ['Windows 8.1'],
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win81 }
             }
           ],
           [
             'Windows Server 2012',
             {
-              'os_patterns' => ['Windows Server 2012']
+              'os_patterns' => ['Windows Server 2012'],
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2012 }
             }
           ],
           [
             'Windows 10 Pro',
             {
-              'os_patterns' => ['Windows Pro Build']
+              'os_patterns' => ['Windows Pro Build'],
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win10_1507 }
             }
           ],
           [
             'Windows 10 Enterprise Evaluation',
             {
-              'os_patterns' => ['Windows 10 Enterprise Evaluation Build']
+              'os_patterns' => ['Windows 10 Enterprise Evaluation Build'],
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win10_1507 }
             }
           ]
         ],

--- a/modules/exploits/windows/smb/smb_rras_erraticgopher.rb
+++ b/modules/exploits/windows/smb/smb_rras_erraticgopher.rb
@@ -76,7 +76,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'os' => 'Windows 2003',
               'sp' => '',
-              'lang' => 'English'
+              'lang' => 'English',
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP0 }
             }
           ],
           [
@@ -84,7 +85,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'os' => 'Windows 2003',
               'sp' => 'Service Pack 1',
-              'lang' => 'English'
+              'lang' => 'English',
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP1 }
             }
           ],
           [
@@ -92,7 +94,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'os' => 'Windows 2003',
               'sp' => 'Service Pack 2',
-              'lang' => 'English'
+              'lang' => 'English',
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP2 }
             }
           ],
           [
@@ -100,7 +103,8 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'os' => 'Windows 2003 R2',
               'sp' => 'Service Pack 2',
-              'lang' => 'English'
+              'lang' => 'English',
+              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP2 }
             }
           ],
         ],

--- a/modules/exploits/windows/smb/smb_rras_erraticgopher.rb
+++ b/modules/exploits/windows/smb/smb_rras_erraticgopher.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'os' => 'Windows 2003',
               'sp' => '',
               'lang' => 'English',
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP0 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Server2003_SP0 }
             }
           ],
           [
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'os' => 'Windows 2003',
               'sp' => 'Service Pack 1',
               'lang' => 'English',
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP1 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Server2003_SP1 }
             }
           ],
           [
@@ -95,7 +95,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'os' => 'Windows 2003',
               'sp' => 'Service Pack 2',
               'lang' => 'English',
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP2 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Server2003_SP2 }
             }
           ],
           [
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'os' => 'Windows 2003 R2',
               'sp' => 'Service Pack 2',
               'lang' => 'English',
-              'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP2 }
+              'PlatformVersions' => { 'win' => Msf::WindowsVersion::Server2003_SP2 }
             }
           ],
         ],

--- a/modules/payloads/singles/windows/metsvc_bind_tcp.rb
+++ b/modules/payloads/singles/windows/metsvc_bind_tcp.rb
@@ -23,7 +23,7 @@ module MetasploitModule
         'Handler' => Msf::Handler::BindTcp,
         'Session' => Msf::Sessions::Meterpreter_x86_Win,
         'SupportedVersions' => {
-          'Windows' => [
+          'win' => [
             Msf::Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
           ]
         },

--- a/modules/payloads/singles/windows/metsvc_bind_tcp.rb
+++ b/modules/payloads/singles/windows/metsvc_bind_tcp.rb
@@ -22,6 +22,11 @@ module MetasploitModule
         'Arch' => ARCH_X86,
         'Handler' => Msf::Handler::BindTcp,
         'Session' => Msf::Sessions::Meterpreter_x86_Win,
+        'SupportedVersions' => {
+          'Windows' => [
+            Msf::Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
+          ]
+        },
         'Payload' => {
           'Offsets' => {},
           'Payload' => ''

--- a/modules/payloads/singles/windows/metsvc_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/metsvc_reverse_tcp.rb
@@ -22,6 +22,11 @@ module MetasploitModule
         'Arch' => ARCH_X86,
         'Handler' => Msf::Handler::ReverseTcp,
         'Session' => Msf::Sessions::Meterpreter_x86_Win,
+        'SupportedVersions' => {
+          'Windows' => [
+            Msf::Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
+          ]
+        },
         'Payload' => {
           'Offsets' => {},
           'Payload' => ''

--- a/modules/payloads/singles/windows/metsvc_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/metsvc_reverse_tcp.rb
@@ -23,7 +23,7 @@ module MetasploitModule
         'Handler' => Msf::Handler::ReverseTcp,
         'Session' => Msf::Sessions::Meterpreter_x86_Win,
         'SupportedVersions' => {
-          'Windows' => [
+          'win' => [
             Msf::Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
           ]
         },

--- a/modules/payloads/stages/windows/patchupmeterpreter.rb
+++ b/modules/payloads/stages/windows/patchupmeterpreter.rb
@@ -22,7 +22,7 @@ module MetasploitModule
         'License' => MSF_LICENSE,
         'Session' => Msf::Sessions::Meterpreter_x86_Win,
         'SupportedVersions' => {
-          'Windows' => [
+          'win' => [
             Msf::Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
           ]
         }

--- a/modules/payloads/stages/windows/patchupmeterpreter.rb
+++ b/modules/payloads/stages/windows/patchupmeterpreter.rb
@@ -20,7 +20,12 @@ module MetasploitModule
         'Description' => 'Inject the meterpreter server DLL (staged)',
         'Author' => 'skape',
         'License' => MSF_LICENSE,
-        'Session' => Msf::Sessions::Meterpreter_x86_Win
+        'Session' => Msf::Sessions::Meterpreter_x86_Win,
+        'SupportedVersions' => {
+          'Windows' => [
+            Msf::Module::VersionRange.new(min: Msf::Payload::Windows::MeterpreterVersion::MINIMUM_VERSION)
+          ]
+        }
       )
     )
 

--- a/spec/integration/payload_version_compatibility/version_compatibility_integration_spec.rb
+++ b/spec/integration/payload_version_compatibility/version_compatibility_integration_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Payload version compatibility integration' do
     {
       'Name' => 'Mock Payload',
       'SupportedVersions' => {
-        'Windows' => [Msf::Module::VersionRange.new(min: Msf::WindowsVersion::XP_SP2)]
+        'win' => [Msf::Module::VersionRange.new(min: Msf::WindowsVersion::XP_SP2)]
       }
     }
   end
@@ -79,7 +79,7 @@ RSpec.describe 'Payload version compatibility integration' do
       end
     end
 
-    context 'when target is Automatic (no RuntimeVersions declared)' do
+    context 'when target is Automatic (no PlatformVersions declared)' do
       before do
         exploit.datastore['TARGET'] = automatic_target_index
       end

--- a/spec/integration/payload_version_compatibility/version_compatibility_integration_spec.rb
+++ b/spec/integration/payload_version_compatibility/version_compatibility_integration_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+RSpec.describe 'Payload version compatibility integration' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:automatic_target_index) { 0 }
+  let(:windows_2000_universal_index) { 1 }
+  let(:windows_xp_sp0_index) { 2 }
+  let(:windows_2003_index) { 3 }
+  let(:windows_xp_sp2_index) { 4 }
+
+  let(:exploit) do
+    load_and_create_module(
+      module_type: 'exploit',
+      # Chosen as it has many targets that allow us to test the payload warning code paths.
+      reference_name: 'windows/smb/ms08_067_netapi'
+    )
+  end
+
+  let(:mock_module_info_without_minimum_versions) { { 'Name' => 'Mock Payload' } }
+  let(:mock_module_info_with_minimum_versions) do
+    {
+      'Name' => 'Mock Payload',
+      'SupportedVersions' => {
+        'Windows' => [Msf::Module::VersionRange.new(min: Msf::WindowsVersion::XP_SP2)]
+      }
+    }
+  end
+
+  # Mock payload
+  let(:payload_with_minimum_versions) do
+    instance = instance_double(Msf::Payload)
+    allow(instance).to receive(:supported_versions).and_return(mock_module_info_with_minimum_versions['SupportedVersions'])
+    instance
+  end
+
+  let(:payload_without_minimum_versions) do
+    instance = instance_double(Msf::Payload)
+    allow(instance).to receive(:supported_versions).and_return(mock_module_info_without_minimum_versions['SupportedVersions'])
+    instance
+  end
+
+  describe '#version_compatibility_warnings' do
+    context 'when target is Windows 2000 (below Meterpreter minimum)' do
+      before do
+        exploit.datastore['TARGET'] = windows_2000_universal_index
+      end
+
+      it 'warns for payload with SupportedVersions' do
+        warnings = exploit.version_compatibility_warnings(payload_with_minimum_versions)
+        expect(warnings).to eq(['Payload requires Windows version within a supported range (minimum Windows XP Service Pack 2 (5.1.2600.2)), but the target provides Windows 2000 (5.0.2195)'])
+      end
+
+      it 'does not warn for payload without SupportedVersions' do
+        warnings = exploit.version_compatibility_warnings(payload_without_minimum_versions)
+        expect(warnings).to be_empty
+      end
+    end
+
+    context 'when target is Windows XP SP0/SP1 (below Meterpreter minimum)' do
+      before do
+        exploit.datastore['TARGET'] = windows_xp_sp0_index
+      end
+
+      it 'warns for payload with SupportedVersions' do
+        warnings = exploit.version_compatibility_warnings(payload_with_minimum_versions)
+        expect(warnings).to eq(["Payload requires Windows version within a supported range (minimum Windows XP Service Pack 2 (5.1.2600.2)), but the target provides Windows XP (5.1.2600.0)"])
+      end
+    end
+
+    context 'when target is Windows XP SP2 (meets Meterpreter minimum)' do
+      before do
+        exploit.datastore['TARGET'] = windows_xp_sp2_index
+      end
+
+      it 'does not warn for payload with SupportedVersions' do
+        warnings = exploit.version_compatibility_warnings(payload_with_minimum_versions)
+        expect(warnings).to be_empty
+      end
+    end
+
+    context 'when target is Automatic (no RuntimeVersions declared)' do
+      before do
+        exploit.datastore['TARGET'] = automatic_target_index
+      end
+
+      it 'warns with the lowest common denominator' do
+        warnings = exploit.version_compatibility_warnings(payload_with_minimum_versions)
+        expect(warnings).to eq(["Payload requires Windows version within a supported range (minimum Windows XP Service Pack 2 (5.1.2600.2)), but the target provides Windows 2000 (5.0.2195)"])
+      end
+    end
+
+    context 'when target is Windows 2003 SP0 (above Meterpreter minimum)' do
+      before do
+        exploit.datastore['TARGET'] = windows_2003_index
+      end
+
+      it 'does not warn for payload with SupportedVersions' do
+        warnings = exploit.version_compatibility_warnings(payload_with_minimum_versions)
+        expect(warnings).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/module/runtime_version_inference_spec.rb
+++ b/spec/lib/msf/core/module/runtime_version_inference_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Module::RuntimeVersionInference do
+  describe '.infer' do
+    it 'infers the Windows runtime version from a target name' do
+      result = described_class.infer('Windows 7 SP1')
+      expect(result).to eq('Windows' => Msf::WindowsVersion::Win7_SP1)
+    end
+
+    it 'returns an empty hash for a generic name' do
+      expect(described_class.infer('Windows x64')).to eq({})
+    end
+
+    it 'does not overwrite a runtime that is already set' do
+      existing = { 'Windows' => Msf::WindowsVersion::XP_SP2 }
+      expect(described_class.infer('Windows 7 SP1', existing: existing)).to eq({})
+    end
+
+    it 'skips inferrers whose platform does not match the declared platform' do
+      # A name that would otherwise resolve to Windows, but the target is linux.
+      result = described_class.infer('Windows Server 2016', platform_names: ['linux'])
+      expect(result).to eq({})
+    end
+
+    it 'applies inferrers when the declared platform matches' do
+      result = described_class.infer('Windows 7', platform_names: ['win'])
+      expect(result).to eq('Windows' => Msf::WindowsVersion::Win7_SP0)
+    end
+
+    it 'falls back to name-based inference when no platform is declared' do
+      result = described_class.infer('Windows 7', platform_names: nil)
+      expect(result).to eq('Windows' => Msf::WindowsVersion::Win7_SP0)
+    end
+  end
+
+  describe 'Inferrer' do
+    let(:resolver) { ->(name) { name == 'match' ? Rex::Version.new('1.0') : nil } }
+    subject(:inferrer) { described_class::Inferrer.new('Example', /osx|mac/i, resolver) }
+
+    it 'delegates version resolution to its resolver' do
+      expect(inferrer.infer('match')).to eq(Rex::Version.new('1.0'))
+      expect(inferrer.infer('no match')).to be_nil
+    end
+
+    it 'is applicable when no platform names are supplied' do
+      expect(inferrer.applicable_to_platforms?(nil)).to be(true)
+      expect(inferrer.applicable_to_platforms?([])).to be(true)
+    end
+
+    it 'is applicable when a declared platform matches its pattern' do
+      expect(inferrer.applicable_to_platforms?(['osx'])).to be(true)
+    end
+
+    it 'is not applicable when no declared platform matches its pattern' do
+      expect(inferrer.applicable_to_platforms?(['linux'])).to be(false)
+    end
+
+    it 'is always applicable when it has no platform pattern' do
+      ungated = described_class::Inferrer.new('Example', nil, resolver)
+      expect(ungated.applicable_to_platforms?(['linux'])).to be(true)
+    end
+  end
+end

--- a/spec/lib/msf/core/module/version_compatibility_spec.rb
+++ b/spec/lib/msf/core/module/version_compatibility_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe Msf::Module::VersionCompatibility do
   end
 
   describe '#version_compatibility_warnings' do
-    context 'when target does not declare RuntimeVersions' do
+    context 'when target does not declare PlatformVersions' do
       let(:target_opts) { {} }
       let(:payload_module_info) do
-        { 'Name' => 'Mock Payload', 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+        { 'Name' => 'Mock Payload', 'SupportedVersions' => supported_versions_from_min('win', Msf::WindowsVersion::XP_SP2) }
       end
 
       it 'returns no warnings' do
@@ -49,7 +49,7 @@ RSpec.describe Msf::Module::VersionCompatibility do
     end
 
     context 'when payload does not declare SupportedVersions' do
-      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000 } } }
       let(:payload_module_info) { {} }
 
       it 'returns no warnings' do
@@ -60,7 +60,7 @@ RSpec.describe Msf::Module::VersionCompatibility do
     context 'when target is nil' do
       let(:target_opts) { nil }
       let(:payload_module_info) do
-        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+        { 'SupportedVersions' => supported_versions_from_min('win', Msf::WindowsVersion::XP_SP2) }
       end
 
       before do
@@ -73,9 +73,9 @@ RSpec.describe Msf::Module::VersionCompatibility do
     end
 
     context 'when target version is below payload minimum' do
-      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win2000 } } }
       let(:payload_module_info) do
-        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+        { 'SupportedVersions' => supported_versions_from_min('win', Msf::WindowsVersion::XP_SP2) }
       end
 
       it 'returns a warning' do
@@ -85,9 +85,9 @@ RSpec.describe Msf::Module::VersionCompatibility do
     end
 
     context 'when target version equals payload minimum' do
-      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'win' => Msf::WindowsVersion::XP_SP2 } } }
       let(:payload_module_info) do
-        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+        { 'SupportedVersions' => supported_versions_from_min('win', Msf::WindowsVersion::XP_SP2) }
       end
 
       it 'returns no warnings' do
@@ -96,9 +96,9 @@ RSpec.describe Msf::Module::VersionCompatibility do
     end
 
     context 'when target version exceeds payload minimum' do
-      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win7_SP0 } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'win' => Msf::WindowsVersion::Win7_SP0 } } }
       let(:payload_module_info) do
-        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+        { 'SupportedVersions' => supported_versions_from_min('win', Msf::WindowsVersion::XP_SP2) }
       end
 
       it 'returns no warnings' do
@@ -107,9 +107,9 @@ RSpec.describe Msf::Module::VersionCompatibility do
     end
 
     context 'when versions are provided as strings' do
-      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => '5.0.2195' } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'win' => '5.0.2195' } } }
       let(:payload_module_info) do
-        { 'SupportedVersions' => supported_versions_from_min('Windows', '5.1.2600.2') }
+        { 'SupportedVersions' => supported_versions_from_min('win', '5.1.2600.2') }
       end
 
       it 'returns a warning' do
@@ -119,9 +119,9 @@ RSpec.describe Msf::Module::VersionCompatibility do
     end
 
     context 'when runtime keys do not overlap' do
-      let(:target_opts) { { 'RuntimeVersions' => { 'Linux' => '5.4.0' } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'linux' => '5.4.0' } } }
       let(:payload_module_info) do
-        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+        { 'SupportedVersions' => supported_versions_from_min('win', Msf::WindowsVersion::XP_SP2) }
       end
 
       it 'returns no warnings' do
@@ -132,17 +132,17 @@ RSpec.describe Msf::Module::VersionCompatibility do
     context 'with multiple runtime keys both incompatible' do
       let(:target_opts) do
         {
-          'RuntimeVersions' => {
-            'Windows' => Msf::WindowsVersion::XP_SP0,
-            'Python' => '2.7'
+          'PlatformVersions' => {
+            'win' => Msf::WindowsVersion::XP_SP0,
+            'python' => '2.7'
           }
         }
       end
       let(:payload_module_info) do
         {
           'SupportedVersions' => {
-            'Windows' => [Msf::Module::VersionRange.new(min: Msf::WindowsVersion::XP_SP2)],
-            'Python' => [Msf::Module::VersionRange.new(min: '3.4')]
+            'win' => [Msf::Module::VersionRange.new(min: Msf::WindowsVersion::XP_SP2)],
+            'python' => [Msf::Module::VersionRange.new(min: '3.4')]
           }
         }
       end
@@ -160,11 +160,11 @@ RSpec.describe Msf::Module::VersionCompatibility do
 
     context 'with multiple version ranges where target falls in a later range' do
       # Python payload: supports 2.5-2.7 and 3.1+
-      let(:target_opts) { { 'RuntimeVersions' => { 'Python' => '3.6' } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'python' => '3.6' } } }
       let(:payload_module_info) do
         {
           'SupportedVersions' => {
-            'Python' => [
+            'python' => [
               Msf::Module::VersionRange.new(min: '2.5', max: '2.7'),
               Msf::Module::VersionRange.new(min: '3.1')
             ]
@@ -178,11 +178,11 @@ RSpec.describe Msf::Module::VersionCompatibility do
     end
 
     context 'with multiple version ranges where target falls in the first range' do
-      let(:target_opts) { { 'RuntimeVersions' => { 'Python' => '2.6' } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'python' => '2.6' } } }
       let(:payload_module_info) do
         {
           'SupportedVersions' => {
-            'Python' => [
+            'python' => [
               Msf::Module::VersionRange.new(min: '2.5', max: '2.7'),
               Msf::Module::VersionRange.new(min: '3.1')
             ]
@@ -197,11 +197,11 @@ RSpec.describe Msf::Module::VersionCompatibility do
 
     context 'with multiple version ranges where target falls in a gap' do
       # Python 3.0 is between 2.7 and 3.1 — unsupported
-      let(:target_opts) { { 'RuntimeVersions' => { 'Python' => '3.0' } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'python' => '3.0' } } }
       let(:payload_module_info) do
         {
           'SupportedVersions' => {
-            'Python' => [
+            'python' => [
               Msf::Module::VersionRange.new(min: '2.5', max: '2.7'),
               Msf::Module::VersionRange.new(min: '3.1')
             ]
@@ -216,9 +216,9 @@ RSpec.describe Msf::Module::VersionCompatibility do
     end
 
     context 'when Windows XP SP0/SP1 target is compared to Meterpreter minimum' do
-      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP0 } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'win' => Msf::WindowsVersion::XP_SP0 } } }
       let(:payload_module_info) do
-        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+        { 'SupportedVersions' => supported_versions_from_min('win', Msf::WindowsVersion::XP_SP2) }
       end
 
       it 'returns a warning' do
@@ -228,9 +228,9 @@ RSpec.describe Msf::Module::VersionCompatibility do
     end
 
     context 'when Windows XP SP2 target is compared to Meterpreter minimum' do
-      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'win' => Msf::WindowsVersion::XP_SP2 } } }
       let(:payload_module_info) do
-        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+        { 'SupportedVersions' => supported_versions_from_min('win', Msf::WindowsVersion::XP_SP2) }
       end
 
       it 'returns no warnings' do
@@ -239,9 +239,9 @@ RSpec.describe Msf::Module::VersionCompatibility do
     end
 
     context 'when Windows Server 2003 SP0 target is compared to Meterpreter minimum' do
-      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP0 } } }
+      let(:target_opts) { { 'PlatformVersions' => { 'win' => Msf::WindowsVersion::Server2003_SP0 } } }
       let(:payload_module_info) do
-        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+        { 'SupportedVersions' => supported_versions_from_min('win', Msf::WindowsVersion::XP_SP2) }
       end
 
       it 'returns no warnings because Server 2003 (5.2) is above XP SP2 (5.1)' do

--- a/spec/lib/msf/core/module/version_compatibility_spec.rb
+++ b/spec/lib/msf/core/module/version_compatibility_spec.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Module::VersionCompatibility do
+  subject do
+    described_mixin = described_class
+    klass = Class.new do
+      include described_mixin
+
+      attr_accessor :target
+    end
+
+    klass.new
+  end
+
+  let(:payload_instance) do
+    instance = instance_double(Msf::Payload)
+    allow(instance).to receive(:supported_versions).and_return(payload_module_info['SupportedVersions'])
+    instance
+  end
+
+  let(:target_with_opts) do
+    target = double(Msf::Target)
+    allow(target).to receive(:opts).and_return(target_opts)
+    allow(target).to receive(:name).and_return('Mock Target')
+    target
+  end
+
+  before do
+    allow(subject).to receive(:target).and_return(target_with_opts)
+  end
+
+  # Helper to build a single-range SupportedVersions entry with just a minimum version.
+  def supported_versions_from_min(runtime, min)
+    { runtime => [Msf::Module::VersionRange.new(min: min)] }
+  end
+
+  describe '#version_compatibility_warnings' do
+    context 'when target does not declare RuntimeVersions' do
+      let(:target_opts) { {} }
+      let(:payload_module_info) do
+        { 'Name' => 'Mock Payload', 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+      end
+
+      it 'returns no warnings' do
+        expect(subject.version_compatibility_warnings(payload_instance)).to be_empty
+      end
+    end
+
+    context 'when payload does not declare SupportedVersions' do
+      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 } } }
+      let(:payload_module_info) { {} }
+
+      it 'returns no warnings' do
+        expect(subject.version_compatibility_warnings(payload_instance)).to be_empty
+      end
+    end
+
+    context 'when target is nil' do
+      let(:target_opts) { nil }
+      let(:payload_module_info) do
+        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+      end
+
+      before do
+        allow(subject).to receive(:target).and_return(nil)
+      end
+
+      it 'returns no warnings' do
+        expect(subject.version_compatibility_warnings(payload_instance)).to be_empty
+      end
+    end
+
+    context 'when target version is below payload minimum' do
+      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win2000 } } }
+      let(:payload_module_info) do
+        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+      end
+
+      it 'returns a warning' do
+        warnings = subject.version_compatibility_warnings(payload_instance)
+        expect(warnings).to eq(["Payload requires Windows version within a supported range (minimum Windows XP Service Pack 2 (5.1.2600.2)), but the target provides Windows 2000 (5.0.2195)"])
+      end
+    end
+
+    context 'when target version equals payload minimum' do
+      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 } } }
+      let(:payload_module_info) do
+        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+      end
+
+      it 'returns no warnings' do
+        expect(subject.version_compatibility_warnings(payload_instance)).to be_empty
+      end
+    end
+
+    context 'when target version exceeds payload minimum' do
+      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Win7_SP0 } } }
+      let(:payload_module_info) do
+        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+      end
+
+      it 'returns no warnings' do
+        expect(subject.version_compatibility_warnings(payload_instance)).to be_empty
+      end
+    end
+
+    context 'when versions are provided as strings' do
+      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => '5.0.2195' } } }
+      let(:payload_module_info) do
+        { 'SupportedVersions' => supported_versions_from_min('Windows', '5.1.2600.2') }
+      end
+
+      it 'returns a warning' do
+        warnings = subject.version_compatibility_warnings(payload_instance)
+        expect(warnings).to eq(["Payload requires Windows version within a supported range (minimum Windows XP Service Pack 2 (5.1.2600.2)), but the target provides Windows 2000 (5.0.2195)"])
+      end
+    end
+
+    context 'when runtime keys do not overlap' do
+      let(:target_opts) { { 'RuntimeVersions' => { 'Linux' => '5.4.0' } } }
+      let(:payload_module_info) do
+        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+      end
+
+      it 'returns no warnings' do
+        expect(subject.version_compatibility_warnings(payload_instance)).to be_empty
+      end
+    end
+
+    context 'with multiple runtime keys both incompatible' do
+      let(:target_opts) do
+        {
+          'RuntimeVersions' => {
+            'Windows' => Msf::WindowsVersion::XP_SP0,
+            'Python' => '2.7'
+          }
+        }
+      end
+      let(:payload_module_info) do
+        {
+          'SupportedVersions' => {
+            'Windows' => [Msf::Module::VersionRange.new(min: Msf::WindowsVersion::XP_SP2)],
+            'Python' => [Msf::Module::VersionRange.new(min: '3.4')]
+          }
+        }
+      end
+
+      it 'returns warnings for each incompatible runtime' do
+        warnings = subject.version_compatibility_warnings(payload_instance)
+        expect(warnings).to eq(
+          [
+            "Payload requires Windows version within a supported range (minimum Windows XP Service Pack 2 (5.1.2600.2)), but the target provides Windows XP (5.1.2600.0)",
+            "Payload requires Python version within a supported range (minimum Python (3.4)), but the target provides Python (2.7)"
+          ]
+        )
+      end
+    end
+
+    context 'with multiple version ranges where target falls in a later range' do
+      # Python payload: supports 2.5-2.7 and 3.1+
+      let(:target_opts) { { 'RuntimeVersions' => { 'Python' => '3.6' } } }
+      let(:payload_module_info) do
+        {
+          'SupportedVersions' => {
+            'Python' => [
+              Msf::Module::VersionRange.new(min: '2.5', max: '2.7'),
+              Msf::Module::VersionRange.new(min: '3.1')
+            ]
+          }
+        }
+      end
+
+      it 'returns no warnings because 3.6 is within the 3.1+ range' do
+        expect(subject.version_compatibility_warnings(payload_instance)).to be_empty
+      end
+    end
+
+    context 'with multiple version ranges where target falls in the first range' do
+      let(:target_opts) { { 'RuntimeVersions' => { 'Python' => '2.6' } } }
+      let(:payload_module_info) do
+        {
+          'SupportedVersions' => {
+            'Python' => [
+              Msf::Module::VersionRange.new(min: '2.5', max: '2.7'),
+              Msf::Module::VersionRange.new(min: '3.1')
+            ]
+          }
+        }
+      end
+
+      it 'returns no warnings because 2.6 is within the 2.5..2.7 range' do
+        expect(subject.version_compatibility_warnings(payload_instance)).to be_empty
+      end
+    end
+
+    context 'with multiple version ranges where target falls in a gap' do
+      # Python 3.0 is between 2.7 and 3.1 — unsupported
+      let(:target_opts) { { 'RuntimeVersions' => { 'Python' => '3.0' } } }
+      let(:payload_module_info) do
+        {
+          'SupportedVersions' => {
+            'Python' => [
+              Msf::Module::VersionRange.new(min: '2.5', max: '2.7'),
+              Msf::Module::VersionRange.new(min: '3.1')
+            ]
+          }
+        }
+      end
+
+      it 'returns a warning because 3.0 is in the gap between ranges' do
+        warnings = subject.version_compatibility_warnings(payload_instance)
+        expect(warnings).to eq(["Payload requires Python version within a supported range (minimum Python (2.5)), but the target provides Python (3.0)"])
+      end
+    end
+
+    context 'when Windows XP SP0/SP1 target is compared to Meterpreter minimum' do
+      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP0 } } }
+      let(:payload_module_info) do
+        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+      end
+
+      it 'returns a warning' do
+        warnings = subject.version_compatibility_warnings(payload_instance)
+        expect(warnings).to eq(["Payload requires Windows version within a supported range (minimum Windows XP Service Pack 2 (5.1.2600.2)), but the target provides Windows XP (5.1.2600.0)"])
+      end
+    end
+
+    context 'when Windows XP SP2 target is compared to Meterpreter minimum' do
+      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 } } }
+      let(:payload_module_info) do
+        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+      end
+
+      it 'returns no warnings' do
+        expect(subject.version_compatibility_warnings(payload_instance)).to be_empty
+      end
+    end
+
+    context 'when Windows Server 2003 SP0 target is compared to Meterpreter minimum' do
+      let(:target_opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::Server2003_SP0 } } }
+      let(:payload_module_info) do
+        { 'SupportedVersions' => supported_versions_from_min('Windows', Msf::WindowsVersion::XP_SP2) }
+      end
+
+      it 'returns no warnings because Server 2003 (5.2) is above XP SP2 (5.1)' do
+        expect(subject.version_compatibility_warnings(payload_instance)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/module/version_range_spec.rb
+++ b/spec/lib/msf/core/module/version_range_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Module::VersionRange do
+  describe '.valid_version_value?' do
+    [
+      { value: nil,     expected: false },
+      { value: 'nil',   expected: false },
+      { value: '',      expected: false },
+      { value: 0,       expected: true  },
+      { value: '0',     expected: true  },
+      { value: false,   expected: false },
+      { value: true,    expected: false },
+      { value: {},      expected: false },
+      { value: [],      expected: false },
+      { value: [{}],    expected: false },
+      { value: '0.0.1', expected: true  },
+      { value: '1.0.0', expected: true  },
+      { value: '1.0.0.0', expected: true },
+    ].each do |test_case|
+      context "when provided with #{test_case[:value].inspect}" do
+        it "returns #{test_case[:expected]}" do
+          expect(described_class.valid_version_value?(test_case[:value])).to eq(test_case[:expected])
+        end
+      end
+    end
+  end
+
+  describe '#initialize' do
+    context 'when neither min nor max is provided' do
+      it 'raises an error' do
+        expect { described_class.new }.to raise_error(RuntimeError, /Improper argument/)
+      end
+    end
+
+    context 'when min is an invalid string' do
+      it 'raises an error' do
+        expect { described_class.new(min: 'nil', max: '1.0.0') }.to raise_error(RuntimeError, /Improper argument/)
+      end
+    end
+
+    context 'when max is an invalid string' do
+      it 'raises an error' do
+        expect { described_class.new(min: '1.0.0', max: 'nil') }.to raise_error(RuntimeError, /Improper argument/)
+      end
+    end
+
+    context 'when both min and max are valid' do
+      it 'does not raise' do
+        expect { described_class.new(min: '1.0.0', max: '2.0.0') }.not_to raise_error
+      end
+    end
+
+    context 'when max is nil (unbounded upper range)' do
+      it 'does not raise' do
+        expect { described_class.new(min: '1.0.0') }.not_to raise_error
+      end
+
+      it 'stores nil max' do
+        range = described_class.new(min: '1.0.0')
+        expect(range.max).to be_nil
+      end
+    end
+
+    context 'when min is nil (unbounded lower range)' do
+      it 'does not raise' do
+        expect { described_class.new(max: '5.0.0') }.not_to raise_error
+      end
+
+      it 'stores nil min' do
+        range = described_class.new(max: '5.0.0')
+        expect(range.min).to be_nil
+      end
+    end
+  end
+
+  describe '#contains?' do
+    [
+      # bounded range
+      { min: '0.0.0', max: '1.0.0', value: nil,     expected: nil   },
+      { min: '0.0.0', max: '1.0.0', value: 'nil',   expected: nil   },
+      { min: '0.0.0', max: '1.0.0', value: '1.0.0', expected: true  },
+      { min: '0.0.0', max: '1.0.0', value: '0.5.0', expected: true  },
+      { min: '0.0.0', max: '1.0.0', value: '1.0.1', expected: false },
+      { min: '0.0.0', max: '1.0.0', value: 0,       expected: true  },
+      { min: '0.0.0', max: '1.0.0', value: 1,       expected: true  },
+      { min: '0.0.0', max: '1.0.0', value: 5,       expected: false },
+      # unbounded range (no max)
+      { min: '1.0.0', max: nil, value: '0.9.0',   expected: false },
+      { min: '1.0.0', max: nil, value: '1.0.0',   expected: true  },
+      { min: '1.0.0', max: nil, value: '99.0.0',  expected: true  },
+      # unbounded range (no min)
+      { min: nil, max: '5.0.0', value: '0.0.1',   expected: true  },
+      { min: nil, max: '5.0.0', value: '4.9.9',   expected: true  },
+      { min: nil, max: '5.0.0', value: '5.0.0',   expected: true  },
+      { min: nil, max: '5.0.0', value: '5.0.1',   expected: false },
+      { min: nil, max: '5.0.0', value: '99.0.0',  expected: false },
+      { min: nil, max: '5.0.0', value: nil,        expected: nil   },
+      { min: nil, max: '5.0.0', value: 'nil',      expected: nil   },
+      { min: nil, max: '5.0.0', value: 0,          expected: true  },
+      { min: nil, max: '5.0.0', value: 5,          expected: true  },
+      { min: nil, max: '5.0.0', value: 6,          expected: false },
+      # boundary conditions
+      { min: '2.5',   max: '2.7', value: '2.4',   expected: false },
+      { min: '2.5',   max: '2.7', value: '2.5',   expected: true  },
+      { min: '2.5',   max: '2.7', value: '2.6',   expected: true  },
+      { min: '2.5',   max: '2.7', value: '2.7',   expected: true  },
+      { min: '2.5',   max: '2.7', value: '3.0',   expected: false },
+    ].each do |test_case|
+      context "with range #{test_case[:min] || '(infinite)'}..#{test_case[:max] || '(infinite)'}" do
+        it "returns #{test_case[:expected].inspect} for value #{test_case[:value].inspect}" do
+          subject = described_class.new(min: test_case[:min], max: test_case[:max])
+          expect(subject.contains?(test_case[:value])).to eq(test_case[:expected])
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/module/version_range_spec.rb
+++ b/spec/lib/msf/core/module/version_range_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Module::VersionRange do
+  describe '.valid_version_value?' do
+    [
+      { value: nil,     expected: false },
+      { value: 'nil',   expected: false },
+      { value: '',      expected: false },
+      { value: 0,       expected: true  },
+      { value: '0',     expected: true  },
+      { value: false,   expected: false },
+      { value: true,    expected: false },
+      { value: {},      expected: false },
+      { value: [],      expected: false },
+      { value: [{}],    expected: false },
+      { value: '0.0.1', expected: true  },
+      { value: '1.0.0', expected: true  },
+      { value: '1.0.0.0', expected: true },
+    ].each do |test_case|
+      context "when provided with #{test_case[:value].inspect}" do
+        it "returns #{test_case[:expected]}" do
+          expect(described_class.valid_version_value?(test_case[:value])).to eq(test_case[:expected])
+        end
+      end
+    end
+  end
+
+  describe '#initialize' do
+    context 'when min is nil' do
+      it 'raises an error' do
+        expect { described_class.new(min: nil, max: '1.0.0') }.to raise_error(RuntimeError, /Improper argument/)
+      end
+    end
+
+    context 'when min is an invalid string' do
+      it 'raises an error' do
+        expect { described_class.new(min: 'nil', max: '1.0.0') }.to raise_error(RuntimeError, /Improper argument/)
+      end
+    end
+
+    context 'when both min and max are valid' do
+      it 'does not raise' do
+        expect { described_class.new(min: '1.0.0', max: '2.0.0') }.not_to raise_error
+      end
+    end
+
+    context 'when max is nil (unbounded range)' do
+      it 'does not raise' do
+        expect { described_class.new(min: '1.0.0') }.not_to raise_error
+      end
+
+      it 'stores nil max' do
+        range = described_class.new(min: '1.0.0')
+        expect(range.max).to be_nil
+      end
+    end
+  end
+
+  describe '#contains?' do
+    [
+      # bounded range
+      { min: '0.0.0', max: '1.0.0', value: nil,     expected: nil   },
+      { min: '0.0.0', max: '1.0.0', value: 'nil',   expected: nil   },
+      { min: '0.0.0', max: '1.0.0', value: '1.0.0', expected: true  },
+      { min: '0.0.0', max: '1.0.0', value: '0.5.0', expected: true  },
+      { min: '0.0.0', max: '1.0.0', value: '1.0.1', expected: false },
+      { min: '0.0.0', max: '1.0.0', value: 0,       expected: true  },
+      { min: '0.0.0', max: '1.0.0', value: 1,       expected: true  },
+      { min: '0.0.0', max: '1.0.0', value: 5,       expected: false },
+      # unbounded range (no max)
+      { min: '1.0.0', max: nil, value: '0.9.0',   expected: false },
+      { min: '1.0.0', max: nil, value: '1.0.0',   expected: true  },
+      { min: '1.0.0', max: nil, value: '99.0.0',  expected: true  },
+      # boundary conditions
+      { min: '2.5',   max: '2.7', value: '2.4',   expected: false },
+      { min: '2.5',   max: '2.7', value: '2.5',   expected: true  },
+      { min: '2.5',   max: '2.7', value: '2.6',   expected: true  },
+      { min: '2.5',   max: '2.7', value: '2.7',   expected: true  },
+      { min: '2.5',   max: '2.7', value: '3.0',   expected: false },
+    ].each do |test_case|
+      context "with range #{test_case[:min]}..#{test_case[:max] || '∞'}" do
+        it "returns #{test_case[:expected].inspect} for value #{test_case[:value].inspect}" do
+          subject = described_class.new(min: test_case[:min], max: test_case[:max])
+          expect(subject.contains?(test_case[:value])).to eq(test_case[:expected])
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/target_spec.rb
+++ b/spec/lib/msf/core/target_spec.rb
@@ -4,4 +4,73 @@ RSpec.describe Msf::Target do
   it 'is an alias for Msf::Module::Target' do
     expect(described_class.name).to eq('Msf::Module::Target')
   end
+
+  describe 'automatic runtime version tagging' do
+    subject(:target) { described_class.new(name, opts) }
+
+    let(:opts) { {} }
+
+    context 'when the name specifies a single Windows version' do
+      let(:name) { 'Windows 7 SP1' }
+
+      it 'infers the Windows runtime version' do
+        expect(target.runtime_versions).to eq('Windows' => Msf::WindowsVersion::Win7_SP1)
+      end
+    end
+
+    context 'when the name is generic' do
+      let(:name) { 'Windows x64' }
+
+      it 'leaves the target untagged' do
+        expect(target.runtime_versions).to be_nil
+      end
+    end
+
+    context 'when the name references several versions' do
+      let(:name) { 'Windows XP SP3 / Windows 7 SP1' }
+
+      it 'leaves the target untagged' do
+        expect(target.runtime_versions).to be_nil
+      end
+    end
+
+    context 'when a Windows version is set manually' do
+      let(:name) { 'Windows 7 SP1' }
+      let(:opts) { { 'RuntimeVersions' => { 'Windows' => Msf::WindowsVersion::XP_SP2 } } }
+
+      it 'preserves the manual value' do
+        expect(target.runtime_versions).to eq('Windows' => Msf::WindowsVersion::XP_SP2)
+      end
+    end
+
+    context 'when other runtime versions are set manually' do
+      let(:name) { 'Windows 7 SP1' }
+      let(:opts) { { 'RuntimeVersions' => { 'Python' => '3.6' } } }
+
+      it 'adds the inferred Windows version alongside them' do
+        expect(target.runtime_versions).to eq(
+          'Python' => '3.6',
+          'Windows' => Msf::WindowsVersion::Win7_SP1
+        )
+      end
+    end
+
+    context 'when the target platform is not Windows' do
+      let(:name) { 'Windows Server 2016' }
+      let(:opts) { { 'Platform' => 'linux' } }
+
+      it 'does not infer a Windows version' do
+        expect(target.runtime_versions).to be_nil
+      end
+    end
+
+    context 'when the target platform is Windows' do
+      let(:name) { 'Windows 7' }
+      let(:opts) { { 'Platform' => 'win' } }
+
+      it 'infers the Windows runtime version' do
+        expect(target.runtime_versions).to eq('Windows' => Msf::WindowsVersion::Win7_SP0)
+      end
+    end
+  end
 end

--- a/spec/lib/msf/core/windows_version_spec.rb
+++ b/spec/lib/msf/core/windows_version_spec.rb
@@ -72,4 +72,105 @@ RSpec.describe Msf::WindowsVersion do
     version_string = described_class.from_ntlm_os_version(major, minor, build)
     expect(version_string).to eq(nil)
   end
+
+  describe '.from_target_name' do
+    context 'with a single, specific workstation version' do
+      {
+        'Windows 7' => described_class::Win7_SP0,
+        'Windows 7 SP1' => described_class::Win7_SP1,
+        'Windows 7 SP1 x64' => described_class::Win7_SP1,
+        'CyberLink LabelPrint <= 2.5 on Windows 7 (64 bit)' => described_class::Win7_SP0,
+        'Windows XP SP3' => described_class::XP_SP3,
+        'on Windows XP SP3 English (w/DEP bypass)' => described_class::XP_SP3,
+        'Windows Vista' => described_class::Vista_SP0,
+        'Windows 8' => described_class::Win8,
+        'Windows 8.1 x64' => described_class::Win81,
+        'Windows 11' => described_class::Win11_21H2
+      }.each do |name, expected|
+        it "resolves #{name.inspect} to #{expected}" do
+          expect(described_class.from_target_name(name)).to eq(expected)
+        end
+      end
+    end
+
+    context 'with a single, specific server version' do
+      {
+        'Server 2003 Sp2' => described_class::Server2003_SP2,
+        'Windows Server 2003 English SP0/SP1' => described_class::Server2003_SP0,
+        'Windows Server 2008 R2' => described_class::Server2008_R2_SP0,
+        'Windows Server 2008 R2 SP1' => described_class::Server2008_R2_SP1,
+        'Windows Server 2012 R2' => described_class::Server2012_R2,
+        'Windows Server 2016' => described_class::Server2016
+      }.each do |name, expected|
+        it "resolves #{name.inspect} to #{expected}" do
+          expect(described_class.from_target_name(name)).to eq(expected)
+        end
+      end
+    end
+
+    context 'when multiple service packs are referenced for one family' do
+      it 'returns the oldest as the minimum version' do
+        expect(described_class.from_target_name('Windows XP SP2/SP3')).to eq(described_class::XP_SP2)
+        expect(described_class.from_target_name('Windows XP SP0/SP1')).to eq(described_class::XP_SP0)
+      end
+    end
+
+    context 'with Windows 2000 service packs' do
+      it 'maps SP0-SP3 to the base build and SP4 to its specific build' do
+        expect(described_class.from_target_name('Windows 2000 SP0-SP4 English')).to eq(described_class::Win2000)
+        expect(described_class.from_target_name('Windows 2000 SP4 English')).to eq(described_class::Win2000_SP4)
+      end
+    end
+
+    context 'with a generic name that does not specify a version' do
+      ['Windows', 'Windows x64', 'Windows Universal', 'Windows (All)', 'Automatic'].each do |name|
+        it "returns nil for #{name.inspect}" do
+          expect(described_class.from_target_name(name)).to be_nil
+        end
+      end
+    end
+
+    context 'with a name that references several different versions' do
+      [
+        'Chasys Draw IES 4.10.01 / Windows XP SP3 / Windows 7 SP1',
+        'Adobe Reader v8.x / Windows XP SP3 / Windows Vista/7/10',
+        '<Win Xp, Win 7, Win 8, Win 10>'
+      ].each do |name|
+        it "returns nil for the ambiguous name #{name.inspect}" do
+          expect(described_class.from_target_name(name)).to be_nil
+        end
+      end
+    end
+
+    context 'with a non-Windows name' do
+      ['Linux x86', 'PHP', 'Java Universal', 'Apple macOS'].each do |name|
+        it "returns nil for #{name.inspect}" do
+          expect(described_class.from_target_name(name)).to be_nil
+        end
+      end
+    end
+
+    it 'does not treat unrelated software release years as an OS version' do
+      # The year is not preceded by "Windows"/"Server", so it must not be read
+      # as a Server SKU.
+      expect(described_class.from_target_name('SomeApp 2016 on Linux')).to be_nil
+    end
+
+    it 'does not treat a CVE year as an OS version' do
+      # "2019" here is part of a CVE id, so the name resolves to Windows 7 only
+      # rather than being treated as ambiguous (Windows 7 + Server 2019).
+      name = 'Windows 7 (x64) sandbox escape via CVE-2019-1458'
+      expect(described_class.from_target_name(name)).to eq(described_class::Win7_SP0)
+    end
+
+    it 'does not match a bare version number without a Windows prefix' do
+      # "8.1" here is a product version, not Windows 8.1.
+      expect(described_class.from_target_name('BEA WebLogic 8.1 SP4')).to be_nil
+    end
+
+    it 'returns nil for non-string input' do
+      expect(described_class.from_target_name(nil)).to be_nil
+      expect(described_class.from_target_name('')).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses https://github.com/rapid7/metasploit-framework/issues/21320

This PR:
- adds a minimum Windows version requirement to Windows Meterpreter payloads
- outputs any required software versions when running the `info` command on a payload
- tags the Python payloads as supporting Python 2.5+ only (no modules utilise this currently, but I added this to show that this approach is not strictly Windows Meterpreter-only)
- tagged some targets for some ms modules with their versions => this seems cumbersome though, maybe we can spike out an improved pattern here? (potentially based on the target name? Or using actual Target objects, such as `Msf::Targets::Windows_XP_SP1.new(ret: 0xFFFF)` etc.)
- adds a warning (not an outright failure) when selecting a payload or target that is incompatible with one another (not a hard error right now due to not all modules having this behaviour, so i think it is the safest to not break this workflow just yet)
- adds unit and integration specs
- adds the platform version warnings when selecting a module, payload or target
  - selecting a module will now result in the first compatible payload. previously an exploit could select a default of Windows Meterpreter even when the target selected would be Windows XP SP1 etc.
  - when setting a payload with a target already selected, the warning will be output if it is not compatible
  - when setting a target with a payload specified, a warning will be shown if they are not compatible
- maps the cryptic Windows build numbers to human-readable strings when outputting the payload version incompatibility warnings
- adds the Windows 2000 Service Pack 4 constant to available Windows versions as it was used by some of the modified modules

Upper bounds or maximum supported versions are not implemented, e.g. `MinimumVersion: Windows 7, MaximumVersion: Windows 7 SP 2`

## Examples

I'm using `windows/smb/ms08_067_netapi` for this example.

### Setting payload
Warning on Meterpreter payload when targeting an old OS target, no warnings with a shell payload
```
msf exploit(windows/smb/ms08_067_netapi) > set target 1 (Windows 2000 Universal)
msf exploit(windows/smb/ms08_067_netapi) > set payload windows/meterpreter/reverse_tcp
[!] Payload requires Windows >= Windows XP Service Pack 2 (5.1.2600.2), but target provides Windows 2000 (5.0.2195)
payload => windows/meterpreter/reverse_tcp

msf exploit(windows/smb/ms08_067_netapi) > set payload windows/shell/reverse_tcp
payload => windows/shell/reverse_tcp
```

### Setting target

```
msf exploit(windows/smb/ms08_067_netapi) > set target 7
target => 7 (windows XP SP3)
# no errors

msf exploit(windows/smb/ms08_067_netapi) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
# No errors

msf exploit(windows/smb/ms08_067_netapi) > set target 1
[!] Payload requires Windows >= Windows XP Service Pack 2 (5.1.2600.2), but target provides Windows 2000 (5.0.2195)
target => 1
# Now warning when setting target after setting payload
```

### Automatic target selection
This scenario will only output a warning if any of the module targets specify a version that is lower than the currently selected payload requirement:
```
msf exploit(windows/smb/ms08_067_netapi) > set target 0
[!] Payload requires Windows >= Windows XP Service Pack 2 (5.1.2600.2), but target provides Windows 2000 (5.0.2195)
target => 0
msf exploit(windows/smb/ms08_067_netapi) > set target 1
[!] Payload requires Windows >= Windows XP Service Pack 2 (5.1.2600.2), but target provides Windows 2000 (5.0.2195)
target => 1
msf exploit(windows/smb/ms08_067_netapi) > set target 39
target => 39
```

### `info` command
```
msf payload(windows/x64/meterpreter/reverse_tcp) > info

             Name: Windows Meterpreter (Reflective Injection x64), Windows x64 Reverse TCP Stager
           Module: payload/windows/x64/meterpreter/reverse_tcp
         Platform: Windows
             Arch: x64
      Needs Admin: No
       Total size: 450
             Rank: Normal
Required Versions:
  Windows: 5.1.2600.2
```

## Verification

- [ ] Start `msfconsole`
- [ ] `use exploit/windows/smb/ms08_067_netapi`
- [ ] `set target ...`
- [ ] `set payload ...`
- [ ] Experiment with different Wdinows version targets and payloads (Meterpreter/shell etc.)
- [ ] Use a `payload` module that has been modified, and confirm that the `info` command outputs the required versions
- [ ] Run the rspec tests: `bundle exec rspec spec/lib/msf/core/module/version_compatibility_spec.rb spec/integration/payload_version_compatibility/version_compatibility_integration_spec.rb`
