### PR TITLE
Add MCP plugin to manage Metasploit MCP server lifecycle within msfconsole

### DIFF
--- a/lib/msf/core/mcp.rb
+++ b/lib/msf/core/mcp.rb
@@ -53,6 +53,10 @@ require_relative 'mcp/metasploit/client'
 require_relative 'mcp/metasploit/response_transformer'
 
 # MCP SDK
+# Suppress MultiJSON deprecation warning from json-schema gem.
+# Remove once json-schema >= 5.x drops MultiJSON support entirely.
+require 'json-schema'
+JSON::Validator.use_multi_json = false
 require 'mcp'
 
 # MCP Layer

--- a/lib/msf/core/mcp.rb
+++ b/lib/msf/core/mcp.rb
@@ -38,6 +38,7 @@ require_relative 'mcp/middleware/request_logger'
 require_relative 'mcp/errors'
 
 # Configuration Layer
+require_relative 'mcp/config/defaults'
 require_relative 'mcp/config/loader'
 require_relative 'mcp/config/validator'
 

--- a/lib/msf/core/mcp/config/defaults.rb
+++ b/lib/msf/core/mcp/config/defaults.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Msf::MCP
+  module Config
+    # Shared default values for MCP server configuration.
+    # Used by both the msfconsole plugin and the standalone msfmcpd daemon
+    # to keep defaults consistent across entry points.
+    # Values are aligned with the established msfmcpd defaults.
+    module Defaults
+      # MCP HTTP server defaults
+      MCP_HOST = 'localhost'
+      MCP_PORT = 3000
+
+      # RPC connection defaults (for msfrpcd / messagepack RPC)
+      RPC_HOST = 'localhost'
+      RPC_PORT = 55_553
+      RPC_USER = 'msf'
+      RPC_SSL  = true
+
+      # The msgrpc plugin binds on a different port than msfrpcd
+      MSGRPC_PORT = 55_552
+
+      # Rate limiting
+      RATE_LIMIT_REQUESTS_PER_MINUTE = 60
+    end
+  end
+end

--- a/lib/msf/core/mcp/config/defaults.rb
+++ b/lib/msf/core/mcp/config/defaults.rb
@@ -12,7 +12,7 @@ module Msf::MCP
       MCP_PORT = 3000
 
       # RPC connection defaults (for msfrpcd / messagepack RPC)
-      RPC_HOST = 'localhost'
+      RPC_HOST = '127.0.0.1'
       RPC_PORT = 55_553
       RPC_USER = 'msf'
       RPC_SSL  = true

--- a/lib/msf/core/mcp/config/defaults.rb
+++ b/lib/msf/core/mcp/config/defaults.rb
@@ -15,7 +15,7 @@ module Msf::MCP
       RPC_HOST = '127.0.0.1'
       RPC_PORT = 55_553
       RPC_USER = 'msf'
-      RPC_SSL  = true
+      RPC_SSL = true
 
       # The msgrpc plugin binds on a different port than msfrpcd
       MSGRPC_PORT = 55_552

--- a/lib/msf/core/mcp/config/loader.rb
+++ b/lib/msf/core/mcp/config/loader.rb
@@ -54,10 +54,10 @@ module Msf::MCP
         config[:logging] ||= {}
 
         config[:msf_api][:type] ||= 'messagepack'
-        config[:msf_api][:host] ||= 'localhost'
-        config[:msf_api][:port] ||= (config[:msf_api][:type] == 'json-rpc') ? 8081 : 55553
+        config[:msf_api][:host] ||= Defaults::RPC_HOST
+        config[:msf_api][:port] ||= (config[:msf_api][:type] == 'json-rpc') ? 8081 : Defaults::RPC_PORT
 
-        config[:msf_api][:ssl] = config[:msf_api].fetch(:ssl, true)
+        config[:msf_api][:ssl] = config[:msf_api].fetch(:ssl, Defaults::RPC_SSL)
         config[:msf_api][:auto_start_rpc] = config[:msf_api].fetch(:auto_start_rpc, true)
 
         config[:msf_api][:endpoint] ||= case config[:msf_api][:type]
@@ -70,12 +70,12 @@ module Msf::MCP
         config[:mcp][:transport] ||= 'stdio'
 
         if config[:mcp][:transport] == 'http'
-          config[:mcp][:host] ||= 'localhost'
-          config[:mcp][:port] ||= 3000
+          config[:mcp][:host] ||= Defaults::MCP_HOST
+          config[:mcp][:port] ||= Defaults::MCP_PORT
         end
 
         config[:rate_limit][:enabled] = config[:rate_limit].fetch(:enabled, true)
-        config[:rate_limit][:requests_per_minute] ||= 60
+        config[:rate_limit][:requests_per_minute] ||= Defaults::RATE_LIMIT_REQUESTS_PER_MINUTE
         config[:rate_limit][:burst_size] ||= 10
 
         config[:logging][:enabled] = config[:logging].fetch(:enabled, false)

--- a/plugins/mcp.rb
+++ b/plugins/mcp.rb
@@ -1,0 +1,561 @@
+# frozen_string_literal: true
+
+require 'msf/core/mcp'
+
+module Msf
+  ###
+  #
+  # This plugin manages the lifecycle of the Metasploit MCP (Model Context Protocol)
+  # server from within the msfconsole session.
+  #
+  ###
+  class Plugin::MCP < Msf::Plugin
+
+    #
+    # Console command dispatcher for the `mcp` command and its subcommands.
+    #
+    class McpCommandDispatcher
+      include Msf::Ui::Console::CommandDispatcher
+
+      # Guard against redefinition when msfconsole's plugin system loads the file twice
+      SUBCOMMANDS = %w[status start stop restart help].freeze unless defined?(SUBCOMMANDS)
+
+      # Valid option keys accepted by `mcp start` and `mcp restart`
+      unless defined?(VALID_OPTIONS)
+        VALID_OPTIONS = %w[
+          Transport ServerHost ServerPort
+          RpcHost RpcPort RpcUser RpcPass RpcSSL
+          RateLimit
+        ].freeze
+      end
+
+      attr_accessor :plugin
+
+      def name
+        'MCP'
+      end
+
+      def commands
+        { 'mcp' => 'Manage the MCP server' }
+      end
+
+      def cmd_mcp(*args)
+        subcommand = args.shift
+
+        case subcommand
+        when 'status'
+          mcp_status
+        when 'start'
+          mcp_start(args)
+        when 'stop'
+          mcp_stop
+        when 'restart'
+          mcp_restart(args)
+        else
+          cmd_mcp_help
+        end
+      end
+
+      def cmd_mcp_help
+        print_line('Usage: mcp <subcommand> [options]')
+        print_line
+        print_line('Subcommands:')
+        print_line('  status  - Display MCP server status')
+        print_line('  start   - Start the MCP server')
+        print_line('  stop    - Stop the MCP server')
+        print_line('  restart - Restart the MCP server')
+        print_line('  help    - Show this help message')
+        print_line
+        print_line('Options (for start/restart):')
+        print_line('  Transport=<http|stdio>      MCP transport type (default: http)')
+        print_line('  ServerHost=<host>           MCP server bind address (default: 127.0.0.1)')
+        print_line('  ServerPort=<port>           MCP server port (default: 3000)')
+        print_line('  RpcHost=<host>              RPC server host (default: 127.0.0.1)')
+        print_line('  RpcPort=<port>              RPC server port (default: 55552)')
+        print_line('  RpcUser=<user>              RPC username (default: msf)')
+        print_line('  RpcPass=<pass>              RPC password')
+        print_line('  RpcSSL=<true|false>         Use SSL for RPC (default: false)')
+        print_line('  RateLimit=<n>               Requests per minute (default: 60)')
+        print_line
+        print_line('Examples:')
+        print_line('  mcp start')
+        print_line('  mcp start Transport=http ServerPort=8080')
+        print_line('  mcp start RpcUser=msf RpcPass=secret')
+        print_line
+      end
+
+      def cmd_mcp_tabs(_str, words)
+        return SUBCOMMANDS if words.length == 1
+
+        []
+      end
+
+      private
+
+      def mcp_status
+        plugin.print_mcp_status
+      end
+
+      def mcp_start(args)
+        opts = parse_options(args)
+        return unless opts
+
+        plugin.start_server(opts)
+      end
+
+      def mcp_stop
+        plugin.stop_server
+      end
+
+      def mcp_restart(args)
+        opts = parse_options(args)
+        return unless opts
+
+        plugin.restart_server(opts)
+      end
+
+      # Parses Key=Value pairs from command arguments into an options hash.
+      # Returns nil and prints an error if any argument is malformed or unrecognized.
+      def parse_options(args)
+        opts = {}
+        args.each do |arg|
+          key, value = arg.split('=', 2)
+          unless key && value && !value.empty?
+            print_error("Invalid option format: #{arg} (expected Key=Value)")
+            return nil
+          end
+          unless VALID_OPTIONS.include?(key)
+            print_error("Unknown option: #{key}")
+            print_error("Valid options: #{VALID_OPTIONS.join(', ')}")
+            return nil
+          end
+          opts[key] = value
+        end
+        opts
+      end
+    end
+
+    attr_accessor :auto_started_rpc, :mcp_server, :server_thread, :msf_client,
+                  :rate_limiter, :server_config, :started_at
+
+    def initialize(framework, opts)
+      super
+
+      @server_config = nil
+      @auto_started_rpc = false
+      register_dispatcher
+      print_status('MCP plugin loaded. Use "mcp start" to start the server.')
+    end
+
+    #
+    # Returns 'mcp'
+    #
+    def name
+      'mcp'
+    end
+
+    #
+    # Returns the plugin description.
+    #
+    def desc
+      'Manages the Metasploit MCP server from within msfconsole'
+    end
+
+    #
+    # Cleans up resources when the plugin is unloaded.
+    #
+    def cleanup
+      if @mcp_server
+        stop_mcp_server
+        print_status('MCP server stopped')
+      end
+      deregister_dispatcher
+      unload_auto_started_rpc
+      super
+    end
+
+    #
+    # Public interface for the command dispatcher to control the server.
+    #
+
+    def print_mcp_status
+      unless @server_config
+        print_status('MCP server status: stopped (not configured)')
+        print_status('  Use "mcp start" to configure and start the server')
+        return
+      end
+
+      mcp_config = @server_config[:mcp]
+      transport = mcp_config[:transport]
+
+      if @mcp_server
+        print_status('MCP server status: running')
+        print_status("  Transport: #{transport}")
+        if transport == 'http'
+          print_status("  Listening: #{mcp_config[:host]}:#{mcp_config[:port]}")
+        else
+          print_status('  Listening: N/A')
+        end
+        print_status("  Uptime:    #{format_uptime}")
+      else
+        print_status('MCP server status: stopped')
+        print_status("  Transport: #{transport}")
+        print_status('  Listening: N/A')
+      end
+    end
+
+    def start_server(opts = {})
+      if @mcp_server
+        print_error('MCP server is already running')
+        return
+      end
+
+      validate_options!(opts)
+      @server_config = resolve_config(opts)
+      @server_config[:rpc] = resolve_rpc_config(opts)
+
+      rpc = @server_config[:rpc]
+      start_mcp_server(rpc, @server_config)
+    rescue StandardError => e
+      # Ensure server is left in a clean stopped state on failure
+      stop_mcp_server
+      unload_auto_started_rpc
+      print_error("Failed to start MCP server: #{e.message}")
+    end
+
+    def stop_server
+      unless @mcp_server
+        print_error('MCP server is already stopped')
+        return
+      end
+
+      stop_mcp_server
+      print_status('MCP server stopped')
+    end
+
+    def restart_server(opts = {})
+      stop_mcp_server if @mcp_server
+      unload_auto_started_rpc
+
+      validate_options!(opts)
+      @server_config = resolve_config(opts)
+      @server_config[:rpc] = resolve_rpc_config(opts)
+
+      rpc = @server_config[:rpc]
+      start_mcp_server(rpc, @server_config)
+    rescue StandardError => e
+      # Ensure server is left in a clean stopped state on failure
+      stop_mcp_server
+      unload_auto_started_rpc
+      print_error("Failed to restart MCP server: #{e.message}")
+    end
+
+    private
+
+    def register_dispatcher
+      dispatcher = add_console_dispatcher(McpCommandDispatcher)
+      dispatcher.plugin = self
+    end
+
+    #
+    # Creates and starts the MCP server with the resolved configuration.
+    #
+    def start_mcp_server(rpc, config)
+      @msf_client = Msf::MCP::Metasploit::Client.new(
+        api_type: 'messagepack',
+        host: rpc[:host],
+        port: rpc[:port],
+        ssl: rpc[:ssl]
+      )
+      authenticate_with_retry(@msf_client, rpc[:user], rpc[:pass])
+
+      mcp_config = config[:mcp]
+      rate_limit = config[:rate_limit]
+      transport = mcp_config[:transport]
+
+      @rate_limiter = Msf::MCP::Security::RateLimiter.new(
+        requests_per_minute: rate_limit[:requests_per_minute]
+      )
+
+      @mcp_server = Msf::MCP::Server.new(
+        msf_client: @msf_client,
+        rate_limiter: @rate_limiter
+      )
+
+      host = mcp_config[:host]
+      port = mcp_config[:port]
+
+      @server_thread = framework.threads.spawn('MCPServer', false) do
+        if transport == 'http'
+          @mcp_server.start(transport: :http, host: host, port: port)
+        else
+          @mcp_server.start(transport: :stdio)
+        end
+      end
+
+      @started_at = Time.now
+      print_server_status(mcp_config)
+    rescue Msf::MCP::Metasploit::AuthenticationError => e
+      raise Msf::MCP::Metasploit::AuthenticationError, "RPC authentication failed: #{e.message}"
+    rescue Msf::MCP::Metasploit::ConnectionError => e
+      raise Msf::MCP::Metasploit::ConnectionError, "RPC connection failed: #{e.message}"
+    rescue Errno::EADDRINUSE
+      raise Msf::MCP::Error, "Address already in use: #{mcp_config[:host]}:#{mcp_config[:port]}"
+    end
+
+    def print_server_status(mcp_config)
+      if mcp_config[:transport] == 'stdio'
+        print_status('MCP server started (transport: stdio)')
+      else
+        print_status("MCP server started on #{mcp_config[:host]}:#{mcp_config[:port]} (transport: http)")
+      end
+    end
+
+    def format_uptime
+      return 'N/A' unless @started_at
+
+      elapsed = (Time.now - @started_at).to_i
+      hours = elapsed / 3600
+      minutes = (elapsed % 3600) / 60
+      seconds = elapsed % 60
+
+      parts = []
+      parts << "#{hours}h" if hours > 0
+      parts << "#{minutes}m" if minutes > 0 || hours > 0
+      parts << "#{seconds}s"
+      parts.join(' ')
+    end
+
+    def stop_mcp_server
+      @mcp_server&.shutdown
+      terminate_server_thread
+      @mcp_server = nil
+      @server_thread = nil
+      @msf_client = nil
+      @rate_limiter = nil
+      @started_at = nil
+    end
+
+    # Retries RPC authentication to allow time for an auto-started msgrpc
+    # server to bind its port before we attempt to connect.
+    def authenticate_with_retry(client, user, pass, max_attempts: 10, delay: 0.5)
+      retries = @auto_started_rpc ? max_attempts : 1
+      attempts = 0
+      begin
+        attempts += 1
+        client.authenticate(user, pass)
+      rescue Msf::MCP::Metasploit::ConnectionError
+        if attempts < retries
+          sleep(delay)
+          retry
+        end
+        raise
+      end
+    end
+
+    # Waits for graceful thread exit, then force kills if necessary
+    def terminate_server_thread
+      return unless @server_thread&.alive?
+
+      unless @server_thread.join(5)
+        @server_thread.kill
+        print_warning('MCP server thread did not terminate gracefully, forced kill')
+      end
+    end
+
+    def deregister_dispatcher
+      remove_console_dispatcher('MCP')
+    rescue StandardError => e
+      print_warning("Failed to deregister MCP console dispatcher: #{e.message}")
+    end
+
+    def unload_auto_started_rpc
+      return unless @auto_started_rpc
+
+      begin
+        msgrpc = framework.plugins.find { |p| p.name == 'msgrpc' }
+        if msgrpc
+          # Give msgrpc server time to initialize before attempting unload
+          sleep(0.5) unless msgrpc.respond_to?(:server) && msgrpc.server
+          framework.plugins.unload(msgrpc)
+        end
+      rescue StandardError => e
+        print_warning("Failed to unload auto-started msgrpc: #{e.message}")
+      end
+      @auto_started_rpc = false
+    end
+
+    #
+    # Validates options before starting the server.
+    # Raises Msf::MCP::Config::ValidationError if any option value is invalid.
+    #
+    def validate_options!(opts)
+      validate_port_option!(opts, 'ServerPort')
+      validate_port_option!(opts, 'RpcPort')
+      validate_transport_option!(opts)
+      validate_rpc_ssl_option!(opts)
+      validate_rate_limit_option!(opts)
+      validate_rpc_credentials!(opts)
+    end
+
+    def validate_port_option!(opts, key)
+      return unless opts[key]
+
+      port = Integer(opts[key], exception: false)
+      if port.nil? || port < 1 || port > 65_535
+        option_error(key, 'an integer between 1 and 65535')
+      end
+    end
+
+    def validate_transport_option!(opts)
+      return unless opts['Transport']
+
+      unless %w[http stdio].include?(opts['Transport'])
+        option_error('Transport', '"http" or "stdio"')
+      end
+    end
+
+    def validate_rpc_ssl_option!(opts)
+      return unless opts['RpcSSL']
+
+      unless %w[true false].include?(opts['RpcSSL'])
+        option_error('RpcSSL', '"true" or "false"')
+      end
+    end
+
+    def validate_rate_limit_option!(opts)
+      return unless opts['RateLimit']
+
+      value = Integer(opts['RateLimit'], exception: false)
+      if value.nil? || value < 1 || value > 10_000
+        option_error('RateLimit', 'an integer between 1 and 10000')
+      end
+    end
+
+    def validate_rpc_credentials!(opts)
+      has_user = opts['RpcUser'] && !opts['RpcUser'].empty?
+      has_pass = opts['RpcPass'] && !opts['RpcPass'].empty?
+
+      if has_user && !has_pass
+        option_error('RpcPass', 'a value (both RpcUser and RpcPass are required)')
+      elsif has_pass && !has_user
+        option_error('RpcUser', 'a value (both RpcUser and RpcPass are required)')
+      end
+    end
+
+    #
+    # Translates validated plugin options into the internal configuration hash
+    # used by the MCP server components.
+    #
+    def resolve_config(opts)
+      transport = opts['Transport'] || 'http'
+
+      mcp_config = { transport: transport }
+      unless transport == 'stdio'
+        mcp_config[:host] = opts['ServerHost'] || '127.0.0.1'
+        mcp_config[:port] = Integer(opts['ServerPort'] || 3000)
+      end
+
+      rate_limit_value = Integer(opts['RateLimit'] || 60)
+
+      {
+        mcp: mcp_config,
+        rate_limit: {
+          requests_per_minute: rate_limit_value,
+          burst_size: rate_limit_value
+        }
+      }
+    end
+
+    #
+    # Resolves RPC connection configuration using a priority-based approach:
+    # introspect loaded msgrpc (with explicit option overrides) > explicit only > auto-start msgrpc.
+    #
+    def resolve_rpc_config(opts)
+      @auto_started_rpc = false
+
+      if (msgrpc = find_loaded_msgrpc)
+        introspect_msgrpc(msgrpc, opts)
+      elsif explicit_rpc_credentials?(opts)
+        resolve_explicit_rpc(opts)
+      else
+        auto_start_msgrpc(opts)
+      end
+    end
+
+    def explicit_rpc_credentials?(opts)
+      (opts['RpcPass'] && !opts['RpcPass'].empty?) ||
+        (opts['RpcUser'] && !opts['RpcUser'].empty?)
+    end
+
+    # Explicit credentials provided — connect to external or local RPC
+    def resolve_explicit_rpc(opts)
+      {
+        host: opts['RpcHost'] || '127.0.0.1',
+        port: Integer(opts['RpcPort'] || 55_552),
+        user: opts['RpcUser'] || 'msf',
+        pass: opts['RpcPass'],
+        ssl: (opts['RpcSSL'] || 'false') == 'true'
+      }
+    end
+
+    def find_loaded_msgrpc
+      framework.plugins.find { |p| p.name == 'msgrpc' }
+    end
+
+    # Extract connection details from a running msgrpc plugin instance
+    def introspect_msgrpc(plugin, opts)
+      server = plugin.server
+      user, pass = server.users.first
+
+      {
+        host: opts['RpcHost'] || server.srvhost,
+        port: Integer(opts['RpcPort'] || server.srvport),
+        user: opts['RpcUser'] || user,
+        pass: opts['RpcPass'] || pass,
+        ssl: resolve_ssl(opts, server)
+      }
+    end
+
+    def resolve_ssl(opts, server)
+      if opts['RpcSSL']
+        opts['RpcSSL'] == 'true'
+      else
+        server.options[:ssl] ? true : false
+      end
+    end
+
+    # No msgrpc loaded and no explicit creds — start one automatically
+    def auto_start_msgrpc(opts)
+      pass = Rex::Text.rand_text_alphanumeric(12)
+      user = 'msf'
+
+      msgrpc_opts = {
+        'Pass' => pass,
+        'User' => user,
+        'ServerHost' => '127.0.0.1',
+        'ServerPort' => 55_552,
+        'SSL' => 'true'
+      }
+
+      framework.plugins.load('msgrpc', msgrpc_opts)
+      @auto_started_rpc = true
+
+      print_status("Auto-started msgrpc - User: #{user}, Pass: #{pass}")
+
+      {
+        host: opts['RpcHost'] || '127.0.0.1',
+        port: Integer(opts['RpcPort'] || 55_552),
+        user: user,
+        pass: pass,
+        ssl: (opts['RpcSSL'] || 'true') == 'true'
+      }
+    end
+
+    def option_error(option_name, expected_format)
+      error_detail = "Invalid value for #{option_name}: expected #{expected_format}"
+      raise Msf::MCP::Config::ValidationError, { option_name => error_detail }
+    end
+
+  end
+end

--- a/plugins/mcp.rb
+++ b/plugins/mcp.rb
@@ -70,7 +70,7 @@ module Msf
         print_line('  Transport=<http>            MCP transport type (default: http)')
         print_line('  ServerHost=<host>           MCP server bind address (default: localhost)')
         print_line('  ServerPort=<port>           MCP server port (default: 3000)')
-        print_line('  RpcHost=<host>              RPC server host (default: localhost)')
+        print_line('  RpcHost=<host>              RPC server host (default: 127.0.0.1)')
         print_line('  RpcPort=<port>              RPC server port (default: 55552)')
         print_line('  RpcUser=<user>              RPC username (default: msf)')
         print_line('  RpcPass=<pass>              RPC password')

--- a/plugins/mcp.rb
+++ b/plugins/mcp.rb
@@ -83,10 +83,20 @@ module Msf
         print_line
       end
 
-      def cmd_mcp_tabs(_str, words)
-        return SUBCOMMANDS if words.length == 1
+      def cmd_mcp_tabs(str, words)
+        # words[0] is always 'mcp' (the command name itself)
+        # When words.length == 1, user is typing the subcommand
+        # When words.length >= 2, subcommand is words[1] and user is typing options
+        if words.length == 1
+          return SUBCOMMANDS.select { |s| s.start_with?(str.downcase) }
+        end
 
-        []
+        subcommand = words[1]
+        if %w[start restart].include?(subcommand)
+          VALID_OPTIONS.map { |opt| "#{opt}=" }.select { |o| o.downcase.start_with?(str.downcase) }
+        else
+          []
+        end
       end
 
       private
@@ -114,6 +124,7 @@ module Msf
       end
 
       # Parses Key=Value pairs from command arguments into an options hash.
+      # Option keys are case-insensitive and normalized to their canonical form.
       # Returns nil and prints an error if any argument is malformed or unrecognized.
       def parse_options(args)
         opts = {}
@@ -123,12 +134,13 @@ module Msf
             print_error("Invalid option format: #{arg} (expected Key=Value)")
             return nil
           end
-          unless VALID_OPTIONS.include?(key)
+          canonical_key = VALID_OPTIONS.find { |opt| opt.casecmp(key).zero? }
+          unless canonical_key
             print_error("Unknown option: #{key}")
             print_error("Valid options: #{VALID_OPTIONS.join(', ')}")
             return nil
           end
-          opts[key] = value
+          opts[canonical_key] = value
         end
         opts
       end

--- a/plugins/mcp.rb
+++ b/plugins/mcp.rb
@@ -23,7 +23,7 @@ module Msf
       # Valid option keys accepted by `mcp start` and `mcp restart`
       unless defined?(VALID_OPTIONS)
         VALID_OPTIONS = %w[
-          Transport ServerHost ServerPort
+          ServerHost ServerPort
           RpcHost RpcPort RpcUser RpcPass RpcSSL
           RateLimit
         ].freeze
@@ -67,7 +67,6 @@ module Msf
         print_line('  help    - Show this help message')
         print_line
         print_line('Options (for start/restart):')
-        print_line('  Transport=<http>            MCP transport type (default: http)')
         print_line('  ServerHost=<host>           MCP server bind address (default: localhost)')
         print_line('  ServerPort=<port>           MCP server port (default: 3000)')
         print_line('  RpcHost=<host>              RPC server host (default: 127.0.0.1)')
@@ -79,7 +78,7 @@ module Msf
         print_line
         print_line('Examples:')
         print_line('  mcp start')
-        print_line('  mcp start Transport=http ServerPort=8080')
+        print_line('  mcp start ServerPort=8080')
         print_line('  mcp start RpcUser=msf RpcPass=secret')
         print_line
       end
@@ -186,21 +185,13 @@ module Msf
       end
 
       mcp_config = @server_config[:mcp]
-      transport = mcp_config[:transport]
 
       if @mcp_server
         print_status('MCP server status: running')
-        print_status("  Transport: #{transport}")
-        if transport == 'http'
-          print_status("  Listening: http://#{mcp_config[:host]}:#{mcp_config[:port]}")
-        else
-          print_status('  Listening: N/A')
-        end
+        print_status("  Listening: http://#{Rex::Socket.to_authority(mcp_config[:host], mcp_config[:port])}")
         print_status("  Uptime:    #{format_uptime}")
       else
         print_status('MCP server status: stopped')
-        print_status("  Transport: #{transport}")
-        print_status('  Listening: N/A')
       end
     end
 
@@ -271,7 +262,6 @@ module Msf
 
       mcp_config = config[:mcp]
       rate_limit = config[:rate_limit]
-      transport = mcp_config[:transport]
 
       @rate_limiter = Msf::MCP::Security::RateLimiter.new(
         requests_per_minute: rate_limit[:requests_per_minute]
@@ -286,11 +276,7 @@ module Msf
       port = mcp_config[:port]
 
       @server_thread = framework.threads.spawn('MCPServer', false) do
-        if transport == 'http'
-          @mcp_server.start(transport: :http, host: host, port: port)
-        else
-          @mcp_server.start(transport: :stdio)
-        end
+        @mcp_server.start(transport: :http, host: host, port: port)
       end
 
       @started_at = Time.now
@@ -300,15 +286,11 @@ module Msf
     rescue Msf::MCP::Metasploit::ConnectionError => e
       raise Msf::MCP::Metasploit::ConnectionError, "RPC connection failed: #{e.message}"
     rescue Errno::EADDRINUSE
-      raise Msf::MCP::Error, "Address already in use: #{mcp_config[:host]}:#{mcp_config[:port]}"
+      raise Msf::MCP::Error, "Address already in use: #{Rex::Socket.to_authority(mcp_config[:host], mcp_config[:port])}"
     end
 
     def print_server_status(mcp_config)
-      if mcp_config[:transport] == 'stdio'
-        print_status('MCP server started (transport: stdio)')
-      else
-        print_status("MCP server started on #{mcp_config[:host]}:#{mcp_config[:port]} (transport: http)")
-      end
+      print_status("MCP server started on #{Rex::Socket.to_authority(mcp_config[:host], mcp_config[:port])} (transport: http)")
     end
 
     def format_uptime
@@ -392,7 +374,6 @@ module Msf
     def validate_options!(opts)
       validate_port_option!(opts, 'ServerPort')
       validate_port_option!(opts, 'RpcPort')
-      validate_transport_option!(opts)
       validate_rpc_ssl_option!(opts)
       validate_rate_limit_option!(opts)
       validate_rpc_credentials!(opts)
@@ -404,15 +385,6 @@ module Msf
       port = Integer(opts[key], exception: false)
       if port.nil? || port < 1 || port > 65_535
         option_error(key, 'an integer between 1 and 65535')
-      end
-    end
-
-    def validate_transport_option!(opts)
-      return unless opts['Transport']
-
-      # stdio transport is not supported from msfconsole; use msfmcpd for stdio
-      unless opts['Transport'] == 'http'
-        option_error('Transport', "\"http\" (stdio is only supported via #{Msf::Ui::Tip.highlight('msfmcpd')})")
       end
     end
 
@@ -436,11 +408,14 @@ module Msf
     def validate_rpc_credentials!(opts)
       has_user = opts['RpcUser'] && !opts['RpcUser'].empty?
       has_pass = opts['RpcPass'] && !opts['RpcPass'].empty?
+      has_host = opts['RpcHost'] && !opts['RpcHost'].empty?
 
       if has_user && !has_pass
         option_error('RpcPass', 'a value (both RpcUser and RpcPass are required)')
       elsif has_pass && !has_user
         option_error('RpcUser', 'a value (both RpcUser and RpcPass are required)')
+      elsif has_host && !has_pass
+        option_error('RpcPass', 'a value (RpcPass is required when connecting to a remote RPC host)')
       end
     end
 
@@ -449,13 +424,11 @@ module Msf
     # used by the MCP server components.
     #
     def resolve_config(opts)
-      transport = opts['Transport'] || 'http'
-
-      mcp_config = { transport: transport }
-      unless transport == 'stdio'
-        mcp_config[:host] = opts['ServerHost'] || Msf::MCP::Config::Defaults::MCP_HOST
-        mcp_config[:port] = Integer(opts['ServerPort'] || Msf::MCP::Config::Defaults::MCP_PORT)
-      end
+      mcp_config = {
+        transport: 'http',
+        host: opts['ServerHost'] || Msf::MCP::Config::Defaults::MCP_HOST,
+        port: Integer(opts['ServerPort'] || Msf::MCP::Config::Defaults::MCP_PORT)
+      }
 
       rate_limit_value = Integer(opts['RateLimit'] || Msf::MCP::Config::Defaults::RATE_LIMIT_REQUESTS_PER_MINUTE)
 
@@ -486,7 +459,8 @@ module Msf
 
     def explicit_rpc_credentials?(opts)
       (opts['RpcPass'] && !opts['RpcPass'].empty?) ||
-        (opts['RpcUser'] && !opts['RpcUser'].empty?)
+        (opts['RpcUser'] && !opts['RpcUser'].empty?) ||
+        (opts['RpcHost'] && !opts['RpcHost'].empty?)
     end
 
     # Explicit credentials provided — connect to external or local RPC
@@ -530,13 +504,16 @@ module Msf
     def auto_start_msgrpc(opts)
       pass = Rex::Text.rand_text_alphanumeric(12)
       user = Msf::MCP::Config::Defaults::RPC_USER
+      host = opts['RpcHost'] || Msf::MCP::Config::Defaults::RPC_HOST
+      port = opts['RpcPort'] || Msf::MCP::Config::Defaults::MSGRPC_PORT
+      ssl = opts['RpcSSL'] || 'false'
 
       msgrpc_opts = {
         'Pass' => pass,
         'User' => user,
-        'ServerHost' => Msf::MCP::Config::Defaults::RPC_HOST,
-        'ServerPort' => Msf::MCP::Config::Defaults::MSGRPC_PORT,
-        'SSL' => 'true'
+        'ServerHost' => host,
+        'ServerPort' => port,
+        'SSL' => ssl
       }
 
       framework.plugins.load('msgrpc', msgrpc_opts)
@@ -545,11 +522,11 @@ module Msf
       print_status("Auto-started msgrpc - User: #{user}, Pass: #{pass}")
 
       {
-        host: opts['RpcHost'] || Msf::MCP::Config::Defaults::RPC_HOST,
-        port: Integer(opts['RpcPort'] || Msf::MCP::Config::Defaults::MSGRPC_PORT),
+        host: host,
+        port: Integer(port),
         user: user,
         pass: pass,
-        ssl: (opts['RpcSSL'] || 'true') == 'true'
+        ssl: ssl == 'true'
       }
     end
 

--- a/plugins/mcp.rb
+++ b/plugins/mcp.rb
@@ -67,10 +67,10 @@ module Msf
         print_line('  help    - Show this help message')
         print_line
         print_line('Options (for start/restart):')
-        print_line('  Transport=<http|stdio>      MCP transport type (default: http)')
-        print_line('  ServerHost=<host>           MCP server bind address (default: 127.0.0.1)')
+        print_line('  Transport=<http>            MCP transport type (default: http)')
+        print_line('  ServerHost=<host>           MCP server bind address (default: localhost)')
         print_line('  ServerPort=<port>           MCP server port (default: 3000)')
-        print_line('  RpcHost=<host>              RPC server host (default: 127.0.0.1)')
+        print_line('  RpcHost=<host>              RPC server host (default: localhost)')
         print_line('  RpcPort=<port>              RPC server port (default: 55552)')
         print_line('  RpcUser=<user>              RPC username (default: msf)')
         print_line('  RpcPass=<pass>              RPC password')
@@ -144,7 +144,7 @@ module Msf
       @server_config = nil
       @auto_started_rpc = false
       register_dispatcher
-      print_status('MCP plugin loaded. Use "mcp start" to start the server.')
+      print_status("MCP plugin loaded. Use #{Msf::Ui::Tip.highlight('mcp start')} to start the server.")
     end
 
     #
@@ -181,7 +181,7 @@ module Msf
     def print_mcp_status
       unless @server_config
         print_status('MCP server status: stopped (not configured)')
-        print_status('  Use "mcp start" to configure and start the server')
+        print_status("  Use #{Msf::Ui::Tip.highlight('mcp start')} to configure and start the server")
         return
       end
 
@@ -192,7 +192,7 @@ module Msf
         print_status('MCP server status: running')
         print_status("  Transport: #{transport}")
         if transport == 'http'
-          print_status("  Listening: #{mcp_config[:host]}:#{mcp_config[:port]}")
+          print_status("  Listening: http://#{mcp_config[:host]}:#{mcp_config[:port]}")
         else
           print_status('  Listening: N/A')
         end
@@ -410,8 +410,9 @@ module Msf
     def validate_transport_option!(opts)
       return unless opts['Transport']
 
-      unless %w[http stdio].include?(opts['Transport'])
-        option_error('Transport', '"http" or "stdio"')
+      # stdio transport is not supported from msfconsole; use msfmcpd for stdio
+      unless opts['Transport'] == 'http'
+        option_error('Transport', "\"http\" (stdio is only supported via #{Msf::Ui::Tip.highlight('msfmcpd')})")
       end
     end
 
@@ -452,11 +453,11 @@ module Msf
 
       mcp_config = { transport: transport }
       unless transport == 'stdio'
-        mcp_config[:host] = opts['ServerHost'] || '127.0.0.1'
-        mcp_config[:port] = Integer(opts['ServerPort'] || 3000)
+        mcp_config[:host] = opts['ServerHost'] || Msf::MCP::Config::Defaults::MCP_HOST
+        mcp_config[:port] = Integer(opts['ServerPort'] || Msf::MCP::Config::Defaults::MCP_PORT)
       end
 
-      rate_limit_value = Integer(opts['RateLimit'] || 60)
+      rate_limit_value = Integer(opts['RateLimit'] || Msf::MCP::Config::Defaults::RATE_LIMIT_REQUESTS_PER_MINUTE)
 
       {
         mcp: mcp_config,
@@ -491,9 +492,9 @@ module Msf
     # Explicit credentials provided — connect to external or local RPC
     def resolve_explicit_rpc(opts)
       {
-        host: opts['RpcHost'] || '127.0.0.1',
-        port: Integer(opts['RpcPort'] || 55_552),
-        user: opts['RpcUser'] || 'msf',
+        host: opts['RpcHost'] || Msf::MCP::Config::Defaults::RPC_HOST,
+        port: Integer(opts['RpcPort'] || Msf::MCP::Config::Defaults::MSGRPC_PORT),
+        user: opts['RpcUser'] || Msf::MCP::Config::Defaults::RPC_USER,
         pass: opts['RpcPass'],
         ssl: (opts['RpcSSL'] || 'false') == 'true'
       }
@@ -528,13 +529,13 @@ module Msf
     # No msgrpc loaded and no explicit creds — start one automatically
     def auto_start_msgrpc(opts)
       pass = Rex::Text.rand_text_alphanumeric(12)
-      user = 'msf'
+      user = Msf::MCP::Config::Defaults::RPC_USER
 
       msgrpc_opts = {
         'Pass' => pass,
         'User' => user,
-        'ServerHost' => '127.0.0.1',
-        'ServerPort' => 55_552,
+        'ServerHost' => Msf::MCP::Config::Defaults::RPC_HOST,
+        'ServerPort' => Msf::MCP::Config::Defaults::MSGRPC_PORT,
         'SSL' => 'true'
       }
 
@@ -544,8 +545,8 @@ module Msf
       print_status("Auto-started msgrpc - User: #{user}, Pass: #{pass}")
 
       {
-        host: opts['RpcHost'] || '127.0.0.1',
-        port: Integer(opts['RpcPort'] || 55_552),
+        host: opts['RpcHost'] || Msf::MCP::Config::Defaults::RPC_HOST,
+        port: Integer(opts['RpcPort'] || Msf::MCP::Config::Defaults::MSGRPC_PORT),
         user: user,
         pass: pass,
         ssl: (opts['RpcSSL'] || 'true') == 'true'

--- a/plugins/msgrpc.rb
+++ b/plugins/msgrpc.rb
@@ -20,12 +20,12 @@ module Msf
     #
     # The default local hostname that the server listens on.
     #
-    DefaultHost = '127.0.0.1'.freeze
+    DefaultHost = '127.0.0.1'.freeze unless defined?(DefaultHost)
 
     #
     # The default local port that the server listens on.
     #
-    DefaultPort = 55552
+    DefaultPort = 55552 unless defined?(DefaultPort)
 
     #
     # ServerPort

--- a/spec/integration/msfmcpd/config_loading_spec.rb
+++ b/spec/integration/msfmcpd/config_loading_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Configuration Loading and Validation Integration' do
       app = Msf::MCP::Application.new(['--config', config_file.path], output: output)
 
       # Stub authentication
-      stub_request(:post, 'https://localhost:55553/api/')
+      stub_request(:post, 'https://127.0.0.1:55553/api/')
         .to_return(
           status: 200,
           body: MessagePack.pack({
@@ -107,7 +107,7 @@ RSpec.describe 'Configuration Loading and Validation Integration' do
       app.send(:validate_configuration)
 
       # Verify defaults were applied
-      expect(app.config[:msf_api][:host]).to eq('localhost')
+      expect(app.config[:msf_api][:host]).to eq('127.0.0.1')
       expect(app.config[:msf_api][:port]).to eq(55553)
       expect(app.config[:rate_limit][:requests_per_minute]).to eq(60)
       expect(app.config[:logging][:level]).to eq('INFO')

--- a/spec/lib/msf/core/mcp/config/loader_spec.rb
+++ b/spec/lib/msf/core/mcp/config/loader_spec.rb
@@ -207,9 +207,9 @@ RSpec.describe Msf::MCP::Config::Loader do
         expect(config[:msf_api][:type]).to eq('messagepack')
       end
 
-      it 'sets default host to localhost' do
+      it 'sets default host to 127.0.0.1' do
         config = described_class.load_from_hash(config_hash)
-        expect(config[:msf_api][:host]).to eq('localhost')
+        expect(config[:msf_api][:host]).to eq('127.0.0.1')
       end
 
       it 'sets default port to 55553 for messagepack' do

--- a/spec/plugins/mcp/console_dispatcher_spec.rb
+++ b/spec/plugins/mcp/console_dispatcher_spec.rb
@@ -98,12 +98,25 @@ RSpec.describe Msf::Plugin::MCP::McpCommandDispatcher do
   end
 
   describe '#cmd_mcp_tabs' do
-    it 'returns all subcommands for the first word' do
-      expect(plugin.cmd_mcp_tabs('', [''])).to eq(%w[status start stop restart help])
+    it 'returns all subcommands when typing subcommand' do
+      # User typed: "mcp <tab>" → words = ['mcp'], str = ''
+      expect(plugin.cmd_mcp_tabs('', ['mcp'])).to contain_exactly('status', 'start', 'stop', 'restart', 'help')
     end
 
-    it 'returns empty array for subsequent words' do
-      expect(plugin.cmd_mcp_tabs('', ['status', ''])).to eq([])
+    it 'filters subcommands by partial input' do
+      # User typed: "mcp st<tab>" → words = ['mcp'], str = 'st'
+      expect(plugin.cmd_mcp_tabs('st', ['mcp'])).to contain_exactly('status', 'start', 'stop')
+    end
+
+    it 'returns option completions for start subcommand' do
+      # User typed: "mcp start <tab>" → words = ['mcp', 'start'], str = ''
+      result = plugin.cmd_mcp_tabs('', ['mcp', 'start'])
+      expect(result).to include('ServerHost=', 'RpcHost=', 'RpcPass=')
+    end
+
+    it 'returns empty array for status subcommand' do
+      # User typed: "mcp status <tab>" → words = ['mcp', 'status'], str = ''
+      expect(plugin.cmd_mcp_tabs('', ['mcp', 'status'])).to eq([])
     end
   end
 

--- a/spec/plugins/mcp/console_dispatcher_spec.rb
+++ b/spec/plugins/mcp/console_dispatcher_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Msf::Plugin::MCP::McpCommandDispatcher do
 
       it 'displays listening address and port' do
         mcp_plugin.print_mcp_status
-        expect(@output.join("\n")).to include('Listening: 127.0.0.1:3000')
+        expect(@output.join("\n")).to include('http://localhost:3000')
       end
 
       it 'displays uptime' do
@@ -145,19 +145,8 @@ RSpec.describe Msf::Plugin::MCP::McpCommandDispatcher do
         mcp_plugin.instance_variable_set(:@started_at, Time.at(1000))
       end
 
-      it 'displays running state' do
-        mcp_plugin.print_mcp_status
-        expect(@output.join("\n")).to include('MCP server status: running')
-      end
-
-      it 'displays stdio transport type' do
-        mcp_plugin.print_mcp_status
-        expect(@output.join("\n")).to include('Transport: stdio')
-      end
-
-      it 'displays N/A for listening address' do
-        mcp_plugin.print_mcp_status
-        expect(@output.join("\n")).to include('Listening: N/A')
+      it 'rejects stdio and does not start' do
+        expect(mcp_plugin.mcp_server).to be_nil
       end
     end
 
@@ -194,7 +183,7 @@ RSpec.describe Msf::Plugin::MCP::McpCommandDispatcher do
 
       it 'displays the custom listening address' do
         mcp_plugin.print_mcp_status
-        expect(@output.join("\n")).to include('Listening: 0.0.0.0:8080')
+        expect(@output.join("\n")).to include('http://0.0.0.0:8080')
       end
     end
 

--- a/spec/plugins/mcp/console_dispatcher_spec.rb
+++ b/spec/plugins/mcp/console_dispatcher_spec.rb
@@ -1,0 +1,347 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rex/text'
+require Metasploit::Framework.root.join('plugins/mcp.rb').to_path
+
+RSpec.describe Msf::Plugin::MCP::McpCommandDispatcher do
+  include_context 'Msf::UIDriver'
+
+  let(:framework) { instance_double(Msf::Framework) }
+  let(:output) { driver_output }
+
+  let(:mock_thread) do
+    instance_double(Thread, alive?: false, join: true, kill: nil)
+  end
+
+  let(:threads_manager) do
+    instance_double('Msf::Framework::ThreadManager').tap do |tm|
+      allow(tm).to receive(:spawn).and_return(mock_thread)
+    end
+  end
+
+  let(:plugins_collection) do
+    instance_double('Msf::PluginManager').tap do |pm|
+      allow(pm).to receive(:find).and_return(nil)
+      allow(pm).to receive(:load).and_return(true)
+      allow(pm).to receive(:unload).and_return(true)
+    end
+  end
+
+  let(:mock_client_class) do
+    Class.new do
+      def initialize(**_args); end
+
+      def authenticate(*_args)
+        'token'
+      end
+    end
+  end
+
+  let(:mock_rate_limiter_class) do
+    Class.new do
+      def initialize(**_args); end
+    end
+  end
+
+  let(:mock_server_class) do
+    Class.new do
+      def initialize(**_args); end
+
+      def start(**_args); end
+
+      def shutdown; end
+    end
+  end
+
+  let(:plugin) do
+    described_class.new(driver).tap do |d|
+      d.plugin = mcp_plugin
+    end
+  end
+
+  let(:base_opts) { { 'LocalOutput' => output } }
+
+  let(:mcp_plugin) { Msf::Plugin::MCP.new(framework, base_opts) }
+
+  before do
+    allow(framework).to receive(:threads).and_return(threads_manager)
+    allow(framework).to receive(:plugins).and_return(plugins_collection)
+
+    stub_const('Msf::MCP::Metasploit::Client', mock_client_class)
+    stub_const('Msf::MCP::Metasploit::AuthenticationError', Class.new(StandardError))
+    stub_const('Msf::MCP::Metasploit::ConnectionError', Class.new(StandardError))
+    stub_const('Msf::MCP::Security::RateLimiter', mock_rate_limiter_class)
+    stub_const('Msf::MCP::Server', mock_server_class)
+
+    allow(Rex::Text).to receive(:rand_text_alphanumeric).with(12).and_return('abcdefghijkl')
+
+    mock_dispatcher = instance_double(described_class)
+    allow(mock_dispatcher).to receive(:plugin=)
+    allow_any_instance_of(Msf::Plugin::MCP).to receive(:add_console_dispatcher).and_return(mock_dispatcher)
+    allow_any_instance_of(Msf::Plugin::MCP).to receive(:remove_console_dispatcher)
+
+    # Capture output from the plugin's print methods
+    capture_logging(mcp_plugin)
+  end
+
+  describe '#name' do
+    it 'returns MCP' do
+      expect(plugin.name).to eq('MCP')
+    end
+  end
+
+  describe '#commands' do
+    it 'registers the mcp command' do
+      expect(plugin.commands).to eq({ 'mcp' => 'Manage the MCP server' })
+    end
+  end
+
+  describe '#cmd_mcp_tabs' do
+    it 'returns all subcommands for the first word' do
+      expect(plugin.cmd_mcp_tabs('', [''])).to eq(%w[status start stop restart help])
+    end
+
+    it 'returns empty array for subsequent words' do
+      expect(plugin.cmd_mcp_tabs('', ['status', ''])).to eq([])
+    end
+  end
+
+  describe 'mcp status' do
+    context 'when server is running with HTTP transport' do
+      before do
+        mcp_plugin.start_server({})
+        reset_logging!
+        allow(Time).to receive(:now).and_return(Time.at(1000))
+        mcp_plugin.instance_variable_set(:@started_at, Time.at(1000))
+      end
+
+      it 'displays running state' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('MCP server status: running')
+      end
+
+      it 'displays transport type' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('Transport: http')
+      end
+
+      it 'displays listening address and port' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('Listening: 127.0.0.1:3000')
+      end
+
+      it 'displays uptime' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('Uptime:')
+      end
+    end
+
+    context 'when server is running with stdio transport' do
+      before do
+        mcp_plugin.start_server('Transport' => 'stdio')
+        reset_logging!
+        allow(Time).to receive(:now).and_return(Time.at(1000))
+        mcp_plugin.instance_variable_set(:@started_at, Time.at(1000))
+      end
+
+      it 'displays running state' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('MCP server status: running')
+      end
+
+      it 'displays stdio transport type' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('Transport: stdio')
+      end
+
+      it 'displays N/A for listening address' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('Listening: N/A')
+      end
+    end
+
+    context 'when server is stopped' do
+      before do
+        mcp_plugin.start_server({})
+        mcp_plugin.stop_server
+        reset_logging!
+      end
+
+      it 'displays stopped state' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('MCP server status: stopped')
+      end
+
+      it 'displays transport type' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('Transport: http')
+      end
+
+      it 'displays N/A for listening address' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('Listening: N/A')
+      end
+    end
+
+    context 'when server is running with custom host and port' do
+      before do
+        mcp_plugin.start_server('ServerHost' => '0.0.0.0', 'ServerPort' => '8080')
+        reset_logging!
+        allow(Time).to receive(:now).and_return(Time.at(1000))
+        mcp_plugin.instance_variable_set(:@started_at, Time.at(1000))
+      end
+
+      it 'displays the custom listening address' do
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('Listening: 0.0.0.0:8080')
+      end
+    end
+
+    context 'uptime formatting' do
+      before do
+        mcp_plugin.start_server({})
+        reset_logging!
+      end
+
+      it 'formats seconds only' do
+        allow(Time).to receive(:now).and_return(Time.at(1045))
+        mcp_plugin.instance_variable_set(:@started_at, Time.at(1000))
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('45s')
+      end
+
+      it 'formats minutes and seconds' do
+        allow(Time).to receive(:now).and_return(Time.at(1125))
+        mcp_plugin.instance_variable_set(:@started_at, Time.at(1000))
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('2m 5s')
+      end
+
+      it 'formats hours, minutes, and seconds' do
+        allow(Time).to receive(:now).and_return(Time.at(4661))
+        mcp_plugin.instance_variable_set(:@started_at, Time.at(1000))
+        mcp_plugin.print_mcp_status
+        expect(@output.join("\n")).to include('1h 1m 1s')
+      end
+    end
+  end
+
+  describe 'mcp help' do
+    it 'prints usage summary with all subcommands' do
+      plugin.cmd_mcp_help
+      combined = @output.join("\n")
+      expect(combined).to include('status')
+      expect(combined).to include('start')
+      expect(combined).to include('stop')
+      expect(combined).to include('restart')
+      expect(combined).to include('help')
+    end
+  end
+
+  describe '#cmd_mcp routing' do
+    it 'routes to help when no subcommand given' do
+      expect(plugin).to receive(:cmd_mcp_help)
+      plugin.cmd_mcp
+    end
+
+    it 'routes to help for unrecognized subcommand' do
+      expect(plugin).to receive(:cmd_mcp_help)
+      plugin.cmd_mcp('unknown')
+    end
+
+    it 'routes to status subcommand' do
+      expect(mcp_plugin).to receive(:print_mcp_status)
+      plugin.cmd_mcp('status')
+    end
+
+    it 'routes to start subcommand' do
+      expect(mcp_plugin).to receive(:start_server)
+      plugin.cmd_mcp('start')
+    end
+
+    it 'routes to stop subcommand' do
+      expect(mcp_plugin).to receive(:stop_server)
+      plugin.cmd_mcp('stop')
+    end
+
+    it 'routes to restart subcommand' do
+      expect(mcp_plugin).to receive(:restart_server)
+      plugin.cmd_mcp('restart')
+    end
+  end
+
+  describe 'mcp start' do
+    context 'when server is stopped' do
+      it 'starts the server successfully' do
+        mcp_plugin.start_server({})
+        expect(@output.join("\n")).to include('MCP server started')
+      end
+
+      it 'sets the server instance' do
+        mcp_plugin.start_server({})
+        expect(mcp_plugin.mcp_server).not_to be_nil
+      end
+    end
+
+    context 'when server is already running' do
+      before { mcp_plugin.start_server({}) }
+
+      it 'prints an error that server is already running' do
+        reset_logging!
+        mcp_plugin.start_server({})
+        expect(@error.join("\n")).to include('already running')
+      end
+    end
+  end
+
+  describe 'mcp stop' do
+    context 'when server is running' do
+      before do
+        mcp_plugin.start_server({})
+        reset_logging!
+      end
+
+      it 'stops the server and prints confirmation' do
+        mcp_plugin.stop_server
+        expect(@output.join("\n")).to include('MCP server stopped')
+      end
+
+      it 'clears the server instance' do
+        mcp_plugin.stop_server
+        expect(mcp_plugin.mcp_server).to be_nil
+      end
+    end
+
+    context 'when server is already stopped' do
+      it 'prints an error that server is already stopped' do
+        mcp_plugin.stop_server
+        expect(@error.join("\n")).to include('already stopped')
+      end
+    end
+  end
+
+  describe 'mcp restart' do
+    context 'when server is running' do
+      before { mcp_plugin.start_server({}) }
+
+      it 'stops and then starts the server' do
+        mcp_plugin.restart_server({})
+        expect(mcp_plugin.mcp_server).not_to be_nil
+      end
+
+      it 'resets the started_at timestamp' do
+        allow(Time).to receive(:now).and_return(Time.at(2000))
+        mcp_plugin.restart_server({})
+        expect(mcp_plugin.started_at).to eq(Time.at(2000))
+      end
+    end
+
+    context 'when server is stopped' do
+      it 'starts the server' do
+        mcp_plugin.restart_server({})
+        expect(mcp_plugin.mcp_server).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/plugins/mcp/console_dispatcher_spec.rb
+++ b/spec/plugins/mcp/console_dispatcher_spec.rb
@@ -121,11 +121,6 @@ RSpec.describe Msf::Plugin::MCP::McpCommandDispatcher do
         expect(@output.join("\n")).to include('MCP server status: running')
       end
 
-      it 'displays transport type' do
-        mcp_plugin.print_mcp_status
-        expect(@output.join("\n")).to include('Transport: http')
-      end
-
       it 'displays listening address and port' do
         mcp_plugin.print_mcp_status
         expect(@output.join("\n")).to include('http://localhost:3000')
@@ -134,19 +129,6 @@ RSpec.describe Msf::Plugin::MCP::McpCommandDispatcher do
       it 'displays uptime' do
         mcp_plugin.print_mcp_status
         expect(@output.join("\n")).to include('Uptime:')
-      end
-    end
-
-    context 'when server is running with stdio transport' do
-      before do
-        mcp_plugin.start_server('Transport' => 'stdio')
-        reset_logging!
-        allow(Time).to receive(:now).and_return(Time.at(1000))
-        mcp_plugin.instance_variable_set(:@started_at, Time.at(1000))
-      end
-
-      it 'rejects stdio and does not start' do
-        expect(mcp_plugin.mcp_server).to be_nil
       end
     end
 
@@ -160,16 +142,6 @@ RSpec.describe Msf::Plugin::MCP::McpCommandDispatcher do
       it 'displays stopped state' do
         mcp_plugin.print_mcp_status
         expect(@output.join("\n")).to include('MCP server status: stopped')
-      end
-
-      it 'displays transport type' do
-        mcp_plugin.print_mcp_status
-        expect(@output.join("\n")).to include('Transport: http')
-      end
-
-      it 'displays N/A for listening address' do
-        mcp_plugin.print_mcp_status
-        expect(@output.join("\n")).to include('Listening: N/A')
       end
     end
 

--- a/spec/plugins/mcp/option_validator_spec.rb
+++ b/spec/plugins/mcp/option_validator_spec.rb
@@ -1,0 +1,351 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require Metasploit::Framework.root.join('plugins/mcp.rb').to_path
+
+RSpec.describe Msf::Plugin::MCP do
+  include_context 'Msf::UIDriver'
+
+  let(:framework) { instance_double(Msf::Framework) }
+  let(:output) { driver_output }
+  let(:base_opts) { { 'LocalOutput' => output } }
+
+  let(:plugins_collection) do
+    instance_double('Msf::PluginManager').tap do |pm|
+      allow(pm).to receive(:find).and_return(nil)
+      allow(pm).to receive(:load).and_return(true)
+    end
+  end
+
+  let(:threads_manager) do
+    instance_double('Msf::Framework::ThreadManager').tap do |tm|
+      allow(tm).to receive(:spawn).and_return(Thread.new {})
+    end
+  end
+
+  let(:mock_client) do
+    instance_double('Msf::MCP::Metasploit::Client').tap do |c|
+      allow(c).to receive(:authenticate).and_return('token')
+      allow(c).to receive(:shutdown)
+    end
+  end
+
+  before do
+    allow(framework).to receive(:plugins).and_return(plugins_collection)
+    allow(framework).to receive(:threads).and_return(threads_manager)
+    stub_const('Msf::MCP::Metasploit::Client', Class.new do
+      def initialize(**_args); end
+      def authenticate(*_args); 'token'; end
+      def shutdown; end
+    end)
+    stub_const('Msf::MCP::Security::RateLimiter', Class.new do
+      def initialize(**_args); end
+    end)
+    stub_const('Msf::MCP::Server', Class.new do
+      def initialize(**_args); end
+      def start(**_args); end
+      def shutdown; end
+    end)
+    allow(Rex::Text).to receive(:rand_text_alphanumeric).with(12).and_return('abcdefghijkl')
+
+    mock_dispatcher = instance_double(described_class::McpCommandDispatcher)
+    allow(mock_dispatcher).to receive(:plugin=)
+    allow_any_instance_of(described_class).to receive(:add_console_dispatcher).and_return(mock_dispatcher)
+    allow_any_instance_of(described_class).to receive(:remove_console_dispatcher)
+  end
+
+  subject(:plugin) { described_class.new(framework, base_opts) }
+
+  describe '#validate_options!' do
+    describe 'ServerPort' do
+      it 'accepts port 1' do
+        expect { plugin.send(:validate_options!, { 'ServerPort' => '1' }) }.not_to raise_error
+      end
+
+      it 'accepts port 3000' do
+        expect { plugin.send(:validate_options!, { 'ServerPort' => '3000' }) }.not_to raise_error
+      end
+
+      it 'accepts port 65535' do
+        expect { plugin.send(:validate_options!, { 'ServerPort' => '65535' }) }.not_to raise_error
+      end
+
+      it 'rejects port 0' do
+        expect { plugin.send(:validate_options!, { 'ServerPort' => '0' }) }.to raise_error(Msf::MCP::Config::ValidationError, /ServerPort/)
+      end
+
+      it 'rejects port 65536' do
+        expect { plugin.send(:validate_options!, { 'ServerPort' => '65536' }) }.to raise_error(Msf::MCP::Config::ValidationError, /ServerPort/)
+      end
+
+      it 'rejects non-numeric value "abc"' do
+        expect { plugin.send(:validate_options!, { 'ServerPort' => 'abc' }) }.to raise_error(Msf::MCP::Config::ValidationError, /ServerPort/)
+      end
+
+      it 'is optional (nil is accepted)' do
+        expect { plugin.send(:validate_options!, {}) }.not_to raise_error
+      end
+    end
+
+    describe 'Transport' do
+      it 'accepts "http"' do
+        expect { plugin.send(:validate_options!, { 'Transport' => 'http' }) }.not_to raise_error
+      end
+
+      it 'accepts "stdio"' do
+        expect { plugin.send(:validate_options!, { 'Transport' => 'stdio' }) }.not_to raise_error
+      end
+
+      it 'rejects "tcp"' do
+        expect { plugin.send(:validate_options!, { 'Transport' => 'tcp' }) }.to raise_error(Msf::MCP::Config::ValidationError, /Transport/)
+      end
+
+      it 'rejects "websocket"' do
+        expect { plugin.send(:validate_options!, { 'Transport' => 'websocket' }) }.to raise_error(Msf::MCP::Config::ValidationError, /Transport/)
+      end
+
+      it 'rejects empty string' do
+        expect { plugin.send(:validate_options!, { 'Transport' => '' }) }.to raise_error(Msf::MCP::Config::ValidationError, /Transport/)
+      end
+    end
+
+    describe 'RpcPort' do
+      it 'accepts port 1' do
+        expect { plugin.send(:validate_options!, { 'RpcPort' => '1' }) }.not_to raise_error
+      end
+
+      it 'accepts port 55552' do
+        expect { plugin.send(:validate_options!, { 'RpcPort' => '55552' }) }.not_to raise_error
+      end
+
+      it 'accepts port 65535' do
+        expect { plugin.send(:validate_options!, { 'RpcPort' => '65535' }) }.not_to raise_error
+      end
+
+      it 'rejects port 0' do
+        expect { plugin.send(:validate_options!, { 'RpcPort' => '0' }) }.to raise_error(Msf::MCP::Config::ValidationError, /RpcPort/)
+      end
+
+      it 'rejects port 65536' do
+        expect { plugin.send(:validate_options!, { 'RpcPort' => '65536' }) }.to raise_error(Msf::MCP::Config::ValidationError, /RpcPort/)
+      end
+
+      it 'rejects non-numeric value "abc"' do
+        expect { plugin.send(:validate_options!, { 'RpcPort' => 'abc' }) }.to raise_error(Msf::MCP::Config::ValidationError, /RpcPort/)
+      end
+    end
+
+    describe 'RpcSSL' do
+      it 'accepts "true"' do
+        expect { plugin.send(:validate_options!, { 'RpcSSL' => 'true' }) }.not_to raise_error
+      end
+
+      it 'accepts "false"' do
+        expect { plugin.send(:validate_options!, { 'RpcSSL' => 'false' }) }.not_to raise_error
+      end
+
+      it 'rejects "yes"' do
+        expect { plugin.send(:validate_options!, { 'RpcSSL' => 'yes' }) }.to raise_error(Msf::MCP::Config::ValidationError, /RpcSSL/)
+      end
+
+      it 'rejects "1"' do
+        expect { plugin.send(:validate_options!, { 'RpcSSL' => '1' }) }.to raise_error(Msf::MCP::Config::ValidationError, /RpcSSL/)
+      end
+
+      it 'rejects empty string' do
+        expect { plugin.send(:validate_options!, { 'RpcSSL' => '' }) }.to raise_error(Msf::MCP::Config::ValidationError, /RpcSSL/)
+      end
+    end
+
+    describe 'RateLimit' do
+      it 'accepts value 1' do
+        expect { plugin.send(:validate_options!, { 'RateLimit' => '1' }) }.not_to raise_error
+      end
+
+      it 'accepts value 60' do
+        expect { plugin.send(:validate_options!, { 'RateLimit' => '60' }) }.not_to raise_error
+      end
+
+      it 'accepts value 10000' do
+        expect { plugin.send(:validate_options!, { 'RateLimit' => '10000' }) }.not_to raise_error
+      end
+
+      it 'rejects value 0' do
+        expect { plugin.send(:validate_options!, { 'RateLimit' => '0' }) }.to raise_error(Msf::MCP::Config::ValidationError, /RateLimit/)
+      end
+
+      it 'rejects value 10001' do
+        expect { plugin.send(:validate_options!, { 'RateLimit' => '10001' }) }.to raise_error(Msf::MCP::Config::ValidationError, /RateLimit/)
+      end
+
+      it 'rejects non-numeric value "fast"' do
+        expect { plugin.send(:validate_options!, { 'RateLimit' => 'fast' }) }.to raise_error(Msf::MCP::Config::ValidationError, /RateLimit/)
+      end
+    end
+
+    describe 'RPC credential pairing' do
+      it 'raises an error when RpcUser is provided without RpcPass' do
+        expect {
+          plugin.send(:validate_options!, { 'RpcUser' => 'msf', 'RpcPass' => '' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /RpcPass/)
+      end
+
+      it 'raises an error when RpcUser is provided and RpcPass is nil' do
+        expect {
+          plugin.send(:validate_options!, { 'RpcUser' => 'msf' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /RpcPass/)
+      end
+
+      it 'raises an error when RpcPass is provided without RpcUser' do
+        expect {
+          plugin.send(:validate_options!, { 'RpcPass' => 'secret', 'RpcUser' => '' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /RpcUser/)
+      end
+
+      it 'raises an error when RpcPass is provided and RpcUser is nil' do
+        expect {
+          plugin.send(:validate_options!, { 'RpcPass' => 'secret' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /RpcUser/)
+      end
+
+      it 'accepts when both RpcUser and RpcPass are provided' do
+        expect {
+          plugin.send(:validate_options!, { 'RpcUser' => 'msf', 'RpcPass' => 'secret' })
+        }.not_to raise_error
+      end
+
+      it 'accepts when neither RpcUser nor RpcPass is provided' do
+        expect { plugin.send(:validate_options!, {}) }.not_to raise_error
+      end
+    end
+
+    describe 'error messages' do
+      it 'names the offending option in the error for ServerPort' do
+        expect {
+          plugin.send(:validate_options!, { 'ServerPort' => 'bad' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /Invalid value for ServerPort/)
+      end
+
+      it 'includes the expected format for ServerPort' do
+        expect {
+          plugin.send(:validate_options!, { 'ServerPort' => 'bad' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /integer between 1 and 65535/)
+      end
+
+      it 'names the offending option in the error for Transport' do
+        expect {
+          plugin.send(:validate_options!, { 'Transport' => 'invalid' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /Invalid value for Transport/)
+      end
+
+      it 'includes the expected format for Transport' do
+        expect {
+          plugin.send(:validate_options!, { 'Transport' => 'invalid' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /\"http\" or \"stdio\"/)
+      end
+
+      it 'names the offending option in the error for RpcSSL' do
+        expect {
+          plugin.send(:validate_options!, { 'RpcSSL' => 'maybe' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /Invalid value for RpcSSL/)
+      end
+
+      it 'includes the expected format for RpcSSL' do
+        expect {
+          plugin.send(:validate_options!, { 'RpcSSL' => 'maybe' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /\"true\" or \"false\"/)
+      end
+
+      it 'names the offending option in the error for RateLimit' do
+        expect {
+          plugin.send(:validate_options!, { 'RateLimit' => '-1' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /Invalid value for RateLimit/)
+      end
+
+      it 'includes the expected format for RateLimit' do
+        expect {
+          plugin.send(:validate_options!, { 'RateLimit' => '-1' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /integer between 1 and 10000/)
+      end
+    end
+  end
+
+  describe '#resolve_config' do
+    describe 'provided options appear in the resolved config' do
+      it 'maps ServerHost to mcp[:host]' do
+        config = plugin.send(:resolve_config, { 'ServerHost' => '0.0.0.0' })
+        expect(config[:mcp][:host]).to eq('0.0.0.0')
+      end
+
+      it 'maps ServerPort to mcp[:port]' do
+        config = plugin.send(:resolve_config, { 'ServerPort' => '8080' })
+        expect(config[:mcp][:port]).to eq(8080)
+      end
+
+      it 'maps Transport to mcp[:transport]' do
+        config = plugin.send(:resolve_config, { 'Transport' => 'http' })
+        expect(config[:mcp][:transport]).to eq('http')
+      end
+
+      it 'maps RateLimit to rate_limit[:requests_per_minute]' do
+        config = plugin.send(:resolve_config, { 'RateLimit' => '120' })
+        expect(config[:rate_limit][:requests_per_minute]).to eq(120)
+      end
+
+      it 'sets rate_limit[:burst_size] equal to requests_per_minute' do
+        config = plugin.send(:resolve_config, { 'RateLimit' => '120' })
+        expect(config[:rate_limit][:burst_size]).to eq(120)
+      end
+    end
+
+    describe 'default values when options are omitted' do
+      let(:config) { plugin.send(:resolve_config, {}) }
+
+      it 'defaults mcp[:transport] to "http"' do
+        expect(config[:mcp][:transport]).to eq('http')
+      end
+
+      it 'defaults mcp[:host] to "127.0.0.1"' do
+        expect(config[:mcp][:host]).to eq('127.0.0.1')
+      end
+
+      it 'defaults mcp[:port] to 3000' do
+        expect(config[:mcp][:port]).to eq(3000)
+      end
+
+      it 'defaults rate_limit[:requests_per_minute] to 60' do
+        expect(config[:rate_limit][:requests_per_minute]).to eq(60)
+      end
+
+      it 'defaults rate_limit[:burst_size] to 60' do
+        expect(config[:rate_limit][:burst_size]).to eq(60)
+      end
+    end
+
+    describe 'stdio transport excludes host and port from mcp config' do
+      let(:config) { plugin.send(:resolve_config, { 'Transport' => 'stdio' }) }
+
+      it 'sets mcp[:transport] to "stdio"' do
+        expect(config[:mcp][:transport]).to eq('stdio')
+      end
+
+      it 'does not include :host in the mcp config' do
+        expect(config[:mcp]).not_to have_key(:host)
+      end
+
+      it 'does not include :port in the mcp config' do
+        expect(config[:mcp]).not_to have_key(:port)
+      end
+
+      it 'ignores ServerHost even when explicitly provided' do
+        config = plugin.send(:resolve_config, { 'Transport' => 'stdio', 'ServerHost' => '0.0.0.0' })
+        expect(config[:mcp]).not_to have_key(:host)
+      end
+
+      it 'ignores ServerPort even when explicitly provided' do
+        config = plugin.send(:resolve_config, { 'Transport' => 'stdio', 'ServerPort' => '9999' })
+        expect(config[:mcp]).not_to have_key(:port)
+      end
+    end
+  end
+end

--- a/spec/plugins/mcp/option_validator_spec.rb
+++ b/spec/plugins/mcp/option_validator_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe Msf::Plugin::MCP do
         expect { plugin.send(:validate_options!, { 'Transport' => 'http' }) }.not_to raise_error
       end
 
-      it 'accepts "stdio"' do
-        expect { plugin.send(:validate_options!, { 'Transport' => 'stdio' }) }.not_to raise_error
+      it 'rejects "stdio"' do
+        expect { plugin.send(:validate_options!, { 'Transport' => 'stdio' }) }.to raise_error(Msf::MCP::Config::ValidationError, /Transport/)
       end
 
       it 'rejects "tcp"' do
@@ -241,7 +241,7 @@ RSpec.describe Msf::Plugin::MCP do
       it 'includes the expected format for Transport' do
         expect {
           plugin.send(:validate_options!, { 'Transport' => 'invalid' })
-        }.to raise_error(Msf::MCP::Config::ValidationError, /\"http\" or \"stdio\"/)
+        }.to raise_error(Msf::MCP::Config::ValidationError, /\"http\"/)
       end
 
       it 'names the offending option in the error for RpcSSL' do
@@ -305,8 +305,8 @@ RSpec.describe Msf::Plugin::MCP do
         expect(config[:mcp][:transport]).to eq('http')
       end
 
-      it 'defaults mcp[:host] to "127.0.0.1"' do
-        expect(config[:mcp][:host]).to eq('127.0.0.1')
+      it 'defaults mcp[:host] to "localhost"' do
+        expect(config[:mcp][:host]).to eq('localhost')
       end
 
       it 'defaults mcp[:port] to 3000' do

--- a/spec/plugins/mcp/option_validator_spec.rb
+++ b/spec/plugins/mcp/option_validator_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'rex/text'
 require Metasploit::Framework.root.join('plugins/mcp.rb').to_path
 
 RSpec.describe Msf::Plugin::MCP do
@@ -84,28 +85,6 @@ RSpec.describe Msf::Plugin::MCP do
 
       it 'is optional (nil is accepted)' do
         expect { plugin.send(:validate_options!, {}) }.not_to raise_error
-      end
-    end
-
-    describe 'Transport' do
-      it 'accepts "http"' do
-        expect { plugin.send(:validate_options!, { 'Transport' => 'http' }) }.not_to raise_error
-      end
-
-      it 'rejects "stdio"' do
-        expect { plugin.send(:validate_options!, { 'Transport' => 'stdio' }) }.to raise_error(Msf::MCP::Config::ValidationError, /Transport/)
-      end
-
-      it 'rejects "tcp"' do
-        expect { plugin.send(:validate_options!, { 'Transport' => 'tcp' }) }.to raise_error(Msf::MCP::Config::ValidationError, /Transport/)
-      end
-
-      it 'rejects "websocket"' do
-        expect { plugin.send(:validate_options!, { 'Transport' => 'websocket' }) }.to raise_error(Msf::MCP::Config::ValidationError, /Transport/)
-      end
-
-      it 'rejects empty string' do
-        expect { plugin.send(:validate_options!, { 'Transport' => '' }) }.to raise_error(Msf::MCP::Config::ValidationError, /Transport/)
       end
     end
 
@@ -232,18 +211,6 @@ RSpec.describe Msf::Plugin::MCP do
         }.to raise_error(Msf::MCP::Config::ValidationError, /integer between 1 and 65535/)
       end
 
-      it 'names the offending option in the error for Transport' do
-        expect {
-          plugin.send(:validate_options!, { 'Transport' => 'invalid' })
-        }.to raise_error(Msf::MCP::Config::ValidationError, /Invalid value for Transport/)
-      end
-
-      it 'includes the expected format for Transport' do
-        expect {
-          plugin.send(:validate_options!, { 'Transport' => 'invalid' })
-        }.to raise_error(Msf::MCP::Config::ValidationError, /\"http\"/)
-      end
-
       it 'names the offending option in the error for RpcSSL' do
         expect {
           plugin.send(:validate_options!, { 'RpcSSL' => 'maybe' })
@@ -282,11 +249,6 @@ RSpec.describe Msf::Plugin::MCP do
         expect(config[:mcp][:port]).to eq(8080)
       end
 
-      it 'maps Transport to mcp[:transport]' do
-        config = plugin.send(:resolve_config, { 'Transport' => 'http' })
-        expect(config[:mcp][:transport]).to eq('http')
-      end
-
       it 'maps RateLimit to rate_limit[:requests_per_minute]' do
         config = plugin.send(:resolve_config, { 'RateLimit' => '120' })
         expect(config[:rate_limit][:requests_per_minute]).to eq(120)
@@ -322,30 +284,5 @@ RSpec.describe Msf::Plugin::MCP do
       end
     end
 
-    describe 'stdio transport excludes host and port from mcp config' do
-      let(:config) { plugin.send(:resolve_config, { 'Transport' => 'stdio' }) }
-
-      it 'sets mcp[:transport] to "stdio"' do
-        expect(config[:mcp][:transport]).to eq('stdio')
-      end
-
-      it 'does not include :host in the mcp config' do
-        expect(config[:mcp]).not_to have_key(:host)
-      end
-
-      it 'does not include :port in the mcp config' do
-        expect(config[:mcp]).not_to have_key(:port)
-      end
-
-      it 'ignores ServerHost even when explicitly provided' do
-        config = plugin.send(:resolve_config, { 'Transport' => 'stdio', 'ServerHost' => '0.0.0.0' })
-        expect(config[:mcp]).not_to have_key(:host)
-      end
-
-      it 'ignores ServerPort even when explicitly provided' do
-        config = plugin.send(:resolve_config, { 'Transport' => 'stdio', 'ServerPort' => '9999' })
-        expect(config[:mcp]).not_to have_key(:port)
-      end
-    end
   end
 end

--- a/spec/plugins/mcp/rpc_resolver_spec.rb
+++ b/spec/plugins/mcp/rpc_resolver_spec.rb
@@ -135,9 +135,9 @@ RSpec.describe Msf::Plugin::MCP do
         expect(config[:user]).to eq('msf')
       end
 
-      it 'defaults host to localhost' do
+      it 'defaults host to 127.0.0.1' do
         config = plugin.send(:resolve_rpc_config, {})
-        expect(config[:host]).to eq('localhost')
+        expect(config[:host]).to eq('127.0.0.1')
       end
 
       it 'defaults port to 55552' do

--- a/spec/plugins/mcp/rpc_resolver_spec.rb
+++ b/spec/plugins/mcp/rpc_resolver_spec.rb
@@ -135,9 +135,9 @@ RSpec.describe Msf::Plugin::MCP do
         expect(config[:user]).to eq('msf')
       end
 
-      it 'defaults host to 127.0.0.1' do
+      it 'defaults host to localhost' do
         config = plugin.send(:resolve_rpc_config, {})
-        expect(config[:host]).to eq('127.0.0.1')
+        expect(config[:host]).to eq('localhost')
       end
 
       it 'defaults port to 55552' do

--- a/spec/plugins/mcp/rpc_resolver_spec.rb
+++ b/spec/plugins/mcp/rpc_resolver_spec.rb
@@ -1,0 +1,283 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rex/text'
+require Metasploit::Framework.root.join('plugins/mcp.rb').to_path
+
+RSpec.describe Msf::Plugin::MCP do
+  include_context 'Msf::UIDriver'
+
+  let(:framework) { instance_double(Msf::Framework) }
+  let(:output) { driver_output }
+  let(:base_opts) { { 'LocalOutput' => output } }
+
+  let(:threads_manager) do
+    instance_double('Msf::Framework::ThreadManager').tap do |tm|
+      allow(tm).to receive(:spawn).and_return(Thread.new {})
+    end
+  end
+
+  before do
+    allow(framework).to receive(:threads).and_return(threads_manager)
+    stub_const('Msf::MCP::Metasploit::Client', Class.new do
+      def initialize(**_args); end
+      def authenticate(*_args); 'token'; end
+      def shutdown; end
+    end)
+    stub_const('Msf::MCP::Security::RateLimiter', Class.new do
+      def initialize(**_args); end
+    end)
+    stub_const('Msf::MCP::Server', Class.new do
+      def initialize(**_args); end
+      def start(**_args); end
+      def shutdown; end
+    end)
+
+    mock_dispatcher = instance_double(described_class::McpCommandDispatcher)
+    allow(mock_dispatcher).to receive(:plugin=)
+    allow_any_instance_of(described_class).to receive(:add_console_dispatcher).and_return(mock_dispatcher)
+    allow_any_instance_of(described_class).to receive(:remove_console_dispatcher)
+  end
+
+  subject(:plugin) { described_class.new(framework, base_opts) }
+
+  describe '#resolve_rpc_config' do
+    describe 'introspection of loaded msgrpc plugin' do
+      let(:msgrpc_server) do
+        instance_double(
+          'Msf::RPC::Service',
+          srvhost: '127.0.0.1',
+          srvport: 55552,
+          users: { 'msf' => 'introspected_pass' },
+          options: { ssl: true }
+        )
+      end
+
+      let(:msgrpc_plugin) do
+        instance_double('Msf::Plugin::MSGRPC', name: 'msgrpc', server: msgrpc_server)
+      end
+
+      let(:plugins_collection) do
+        [msgrpc_plugin]
+      end
+
+      before do
+        allow(framework).to receive(:plugins).and_return(plugins_collection)
+      end
+
+      it 'extracts the host from the msgrpc server' do
+        config = plugin.send(:resolve_rpc_config, {})
+        expect(config[:host]).to eq('127.0.0.1')
+      end
+
+      it 'extracts the port from the msgrpc server' do
+        config = plugin.send(:resolve_rpc_config, {})
+        expect(config[:port]).to eq(55552)
+      end
+
+      it 'extracts the username from the msgrpc server users hash' do
+        config = plugin.send(:resolve_rpc_config, {})
+        expect(config[:user]).to eq('msf')
+      end
+
+      it 'extracts the password from the msgrpc server users hash' do
+        config = plugin.send(:resolve_rpc_config, {})
+        expect(config[:pass]).to eq('introspected_pass')
+      end
+
+      it 'extracts the ssl setting from the msgrpc server options' do
+        config = plugin.send(:resolve_rpc_config, {})
+        expect(config[:ssl]).to eq(true)
+      end
+
+      it 'does not set auto_started_rpc flag' do
+        plugin.send(:resolve_rpc_config, {})
+        expect(plugin.auto_started_rpc).to eq(false)
+      end
+    end
+
+    describe 'auto-start path' do
+      let(:plugins_collection) do
+        instance_double('Msf::PluginManager').tap do |pm|
+          allow(pm).to receive(:find).and_return(nil)
+          allow(pm).to receive(:load).and_return(true)
+        end
+      end
+
+      before do
+        allow(framework).to receive(:plugins).and_return(plugins_collection)
+        allow(Rex::Text).to receive(:rand_text_alphanumeric).with(12).and_return('abcdefghijkl')
+      end
+
+      it 'generates a password of at least 8 characters' do
+        config = plugin.send(:resolve_rpc_config, {})
+        expect(config[:pass].length).to be >= 8
+      end
+
+      it 'prints credentials to the console' do
+        plugin.send(:resolve_rpc_config, {})
+        expect(@output.join("\n")).to match(/msf/)
+        expect(@output.join("\n")).to match(/abcdefghijkl/)
+      end
+
+      it 'sets auto_started_rpc flag to true' do
+        plugin.send(:resolve_rpc_config, {})
+        expect(plugin.auto_started_rpc).to eq(true)
+      end
+
+      it 'loads the msgrpc plugin via framework.plugins' do
+        expect(plugins_collection).to receive(:load).with('msgrpc', hash_including('Pass' => 'abcdefghijkl'))
+        plugin.send(:resolve_rpc_config, {})
+      end
+
+      it 'uses "msf" as the default username' do
+        config = plugin.send(:resolve_rpc_config, {})
+        expect(config[:user]).to eq('msf')
+      end
+
+      it 'defaults host to 127.0.0.1' do
+        config = plugin.send(:resolve_rpc_config, {})
+        expect(config[:host]).to eq('127.0.0.1')
+      end
+
+      it 'defaults port to 55552' do
+        config = plugin.send(:resolve_rpc_config, {})
+        expect(config[:port]).to eq(55_552)
+      end
+    end
+
+    describe 'explicit credentials path overrides introspected values' do
+      let(:msgrpc_server) do
+        instance_double(
+          'Msf::RPC::Service',
+          srvhost: '10.0.0.1',
+          srvport: 55553,
+          users: { 'other_user' => 'other_pass' },
+          options: { ssl: false }
+        )
+      end
+
+      let(:msgrpc_plugin) do
+        instance_double('Msf::Plugin::MSGRPC', name: 'msgrpc', server: msgrpc_server)
+      end
+
+      let(:plugins_collection) do
+        [msgrpc_plugin]
+      end
+
+      before do
+        allow(framework).to receive(:plugins).and_return(plugins_collection)
+      end
+
+      it 'uses explicit RpcUser instead of introspected user' do
+        config = plugin.send(:resolve_rpc_config, { 'RpcUser' => 'admin', 'RpcPass' => 'explicit_pass' })
+        expect(config[:user]).to eq('admin')
+      end
+
+      it 'uses explicit RpcPass instead of introspected password' do
+        config = plugin.send(:resolve_rpc_config, { 'RpcUser' => 'admin', 'RpcPass' => 'explicit_pass' })
+        expect(config[:pass]).to eq('explicit_pass')
+      end
+
+      it 'uses introspected host/port/ssl when not explicitly overridden' do
+        config = plugin.send(:resolve_rpc_config, { 'RpcUser' => 'admin', 'RpcPass' => 'explicit_pass' })
+        expect(config[:host]).to eq('10.0.0.1')
+        expect(config[:port]).to eq(55553)
+        expect(config[:ssl]).to eq(false)
+      end
+
+      it 'allows explicit RpcHost to override the introspected host' do
+        config = plugin.send(:resolve_rpc_config, { 'RpcHost' => '192.0.2.0', 'RpcUser' => 'admin', 'RpcPass' => 'explicit_pass' })
+        expect(config[:host]).to eq('192.0.2.0')
+      end
+
+      it 'does not set auto_started_rpc flag' do
+        plugin.send(:resolve_rpc_config, { 'RpcUser' => 'admin', 'RpcPass' => 'explicit_pass' })
+        expect(plugin.auto_started_rpc).to eq(false)
+      end
+    end
+
+    describe 'error when only one of RpcUser/RpcPass provided' do
+      let(:plugins_collection) do
+        instance_double('Msf::PluginManager').tap do |pm|
+          allow(pm).to receive(:find).and_return(nil)
+          allow(pm).to receive(:load).and_return(true)
+        end
+      end
+
+      before do
+        allow(framework).to receive(:plugins).and_return(plugins_collection)
+        allow(Rex::Text).to receive(:rand_text_alphanumeric).with(12).and_return('abcdefghijkl')
+      end
+
+      it 'raises an error when RpcUser is provided without RpcPass' do
+        expect {
+          plugin.send(:validate_options!, { 'RpcUser' => 'msf' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /RpcPass/)
+      end
+
+      it 'raises an error when RpcPass is provided without RpcUser' do
+        expect {
+          plugin.send(:validate_options!, { 'RpcPass' => 'secret' })
+        }.to raise_error(Msf::MCP::Config::ValidationError, /RpcUser/)
+      end
+    end
+
+    describe 'connection to external RPC when RpcHost+RpcPass provided without msgrpc loaded' do
+      let(:plugins_collection) do
+        instance_double('Msf::PluginManager').tap do |pm|
+          allow(pm).to receive(:find).and_return(nil)
+          allow(pm).to receive(:load).and_return(true)
+        end
+      end
+
+      before do
+        allow(framework).to receive(:plugins).and_return(plugins_collection)
+        allow(Rex::Text).to receive(:rand_text_alphanumeric).with(12).and_return('abcdefghijkl')
+      end
+
+      it 'uses the provided RpcHost' do
+        config = plugin.send(:resolve_rpc_config, { 'RpcHost' => '192.0.2.0', 'RpcPass' => 'remote_pass' })
+        expect(config[:host]).to eq('192.0.2.0')
+      end
+
+      it 'uses the provided RpcPass' do
+        config = plugin.send(:resolve_rpc_config, { 'RpcHost' => '192.0.2.0', 'RpcPass' => 'remote_pass' })
+        expect(config[:pass]).to eq('remote_pass')
+      end
+
+      it 'does not auto-start msgrpc when explicit RpcPass is provided' do
+        plugin.send(:resolve_rpc_config, { 'RpcHost' => '192.0.2.0', 'RpcPass' => 'remote_pass' })
+        expect(plugin.auto_started_rpc).to eq(false)
+      end
+
+      it 'does not set auto_started_rpc flag' do
+        plugin.send(:resolve_rpc_config, { 'RpcHost' => '192.0.2.0', 'RpcPass' => 'remote_pass' })
+        expect(plugin.auto_started_rpc).to eq(false)
+      end
+    end
+
+    describe 'RpcUser defaults to "msf" when only RpcHost+RpcPass are provided' do
+      let(:plugins_collection) do
+        instance_double('Msf::PluginManager').tap do |pm|
+          allow(pm).to receive(:find).and_return(nil)
+          allow(pm).to receive(:load).and_return(true)
+        end
+      end
+
+      before do
+        allow(framework).to receive(:plugins).and_return(plugins_collection)
+      end
+
+      it 'defaults RpcUser to "msf"' do
+        config = plugin.send(:resolve_rpc_config, { 'RpcHost' => '192.0.2.0', 'RpcPass' => 'remote_pass' })
+        expect(config[:user]).to eq('msf')
+      end
+
+      it 'uses explicit RpcUser when provided alongside RpcHost+RpcPass' do
+        config = plugin.send(:resolve_rpc_config, { 'RpcHost' => '192.0.2.0', 'RpcUser' => 'custom', 'RpcPass' => 'remote_pass' })
+        expect(config[:user]).to eq('custom')
+      end
+    end
+  end
+end

--- a/spec/plugins/mcp_spec.rb
+++ b/spec/plugins/mcp_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Msf::Plugin::MCP do
 
     it 'prints a message about using mcp start' do
       plugin
-      expect(@output.join("\n")).to include('Use "mcp start" to start the server')
+      expect(@output.join("\n")).to include('mcp start')
     end
 
     it 'registers the command dispatcher' do
@@ -123,7 +123,7 @@ RSpec.describe Msf::Plugin::MCP do
       end
 
       it 'prints a status message with the listening address' do
-        expect(@output.join("\n")).to include('MCP server started on 127.0.0.1:3000 (transport: http)')
+        expect(@output.join("\n")).to include('MCP server started on localhost:3000 (transport: http)')
       end
 
       it 'stores the server configuration' do
@@ -142,10 +142,9 @@ RSpec.describe Msf::Plugin::MCP do
     end
 
     context 'with stdio transport' do
-      before { plugin.start_server('Transport' => 'stdio') }
-
-      it 'prints a status message with transport type' do
-        expect(@output.join("\n")).to include('MCP server started (transport: stdio)')
+      it 'rejects stdio since it is not supported from msfconsole' do
+        plugin.start_server('Transport' => 'stdio')
+        expect(@error.join("\n")).to include('Invalid value for Transport')
       end
     end
 
@@ -315,7 +314,7 @@ RSpec.describe Msf::Plugin::MCP do
         combined = @output.join("\n")
         expect(combined).to include('MCP server status: running')
         expect(combined).to include('Transport: http')
-        expect(combined).to include('127.0.0.1:3000')
+        expect(combined).to include('http://localhost:3000')
       end
     end
 
@@ -541,8 +540,13 @@ RSpec.describe Msf::Plugin::MCP do
     end
 
     context 'with invalid Transport' do
-      it 'prints an error' do
+      it 'prints an error for unsupported transport' do
         plugin.start_server('Transport' => 'websocket')
+        expect(@error.join("\n")).to include('Invalid value for Transport')
+      end
+
+      it 'prints an error for stdio transport' do
+        plugin.start_server('Transport' => 'stdio')
         expect(@error.join("\n")).to include('Invalid value for Transport')
       end
     end
@@ -591,9 +595,9 @@ RSpec.describe Msf::Plugin::MCP do
     describe '#cmd_mcp with start subcommand' do
       it 'parses Key=Value options and passes them to start_server' do
         expect(plugin_instance).to receive(:start_server) do |opts|
-          expect(opts).to eq('Transport' => 'stdio', 'RateLimit' => '120')
+          expect(opts).to eq('Transport' => 'http', 'RateLimit' => '120')
         end
-        dispatcher.cmd_mcp('start', 'Transport=stdio', 'RateLimit=120')
+        dispatcher.cmd_mcp('start', 'Transport=http', 'RateLimit=120')
       end
 
       it 'starts with empty opts when no options given' do
@@ -630,7 +634,7 @@ RSpec.describe Msf::Plugin::MCP do
         dispatcher.cmd_mcp('help')
         combined = @output.join("\n")
         expect(combined).to include('Usage: mcp <subcommand> [options]')
-        expect(combined).to include('Transport=<http|stdio>')
+        expect(combined).to include('Transport=<http>')
         expect(combined).to include('mcp start RpcUser=msf RpcPass=secret')
       end
     end

--- a/spec/plugins/mcp_spec.rb
+++ b/spec/plugins/mcp_spec.rb
@@ -1,0 +1,650 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rex/text'
+require Metasploit::Framework.root.join('plugins/mcp.rb').to_path
+
+RSpec.describe Msf::Plugin::MCP do
+  include_context 'Msf::UIDriver'
+
+  let(:framework) { instance_double(Msf::Framework) }
+  let(:framework_datastore) { { 'VERBOSE' => false } }
+  let(:output) { driver_output }
+  let(:base_opts) { { 'LocalOutput' => output } }
+
+  let(:mock_thread) do
+    instance_double(Thread, alive?: false, join: true, kill: nil)
+  end
+
+  let(:threads_manager) do
+    instance_double('Msf::Framework::ThreadManager').tap do |tm|
+      allow(tm).to receive(:spawn).and_return(mock_thread)
+    end
+  end
+
+  let(:plugins_collection) do
+    instance_double('Msf::PluginManager').tap do |pm|
+      allow(pm).to receive(:find).and_return(nil)
+      allow(pm).to receive(:load).and_return(true)
+      allow(pm).to receive(:unload).and_return(true)
+    end
+  end
+
+  let(:mock_client_class) do
+    Class.new do
+      def initialize(**_args); end
+
+      def authenticate(*_args)
+        'token'
+      end
+    end
+  end
+
+  let(:mock_rate_limiter_class) do
+    Class.new do
+      def initialize(**_args); end
+    end
+  end
+
+  let(:mock_server_class) do
+    Class.new do
+      def initialize(**_args); end
+      def start(**_args); end
+      def shutdown; end
+    end
+  end
+
+  before do
+    allow(framework).to receive(:threads).and_return(threads_manager)
+    allow(framework).to receive(:plugins).and_return(plugins_collection)
+    allow(framework).to receive(:datastore).and_return(framework_datastore)
+
+    stub_const('Msf::MCP::Metasploit::Client', mock_client_class)
+    stub_const('Msf::MCP::Metasploit::AuthenticationError', Class.new(StandardError))
+    stub_const('Msf::MCP::Metasploit::ConnectionError', Class.new(StandardError))
+    stub_const('Msf::MCP::Security::RateLimiter', mock_rate_limiter_class)
+    stub_const('Msf::MCP::Server', mock_server_class)
+
+    allow(Rex::Text).to receive(:rand_text_alphanumeric).with(12).and_return('abcdefghijkl')
+    allow_any_instance_of(described_class).to receive(:sleep)
+
+    mock_dispatcher = instance_double(Msf::Plugin::MCP::McpCommandDispatcher)
+    allow(mock_dispatcher).to receive(:plugin=)
+    allow_any_instance_of(Msf::Plugin::MCP).to receive(:add_console_dispatcher).and_return(mock_dispatcher)
+    allow_any_instance_of(Msf::Plugin::MCP).to receive(:remove_console_dispatcher)
+  end
+
+  describe '#initialize' do
+    subject(:plugin) { described_class.new(framework, base_opts) }
+
+    it 'creates the plugin successfully without starting the server' do
+      expect { plugin }.not_to raise_error
+    end
+
+    it 'does not create an MCP client' do
+      expect(mock_client_class).not_to receive(:new)
+      plugin
+    end
+
+    it 'does not spawn a server thread' do
+      expect(threads_manager).not_to receive(:spawn)
+      plugin
+    end
+
+    it 'prints a message about using mcp start' do
+      plugin
+      expect(@output.join("\n")).to include('Use "mcp start" to start the server')
+    end
+
+    it 'registers the command dispatcher' do
+      expect_any_instance_of(described_class).to receive(:add_console_dispatcher)
+        .with(described_class::McpCommandDispatcher)
+        .and_return(instance_double(described_class::McpCommandDispatcher, :plugin= => nil))
+      plugin
+    end
+
+    it 'has nil server_config' do
+      expect(plugin.server_config).to be_nil
+    end
+  end
+
+  describe '#start_server' do
+    subject(:plugin) { described_class.new(framework, base_opts) }
+
+    context 'with default options' do
+      before { plugin.start_server({}) }
+
+      it 'creates an MCP client' do
+        expect(plugin.msf_client).not_to be_nil
+      end
+
+      it 'starts the server in a background thread' do
+        expect(threads_manager).to have_received(:spawn).with('MCPServer', false)
+      end
+
+      it 'prints a status message with the listening address' do
+        expect(@output.join("\n")).to include('MCP server started on 127.0.0.1:3000 (transport: http)')
+      end
+
+      it 'stores the server configuration' do
+        expect(plugin.server_config).to be_a(Hash)
+        expect(plugin.server_config[:mcp][:transport]).to eq('http')
+      end
+    end
+
+    context 'with custom options' do
+      before { plugin.start_server('ServerHost' => '0.0.0.0', 'ServerPort' => '8080') }
+
+      it 'applies the provided host and port' do
+        expect(plugin.server_config[:mcp][:host]).to eq('0.0.0.0')
+        expect(plugin.server_config[:mcp][:port]).to eq(8080)
+      end
+    end
+
+    context 'with stdio transport' do
+      before { plugin.start_server('Transport' => 'stdio') }
+
+      it 'prints a status message with transport type' do
+        expect(@output.join("\n")).to include('MCP server started (transport: stdio)')
+      end
+    end
+
+    context 'when server is already running' do
+      before do
+        plugin.start_server({})
+        reset_logging!
+      end
+
+      it 'prints an error and does not restart' do
+        plugin.start_server({})
+        expect(@error.join("\n")).to include('MCP server is already running')
+      end
+    end
+
+    context 'when port is already in use' do
+      let(:failing_server_class) do
+        Class.new do
+          def initialize(**_args); end
+
+          def start(**_args)
+            raise Errno::EADDRINUSE
+          end
+
+          def shutdown; end
+        end
+      end
+
+      before do
+        stub_const('Msf::MCP::Server', failing_server_class)
+        allow(threads_manager).to receive(:spawn) do |_name, _critical, &block|
+          block.call
+        end
+      end
+
+      it 'prints an error with address-in-use message' do
+        plugin.start_server({})
+        expect(@error.join("\n")).to include('Address already in use')
+      end
+    end
+
+    context 'when RPC authentication fails' do
+      let(:failing_client_class) do
+        error_class = Msf::MCP::Metasploit::AuthenticationError
+        Class.new do
+          define_method(:initialize) { |**_args| }
+          define_method(:authenticate) { |*_args| raise error_class, 'bad credentials' }
+        end
+      end
+
+      before do
+        stub_const('Msf::MCP::Metasploit::Client', failing_client_class)
+      end
+
+      it 'prints an error with authentication failure message' do
+        plugin.start_server({})
+        expect(@error.join("\n")).to include('RPC authentication failed')
+      end
+    end
+
+    context 'when RPC connection fails' do
+      let(:failing_client_class) do
+        error_class = Msf::MCP::Metasploit::ConnectionError
+        Class.new do
+          define_method(:initialize) { |**_args| }
+          define_method(:authenticate) { |*_args| raise error_class, 'connection refused' }
+        end
+      end
+
+      before do
+        stub_const('Msf::MCP::Metasploit::Client', failing_client_class)
+      end
+
+      it 'prints an error with connection failure message' do
+        plugin.start_server({})
+        expect(@error.join("\n")).to include('RPC connection failed')
+      end
+
+      it 'unloads the auto-started msgrpc plugin on failure' do
+        msgrpc_plugin = instance_double('Msf::Plugin::MSGRPC', name: 'msgrpc')
+        call_count = 0
+        allow(plugins_collection).to receive(:find) do
+          call_count += 1
+          call_count > 1 ? msgrpc_plugin : nil
+        end
+        expect(plugins_collection).to receive(:unload).with(msgrpc_plugin)
+        plugin.start_server({})
+      end
+    end
+  end
+
+  describe '#stop_server' do
+    subject(:plugin) { described_class.new(framework, base_opts) }
+
+    context 'when server is running' do
+      before do
+        plugin.start_server({})
+        reset_logging!
+      end
+
+      it 'stops the server and prints a message' do
+        plugin.stop_server
+        expect(@output.join("\n")).to include('MCP server stopped')
+      end
+
+      it 'nils out the server reference' do
+        plugin.stop_server
+        expect(plugin.mcp_server).to be_nil
+      end
+
+      it 'nils out the client reference' do
+        plugin.stop_server
+        expect(plugin.msf_client).to be_nil
+      end
+    end
+
+    context 'when server is not running' do
+      it 'prints an error' do
+        plugin.stop_server
+        expect(@error.join("\n")).to include('MCP server is already stopped')
+      end
+    end
+  end
+
+  describe '#restart_server' do
+    subject(:plugin) { described_class.new(framework, base_opts) }
+
+    context 'when server is running' do
+      before do
+        plugin.start_server({})
+        reset_logging!
+      end
+
+      it 'restarts with new options' do
+        plugin.restart_server('ServerPort' => '9090')
+        expect(plugin.server_config[:mcp][:port]).to eq(9090)
+      end
+    end
+
+    context 'when server is not running' do
+      it 'starts the server fresh' do
+        plugin.restart_server('ServerPort' => '8080')
+        expect(plugin.server_config[:mcp][:port]).to eq(8080)
+        expect(plugin.mcp_server).not_to be_nil
+      end
+    end
+  end
+
+  describe '#print_mcp_status' do
+    subject(:plugin) { described_class.new(framework, base_opts) }
+
+    context 'when server has never been configured' do
+      it 'prints not configured status' do
+        plugin.print_mcp_status
+        expect(@output.join("\n")).to include('stopped (not configured)')
+      end
+    end
+
+    context 'when server is running' do
+      before do
+        plugin.start_server({})
+        reset_logging!
+      end
+
+      it 'prints running status with details' do
+        plugin.print_mcp_status
+        combined = @output.join("\n")
+        expect(combined).to include('MCP server status: running')
+        expect(combined).to include('Transport: http')
+        expect(combined).to include('127.0.0.1:3000')
+      end
+    end
+
+    context 'when server was started then stopped' do
+      before do
+        plugin.start_server({})
+        plugin.stop_server
+        reset_logging!
+      end
+
+      it 'prints stopped status with last known config' do
+        plugin.print_mcp_status
+        combined = @output.join("\n")
+        expect(combined).to include('MCP server status: stopped')
+        expect(combined).to include('Transport: http')
+      end
+    end
+  end
+
+  describe '#cleanup' do
+    subject(:plugin) { described_class.new(framework, base_opts) }
+
+    before do
+      allow(plugin).to receive(:remove_console_dispatcher)
+    end
+
+    context 'when server is running' do
+      before do
+        plugin.start_server({})
+        reset_logging!
+      end
+
+      it 'shuts down the MCP server' do
+        server = plugin.mcp_server
+        expect(server).to receive(:shutdown)
+        plugin.cleanup
+      end
+
+      it 'prints a stop message' do
+        plugin.cleanup
+        expect(@output.join("\n")).to include('MCP server stopped')
+      end
+
+      it 'nils out all references' do
+        plugin.cleanup
+        expect(plugin.mcp_server).to be_nil
+        expect(plugin.server_thread).to be_nil
+        expect(plugin.msf_client).to be_nil
+        expect(plugin.rate_limiter).to be_nil
+        expect(plugin.started_at).to be_nil
+      end
+    end
+
+    context 'when server was never started' do
+      it 'deregisters the console dispatcher without error' do
+        expect(plugin).to receive(:remove_console_dispatcher).with('MCP')
+        expect { plugin.cleanup }.not_to raise_error
+      end
+    end
+
+    context 'when msgrpc was auto-started' do
+      before { plugin.start_server({}) }
+
+      it 'unloads the auto-started msgrpc plugin' do
+        plugin.auto_started_rpc = true
+        msgrpc_plugin = instance_double('Msf::Plugin::MSGRPC', name: 'msgrpc')
+        allow(plugins_collection).to receive(:find).and_return(msgrpc_plugin)
+        expect(plugins_collection).to receive(:unload).with(msgrpc_plugin)
+        plugin.cleanup
+      end
+    end
+
+    context 'when msgrpc was pre-existing' do
+      before { plugin.start_server({}) }
+
+      it 'does not unload the msgrpc plugin' do
+        plugin.auto_started_rpc = false
+        expect(plugins_collection).not_to receive(:unload)
+        plugin.cleanup
+      end
+    end
+
+    context 'when msgrpc unload fails' do
+      before { plugin.start_server({}) }
+
+      it 'prints a warning and continues cleanup' do
+        plugin.auto_started_rpc = true
+        msgrpc_plugin = instance_double('Msf::Plugin::MSGRPC', name: 'msgrpc')
+        allow(plugins_collection).to receive(:find).and_return(msgrpc_plugin)
+        allow(plugins_collection).to receive(:unload).and_raise(StandardError, 'unload failed')
+
+        plugin.cleanup
+
+        expect(@error.join("\n")).to include('Failed to unload auto-started msgrpc')
+        expect(plugin.mcp_server).to be_nil
+      end
+    end
+  end
+
+  describe '#terminate_server_thread' do
+    subject(:plugin) { described_class.new(framework, base_opts) }
+
+    context 'when thread terminates within 5 seconds' do
+      it 'does not force kill the thread' do
+        alive_thread = instance_double(Thread, alive?: true, join: true)
+        plugin.server_thread = alive_thread
+        expect(alive_thread).not_to receive(:kill)
+        plugin.send(:terminate_server_thread)
+      end
+    end
+
+    context 'when thread does not terminate within 5 seconds' do
+      it 'force kills the thread' do
+        stuck_thread = instance_double(Thread, alive?: true, join: nil, kill: nil)
+        plugin.server_thread = stuck_thread
+        expect(stuck_thread).to receive(:kill)
+        plugin.send(:terminate_server_thread)
+      end
+
+      it 'prints a warning message' do
+        stuck_thread = instance_double(Thread, alive?: true, join: nil, kill: nil)
+        plugin.server_thread = stuck_thread
+        plugin.send(:terminate_server_thread)
+        expect(@error.join("\n")).to include('did not terminate gracefully')
+      end
+    end
+
+    context 'when thread is already dead' do
+      it 'does nothing' do
+        dead_thread = instance_double(Thread, alive?: false)
+        plugin.server_thread = dead_thread
+        expect(dead_thread).not_to receive(:join)
+        expect(dead_thread).not_to receive(:kill)
+        plugin.send(:terminate_server_thread)
+      end
+    end
+
+    context 'when server_thread is nil' do
+      it 'does nothing' do
+        plugin.server_thread = nil
+        expect { plugin.send(:terminate_server_thread) }.not_to raise_error
+      end
+    end
+  end
+
+  describe 'RPC resolution' do
+    subject(:plugin) { described_class.new(framework, base_opts) }
+
+    context 'with explicit RPC credentials' do
+      it 'uses the provided credentials' do
+        plugin.start_server('RpcUser' => 'admin', 'RpcPass' => 'secret123')
+        expect(plugin.server_config[:rpc][:user]).to eq('admin')
+        expect(plugin.server_config[:rpc][:pass]).to eq('secret123')
+      end
+    end
+
+    context 'when msgrpc is already loaded (introspection path)' do
+      let(:mock_msgrpc_server) do
+        instance_double('Msf::RPC::Service').tap do |s|
+          allow(s).to receive(:users).and_return({ 'admin' => 'secretpass' })
+          allow(s).to receive(:srvhost).and_return('127.0.0.1')
+          allow(s).to receive(:srvport).and_return(55_553)
+          allow(s).to receive(:options).and_return({ ssl: true })
+        end
+      end
+
+      let(:mock_msgrpc_plugin) do
+        instance_double('Msf::Plugin::MSGRPC', name: 'msgrpc', server: mock_msgrpc_server)
+      end
+
+      before do
+        allow(plugins_collection).to receive(:find) do |&block|
+          [mock_msgrpc_plugin].find(&block)
+        end
+      end
+
+      it 'uses credentials from the loaded msgrpc plugin' do
+        plugin.start_server({})
+        expect(plugin.server_config[:rpc][:user]).to eq('admin')
+        expect(plugin.server_config[:rpc][:pass]).to eq('secretpass')
+      end
+
+      it 'uses host and port from the loaded msgrpc plugin' do
+        plugin.start_server({})
+        expect(plugin.server_config[:rpc][:host]).to eq('127.0.0.1')
+        expect(plugin.server_config[:rpc][:port]).to eq(55_553)
+      end
+
+      it 'does not auto-start msgrpc' do
+        expect(plugins_collection).not_to receive(:load)
+        plugin.start_server({})
+      end
+
+      it 'does not set auto_started_rpc flag' do
+        plugin.start_server({})
+        expect(plugin.auto_started_rpc).to be false
+      end
+    end
+
+    context 'when no msgrpc is loaded and no creds provided (auto-start path)' do
+      it 'auto-starts msgrpc and prints credentials' do
+        expect(plugins_collection).to receive(:load).with('msgrpc', hash_including('Pass' => 'abcdefghijkl', 'User' => 'msf'))
+        plugin.start_server({})
+        expect(@output.join("\n")).to include('Auto-started msgrpc')
+        expect(@output.join("\n")).to include('abcdefghijkl')
+      end
+
+      it 'sets auto_started_rpc flag' do
+        plugin.start_server({})
+        expect(plugin.auto_started_rpc).to be true
+      end
+    end
+  end
+
+  describe 'option validation' do
+    subject(:plugin) { described_class.new(framework, base_opts) }
+
+    context 'with invalid ServerPort' do
+      it 'prints an error' do
+        plugin.start_server('ServerPort' => '99999')
+        expect(@error.join("\n")).to include('Invalid value for ServerPort')
+      end
+    end
+
+    context 'with invalid Transport' do
+      it 'prints an error' do
+        plugin.start_server('Transport' => 'websocket')
+        expect(@error.join("\n")).to include('Invalid value for Transport')
+      end
+    end
+
+    context 'with invalid RpcSSL' do
+      it 'prints an error' do
+        plugin.start_server('RpcSSL' => 'maybe')
+        expect(@error.join("\n")).to include('Invalid value for RpcSSL')
+      end
+    end
+
+    context 'with invalid RateLimit' do
+      it 'prints an error' do
+        plugin.start_server('RateLimit' => '0')
+        expect(@error.join("\n")).to include('Invalid value for RateLimit')
+      end
+    end
+
+    context 'with RpcUser but no RpcPass' do
+      it 'prints an error' do
+        plugin.start_server('RpcUser' => 'admin')
+        expect(@error.join("\n")).to include('Invalid value for RpcPass')
+      end
+    end
+
+    context 'with RpcPass but no RpcUser' do
+      it 'prints an error' do
+        plugin.start_server('RpcPass' => 'secret')
+        expect(@error.join("\n")).to include('Invalid value for RpcUser')
+      end
+    end
+  end
+
+  describe Msf::Plugin::MCP::McpCommandDispatcher do
+    let(:plugin_instance) { Msf::Plugin::MCP.new(framework, base_opts) }
+    let(:dispatcher) do
+      d = Msf::Plugin::MCP::McpCommandDispatcher.new(driver)
+      d.plugin = plugin_instance
+      d
+    end
+
+    before do
+      capture_logging(dispatcher)
+    end
+
+    describe '#cmd_mcp with start subcommand' do
+      it 'parses Key=Value options and passes them to start_server' do
+        expect(plugin_instance).to receive(:start_server) do |opts|
+          expect(opts).to eq('Transport' => 'stdio', 'RateLimit' => '120')
+        end
+        dispatcher.cmd_mcp('start', 'Transport=stdio', 'RateLimit=120')
+      end
+
+      it 'starts with empty opts when no options given' do
+        expect(plugin_instance).to receive(:start_server) do |opts|
+          expect(opts).to eq({})
+        end
+        dispatcher.cmd_mcp('start')
+      end
+
+      it 'rejects malformed options' do
+        expect(plugin_instance).not_to receive(:start_server)
+        dispatcher.cmd_mcp('start', 'badoption')
+        expect(@error.join("\n")).to include('Invalid option format')
+      end
+
+      it 'rejects unknown option keys' do
+        expect(plugin_instance).not_to receive(:start_server)
+        dispatcher.cmd_mcp('start', 'FakeOption=value')
+        expect(@error.join("\n")).to include('Unknown option: FakeOption')
+      end
+    end
+
+    describe '#cmd_mcp with restart subcommand' do
+      it 'parses options and passes them to restart_server' do
+        expect(plugin_instance).to receive(:restart_server) do |opts|
+          expect(opts).to eq('ServerPort' => '9090')
+        end
+        dispatcher.cmd_mcp('restart', 'ServerPort=9090')
+      end
+    end
+
+    describe '#cmd_mcp with help subcommand' do
+      it 'prints usage information including option examples' do
+        dispatcher.cmd_mcp('help')
+        combined = @output.join("\n")
+        expect(combined).to include('Usage: mcp <subcommand> [options]')
+        expect(combined).to include('Transport=<http|stdio>')
+        expect(combined).to include('mcp start RpcUser=msf RpcPass=secret')
+      end
+    end
+
+    describe '#cmd_mcp_tabs' do
+      it 'returns subcommands for first word' do
+        result = dispatcher.cmd_mcp_tabs('', [''])
+        expect(result).to contain_exactly('status', 'start', 'stop', 'restart', 'help')
+      end
+
+      it 'returns empty for subsequent words' do
+        result = dispatcher.cmd_mcp_tabs('', %w[start something])
+        expect(result).to eq([])
+      end
+    end
+  end
+end

--- a/spec/plugins/mcp_spec.rb
+++ b/spec/plugins/mcp_spec.rb
@@ -142,9 +142,12 @@ RSpec.describe Msf::Plugin::MCP do
     end
 
     context 'with stdio transport' do
-      it 'rejects stdio since it is not supported from msfconsole' do
-        plugin.start_server('Transport' => 'stdio')
-        expect(@error.join("\n")).to include('Invalid value for Transport')
+      it 'rejects stdio as an unknown option since Transport is no longer accepted' do
+        dispatcher = Msf::Plugin::MCP::McpCommandDispatcher.new(driver)
+        dispatcher.plugin = plugin
+        capture_logging(dispatcher)
+        dispatcher.cmd_mcp('start', 'Transport=stdio')
+        expect(@error.join("\n")).to include('Unknown option: Transport')
       end
     end
 
@@ -313,7 +316,6 @@ RSpec.describe Msf::Plugin::MCP do
         plugin.print_mcp_status
         combined = @output.join("\n")
         expect(combined).to include('MCP server status: running')
-        expect(combined).to include('Transport: http')
         expect(combined).to include('http://localhost:3000')
       end
     end
@@ -329,7 +331,6 @@ RSpec.describe Msf::Plugin::MCP do
         plugin.print_mcp_status
         combined = @output.join("\n")
         expect(combined).to include('MCP server status: stopped')
-        expect(combined).to include('Transport: http')
       end
     end
   end
@@ -540,14 +541,12 @@ RSpec.describe Msf::Plugin::MCP do
     end
 
     context 'with invalid Transport' do
-      it 'prints an error for unsupported transport' do
-        plugin.start_server('Transport' => 'websocket')
-        expect(@error.join("\n")).to include('Invalid value for Transport')
-      end
-
-      it 'prints an error for stdio transport' do
-        plugin.start_server('Transport' => 'stdio')
-        expect(@error.join("\n")).to include('Invalid value for Transport')
+      it 'rejects Transport as an unknown option' do
+        dispatcher = Msf::Plugin::MCP::McpCommandDispatcher.new(driver)
+        dispatcher.plugin = plugin
+        capture_logging(dispatcher)
+        dispatcher.cmd_mcp('start', 'Transport=websocket')
+        expect(@error.join("\n")).to include('Unknown option: Transport')
       end
     end
 
@@ -595,9 +594,9 @@ RSpec.describe Msf::Plugin::MCP do
     describe '#cmd_mcp with start subcommand' do
       it 'parses Key=Value options and passes them to start_server' do
         expect(plugin_instance).to receive(:start_server) do |opts|
-          expect(opts).to eq('Transport' => 'http', 'RateLimit' => '120')
+          expect(opts).to eq('RateLimit' => '120')
         end
-        dispatcher.cmd_mcp('start', 'Transport=http', 'RateLimit=120')
+        dispatcher.cmd_mcp('start', 'RateLimit=120')
       end
 
       it 'starts with empty opts when no options given' do
@@ -634,7 +633,7 @@ RSpec.describe Msf::Plugin::MCP do
         dispatcher.cmd_mcp('help')
         combined = @output.join("\n")
         expect(combined).to include('Usage: mcp <subcommand> [options]')
-        expect(combined).to include('Transport=<http>')
+        expect(combined).to include('ServerHost=<host>')
         expect(combined).to include('mcp start RpcUser=msf RpcPass=secret')
       end
     end

--- a/spec/plugins/mcp_spec.rb
+++ b/spec/plugins/mcp_spec.rb
@@ -639,13 +639,33 @@ RSpec.describe Msf::Plugin::MCP do
     end
 
     describe '#cmd_mcp_tabs' do
-      it 'returns subcommands for first word' do
-        result = dispatcher.cmd_mcp_tabs('', [''])
+      it 'returns subcommands when typing subcommand' do
+        # User typed: "mcp <tab>" → words = ['mcp'], str = ''
+        result = dispatcher.cmd_mcp_tabs('', ['mcp'])
         expect(result).to contain_exactly('status', 'start', 'stop', 'restart', 'help')
       end
 
-      it 'returns empty for subsequent words' do
-        result = dispatcher.cmd_mcp_tabs('', %w[start something])
+      it 'returns option completions for start subcommand' do
+        # User typed: "mcp start <tab>" → words = ['mcp', 'start'], str = ''
+        result = dispatcher.cmd_mcp_tabs('', ['mcp', 'start'])
+        expect(result).to include('ServerHost=', 'ServerPort=', 'RpcHost=', 'RpcPass=')
+      end
+
+      it 'filters options by partial input' do
+        # User typed: "mcp start Rpc<tab>" → words = ['mcp', 'start'], str = 'Rpc'
+        result = dispatcher.cmd_mcp_tabs('Rpc', ['mcp', 'start'])
+        expect(result).to contain_exactly('RpcHost=', 'RpcPort=', 'RpcUser=', 'RpcPass=', 'RpcSSL=')
+      end
+
+      it 'filters options case-insensitively' do
+        # User typed: "mcp start rpc<tab>" → words = ['mcp', 'start'], str = 'rpc'
+        result = dispatcher.cmd_mcp_tabs('rpc', ['mcp', 'start'])
+        expect(result).to contain_exactly('RpcHost=', 'RpcPort=', 'RpcUser=', 'RpcPass=', 'RpcSSL=')
+      end
+
+      it 'returns empty for non-start/restart subcommands' do
+        # User typed: "mcp status <tab>" → words = ['mcp', 'status'], str = ''
+        result = dispatcher.cmd_mcp_tabs('', ['mcp', 'status'])
         expect(result).to eq([])
       end
     end


### PR DESCRIPTION
part  of #21297

Add MCP plugin to manage Metasploit MCP server lifecycle within msfconsole

## Verification Steps

### Plugin load/unload lifecycle

- [x] Start `msfconsole`
- [x] `load mcp`
- [x] **Verify** plugin loads successfully and prints `MCP plugin loaded. Use "mcp start" to start the server.`
- [x] **Verify** no RPC server is auto-started on load
- [x] `mcp status`
- [x] **Verify** output shows `stopped (not configured)`
- [x] `unload mcp`
- [x] **Verify** plugin unloads cleanly without errors

### Starting the MCP server with defaults (auto-starts msgrpc)

- [x] `load mcp`
- [x] `mcp start`
- [x] **Verify** output shows `Auto-started msgrpc` with generated credentials
- [x] **Verify** output shows `MCP server started on 127.0.0.1:3000 (transport: http)`
- [x] `mcp status`
- [x] **Verify** output shows `running`, transport `http`, listening on `127.0.0.1:3000`, and uptime

### Starting with custom options

- [x] `unload mcp` (clean slate)
- [x] `load mcp`
- [x] `mcp start ServerPort=8080 ServerHost=0.0.0.0`
- [x] **Verify** output shows `MCP server started on 0.0.0.0:8080 (transport: http)`
- [x] `mcp status`
- [x] **Verify** status reflects the custom host and port

### Starting with explicit RPC credentials

- [x] `unload mcp` (clean slate)
- [x] `load msgrpc Pass=testpass User=testuser`
- [x] `load mcp`
- [x] `mcp start RpcUser=testuser RpcPass=testpass`
- [x] **Verify** the MCP server starts without auto-starting a second msgrpc instance
- [x] **Verify** no `Auto-started msgrpc` message appears

### Introspection of existing msgrpc

- [x] `unload mcp` (clean slate, leave msgrpc loaded)
- [x] `load mcp`
- [x] `mcp start`
- [x] **Verify** the MCP server detects and uses the already-loaded msgrpc credentials
- [x] **Verify** no `Auto-started msgrpc` message appears

### Stop and restart

- [x] `mcp stop`
- [x] **Verify** output shows `MCP server stopped`
- [x] `mcp stop`
- [x] **Verify** error message `MCP server is already stopped`
- [x] `mcp start`
- [x] **Verify** server starts again successfully
- [x] `mcp start`
- [x] **Verify** error message `MCP server is already running`
- [x] `mcp restart ServerPort=9090`
- [x] **Verify** server restarts on the new port
- [x] `mcp status`
- [x] **Verify** status shows port 9090

### Option validation

- [x] `mcp stop`
- [x] `mcp start ServerPort=99999`
- [x] **Verify** error about invalid ServerPort
- [x] `mcp start Transport=websocket`
- [x] **Verify** error about invalid Transport
- [x] `mcp start RpcUser=admin`
- [x] **Verify** error that RpcPass is also required
- [x] `mcp start RateLimit=0`
- [x] **Verify** error about invalid RateLimit
- [x] `mcp start FakeOption=value`
- [x] **Verify** error about unknown option
- [x] **Verify** the server does not start after any of the above

### Help and tab completion

- [x] `mcp help`
- [x] **Verify** help output lists all subcommands, options with defaults, and examples
- [x] Type `mcp ` and press Tab
- [ ] **Verify** tab completion suggests `status start stop restart help`

### Cleanup on plugin unload while server is running

- [x] `mcp start`
- [x] `unload mcp`
- [x] **Verify** output shows `MCP server stopped`
- [x] **Verify** auto-started msgrpc is also unloaded (if applicable)


### MCP server responds to tool calls

#### Option A: Using curl

- [ ] `load mcp`
- [ ] `mcp start`
- [ ] In a separate terminal, initialize a session (note the `Mcp-Session-Id` header in the response):
```
curl -si -X POST http://127.0.0.1:3000/mcp -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
```

- [ ] **Verify** the response includes `serverInfo` with name `msfmcp` and a `Mcp-Session-Id` header
- [ ] Send the `initialized` notification using the session ID from above:
```
curl -si -X POST http://127.0.0.1:3000/mcp -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -H "Mcp-Session-Id: <SESSION_ID>" -d '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}'
```

- [ ] List available tools:
```
curl -s -X POST http://127.0.0.1:3000/mcp -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -H "Mcp-Session-Id: <SESSION_ID>" -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
```

- [ ] **Verify** the response contains a list of tools (e.g. `search_modules`, `module_info`, `host_info`)
- [ ] Call a tool:
```
curl -s -X POST http://127.0.0.1:3000/mcp -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -H "Mcp-Session-Id: <SESSION_ID>" -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"search_modules","arguments":{"query":"psexec","type":"exploit"}}}'
```

- [ ] **Verify** the response contains module search results
- [ ] `mcp stop`
- [ ] `unload mcp`

#### Option B: Using MCP Inspector

- [ ] `load mcp`
- [ ] `mcp start`
- [ ] In a separate terminal, launch the inspector:
`npx @modelcontextprotocol/inspector`
- [ ] In the inspector UI, set transport type to **Streamable HTTP** and URL to `http://127.0.0.1:3000/mcp`
- [ ] Click **Connect**
- [ ] **Verify** the connection succeeds and server info shows `msfmcp`
- [ ] Navigate to the **Tools** tab
- [ ] **Verify** tools are listed (e.g. `search_modules`, `module_info`, `host_info`)
- [ ] Select `search_modules`, enter arguments `{"query": "psexec", "type": "exploit"}`, and click **Run**
- [ ] **Verify** the response contains module search results
- [ ] `mcp stop`
- [ ] `unload mcp`