### PR TITLE
Update check setup methods on http scanners

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/axis_login.md
+++ b/documentation/modules/auxiliary/scanner/http/axis_login.md
@@ -4,6 +4,15 @@ This module attempts to login to an Apache Axis2 instance using username and pas
 combinations indicated by the USER_FILE, PASS_FILE, and USERPASS_FILE options.
 It has been verified to work on at least versions 1.4.1 and 1.6.2.
 
+A Docker target is available for testing. Build and run it with:
+
+```
+docker build -t axis2-msf-test test/axis2/
+docker run --rm -p 8080:8080 axis2-msf-test
+```
+
+The default Axis2 admin credentials are `admin` / `axis2`.
+
 ## Verification Steps
 1. Start msfconsole
 2. Do: `use auxiliary/scanner/http/axis_login`

--- a/documentation/modules/auxiliary/scanner/http/tomcat_mgr_login.md
+++ b/documentation/modules/auxiliary/scanner/http/tomcat_mgr_login.md
@@ -31,6 +31,15 @@ loaded.
 
 ## Vulnerable Application
 
+A Docker target is available. Build and run it with:
+
+```
+docker build -t tomcat-msf-test test/tomcat/
+docker run --rm -p 8080:8080 tomcat-msf-test
+```
+
+The test credentials are `tomcat` / `tomcat`.
+
 To download the vulnerable application, you can find it here: https://tomcat.apache.org/whichversion.html.
 
 ## Verification Steps

--- a/lib/metasploit/framework/login_scanner/axis2.rb
+++ b/lib/metasploit/framework/login_scanner/axis2.rb
@@ -14,6 +14,24 @@ module Metasploit
         CAN_GET_SESSION = true
         PRIVATE_TYPES   = [ :password ]
 
+        # Checks if the target is Apache Axis2
+        #
+        # @return [false] if the target looks like Axis2
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          res = send_request({
+            'method' => 'GET',
+            'uri'    => uri
+          })
+
+          return 'Unable to connect to the Axis2 login page' unless res
+          return 'Unable to locate Axis2 login page (Is this really Apache Axis2?)' unless res.code == 200 && res.body.include?('axis2-admin')
+
+          report_service(service_opts)
+
+          false
+        end
+
         # (see Base#attempt_login)
         def attempt_login(credential)
           result_opts = {

--- a/lib/metasploit/framework/login_scanner/buffalo.rb
+++ b/lib/metasploit/framework/login_scanner/buffalo.rb
@@ -13,6 +13,26 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
+        # Checks if the target is a Buffalo NAS device.
+        # Note: probes / for the fingerprint page rather than the login endpoint
+        # (/dynamic.pl) since that only responds meaningfully to POST requests.
+        #
+        # @return [false] if the target looks like a Buffalo NAS
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          res = send_request({
+            'method' => 'GET',
+            'uri'    => '/'
+          })
+
+          return 'Unable to connect to the Buffalo NAS web interface' unless res
+          return 'Unable to locate Buffalo NAS web interface (Is this really a Buffalo NAS?)' unless res.code == 200 && (res.body.include?('Buffalo') && res.body.include?('bufaction'))
+
+          report_service(service_opts)
+
+          false
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           self.uri = "/dynamic.pl" if self.uri.nil?
@@ -52,7 +72,7 @@ module Metasploit
         end
 
         def service_opts
-          build_service_opts('buffalo')
+          build_service_opts('buffalo-nas')
         end
       end
     end

--- a/lib/metasploit/framework/login_scanner/gitlab.rb
+++ b/lib/metasploit/framework/login_scanner/gitlab.rb
@@ -10,6 +10,35 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
+        # Checks if the target is a GitLab instance
+        #
+        # @return [false] if the target looks like GitLab
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          res = send_request(
+            'method' => 'GET',
+            'cookie' => 'request_method=GET',
+            'uri'    => uri
+          )
+
+          return 'Unable to connect to the GitLab login page' unless res
+          return 'Unable to locate GitLab login page (Is this really GitLab?)' unless res.code == 200 && (res.body.include?('user[email]') || res.body.include?('user[login]'))
+
+          if res.body.include?('user[email]')
+            framework_module&.vprint_status('GitLab v5 login page')
+          elsif res.body.include?('user[login]')
+            framework_module&.vprint_status('GitLab v7 login page')
+          end
+
+          report_service(service_opts)
+
+          false
+        end
+
+        def service_opts
+          build_service_opts('gitlab')
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           self.uri = '/users/sign_in' if uri.nil?
@@ -23,7 +52,7 @@ module Metasploit
             credential: credential,
             **service_as_result(service_opts)
           }
-          begin 
+          begin
             # Get a valid session cookie and authenticity_token for the next step
             res = send_request(
               'method' => 'GET',

--- a/lib/metasploit/framework/login_scanner/ipboard.rb
+++ b/lib/metasploit/framework/login_scanner/ipboard.rb
@@ -15,6 +15,28 @@ module Metasploit
         # @return [String]
         attr_accessor :http_password
 
+        # Checks if the target is an IP Board instance
+        #
+        # @return [false] if the target looks like IP Board
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          res = send_request({
+            'uri'    => uri,
+            'method' => 'GET'
+          })
+
+          return 'Unable to connect to the IP Board login page' unless res
+          return 'Unable to locate IP Board login page (Is this really IP Board?)' unless res.code == 200 && res.body =~ /name='auth_key'\s+value='/i
+
+          report_service(service_opts)
+
+          false
+        end
+
+        def service_opts
+          build_service_opts('ipboard')
+        end
+
         # (see Base#attempt_login)
         def attempt_login(credential)
           result_opts = {

--- a/lib/metasploit/framework/login_scanner/jupyter.rb
+++ b/lib/metasploit/framework/login_scanner/jupyter.rb
@@ -12,6 +12,28 @@ module Metasploit
         DEFAULT_PORT    = 8888
         PRIVATE_TYPES   = [ :password ]
 
+        # Checks if the target is a Jupyter instance
+        #
+        # @return [false] if the target looks like Jupyter
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          res = send_request({
+            'method' => 'GET',
+            'uri'    => normalize_uri(uri)
+          })
+
+          return 'Unable to connect to the Jupyter login page' unless res
+          return 'Unable to locate Jupyter login page (Is this really Jupyter?)' unless res.code == 200 && res.body.include?('jupyter') && res.body.include?('password')
+
+          report_service(service_opts)
+
+          false
+        end
+
+        def service_opts
+          build_service_opts('jupyter')
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           self.uri = '/login' if self.uri.nil?

--- a/lib/metasploit/framework/login_scanner/mybook_live.rb
+++ b/lib/metasploit/framework/login_scanner/mybook_live.rb
@@ -12,6 +12,28 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
+        # Checks if the target is a Western Digital MyBook Live device
+        #
+        # @return [false] if the target looks like MyBook Live
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          res = send_request({
+            'method' => 'GET',
+            'uri'    => uri
+          })
+
+          return 'Unable to connect to the MyBook Live login page' unless res
+          return 'Unable to locate MyBook Live login page (Is this really Western Digital MyBook Live?)' unless res.code == 200 && res.body.include?('My Book Live')
+
+          report_service(service_opts)
+
+          false
+        end
+
+        def service_opts
+          build_service_opts('mybook-live')
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           self.uri = '/UI/login' if self.uri.nil?

--- a/lib/metasploit/framework/login_scanner/octopusdeploy.rb
+++ b/lib/metasploit/framework/login_scanner/octopusdeploy.rb
@@ -13,6 +13,28 @@ module Metasploit
         DEFAULT_PORT    = 80
         PRIVATE_TYPES   = [ :password ]
 
+        # Checks if the target is an Octopus Deploy server
+        #
+        # @return [false] if the target looks like Octopus Deploy
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          res = send_request({
+            'method' => 'GET',
+            'uri'    => '/api'
+          })
+
+          return 'Unable to connect to the Octopus Deploy API' unless res
+          return 'Unable to locate Octopus Deploy API (Is this really Octopus Deploy?)' unless res.code == 200 && res.body.include?('OctopusDeploy')
+
+          report_service(service_opts)
+
+          false
+        end
+
+        def service_opts
+          build_service_opts('octopusdeploy')
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           uri = '/api/users/login' if uri.nil?

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -12,6 +12,27 @@ module Metasploit
         PRIVATE_TYPES = [ :password ]
         CAN_GET_SESSION = true
 
+        # Checks if the target is HP System Management Homepage
+        #
+        # @return [false] if the target looks like HP SMH
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          res = send_request({
+            'method' => 'GET',
+            'uri'    => normalize_uri('/cpqlogin.htm')
+          })
+
+          return 'Unable to connect to the HP System Management Homepage login page' unless res
+          return 'Unable to locate HP System Management Homepage login page (Is this really HP SMH?)' unless res.code == 200 && res.body.include?('HP System Management Homepage')
+
+          report_service(service_opts)
+
+          false
+        end
+
+        def service_opts
+          build_service_opts('hp-smh')
+        end
 
         # (see Base#attempt_login)
         def attempt_login(credential)

--- a/lib/metasploit/framework/login_scanner/tomcat.rb
+++ b/lib/metasploit/framework/login_scanner/tomcat.rb
@@ -13,6 +13,29 @@ module Metasploit
         DEFAULT_PORT    = 8180
         PRIVATE_TYPES   = [ :password ]
 
+        # Checks if the target is a Tomcat Manager instance
+        #
+        # @return [false] if the target looks like Tomcat Manager
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          res = send_request({
+            'method'   => 'GET',
+            'uri'      => uri,
+            'username' => Rex::Text.rand_text_alpha(8)
+          })
+
+          return 'Unable to connect to the Tomcat Manager page' unless res
+          return 'Tomcat Manager does not appear to require authentication (Is this really Tomcat Manager?)' unless res.code == 401 && res.headers['WWW-Authenticate'].to_s.include?('Tomcat')
+
+          report_service(service_opts)
+
+          false
+        end
+
+        def service_opts
+          build_service_opts('tomcat')
+        end
+
         # (see Base#set_sane_defaults)
         def set_sane_defaults
           self.uri = "/manager/html" if self.uri.nil?

--- a/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_multicall.rb
@@ -35,6 +35,30 @@ module Metasploit
           @chunk_size ||= 1700
         end
 
+        # Checks if the target is a WordPress site with XML-RPC enabled
+        #
+        # @return [false] if the target looks like WordPress with XML-RPC
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          set_default
+          xmlrpc_uri = normalize_uri(base_uri, wordpress_url_xmlrpc)
+          res = send_request({
+            'method' => 'GET',
+            'uri'    => xmlrpc_uri
+          })
+
+          return 'Unable to connect to the WordPress XML-RPC endpoint' unless res
+          return 'Unable to locate WordPress XML-RPC endpoint (Is WordPress installed and is XML-RPC enabled?)' unless res.code == 200 && res.body.include?('XML-RPC server accepts POST requests only')
+
+          report_service(service_opts)
+
+          false
+        end
+
+        def service_opts
+          build_service_opts('wordpress')
+        end
+
         # Returns the XML data that is used for the login.
         #
         # @param user [String] username

--- a/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
+++ b/lib/metasploit/framework/login_scanner/wordpress_rpc.rb
@@ -7,6 +7,28 @@ module Metasploit
       # Wordpress XML RPC login scanner
       class WordpressRPC < HTTP
 
+        # Checks if the target is a WordPress XML-RPC endpoint
+        #
+        # @return [false] if the target looks like a WordPress XML-RPC endpoint
+        # @return [String] a human-readable error message if it doesn't
+        def check_setup
+          res = send_request({
+            'method' => 'GET',
+            'uri'    => uri
+          })
+
+          return 'Unable to connect to the WordPress XML-RPC endpoint' unless res
+          return 'Unable to locate WordPress XML-RPC endpoint (Is WordPress installed and is XML-RPC enabled?)' unless res.code == 200 && res.body.include?('XML-RPC server accepts POST requests only')
+
+          report_service(service_opts)
+
+          false
+        end
+
+        def service_opts
+          build_service_opts('wordpress')
+        end
+
         # (see Base#attempt_login)
         def attempt_login(credential)
           result_opts = {

--- a/modules/auxiliary/scanner/http/appletv_login.rb
+++ b/modules/auxiliary/scanner/http/appletv_login.rb
@@ -57,6 +57,21 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => '/server-info'
+    })
+
+    unless res
+      print_error("#{peer} - Could not connect to the AppleTV service")
+      return
+    end
+
+    unless res.headers['Server']&.include?('AirTunes')
+      print_error("#{peer} - Host does not appear to be an AppleTV AirPlay device. Module will not continue.")
+      return
+    end
+
     uri = "/stop"
     if datastore['PASS_FILE'] && !datastore['PASS_FILE'].empty?
       print_status("Attempting to login to #{uri} using password list")

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -45,20 +45,6 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     uri = normalize_uri(target_uri.path)
 
-    print_status("Verifying login exists at #{target_url}")
-    begin
-      send_request_cgi({
-        'method' => 'GET',
-        'uri' => uri
-      }, 20)
-    rescue => e
-      print_error("Failed to retrieve Axis2 login page at #{target_url}")
-      print_error("Error: #{e.class}: #{e}")
-      return
-    end
-
-    print_status "#{target_url} - Apache Axis - Attempting authentication"
-
     cred_collection = build_credential_collection(
       username: datastore['USERNAME'],
       password: datastore['PASSWORD']
@@ -75,6 +61,14 @@ class MetasploitModule < Msf::Auxiliary
         http_password: datastore['HttpPassword']
       )
     )
+
+    msg = scanner.check_setup
+    if msg
+      print_error("#{peer} - #{msg}")
+      return
+    end
+
+    print_status "#{target_url} - Apache Axis - Attempting authentication"
 
     scanner.scan! do |result|
       credential_data = result.to_h

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -47,6 +47,12 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
 
+    msg = scanner.check_setup
+    if msg
+      print_error("#{peer} - #{msg}")
+      return
+    end
+
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
@@ -58,10 +64,10 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
 
-        print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
+        print_good "#{Rex::Socket.to_authority(ip, rport)} - Login Successful: #{result.credential}"
       else
         invalidate_login(credential_data)
-        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
+        vprint_error "#{Rex::Socket.to_authority(ip, rport)} - LOGIN FAILED: #{result.credential} (#{result.status})"
       end
     end
   end

--- a/modules/auxiliary/scanner/http/dolibarr_login.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_login.rb
@@ -149,6 +149,21 @@ class MetasploitModule < Msf::Auxiliary
     @uri = target_uri.path
     @uri << "/" if @uri[-1, 1] != "/"
 
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri'    => normalize_uri(@uri)
+    })
+
+    unless res
+      print_error("#{peer} - Could not connect to the Dolibarr login page")
+      return
+    end
+
+    unless res.code == 200 && res.body.include?('Dolibarr')
+      print_error("#{peer} - Application does not appear to be Dolibarr. Module will not continue.")
+      return
+    end
+
     super
   end
 

--- a/modules/auxiliary/scanner/http/gitlab_login.rb
+++ b/modules/auxiliary/scanner/http/gitlab_login.rb
@@ -35,20 +35,6 @@ class MetasploitModule < Msf::Auxiliary
 
   def run_host(ip)
     uri = normalize_uri(target_uri.path.to_s, 'users', 'sign_in')
-    res = send_request_cgi(
-      'method' => 'GET',
-      'cookie' => 'request_method=GET',
-      'uri' => uri
-    )
-
-    if res && res.body && res.body.include?('user[email]')
-      vprint_status('GitLab v5 login page')
-    elsif res && res.body && res.body.include?('user[login]')
-      vprint_status('GitLab v7 login page')
-    else
-      vprint_error('Not a valid GitLab login page')
-      return
-    end
 
     cred_collection = build_credential_collection(
       username: datastore['USERNAME'],
@@ -65,6 +51,12 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
 
+    msg = scanner.check_setup
+    if msg
+      print_error("#{peer} - #{msg}")
+      return
+    end
+
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
@@ -76,10 +68,10 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
 
-        print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
+        print_good "#{Rex::Socket.to_authority(ip, rport)} - Login Successful: #{result.credential}"
       else
         invalidate_login(credential_data)
-        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
+        vprint_error "#{Rex::Socket.to_authority(ip, rport)} - LOGIN FAILED: #{result.credential} (#{result.status})"
       end
     end
   end

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -46,6 +46,12 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
 
+    msg = scanner.check_setup
+    if msg
+      print_error("#{peer} - #{msg}")
+      return
+    end
+
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(

--- a/modules/auxiliary/scanner/http/mybook_live_login.rb
+++ b/modules/auxiliary/scanner/http/mybook_live_login.rb
@@ -68,6 +68,12 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
 
+    msg = scanner.check_setup
+    if msg
+      print_error("#{peer} - #{msg}")
+      return
+    end
+
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
@@ -79,10 +85,10 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
 
-        print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
+        print_good "#{Rex::Socket.to_authority(ip, rport)} - Login Successful: #{result.credential}"
       else
         invalidate_login(credential_data)
-        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
+        vprint_error "#{Rex::Socket.to_authority(ip, rport)} - LOGIN FAILED: #{result.credential} (#{result.status})"
       end
     end
   end

--- a/modules/auxiliary/scanner/http/octopusdeploy_login.rb
+++ b/modules/auxiliary/scanner/http/octopusdeploy_login.rb
@@ -49,6 +49,12 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
 
+    msg = scanner.check_setup
+    if msg
+      print_error("#{peer} - #{msg}")
+      return
+    end
+
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
@@ -60,10 +66,10 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
 
-        print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
+        print_good "#{Rex::Socket.to_authority(ip, rport)} - Login Successful: #{result.credential}"
       else
         invalidate_login(credential_data)
-        vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
+        vprint_error "#{Rex::Socket.to_authority(ip, rport)} - LOGIN FAILED: #{result.credential} (#{result.status})"
       end
     end
   end

--- a/modules/auxiliary/scanner/http/opnsense_login.rb
+++ b/modules/auxiliary/scanner/http/opnsense_login.rb
@@ -94,6 +94,13 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::OPNSense.new(scanner_opts)
+
+    msg = scanner.check_setup
+    if msg
+      print_error("#{peer} - #{msg}")
+      return
+    end
+
     run_scanner(scanner)
   end
 end

--- a/modules/auxiliary/scanner/http/pfsense_login.rb
+++ b/modules/auxiliary/scanner/http/pfsense_login.rb
@@ -95,6 +95,13 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     scanner = Metasploit::Framework::LoginScanner::PfSense.new(scanner_opts)
+
+    msg = scanner.check_setup
+    if msg
+      print_error("#{peer} - #{msg}")
+      return
+    end
+
     run_scanner(scanner)
   end
 end

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -77,28 +77,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    begin
-      uri = normalize_uri(target_uri.path)
-      res = send_request_cgi({
-        'uri' => uri,
-        'method' => 'GET',
-        'username' => Rex::Text.rand_text_alpha(8)
-      }, 25)
-      http_fingerprint({ :response => res })
-    rescue ::Rex::ConnectionError => e
-      vprint_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{uri} - #{e}")
-      return
-    end
-
-    if not res
-      vprint_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{uri} - No response")
-      return
-    end
-    if res.code != 401
-      vprint_error("http://#{Rex::Socket.to_authority(rhost, rport)}#{uri} - Authorization not requested")
-      return
-    end
-
     cred_collection = build_credential_collection(
       username: datastore['USERNAME'],
       password: datastore['PASSWORD']
@@ -115,6 +93,12 @@ class MetasploitModule < Msf::Auxiliary
       )
     )
 
+    msg = scanner.check_setup
+    if msg
+      print_error("#{peer} - #{msg}")
+      return
+    end
+
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
@@ -127,13 +111,13 @@ class MetasploitModule < Msf::Auxiliary
         credential_data[:core] = credential_core
         create_credential_login(credential_data)
 
-        print_good "#{ip}:#{rport} - Login Successful: #{result.credential}"
+        print_good "#{Rex::Socket.to_authority(ip, rport)} - Login Successful: #{result.credential}"
       else
         invalidate_login(credential_data)
         if result.proof
-          vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
+          vprint_error "#{Rex::Socket.to_authority(ip, rport)} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"
         else
-          vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status})"
+          vprint_error "#{Rex::Socket.to_authority(ip, rport)} - LOGIN FAILED: #{result.credential} (#{result.status})"
         end
       end
     end

--- a/modules/auxiliary/scanner/http/vcms_login.rb
+++ b/modules/auxiliary/scanner/http/vcms_login.rb
@@ -143,6 +143,21 @@ class MetasploitModule < Msf::Auxiliary
     @uri = normalize_uri(target_uri.path)
     @uri << "/" if @uri[-1, 1] != "/"
 
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri' => @uri
+    })
+
+    unless res
+      print_error("#{peer} - Could not connect to the V-CMS login page")
+      return
+    end
+
+    unless res.code == 200 && res.body.include?('V-CMS')
+      print_error("#{peer} - Application does not appear to be V-CMS. Module will not continue.")
+      return
+    end
+
     super
   end
 

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -49,16 +49,6 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
-    print_status("#{peer}:#{wordpress_url_xmlrpc} - Sending Hello...")
-    if wordpress_xmlrpc_enabled?
-      vprint_good("XMLRPC enabled, Hello message received!")
-    else
-      print_error("XMLRPC is not enabled! Aborting")
-      return :abort
-    end
-
-    print_status("Starting XML-RPC login sweep...")
-
     cred_collection = build_credential_collection(
       username: datastore['USERNAME'],
       password: datastore['PASSWORD']
@@ -75,6 +65,14 @@ class MetasploitModule < Msf::Auxiliary
         http_password: datastore['HttpPassword']
       )
     )
+
+    msg = scanner.check_setup
+    if msg
+      print_error("#{peer} - #{msg}")
+      return
+    end
+
+    print_status("Starting XML-RPC login sweep...")
 
     scanner.scan! do |result|
       credential_data = result.to_h

--- a/test/axis2/Dockerfile
+++ b/test/axis2/Dockerfile
@@ -1,0 +1,17 @@
+FROM tomcat:9.0
+
+# Download Axis2 1.6.2 WAR (last version verified by the Metasploit module)
+RUN apt-get update -qq && apt-get install -y --no-install-recommends wget && rm -rf /var/lib/apt/lists/*
+RUN wget -q https://archive.apache.org/dist/axis/axis2/java/core/1.6.2/axis2-1.6.2-war.zip \
+    -O /tmp/axis2.zip && \
+    apt-get update -qq && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/* && \
+    unzip -q /tmp/axis2.zip -d /tmp/axis2 && \
+    cp /tmp/axis2/axis2.war /usr/local/tomcat/webapps/ && \
+    rm -rf /tmp/axis2 /tmp/axis2.zip
+
+# Move the bundled Tomcat apps into place (they live in webapps.dist in modern images)
+RUN cp -r /usr/local/tomcat/webapps.dist/. /usr/local/tomcat/webapps/
+
+# Restore the Server header so fingerprint checks pass (Tomcat 9 suppresses it by default)
+RUN sed -i 's|<Connector port="8080"|<Connector port="8080" server="Apache-Coyote/1.1"|' \
+    /usr/local/tomcat/conf/server.xml

--- a/test/tomcat/Dockerfile
+++ b/test/tomcat/Dockerfile
@@ -1,0 +1,11 @@
+FROM tomcat:9.0
+
+# The manager app lives in webapps.dist in modern Tomcat images — move it into place
+RUN cp -r /usr/local/tomcat/webapps.dist/. /usr/local/tomcat/webapps/
+
+# Add a manager-gui and manager-script user for testing
+RUN sed -i 's|</tomcat-users>|<role rolename="manager-gui"/><role rolename="manager-script"/><user username="tomcat" password="tomcat" roles="manager-gui,manager-script"/></tomcat-users>|' \
+    /usr/local/tomcat/conf/tomcat-users.xml
+
+# Remove the localhost-only RemoteAddrValve so the manager is reachable from outside the container
+RUN sed -i '/<Valve/d' /usr/local/tomcat/webapps/manager/META-INF/context.xml


### PR DESCRIPTION
Update check setup methods on http scanners

This PR should:
- Ensure HTTP modules call `check_setup` consistently as pre-requisite to running the scanner.scan! logic
- Remove any existing adhoc remote fingerprinting logic in the module or scanner to now be in the `check_setup` method
- Remove any adhoc remote fingerprinting logic in the `atttempt_login` or `scan!` methods to now be in `check_setup`

## Verification

Ensure the login scanners validate the remote target as a pre-requisite to running the login attempts