### PR TITLE
Make WebDAV upload PHP exploit checks less strict

### DIFF
--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -167,8 +167,20 @@ class MetasploitModule < Msf::Exploit::Remote
     correct_header = res.headers['DAV']&.match?(header_url_regex)
 
     unless correct_header
-      print_error "Target responded with an unknown DAV header: '#{res.headers['DAV']}', should be '#{header_url_regex}'"
-      return Exploit::CheckCode::Unknown('Target responded with an unknown DAV header')
+      # The DAV header check may miss servers that don't advertise WebDAV on OPTIONS
+      # per RFC 4918 §10.1 note. Fall back to a PROPFIND probe — a WebDAV-only method
+      # (RFC 4918 §9.1) that returns 207 Multi-Status on compliant servers and 405 elsewhere.
+      print_warning 'No DAV header found, probing with PROPFIND...'
+      res = send_request_raw({
+        'uri' => normalize_uri(datastore['URI']),
+        'method' => 'PROPFIND',
+        'headers' => { 'Depth' => '0' }
+      }.merge(res_creds), 10)
+      return Exploit::CheckCode::Unknown('No response received from the target') unless res
+
+      unless res.code == 207
+        return Exploit::CheckCode::Safe("Target does not appear to support WebDAV (PROPFIND returned HTTP #{res.code})")
+      end
     end
 
     # Record results!

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -163,17 +163,12 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown("Target responded with unexpected HTTP status #{res.code}")
     end
 
-    header_url_regex = %r{^\d,\d, <http://apache.org/dav/propset/fs/\d>$}
+    header_url_regex = %r{^\d,?} # No anchor, we only check to ensure the header value begins with an integer (WebDAV compliance class)
     correct_header = res.headers['DAV']&.match?(header_url_regex)
 
     unless correct_header
       print_error "Target responded with an unknown DAV header: '#{res.headers['DAV']}', should be '#{header_url_regex}'"
       return Exploit::CheckCode::Unknown('Target responded with an unknown DAV header')
-    end
-
-    unless res.message == 'OK'
-      print_error "Target responded with an unknown message: '#{res.message}', should be 'OK'"
-      return Exploit::CheckCode::Unknown('Target responded with an unexpected message')
     end
 
     # Record results!

--- a/modules/exploits/multi/http/webdav_upload_php.rb
+++ b/modules/exploits/multi/http/webdav_upload_php.rb
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown("Target responded with unexpected HTTP status #{res.code}")
     end
 
-    header_url_regex = %r{^\d,?} # No anchor, we only check to ensure the header value begins with an integer (WebDAV compliance class)
+    header_url_regex = /^\d,?/ # No anchor, we only check to ensure the header value begins with an integer (WebDAV compliance class)
     correct_header = res.headers['DAV']&.match?(header_url_regex)
 
     unless correct_header


### PR DESCRIPTION
Follow on from: https://github.com/rapid7/metasploit-framework/pull/21543

After reading the RFC document here: https://datatracker.ietf.org/doc/html/rfc4918
turns out the previous check might have been too strict. E.g. the RFC doc doesn't mention the `OK` message, and I've corrected the WebDAV compliance class regex check based on: https://datatracker.ietf.org/doc/html/rfc4918#page-103
The RFC doc calls out: `Note that many WebDAV servers do not advertise WebDAV support in response to "OPTIONS *"` but I don't know if there's anything actionable here.

## Verification

Run the two Docker containers from the previous PR

- [ ] Start `msfconsole`
- [ ] `use webdav php upload`
- [ ] Verify runs against both containers result in the expected services being registered for the webdav container only.