### PR TITLE
fix: add CVE-1999-0512 reference to smtp_relay module

### DIFF
--- a/modules/auxiliary/scanner/smtp/smtp_relay.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_relay.rb
@@ -19,6 +19,7 @@ class MetasploitModule < Msf::Auxiliary
       'References' => [
         ['URL', 'http://www.ietf.org/rfc/rfc2821.txt'],
         ['URL', 'https://svn.nmap.org/nmap/scripts/smtp-open-relay.nse'],
+        ['CVE', '1999-0512'],
       ],
       'Author' => [
         'Campbell Murray',


### PR DESCRIPTION
Fixes #21544

Adds the missing CVE-1999-0512 reference to modules/auxiliary/scanner/smtp/smtp_relay.rb as suggested.

## Verification
- Open modules/auxiliary/scanner/smtp/smtp_relay.rb
- Verify CVE-1999-0512 is present in the References section