### PR TITLE
Fix db_import crash

### DIFF
--- a/lib/metasploit/framework/spec/threads/logger.rb
+++ b/lib/metasploit/framework/spec/threads/logger.rb
@@ -10,32 +10,38 @@ require 'securerandom'
 
 require 'metasploit/framework/spec/threads/suite'
 
-original_thread_new = Thread.method(:new)
+# Guard against double-patching if loaded via both RUBYOPT and spec_helper
+unless Thread.respond_to?(:_metasploit_thread_logger_enabled)
+  original_thread_new = Thread.method(:new)
 
-# Patches `Thread.new` so that if logs `caller` so thread leaks can be traced
-Thread.define_singleton_method(:new) { |*args, &block|
-  uuid = SecureRandom.uuid
-  # tag caller with uuid so that only leaked threads caller needs to be printed
-  lines = ["BEGIN Thread.new caller (#{uuid})"]
+  # Patches `Thread.new` so that if logs `caller` so thread leaks can be traced
+  Thread.define_singleton_method(:new) { |*args, &block|
+    uuid = SecureRandom.uuid
+    # tag caller with uuid so that only leaked threads caller needs to be printed
+    lines = ["BEGIN Thread.new caller (#{uuid})"]
 
-  caller.each do |frame|
-    lines << "  #{frame}"
-  end
+    caller.each do |frame|
+      lines << "  #{frame}"
+    end
 
-  lines << 'END Thread.new caller'
+    lines << 'END Thread.new caller'
 
-  Metasploit::Framework::Spec::Threads::Suite::LOG_PATHNAME.parent.mkpath
+    Metasploit::Framework::Spec::Threads::Suite::LOG_PATHNAME.parent.mkpath
 
-  Metasploit::Framework::Spec::Threads::Suite::LOG_PATHNAME.open('a') { |f|
-    # single puts so threads can't write in between each other.
-    f.puts lines.join("\n")
+    Metasploit::Framework::Spec::Threads::Suite::LOG_PATHNAME.open('a') { |f|
+      # single puts so threads can't write in between each other.
+      f.puts lines.join("\n")
+    }
+
+    options = {original_args: args, uuid: uuid}
+
+    original_thread_new.call(options) {
+      # record uuid for thread-leak detection can used uuid to correlate log with this thread.
+      Thread.current[Metasploit::Framework::Spec::Threads::Suite::UUID_THREAD_LOCAL_VARIABLE] = options.fetch(:uuid)
+      block.call(*options.fetch(:original_args))
+    }
   }
 
-  options = {original_args: args, uuid: uuid}
-
-  original_thread_new.call(options) {
-    # record uuid for thread-leak detection can used uuid to correlate log with this thread.
-    Thread.current[Metasploit::Framework::Spec::Threads::Suite::UUID_THREAD_LOCAL_VARIABLE] = options.fetch(:uuid)
-    block.call(*options.fetch(:original_args))
-  }
-}
+  # Marker method to indicate the logger patch has been applied
+  Thread.define_singleton_method(:_metasploit_thread_logger_enabled) { true }
+end

--- a/lib/metasploit/framework/spec/threads/suite.rb
+++ b/lib/metasploit/framework/spec/threads/suite.rb
@@ -91,27 +91,43 @@ module Metasploit
                   if thread_count > EXPECTED_THREAD_COUNT_AROUND_SUITE
                     error_lines = []
 
-                    if LOG_PATHNAME.exist?
-                      caller_by_thread_uuid = Metasploit::Framework::Spec::Threads::Suite.caller_by_thread_uuid
+                    caller_by_thread_uuid = if LOG_PATHNAME.exist?
+                                              Metasploit::Framework::Spec::Threads::Suite.caller_by_thread_uuid
+                                            else
+                                              error_lines << "Note: #{LOG_PATHNAME} does not exist. Run `rake spec` to log where Thread.new is called.\n\n"
+                                              {}
+                                            end
 
-                      thread_list.each do |thread|
-                        thread_uuid = thread[Metasploit::Framework::Spec::Threads::Suite::UUID_THREAD_LOCAL_VARIABLE]
-                        thread_name = thread[:tm_name]
+                    thread_list.each_with_index do |thread, index|
+                      thread_uuid = thread[Metasploit::Framework::Spec::Threads::Suite::UUID_THREAD_LOCAL_VARIABLE]
+                      thread_name = thread[:tm_name]
 
-                        # unmanaged thread, such as the main VM thread
-                        unless thread_uuid
-                          next
+                      error_lines << "--- Thread #{index + 1}/#{thread_count} ---\n"
+                      error_lines << "  UUID: #{thread_uuid || '(none - unmanaged thread)'}\n"
+                      error_lines << "  Name: #{thread_name.inspect}\n"
+                      error_lines << "  Status: #{thread.status.inspect}\n"
+                      error_lines << "  Class: #{thread.class.name}\n"
+                      error_lines << "  Priority: #{thread.priority}\n"
+                      error_lines << "  Thread locals: #{thread.keys.map(&:to_s).sort.inspect}\n"
+
+                      if thread_uuid && caller_by_thread_uuid[thread_uuid]
+                        error_lines << "  Creation caller:\n"
+                        caller_by_thread_uuid[thread_uuid].each do |caller_line|
+                          error_lines << "    #{caller_line}"
                         end
-
-                        caller = caller_by_thread_uuid[thread_uuid]
-
-                        error_lines << "Thread #{thread_uuid}'s (name=#{thread_name} status is #{thread.status.inspect} " \
-                                       "and was started here:\n"
-                        error_lines.concat(caller)
-                        error_lines << "The thread backtrace was:\n#{thread.backtrace ? thread.backtrace.join("\n") : 'nil (no backtrace)'}\n"
                       end
-                    else
-                      error_lines << "Run `rake spec` to log where Thread.new is called."
+
+                      backtrace = thread.backtrace
+                      if backtrace
+                        error_lines << "  Current backtrace:\n"
+                        backtrace.each do |bt_line|
+                          error_lines << "    #{bt_line}\n"
+                        end
+                      else
+                        error_lines << "  Current backtrace: nil (no backtrace available)\n"
+                      end
+
+                      error_lines << "\n"
                     end
 
                     raise RuntimeError,

--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -184,14 +184,19 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
     # mkdir all of the base directories we just pulled out, if they don't
     # already exist
     @import_filedata[:zip_tmp_subdirs].each {|sub|
-      tmp_subdirs = ::File.join(@import_filedata[:zip_tmp],sub)
+      tmp_subdirs = File.expand_path(::File.join(@import_filedata[:zip_tmp], sub))
+
+      # Skip if the resolved directory would be outside the zip tmp dir
+      # to mitigate directory traversal attacks
+      next unless is_child_of?(@import_filedata[:zip_tmp], tmp_subdirs)
+
       if File.exist? tmp_subdirs
         unless (::File.directory?(tmp_subdirs) && File.writable?(tmp_subdirs))
           # if it exists but we can't write to it, give up
           raise Msf::DBImportError.new("Could not extract zip file to #{tmp_subdirs}")
         end
       else
-        ::FileUtils.mkdir(tmp_subdirs)
+        ::FileUtils.mkdir_p(tmp_subdirs)
       end
     }
 
@@ -203,7 +208,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
       # tmp dir to mitigate any directory traversal attacks
       next unless is_child_of?(@import_filedata[:zip_tmp], target)
 
-      e.extract(target)
+      e.extract(e.name, destination_directory: @import_filedata[:zip_tmp])
 
       if target =~ /\.xml\z/
         target_data = ::File.open(target, "rb") {|f| f.read 1024}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -195,6 +195,11 @@ end
 
 if load_metasploit
   Metasploit::Framework::Spec::Constants::Suite.configure!
+
+  # Always enable thread-creation logging so that leaked threads can be traced
+  # back to their origin, even when specs are run without `rake spec`.
+  require 'metasploit/framework/spec/threads/logger'
+
   Metasploit::Framework::Spec::Threads::Suite.configure!
 end
 

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/zip.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/zip.rb
@@ -1,4 +1,99 @@
 RSpec.shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::Zip' do
   it { is_expected.to respond_to :import_msf_collateral }
   it { is_expected.to respond_to :import_msf_zip }
+
+  describe '#import_msf_zip' do
+    before(:each) do
+      skip("Not supported with remote DB") if ENV['REMOTE_DB']
+    end
+
+    let(:controlled_tmpdir) { Dir.mktmpdir('msf-zip-import-test') }
+
+    # Redirect Dir.tmpdir so import_msf_zip extracts into our controlled directory
+    before(:each) do
+      allow(Dir).to receive(:tmpdir).and_return(controlled_tmpdir)
+    end
+
+    after { FileUtils.rm_rf(controlled_tmpdir) }
+
+    def create_msf_zip(path, entries)
+      Zip::OutputStream.open(path) do |zos|
+        entries.each do |name, content|
+          zos.put_next_entry(name)
+          zos.write(content)
+        end
+      end
+    end
+
+    def valid_msf_xml
+      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<MetasploitV5>\n</MetasploitV5>\n"
+    end
+
+    # Find the extraction directory created by import_msf_zip under our controlled tmpdir
+    def find_extracted_dir
+      Dir.glob(File.join(controlled_tmpdir, 'msf', 'imp_*', '*')).first
+    end
+
+    context 'with a valid MSF zip containing loot and task entries' do
+      let(:zip_path) { File.join(controlled_tmpdir, 'test_export.zip') }
+
+      before do
+        create_msf_zip(zip_path, {
+          'test_export.xml' => valid_msf_xml,
+          'loot/file1.bin' => 'loot content here',
+          'tasks/task1.log' => 'task log content'
+        })
+      end
+
+      it 'extracts zip entries to the temporary directory' do
+        begin
+          framework.db.import_file(filename: zip_path)
+        rescue Msf::DBImportError
+          # Expected — our minimal XML passes detection but not full parsing
+        end
+
+        extracted_tmp = find_extracted_dir
+        expect(extracted_tmp).not_to be_nil
+        expect(File.exist?(File.join(extracted_tmp, 'test_export.xml'))).to be true
+        expect(File.exist?(File.join(extracted_tmp, 'loot', 'file1.bin'))).to be true
+        expect(File.exist?(File.join(extracted_tmp, 'tasks', 'task1.log'))).to be true
+        expect(File.read(File.join(extracted_tmp, 'loot', 'file1.bin'))).to eq('loot content here')
+      end
+    end
+
+    context 'with a zip containing path traversal entries' do
+      let(:zip_path) { File.join(controlled_tmpdir, 'malicious.zip') }
+
+      before do
+        create_msf_zip(zip_path, {
+          '../escaped/pwned.txt' => 'pwned',
+          'legit.xml' => valid_msf_xml
+        })
+      end
+
+      it 'does not extract traversal entries outside the extraction directory' do
+        original_stderr = $stderr
+        $stderr = StringIO.new
+        begin
+          framework.db.import_file(filename: zip_path)
+        rescue => _e
+          # Expected
+        ensure
+          $stderr = original_stderr
+        end
+
+        # The extraction dir is at controlled_tmpdir/msf/imp_XXXX/malicious/
+        # A ../escaped entry would land at controlled_tmpdir/msf/imp_XXXX/escaped/
+        # Verify no escaped/ directory was created alongside the extraction dir
+        extracted_dir = find_extracted_dir
+        expect(extracted_dir).not_to be_nil
+        parent_of_extraction = File.dirname(extracted_dir)
+        expect(Dir.exist?(File.join(parent_of_extraction, 'escaped'))).to be false
+        expect(File.exist?(File.join(parent_of_extraction, 'escaped', 'pwned.txt'))).to be false
+
+        # Also verify the traversal file didn't end up anywhere else in the controlled tmpdir
+        expect(File.exist?(File.join(controlled_tmpdir, 'escaped', 'pwned.txt'))).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes a `db_import` crash when importing zip files

## Verification

- Ensure CI passes
- Open msfconsole: `db_export -f xml
- Add to zip: `zip new_archive.zip test_export.xml`
- in msfconsole import it: `db_import new_archive.zip`

Master:

```
msf > db_import new_archive.zip
[*] Importing 'Metasploit Zip Export' data
[-] Error while running command db_import: No such file or directory @ rb_sysopen - /Users/user/Documents/code/metasploit-framework/var/folders/wp/fp12h8q13kq7mvf4mll72c140000gq/T/msf/imp_1QUr/new_archive/test_export.xml

Call stack:
/Users/user/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/rubyzip-3.3.0/lib/zip/entry.rb:757:in `initialize'
```

This branch:

```
bundle exec ruby ./msfconsole -q
msf > db_import new_archive.zip
[*] Importing 'Metasploit Zip Export' data
[*] Importing 'Metasploit XML' data
[*] Importing host 127.0.0.1
[*] Importing host 192.168.123.198
...
```
