### PR TITLE
Remove unused imports in wmiexec.py

### DIFF
--- a/modules/auxiliary/scanner/smb/impacket/wmiexec.py
+++ b/modules/auxiliary/scanner/smb/impacket/wmiexec.py
@@ -7,9 +7,6 @@
 #
 
 import logging
-import os
-import string
-import sys
 
 try:
     from impacket.smbconnection import SessionError, SMBConnection, \


### PR DESCRIPTION
Removed unused imports from modules/auxiliary/scanner/smb/impacket/wmiexec.py for better code clarity. These are legacy imports which are no longer necessary.

Removed imports were os, string, and sys.