### PR TITLE
Fix webdav upload php false positive

### DIFF
--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -163,14 +163,17 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown("Target responded with unexpected HTTP status #{res.code}")
     end
 
-    correct_message = res.message == 'OK'
     header_url_regex = %r{^\d,\d, <http://apache.org/dav/propset/fs/\d>$}
     correct_header = res.headers['DAV']&.match?(header_url_regex)
 
-    unless correct_message && correct_header
-      print_error "Target responded with an unknown message: '#{res.message}', should be 'OK'" unless correct_message
-      print_error "Target responded with an unknown DAV header: '#{res.headers['DAV']}', should be '#{header_url_regex}'" unless correct_header
-      return Exploit::CheckCode::Unknown('Target responded with unexpected message and/or header')
+    unless correct_header
+      print_error "Target responded with an unknown DAV header: '#{res.headers['DAV']}', should be '#{header_url_regex}'"
+      return Exploit::CheckCode::Unknown('Target responded with an unknown DAV header')
+    end
+
+    unless res.message == 'OK'
+      print_error "Target responded with an unknown message: '#{res.message}', should be 'OK'"
+      return Exploit::CheckCode::Unknown('Target responded with an unexpected message')
     end
 
     # Record results!

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -163,6 +163,16 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown("Target responded with unexpected HTTP status #{res.code}")
     end
 
+    correct_message = res.message == 'OK'
+    header_url_regex = %r{^\d,\d, <http://apache.org/dav/propset/fs/\d>$}
+    correct_header = res.headers['DAV']&.match?(header_url_regex)
+
+    unless correct_message && correct_header
+      print_error "Target responded with an unknown message: '#{res.message}', should be 'OK'" unless correct_message
+      print_error "Target responded with an unknown DAV header: '#{res.headers['DAV']}', should be '#{header_url_regex}'" unless correct_header
+      return Exploit::CheckCode::Unknown('Target responded with unexpected message and/or header')
+    end
+
     # Record results!
     opts, service = report_webdav_service(res, res_creds)
 


### PR DESCRIPTION
This PR addresses a recent issue stemming from the recently-made changes to the webdav upload php module, where a false positive was being reported based on only the response code.

This PR adds a header and a message check, to try and get rid of the false positive.

`res.body` is an empty string, so there isn't anything we can search for there that is specific to webdav. I resorted to the headers that are being returned instead:
```ruby
[2] pry(#<Msf::Modules::Exploit__Multi__Http__Webdav_upload_php::MetasploitModule>)> res.body
=> ""
[6] pry(#<Msf::Modules::Exploit__Multi__Http__Webdav_upload_php::MetasploitModule>)> res.headers
=> {"Date"=>"xxx",
 "Server"=>"Apache/2.4.37 (Unix)",
 "Authentication-Info"=>"rspauth=\"xxx\", cnonce=\"xxx\", nc=xxx, qop=auth",
 "DAV"=>"1,2, <http://apache.org/dav/propset/fs/1>",
 "MS-Author-Via"=>"DAV",
 "Allow"=>"OPTIONS,MKCOL,PUT,LOCK",
 "Content-Length"=>"0"}
```


## Before & After
Run a Docker container that will give us a 200 response code, without actually having WebDAV running:
`docker run --rm -d -p 9090:80 --name false-positive-test httpd:2.4`

### Before
```
msf exploit(multi/http/webdav_upload_php) > run rhost=127.0.0.1 rport=9090
s[*] Started reverse TCP handler on 192.168.1.230:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
e[-] Error with upload request (HTTP 405, should be 2xx)
[-] Exploit aborted due to failure: unknown: Cannot reliably check exploitability. Upload request failed with HTTP status 405 "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
rmsf exploit(multi/http/webdav_upload_php) > services
Services
========

host       port  proto  name    state  info                  resource  parents
----       ----  -----  ----    -----  ----                  --------  -------
127.0.0.1  9090  tcp    tcp     open                         {}
127.0.0.1  9090  tcp    webdav  open   Apache/2.4.67 (Unix)  {}        http (9090/tcp)
127.0.0.1  9090  tcp    http    open                         {}        tcp (9090/tcp)
```

### After
```
msf exploit(multi/http/webdav_upload_php) > run rhost=127.0.0.1 rport=9090
[*] Started reverse TCP handler on 192.168.1.230:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Target responded with an unknown DAV header: '', should be '(?-mix:^\d,\d, <http:\/\/apache.org\/dav\/propset\/fs\/\d>$)'
[-] Exploit aborted due to failure: unknown: Cannot reliably check exploitability. Target responded with unexpected message and/or header "set ForceExploit true" to override check result.
[*] Exploit completed, but no session was created.
msf exploit(multi/http/webdav_upload_php) > services
Services
========

host  port  proto  name  state  info  resource  parents
----  ----  -----  ----  -----  ----  --------  -------
```
No false positive.


## Verification

- [x] Start docker container: `docker run --restart always -e AUTH_TYPE=Digest -e USERNAME=wampp -e PASSWORD=xampp --publish 8000:80 bytemark/webdav`
- [x] Start `msfconsole`
- [x] `use multi/http/webdav_upload_php`
- [x] `run rhost=127.0.0.1 rport=8000 username=wampp password=xampp uri=/`