### PR TITLE
Fix typos in module comments and error messages

### DIFF
--- a/modules/exploits/multi/http/jetbrains_teamcity_rce_cve_2023_42793.rb
+++ b/modules/exploits/multi/http/jetbrains_teamcity_rce_cve_2023_42793.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     # A token named 'RPC2' may already exist if this system has been exploited before and previous exploitation
-    # did not delete teh token after use. We detect that here, delete the token (as we dont know its value) if required
+    # did not delete the token after use. We detect that here, delete the token (as we dont know its value) if required
     # and then proceed to create a new token for our use.
     if res && (res.code == 400) && res.body.include?('Token already exists')
 

--- a/modules/exploits/multi/misc/consul_rexec_exec.rb
+++ b/modules/exploits/multi/misc/consul_rexec_exec.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => { :Command => "#{cmd}", :Wait => 2000000000 }.to_json
     })
     if res and not res.code == 200 or res.body == 'false'
-      fail_with(Failure::Unknown, 'An error occured when contacting the Consul API.')
+      fail_with(Failure::Unknown, 'An error occurred when contacting the Consul API.')
     end
 
     print_status("Triggering execution on rexec session #{sess['ID']}")
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => { :Prefix => "_rexec", :Session => "#{sess['ID']}" }.to_json
     })
     if res and not res.code == 200
-      fail_with(Failure::Unknown, 'An error occured when contacting the Consul API.')
+      fail_with(Failure::Unknown, 'An error occurred when contacting the Consul API.')
     end
 
     begin
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and not res.code == 200 or res.body == 'false'
-      fail_with(Failure::Unknown, 'An error occured when contacting the Consul API.')
+      fail_with(Failure::Unknown, 'An error occurred when contacting the Consul API.')
     end
 
     res = send_request_cgi({
@@ -174,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
 
     if res and not res.code == 200 or res.body == 'false'
-      fail_with(Failure::Unknown, 'An error occured when contacting the Consul API.')
+      fail_with(Failure::Unknown, 'An error occurred when contacting the Consul API.')
     end
   end
 

--- a/modules/exploits/multi/misc/consul_service_exec.rb
+++ b/modules/exploits/multi/misc/consul_service_exec.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }.to_json
     })
     unless res && res.code == 200
-      fail_with(Failure::UnexpectedReply, 'An error occured when contacting the Consul API.')
+      fail_with(Failure::UnexpectedReply, 'An error occurred when contacting the Consul API.')
     end
     print_status("Service '#{service_name}' successfully created.")
     print_status("Waiting for service '#{service_name}' script to trigger")
@@ -152,7 +152,7 @@ class MetasploitModule < Msf::Exploit::Remote
     })
     if res && res.code != 200
       fail_with(Failure::UnexpectedReply,
-                'An error occured when contacting the Consul API.')
+                'An error occurred when contacting the Consul API.')
     end
   end
 

--- a/modules/exploits/multi/misc/nomad_exec.rb
+++ b/modules/exploits/multi/misc/nomad_exec.rb
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }.to_json
     })
     unless res && res.code == 200
-      fail_with(Failure::UnexpectedReply, 'An error occured when contacting the Nomad API.')
+      fail_with(Failure::UnexpectedReply, 'An error occurred when contacting the Nomad API.')
     end
 
     job_info = JSON.parse(res.body)

--- a/modules/exploits/windows/browser/samsung_security_manager_put.rb
+++ b/modules/exploits/windows/browser/samsung_security_manager_put.rb
@@ -200,7 +200,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     # we can bypass Access-Control-Allow-Origin (CORS) in all browsers using iframe since it makes a GET request
-    # and the response is recieved in the page (even though we cant access it due to SOP) which then fires the XSS
+    # and the response is received in the page (even though we cant access it due to SOP) which then fires the XSS
     html_content = %Q|
     <html>
     <body>

--- a/modules/exploits/windows/local/tokenmagic.rb
+++ b/modules/exploits/windows/local/tokenmagic.rb
@@ -154,7 +154,7 @@ minutes to trigger', 'SERVICE', ['SERVICE', 'DLL']
     if datastore['METHOD'] =~ /DLL/i
       launch_dll_trigger
       print_status("Note that the System Orchestrator service which loads the overwritten DLL when using the DLL method can take up to 10
-minutes to trigger and recieve a shell.")
+minutes to trigger and receive a shell.")
     end
     print_good('Enjoy the shell!')
   end

--- a/modules/post/multi/gather/enum_software_versions.rb
+++ b/modules/post/multi/gather/enum_software_versions.rb
@@ -45,7 +45,7 @@ class MetasploitModule < Msf::Post
     end
     listing = cmd_exec('pm list packages -f').to_s
     if listing.empty?
-      print_error('No results were returned when trying to get software installed on the Linux host. An error likely occured.')
+      print_error('No results were returned when trying to get software installed on the Linux host. An error likely occurred.')
       return nil
     end
     listing
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Post
       else
         listing = cmd_exec(cmd.join(' ')).to_s
         if listing.empty?
-          print_error('No results were returned when trying to get software installed on the Linux host. An error likely occured.')
+          print_error('No results were returned when trying to get software installed on the Linux host. An error likely occurred.')
           return
         end
         store_linux_loot(listing)
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Post
       end
       listing = cmd_exec('pkg info').to_s
       if listing.empty?
-        print_error('No results were returned when trying to get software installed on the BSD/Solaris host. An error likely occured.')
+        print_error('No results were returned when trying to get software installed on the BSD/Solaris host. An error likely occurred.')
         return
       end
       file = store_loot('host.bsd.solaris.software.versions', 'text/plain', session, listing, 'installed_software.txt', 'Installed Software and Versions')


### PR DESCRIPTION
Fixes minor spelling errors in comments and error message strings:

- `occured` → `occurred` in consul_rexec_exec, consul_service_exec, nomad_exec, enum_software_versions
- `teh` → `the` in jetbrains_teamcity comment
- `recieve`/`recieved` → `receive`/`received` in samsung_security_manager_put, tokenmagic