### PR TITLE
enforce authentication in API tests and improve error handling for unauthenticated requests

### DIFF
--- a/spec/api/metasploit_api_app_spec.rb
+++ b/spec/api/metasploit_api_app_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe Msf::WebServices::MetasploitApiApp do
 
   before(:example) do
     header 'Content-Type', 'application/json'
+    # Create a user so authentication is enforced (auth_initialized = true).
+    # Without this, the API auto-succeeds auth for all requests.
+    Mdm::User.where(username: 'test_user').first_or_create!(
+      crypted_password: BCrypt::Password.create('test_password'),
+      admin: false
+    )
   end
 
   describe 'host authorization' do
@@ -20,14 +26,16 @@ RSpec.describe Msf::WebServices::MetasploitApiApp do
   end
 
   describe 'authentication' do
-    it 'does not return 200 for unauthenticated requests to protected endpoints' do
+    it 'returns 401 for unauthenticated requests to protected endpoints' do
       get '/api/v1/hosts'
-      expect(last_response.status).not_to eq(200)
+      expect(last_response.status).to eq(401)
     end
 
-    it 'returns a JSON response body' do
+    it 'returns a JSON error body for unauthenticated requests' do
       get '/api/v1/hosts'
-      expect { JSON.parse(last_response.body) }.not_to raise_error
+      json = JSON.parse(last_response.body)
+      expect(json).to have_key('error')
+      expect(json['error']['message']).to include('Authenticate to access this resource')
     end
   end
 


### PR DESCRIPTION
Was getting this stacktrace 
```
Msf::WebServices::MetasploitApiApp [-] Error handling request: opts must include a valid :workspace.
    Call Stack:
	 /Users/dwelch/dev/metasploit-framework/lib/msf/util/db_manager.rb:37:in `process_opts_workspace'
	 /Users/dwelch/dev/metasploit-framework/lib/msf/core/db_manager/host.rb:164:in `block in hosts'
	 /Users/dwelch/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/activerecord-7.2.2.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:415:in `with_connection'
	 /Users/dwelch/dev/metasploit-framework/lib/msf/core/db_manager/host.rb:158:in `hosts'
```

dug into it and it seems like a brittle test that was logging out the error but not causing the test itself to fail, this PR addresses that 

# Verification steps
- [ ] CI passes
- [ ] The stacktrace does not appear in the CI logs
- [ ] `bundle exec rspec spec/api/metasploit_api_app_spec.rb` 