### PR TITLE
fix: handle ActiveRecord::RecordInvalid in ssh_creds when workspace is reset

### DIFF
--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -108,8 +108,9 @@ class MetasploitModule < Msf::Post
             username: user,
             workspace_id: myworkspace_id
           }
-
           create_credential(credential_data)
+        rescue ActiveRecord::RecordInvalid => e
+          print_warning("Could not save credential to database: #{e.message}")
         rescue OpenSSL::OpenSSLError => e
           print_error("Could not load SSH Key: #{e.message}")
         end


### PR DESCRIPTION
Fixes #21480

When `workspace -D` is run while a session is active, the session's 
database record gets deleted but the session itself stays alive. When 
`post/multi/gather/ssh_creds` tries to save credentials, it fails with 
`ActiveRecord::RecordInvalid: Session can't be blank` and crashes the module.

This fix adds a rescue for `ActiveRecord::RecordInvalid` so the module 
prints a warning and continues instead of crashing.

## Verification

- Start msfconsole
- Get a session on target
- Run `post/multi/gather/ssh_creds` — works fine
- Run `workspace -D`
- Run `post/multi/gather/ssh_creds` again
- Verify module prints a warning instead of crashing
- Verify files are still downloaded successfully