### PR TITLE
Align UDP #recvfrom usage with the stdlib

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -551,7 +551,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.65)
+    rex-socket (0.1.69)
       dnsruby
       rex-core
     rex-sslscan (0.1.13)

--- a/lib/metasploit/framework/login_scanner/snmp.rb
+++ b/lib/metasploit/framework/login_scanner/snmp.rb
@@ -205,7 +205,8 @@ module Metasploit
         def recv_wrapper(sock, max_size, timeout)
           res = nil
           if protocol == 'udp'
-            res = sock.recvfrom(max_size, timeout)
+            data, addr = sock.timed_recvfrom(max_size, timeout)
+            res = [data, addr[3], addr[1]] if addr
           elsif protocol == 'tcp'
             ready = ::IO.select([sock], nil, nil, timeout)
             if ready

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -173,7 +173,13 @@ module Auxiliary::UDPScanner
       readable, _, _ = ::IO.select(@udp_sockets.values, nil, nil, timeout)
       if readable
         for sock in readable
-          res = sock.recvfrom(65535)
+          begin
+            res = sock.recvfrom(65535)
+          rescue ::Rex::ConnectionError, ::Errno::ECONNREFUSED
+            # A connected UDP socket surfaces ICMP port-unreachable as ECONNREFUSED
+            # on recvfrom; skip this socket and keep processing the others.
+            next
+          end
 
           # Ignore invalid responses
           break if not res[1]

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -173,7 +173,7 @@ module Auxiliary::UDPScanner
       readable, _, _ = ::IO.select(@udp_sockets.values, nil, nil, timeout)
       if readable
         for sock in readable
-          res = sock.recvfrom(65535, timeout)
+          res = sock.recvfrom(65535)
 
           # Ignore invalid responses
           break if not res[1]
@@ -182,12 +182,12 @@ module Auxiliary::UDPScanner
           next if not (res[0] and res[0].length > 0)
 
           # Trim the IPv6-compat prefix off if needed
-          shost = res[1].sub(/^::ffff:/, '')
+          shost = res[1][3].sub(/^::ffff:/, '')
 
           # Ignore the response if we have a boundary
           next unless inside_workspace_boundary?(shost)
 
-          queue << [res[0], shost, res[2]]
+          queue << [res[0], shost, res[1][1]]
 
           if queue.length > datastore['ScannerRecvQueueLimit']
             break

--- a/lib/msf/core/exploit/remote/mssql.rb
+++ b/lib/msf/core/exploit/remote/mssql.rb
@@ -78,7 +78,7 @@ module Exploit::Remote::MSSQL
         })
 
     ping_sock.put("\x02")
-    resp, _saddr, _sport = ping_sock.recvfrom(65535, timeout)
+    resp, = ping_sock.timed_recvfrom(65535, timeout)
     ping_sock.close
 
     return data if not resp

--- a/lib/msf/core/exploit/remote/wdbrpc_client.rb
+++ b/lib/msf/core/exploit/remote/wdbrpc_client.rb
@@ -39,7 +39,7 @@ module Exploit::Remote::WDBRPC_Client
     wdbrpc_client_send_disconnect()
 
     udp_sock.sendto(wdbrpc_request_connect(rhost), rhost, rport, 0)
-    res,src = udp_sock.recvfrom(65535, 5)
+    res, = udp_sock.timed_recvfrom(65535, 5)
     if not res
       print_error("No response to TARGET_CONNECT (WDB4)")
       return
@@ -84,7 +84,7 @@ module Exploit::Remote::WDBRPC_Client
     wdbrpc_client_send_disconnect()
 
     udp_sock.sendto(wdbrpc_request_connect2(rhost), rhost, rport, 0)
-    res,src = udp_sock.recvfrom(65535, 5)
+    res, = udp_sock.timed_recvfrom(65535, 5)
     if not res
       print_error("No response to TARGET_CONNECT2")
       return
@@ -115,12 +115,8 @@ module Exploit::Remote::WDBRPC_Client
 
     begin
       udp_sock.sendto(pkt, rhost, rport, 0)
-      res,src = udp_sock.recvfrom(65535, 0.5)
-      if not res and src
-        raise RuntimeError, "no reply"
-      end
-
-      if res.length <= 48
+      res, = udp_sock.timed_recvfrom(65535, 0.5)
+      if res.nil? || res.length <= 48
         raise RuntimeError, "short read"
       end
 
@@ -142,9 +138,9 @@ module Exploit::Remote::WDBRPC_Client
     res = nil
 
     udp_sock.sendto(pkt, rhost, rport, 0)
-    res,src = udp_sock.recvfrom(65535, 5.0)
+    res, = udp_sock.timed_recvfrom(65535, 5.0)
 
-    if not res and src
+    unless res
       raise RuntimeError, "no reply"
     end
     res[-4,4].unpack("N")[0]
@@ -157,9 +153,9 @@ module Exploit::Remote::WDBRPC_Client
     res = nil
 
     udp_sock.sendto(pkt, rhost, rport, 0)
-    res,src = udp_sock.recvfrom(65535, 5.0)
+    res, = udp_sock.timed_recvfrom(65535, 5.0)
 
-    if not res and src
+    unless res
       raise RuntimeError, "no reply"
     end
     p res
@@ -173,7 +169,7 @@ module Exploit::Remote::WDBRPC_Client
 
     begin
       udp_sock.sendto(pkt, rhost, rport, 0)
-      res,src = udp_sock.recvfrom(65535, 0.5)
+      res, = udp_sock.timed_recvfrom(65535, 0.5)
 
     rescue ::Interrupt
       raise $!
@@ -187,7 +183,7 @@ module Exploit::Remote::WDBRPC_Client
     begin
       if self.udp_sock
         self.udp_sock.sendto(pkt, rhost, rport, 0)
-        self.udp_sock.recvfrom(65535, 5)
+        self.udp_sock.timed_recvfrom(65535, 5)
       end
     rescue ::Interrupt
       raise $!

--- a/lib/msf/core/handler/reverse_udp.rb
+++ b/lib/msf/core/handler/reverse_udp.rb
@@ -159,7 +159,8 @@ module ReverseUdp
       loop do
         # Accept a client connection
         begin
-          inbound, peerhost, peerport = self.listener_sock.recvfrom
+          inbound, addr = self.listener_sock.recvfrom(65535)
+          peerhost, peerport = addr[3], addr[1]
           next if peerhost.nil?
           comm = self.listener_sock.channel.client if self.listener_sock.respond_to?(:channel) && self.listener_sock.channel.respond_to?(:client)
 

--- a/lib/rex/post/meterpreter/channels/datagram.rb
+++ b/lib/rex/post/meterpreter/channels/datagram.rb
@@ -29,13 +29,16 @@ class Datagram < Rex::Post::Meterpreter::Channel
 
   module SocketInterface
     include Rex::Post::Meterpreter::SocketAbstraction::SocketInterface
+
+    MAX_SOCKADDR_LENGTH = 128
+
     def type?
       'udp'
     end
 
     def recvfrom_nonblock(length, flags = 0)
       data = super(length, flags)[0]
-      sockaddr = super(length, flags)[0]
+      sockaddr = super(MAX_SOCKADDR_LENGTH, flags)[0]
       [data, sockaddr]
     end
 

--- a/lib/rex/proto/dhcp/server.rb
+++ b/lib/rex/proto/dhcp/server.rb
@@ -179,7 +179,8 @@ protected
       r,_,_ = ::IO.select(rds,wds,eds,1)
 
       if (r != nil and r[0] == self.sock)
-        buf,host,port = self.sock.recvfrom(65535)
+        buf, addr = self.sock.recvfrom(65535)
+        host, port = addr[3], addr[1]
         # Lame compatabilitiy :-/
         from = [host, port]
         dispatch_request(from, buf)

--- a/lib/rex/proto/dns/resolver.rb
+++ b/lib/rex/proto/dns/resolver.rb
@@ -342,7 +342,7 @@ module DNS
         @logger.info "Contacting nameserver #{ns} port #{@config[:port]}"
         #socket.sendto(packet_data, ns.to_s, @config[:port].to_i, 0)
         socket.write(packet_data)
-        ans = socket.recvfrom(@config[:packet_size])
+        ans = socket.timed_recvfrom(@config[:packet_size])
         break if ans
       rescue Timeout::Error
         @logger.warn "Nameserver #{ns} not responding within UDP timeout, trying next one"

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -218,7 +218,8 @@ protected
       r,_,_ = ::IO.select(rds,wds,eds,1)
 
       if (r != nil and r[0] == self.udp_sock)
-        buf,host,port = self.udp_sock.recvfrom(65535)
+        buf, addr = self.udp_sock.recvfrom(65535)
+        host, port = addr[3], addr[1]
         # Mock up a client object for sending back data
         cli = MockDnsClient.new(host, port, r[0])
         dispatch_request(cli, buf)

--- a/lib/rex/proto/iax2/client.rb
+++ b/lib/rex/proto/iax2/client.rb
@@ -62,7 +62,7 @@ class Client
   def monitor_socket
     while true
       begin
-        pkt, src = self.sock.recvfrom(65535)
+        pkt, = self.sock.recvfrom(65535)
         next if not pkt
 
         # Find the matching call object

--- a/lib/rex/proto/ldap/server.rb
+++ b/lib/rex/proto/ldap/server.rb
@@ -375,7 +375,8 @@ module Rex
 
             next unless (!r.nil? && (r[0] == udp_sock))
 
-            buf, host, port = udp_sock.recvfrom(65535)
+            buf, addr = udp_sock.recvfrom(65535)
+            host, port = addr[3], addr[1]
             # Mock up a client object for sending back data
             cli = MockLdapClient.new(host, port, r[0])
             cli.extend(LdapClient)

--- a/lib/rex/proto/natpmp/packet.rb
+++ b/lib/rex/proto/natpmp/packet.rb
@@ -18,7 +18,7 @@ module NATPMP::Packet
     vprint_status("#{host}:#{port} - Probing NAT-PMP for external address")
     udp_sock.sendto(external_address_request, host, port, 0)
     external_address = nil
-    while (r = udp_sock.recvfrom(12, timeout) and r[1])
+    while (r = udp_sock.timed_recvfrom(12, timeout))
       (ver, op, result, epoch, external_address) = parse_external_address_response(r[0])
       if external_address
         vprint_good("#{host}:#{port} - NAT-PMP external address is #{external_address}")
@@ -43,7 +43,7 @@ module NATPMP::Packet
     # send it
     udp_sock.sendto(req, host, datastore['RPORT'], 0)
     # handle the reply
-    while (r = udp_sock.recvfrom(16, timeout) and r[1])
+    while (r = udp_sock.timed_recvfrom(16, timeout))
       (_, _, result, _, _, actual_ext_port, _) = parse_map_port_response(r[0])
       return (result == 0 ? actual_ext_port : nil)
     end

--- a/lib/rex/proto/tftp/client.rb
+++ b/lib/rex/proto/tftp/client.rb
@@ -84,7 +84,8 @@ class Client
 
   def monitor_server_sock
     yield "Listening for incoming ACKs" if block_given?
-    res = self.server_sock.recvfrom(65535)
+    res = self.server_sock.timed_recvfrom(65535)
+    res = res ? [res[0], res[1][3], res[1][1]] : ['', nil, nil]
     if res and res[0]
       code, type, data = parse_tftp_response(res[0])
       if code == Constants::OpAck and self.action == :upload
@@ -112,7 +113,8 @@ class Client
   end
 
   def monitor_client_sock
-    res = self.client_sock.recvfrom(65535)
+    res = self.client_sock.timed_recvfrom(65535)
+    res = res ? [res[0], res[1][3], res[1][1]] : ['', nil, nil]
     if res[1] # Got a response back, so that's never good; Acks come back on server_sock.
       code, type, data = parse_tftp_response(res[0])
       yield("Aborting, got code:%d, type:%d, message:'%s'" % [code, type, data]) if block_given?
@@ -190,7 +192,8 @@ class Client
     end
     current_block = first_block
     while current_block.size == 512
-      res = self.server_sock.recvfrom(65535)
+      res = self.server_sock.timed_recvfrom(65535)
+      res = res ? [res[0], res[1][3], res[1][1]] : ['', nil, nil]
       if res and res[0]
         code, block_num, current_block = parse_tftp_response(res[0])
         if code == 3
@@ -313,7 +316,8 @@ class Client
           end
         end
         send_retries = 0
-        res = self.server_sock.recvfrom(65535)
+        res = self.server_sock.timed_recvfrom(65535)
+        res = res ? [res[0], res[1][3], res[1][1]] : ['', nil, nil]
         if res
           code, type, msg = parse_tftp_response(res[0])
           if code == 4

--- a/lib/rex/proto/tftp/server.rb
+++ b/lib/rex/proto/tftp/server.rb
@@ -240,7 +240,8 @@ protected
       r,w,e = ::IO.select(rds,wds,eds,1)
 
       if (r != nil and r[0] == self.sock)
-        buf,host,port = self.sock.recvfrom(65535)
+        buf, addr = self.sock.recvfrom(65535)
+        host, port = addr[3], addr[1]
         # Lame compatabilitiy :-/
         from = [host, port]
         dispatch_request(from, buf)

--- a/modules/auxiliary/dos/scada/allen_bradley_pccc.rb
+++ b/modules/auxiliary/dos/scada/allen_bradley_pccc.rb
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Auxiliary
     connect_udp
 
     udp_sock.put(enip_list_identify_pkt)
-    res = udp_sock.recvfrom(90)
+    res = udp_sock.timed_recvfrom(90)
 
     disconnect_udp
 

--- a/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
+++ b/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
@@ -47,7 +47,7 @@ class MetasploitModule < Msf::Auxiliary
 
   def send_probe(udp_sock, probe)
     udp_sock.put(probe)
-    data = udp_sock.recvfrom
+    data = udp_sock.timed_recvfrom(65535)
     if data && !data[0].empty?
       return data[0]
     else

--- a/modules/auxiliary/dos/windows/games/kaillera.rb
+++ b/modules/auxiliary/dos/windows/games/kaillera.rb
@@ -40,7 +40,7 @@ class MetasploitModule < Msf::Auxiliary
     connect_udp
     print_status('Sending Crash request...')
     udp_sock.put("HELLO0.83\0")
-    res = udp_sock.recvfrom(15)
+    res = udp_sock.timed_recvfrom(15) || ['']
     disconnect_udp
 
     if res[0] =~ /HELLOD00D([0-9]{1,5})/
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Auxiliary
     connect_udp
     print_status('Checking target...')
     udp_sock.put("HELLO0.83\0")
-    res = udp_sock.recvfrom(15)
+    res = udp_sock.timed_recvfrom(15) || ['']
     disconnect_udp
 
     if res[0] =~ /HELLO/

--- a/modules/auxiliary/fuzzers/dns/dns_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/dns/dns_fuzzer.rb
@@ -123,7 +123,7 @@ class MetasploitModule < Msf::Auxiliary
 
     if method == 'UDP'
       udp_sock.put(testing_pkt)
-      res, = udp_sock.recvfrom(65535)
+      res, = udp_sock.timed_recvfrom(65535)
       disconnect_udp
     elsif method == 'TCP'
       sock.put(testing_pkt)
@@ -131,7 +131,7 @@ class MetasploitModule < Msf::Auxiliary
       disconnect
     end
 
-    if res && res.empty?
+    if res.nil? || res.empty?
       print_error("#{msg} The remote server is not responding to DNS requests.")
       return false
     end
@@ -283,13 +283,13 @@ class MetasploitModule < Msf::Auxiliary
     udp_sock.put(data) if method == 'UDP'
     sock.put(data) if method == 'TCP'
 
-    res, = udp_sock.recvfrom(65535, 1) if method == 'UDP'
+    res, = udp_sock.timed_recvfrom(65535, 1) if method == 'UDP'
     res, = sock.get_once(-1, 1) if method == 'TCP'
 
     disconnect_udp if method == 'UDP'
     disconnect if method == 'TCP'
 
-    if res && res.empty?
+    if res.nil? || res.empty?
       @fail_count += 1
       if @fail_count == 1
         @probably_vuln = @lastdata if !@lastdata.nil?

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -189,10 +189,10 @@ class MetasploitModule < Msf::Auxiliary
     rescue ::Errno::EISCONN
       udp_sock.write(message)
     end
-    reply = udp_sock.recvfrom(65535, datastore['WAIT'] / 1000.0)
+    reply = udp_sock.timed_recvfrom(65535, datastore['WAIT'] / 1000.0)
     while reply && reply[1]
       replies << reply
-      reply = udp_sock.recvfrom(65535, datastore['WAIT'] / 1000.0)
+      reply = udp_sock.timed_recvfrom(65535, datastore['WAIT'] / 1000.0)
     end
     replies
   end

--- a/modules/auxiliary/scanner/chargen/chargen_probe.rb
+++ b/modules/auxiliary/scanner/chargen/chargen_probe.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Auxiliary
       begin
         connect_udp
         udp_sock.write(data)
-        r = udp_sock.recvfrom(65535, 0.1)
+        r = udp_sock.timed_recvfrom(65535, 0.1)
 
         if r and r[1]
           vprint_status("#{Rex::Socket.to_authority(rhost, rport)} - Response: #{r[0]}")

--- a/modules/auxiliary/scanner/discovery/udp_probe.rb
+++ b/modules/auxiliary/scanner/discovery/udp_probe.rb
@@ -86,8 +86,8 @@ class MetasploitModule < Msf::Auxiliary
 
         udp_sock.put(data)
 
-        r = udp_sock.recvfrom(65535, 0.1) and r[1]
-        parse_reply(r) if r
+        r = udp_sock.timed_recvfrom(65535, 0.1)
+        parse_reply([r[0], r[1][3], r[1][1]]) if r
       rescue ::Interrupt
         raise $ERROR_INFO
       rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused, ::IOError

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -355,8 +355,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def udp_recv(timeo)
-    r = udp_sock.recvfrom(65535, timeo)
-    r[1] ? r : nil
+    r = udp_sock.timed_recvfrom(65535, timeo)
+    return nil unless r
+
+    [r[0], r[1][3], r[1][1]]
   end
 
   def rhost

--- a/modules/auxiliary/scanner/jenkins/jenkins_udp_broadcast_enum.rb
+++ b/modules/auxiliary/scanner/jenkins/jenkins_udp_broadcast_enum.rb
@@ -68,8 +68,8 @@ class MetasploitModule < Msf::Auxiliary
 
     # loop a few times to account for multiple or slow responders
     iter = 0
-    while (r = udp_sock.recvfrom(65535, 0.1)) && (iter < 20)
-      parse_reply(r)
+    while (r = udp_sock.timed_recvfrom(65535, 0.1)) && (iter < 20)
+      parse_reply([r[0], r[1][3], r[1][1]])
       iter += 1
     end
   end

--- a/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
+++ b/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
@@ -52,11 +52,11 @@ class MetasploitModule < Msf::Auxiliary
 
       udp_sock.put(target_mac + cmd)
 
-      res = udp_sock.recvfrom(65535, 0.5) and res[1]
+      res = udp_sock.timed_recvfrom(65535, 0.5)
 
       # Parse the reply if we get a response
       if res
-        password = parse_reply(res)
+        password = parse_reply([res[0], res[1][3], res[1][1]])
       end
     rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused, ::IOError
       print_error("Connection error")

--- a/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
+++ b/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
@@ -48,8 +48,8 @@ class MetasploitModule < Msf::Auxiliary
       Rex::Socket.portspec_crack(datastore['PORTS']).each do |port|
         map_req = map_port_request(port, port, Rex::Proto::NATPMP.const_get(datastore['PROTOCOL']), 1)
         udp_sock.sendto(map_req, host, datastore['RPORT'], 0)
-        while (r = udp_sock.recvfrom(16, 1.0) and r[1])
-          break if handle_reply(host, external_address, r)
+        while (r = udp_sock.timed_recvfrom(16, 1.0))
+          break if handle_reply(host, external_address, [r[0], r[1][3], r[1][1]])
         end
       end
     rescue ::Interrupt

--- a/modules/auxiliary/scanner/ntp/timeroast.rb
+++ b/modules/auxiliary/scanner/ntp/timeroast.rb
@@ -65,12 +65,12 @@ class MetasploitModule < Msf::Auxiliary
 
   def recv_response(timeout: 0)
     begin
-      raw, = udp_sock.recvfrom(68, timeout) # 68 is always the number of bytes expected
+      raw, = udp_sock.timed_recvfrom(68, timeout) # 68 is always the number of bytes expected
     rescue ::Rex::SocketError, ::IOError
       return nil
     end
 
-    return nil if raw.empty?
+    return nil if raw.nil? || raw.empty?
 
     Rex::Proto::NTP::Header::NTPHeader.read(raw)
   end

--- a/modules/auxiliary/scanner/scada/bacnet_l3.rb
+++ b/modules/auxiliary/scanner/scada/bacnet_l3.rb
@@ -154,12 +154,12 @@ class MetasploitModule < Msf::Auxiliary
 
     # Collect responses with unicast or broadcast destination.
     loop do
-      data, host, port = lsocket.recvfrom(65535, datastore['TIMEOUT'])
-      data2, host2, port2 = ssocket.recvfrom(65535, datastore['TIMEOUT'])
-      break if host.nil? && host2.nil?
+      res1 = lsocket.timed_recvfrom(65535, datastore['TIMEOUT'])
+      res2 = ssocket.timed_recvfrom(65535, datastore['TIMEOUT'])
+      break if res1.nil? && res2.nil?
 
-      cap << [data, host, port] if host
-      cap << [data2, host2, port2] if host2
+      cap << [res1[0], res1[1][3], res1[1][1]] if res1
+      cap << [res2[0], res2[1][3], res2[1][1]] if res2
     end
     lsocket.close
     cap
@@ -292,10 +292,10 @@ class MetasploitModule < Msf::Auxiliary
     messages.each do |message|
       ssocket.sendto(message, ip, datastore['PORT'], 0)
       loop do
-        data, host, port = ssocket.recvfrom(65535, datastore['TIMEOUT'])
-        break if host.nil?
+        res = ssocket.timed_recvfrom(65535, datastore['TIMEOUT'])
+        break if res.nil?
 
-        cap << [data, host, port]
+        cap << [res[0], res[1][3], res[1][1]]
       end
     end
     ssocket.close

--- a/modules/auxiliary/scanner/scada/koyo_login.rb
+++ b/modules/auxiliary/scanner/scada/koyo_login.rb
@@ -164,7 +164,7 @@ class MetasploitModule < Msf::Auxiliary
     #
     # Another way to speed things up is to use fancy threading, but that's for another
     # day.
-    while (r = @udp_sock.recvfrom(65535, 0.1) and recvpacks < 2)
+    while (r = @udp_sock.timed_recvfrom(65535, 0.1) and recvpacks < 2)
       res = r[0]
       if res.length == 269 # auth reply packet
         if res[17, 1] == "\x00" and res[19, 1] == "\xD2" # Magic bytes

--- a/modules/auxiliary/scanner/sip/enumerator.rb
+++ b/modules/auxiliary/scanner/sip/enumerator.rb
@@ -77,8 +77,8 @@ class MetasploitModule < Msf::Auxiliary
           end
 
           if (idx % 10 == 0)
-            while (r = udp_sock.recvfrom(65535, 0.01) and r[1])
-              parse_reply(r, datastore['METHOD'])
+            while (r = udp_sock.timed_recvfrom(65535, 0.01))
+              parse_reply([r[0], r[1][3], r[1][1]], datastore['METHOD'])
             end
           end
 
@@ -86,8 +86,8 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
 
-      while (r = udp_sock.recvfrom(65535, 3) and r[1])
-        parse_reply(r, datastore['METHOD'])
+      while (r = udp_sock.timed_recvfrom(65535, 3))
+        parse_reply([r[0], r[1][3], r[1][1]], datastore['METHOD'])
       end
     rescue ::Interrupt
       raise $!

--- a/modules/auxiliary/scanner/sip/sipdroid_ext_enum.rb
+++ b/modules/auxiliary/scanner/sip/sipdroid_ext_enum.rb
@@ -89,7 +89,8 @@ class MetasploitModule < Msf::Auxiliary
         udp_sock.put(data)
 
         while not rcv.nil?
-          msg = udp_sock.recvfrom(1024, 4)
+          msg = udp_sock.timed_recvfrom(1024, 4)
+          msg = msg ? [msg[0], msg[1][3], msg[1][1]] : ['', nil, nil]
           if not msg[0].eql?("")
             if msg[0].include?("SIP/2.0 180 Ringing")
               origin = /o=\w+\@[\w+\.]+/.match(msg[0])

--- a/modules/auxiliary/scanner/telnet/lantronix_telnet_password.rb
+++ b/modules/auxiliary/scanner/telnet/lantronix_telnet_password.rb
@@ -54,9 +54,9 @@ class MetasploitModule < Msf::Auxiliary
         rem_sock = Rex::Socket::Udp.create(sock_opts)
       end
       rem_sock.put(setup_probe)
-      res = rem_sock.recvfrom(65535, 0.5) and res[1]
+      res = rem_sock.timed_recvfrom(65535, 0.5)
 
-      password = parse_reply(res)
+      password = res && parse_reply(res)
     rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused, ::IOError
       print_error("Connection error")
     rescue ::Interrupt

--- a/modules/auxiliary/scanner/tftp/ipswitch_whatsupgold_tftp.rb
+++ b/modules/auxiliary/scanner/tftp/ipswitch_whatsupgold_tftp.rb
@@ -72,7 +72,8 @@ class MetasploitModule < Msf::Auxiliary
     file_data = ''
     udp_sock.sendto(pkt, ip, datastore['RPORT'].to_i)
 
-    while (r = udp_sock.recvfrom(65535, 0.1) and r[1])
+    while (r = udp_sock.timed_recvfrom(65535, 0.1))
+      r = [r[0], r[1][3], r[1][1]]
 
       opcode, block, data = r[0].unpack("nna*") # Parse reply
       if opcode != 3 # Check opcode: 3 => Data Packet

--- a/modules/auxiliary/scanner/tftp/netdecision_tftp.rb
+++ b/modules/auxiliary/scanner/tftp/netdecision_tftp.rb
@@ -71,7 +71,8 @@ class MetasploitModule < Msf::Auxiliary
     file_data = ''
     udp_sock.sendto(pkt, ip, datastore['RPORT'].to_i)
 
-    while (r = udp_sock.recvfrom(65535, 0.1) and r[1])
+    while (r = udp_sock.timed_recvfrom(65535, 0.1))
+      r = [r[0], r[1][3], r[1][1]]
 
       opcode, block, data = r[0].unpack("nna*") # Parse reply
       if opcode != 3 # Check opcode: 3 => Data Packet

--- a/modules/auxiliary/scanner/vxworks/wdbrpc_bootline.rb
+++ b/modules/auxiliary/scanner/vxworks/wdbrpc_bootline.rb
@@ -58,8 +58,8 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         if (idx % 10 == 0)
-          while (r = udp_sock.recvfrom(65535, 0.01) and r[1])
-            parse_reply(r)
+          while (r = udp_sock.timed_recvfrom(65535, 0.01))
+            parse_reply([r[0], r[1][3], r[1][1]])
           end
         end
 
@@ -69,8 +69,8 @@ class MetasploitModule < Msf::Auxiliary
       cnt = 0
       del = 10
       sts = Time.now.to_i
-      while (r = udp_sock.recvfrom(65535, del) and r[1])
-        parse_reply(r)
+      while (r = udp_sock.timed_recvfrom(65535, del))
+        parse_reply([r[0], r[1][3], r[1][1]])
 
         # Prevent an indefinite loop if the targets keep replying
         cnt += 1

--- a/modules/auxiliary/scanner/vxworks/wdbrpc_version.rb
+++ b/modules/auxiliary/scanner/vxworks/wdbrpc_version.rb
@@ -56,8 +56,8 @@ class MetasploitModule < Msf::Auxiliary
         end
 
         if (idx % 10 == 0)
-          while (r = udp_sock.recvfrom(65535, 0.01) and r[1])
-            parse_reply(r)
+          while (r = udp_sock.timed_recvfrom(65535, 0.01))
+            parse_reply([r[0], r[1][3], r[1][1]])
           end
         end
 
@@ -67,8 +67,8 @@ class MetasploitModule < Msf::Auxiliary
       cnt = 0
       del = 10
       sts = Time.now.to_i
-      while (r = udp_sock.recvfrom(65535, del) and r[1])
-        parse_reply(r)
+      while (r = udp_sock.timed_recvfrom(65535, del))
+        parse_reply([r[0], r[1][3], r[1][1]])
 
         # Prevent an indefinite loop if the targets keep replying
         cnt += 1

--- a/modules/auxiliary/server/capture/sip.rb
+++ b/modules/auxiliary/server/capture/sip.rb
@@ -147,12 +147,14 @@ class MetasploitModule < Msf::Auxiliary
     server_ip = sip_sanitize_address(srvhost)
 
     while @run
-      res = @sock.recvfrom
+      res = @sock.timed_recvfrom(65535)
+      next unless res
+
       @requestor = {
-        ip: res[1],
-        port: res[2]
+        ip: res[1][3],
+        port: res[1][1]
       }
-      client_ip = sip_sanitize_address(res[1])
+      client_ip = sip_sanitize_address(res[1][3])
       next if !res[0] || res[0].empty?
 
       request = sip_parse_request(res[0])

--- a/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
@@ -100,7 +100,7 @@ class MetasploitModule < Msf::Auxiliary
       req.rd = 1
 
       srv_sock.put(req.encode)
-      res, = srv_sock.recvfrom(65535, 1.0)
+      res, = srv_sock.timed_recvfrom(65535, 1.0)
 
       if res && !res.empty?
         reps += 1
@@ -182,7 +182,7 @@ class MetasploitModule < Msf::Auxiliary
       req.rd = 1
 
       srv_sock.put(req.encode)
-      res, = srv_sock.recvfrom
+      res, = srv_sock.timed_recvfrom(65535)
 
       if res && !res.empty?
         res = Resolv::DNS::Message.decode(res)
@@ -209,7 +209,7 @@ class MetasploitModule < Msf::Auxiliary
       loop do
         cached = false
         srv_sock.put(query.encode)
-        answer, = srv_sock.recvfrom
+        answer, = srv_sock.timed_recvfrom(65535)
 
         if answer && !answer.empty?
           answer = Resolv::DNS::Message.decode(answer)
@@ -367,7 +367,7 @@ class MetasploitModule < Msf::Auxiliary
         query.rd = 0
 
         srv_sock.put(query.encode)
-        answer, = srv_sock.recvfrom
+        answer, = srv_sock.timed_recvfrom(65535)
 
         if answer && !answer.empty?
           answer = Resolv::DNS::Message.decode(answer)
@@ -419,7 +419,7 @@ class MetasploitModule < Msf::Auxiliary
     req.rd = 0
 
     while (times.length < num)
-      res, = sock.recvfrom(65535, 0.01)
+      res, = sock.timed_recvfrom(65535, 0.01)
 
       if res && !res.empty?
         res = Resolv::DNS::Message.decode(res)

--- a/modules/auxiliary/spoof/dns/bailiwicked_host.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_host.rb
@@ -96,7 +96,7 @@ class MetasploitModule < Msf::Auxiliary
       req.rd = 1
 
       srv_sock.put(req.encode)
-      res, = srv_sock.recvfrom(65535, 1.0)
+      res, = srv_sock.timed_recvfrom(65535, 1.0)
 
       if res && !res.empty?
         reps += 1
@@ -181,7 +181,7 @@ class MetasploitModule < Msf::Auxiliary
       req.rd = 1
 
       srv_sock.put(req.encode)
-      res, = srv_sock.recvfrom
+      res, = srv_sock.timed_recvfrom(65535)
 
       if res && !res.empty?
         res = Resolv::DNS::Message.decode(res)
@@ -208,7 +208,7 @@ class MetasploitModule < Msf::Auxiliary
       loop do
         cached = false
         srv_sock.put(query.encode)
-        answer, = srv_sock.recvfrom
+        answer, = srv_sock.timed_recvfrom(65535)
 
         if answer && !answer.empty?
           answer = Resolv::DNS::Message.decode(answer)
@@ -366,7 +366,7 @@ class MetasploitModule < Msf::Auxiliary
         query.rd = 0
 
         srv_sock.put(query.encode)
-        answer, = srv_sock.recvfrom
+        answer, = srv_sock.timed_recvfrom(65535)
 
         if answer && !answer.empty?
           answer = Resolv::DNS::Message.decode(answer)
@@ -418,7 +418,7 @@ class MetasploitModule < Msf::Auxiliary
     req.rd = 0
 
     while (times.length < num)
-      res, = sock.recvfrom(65535, 0.01)
+      res, = sock.timed_recvfrom(65535, 0.01)
 
       if res && !res.empty?
         res = Resolv::DNS::Message.decode(res)

--- a/modules/auxiliary/spoof/dns/compare_results.rb
+++ b/modules/auxiliary/spoof/dns/compare_results.rb
@@ -78,8 +78,8 @@ class MetasploitModule < Msf::Auxiliary
       base_sock.put(buf)
       targ_sock.put(buf)
 
-      base_res, = base_sock.recvfrom(65535, 3.0)
-      targ_res, = targ_sock.recvfrom(65535, 3.0)
+      base_res, = base_sock.timed_recvfrom(65535, 3.0)
+      targ_res, = targ_sock.timed_recvfrom(65535, 3.0)
 
       if !(base_res && targ_res && !base_res.empty? && !targ_res.empty?)
         print_error('  Error: The baseline server did not respond to our request.') if !(base_res && !base_res.empty?)

--- a/modules/auxiliary/spoof/llmnr/llmnr_response.rb
+++ b/modules/auxiliary/spoof/llmnr/llmnr_response.rb
@@ -166,8 +166,8 @@ class MetasploitModule < Msf::Auxiliary
       r, = ::IO.select(rds, wds, eds, 0.25)
 
       if !r.nil? && (r[0] == sock)
-        packet, host, port = sock.recvfrom(65535)
-        dispatch_request(packet, host, port)
+        packet, addr = sock.recvfrom(65535)
+        dispatch_request(packet, addr[3], addr[1])
       end
     end
   end

--- a/modules/auxiliary/spoof/mdns/mdns_response.rb
+++ b/modules/auxiliary/spoof/mdns/mdns_response.rb
@@ -187,8 +187,8 @@ class MetasploitModule < Msf::Auxiliary
       r, = ::IO.select(rds, wds, eds, 0.25)
 
       if !r.nil? && (r[0] == sock)
-        packet, host, port = sock.recvfrom(65535)
-        dispatch_request(packet, host, port)
+        packet, addr = sock.recvfrom(65535)
+        dispatch_request(packet, addr[3], addr[1])
       end
     end
   end

--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -133,8 +133,8 @@ class MetasploitModule < Msf::Auxiliary
 
       r, = ::IO.select(rds, wds, eds, 0.25)
       if !r.nil? && (r[0] == sock)
-        packet, host, port = sock.recvfrom(65535)
-        dispatch_request(packet, host, port)
+        packet, addr = sock.recvfrom(65535)
+        dispatch_request(packet, addr[3], addr[1])
       end
     end
   end

--- a/modules/auxiliary/voip/sip_deregister.rb
+++ b/modules/auxiliary/voip/sip_deregister.rb
@@ -83,8 +83,8 @@ class MetasploitModule < Msf::Auxiliary
     udp_sock.put(req)
     response = false
 
-    while ((r = udp_sock.recvfrom(65535, 3))) && r[1]
-      response = parse_reply(r)
+    while ((r = udp_sock.timed_recvfrom(65535, 3)))
+      response = parse_reply([r[0], r[1][3], r[1][1]])
     end
 
     # print error information if no response has been received

--- a/modules/exploits/linux/games/ut2004_secure.rb
+++ b/modules/exploits/linux/games/ut2004_secure.rb
@@ -83,7 +83,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def ut_version
     connect_udp
     udp_sock.put('\\basic\\')
-    res = udp_sock.recvfrom(8192)
+    res, = udp_sock.timed_recvfrom(8192)
     disconnect_udp
 
     if res && (m = res.match(/\\gamever\\([0-9]{1,5})/))

--- a/modules/exploits/linux/misc/cve_2020_13160_anydesk.rb
+++ b/modules/exploits/linux/misc/cve_2020_13160_anydesk.rb
@@ -102,12 +102,13 @@ class MetasploitModule < Msf::Exploit::Remote
     timeout = 10
     while timeout > 0
       start_time = Time.now
-      response, host, = server_sock.recvfrom(8192, timeout)
-      break if host == datastore['RHOST']
+      response, addr = server_sock.timed_recvfrom(8192, timeout)
+      break if addr && addr[3] == datastore['RHOST']
 
       timeout = Time.now - start_time
     end
 
+    return nil if response.nil?
     return nil unless response[0..2].bytes == [0x3e, 0xd1, 0x01]
     return nil unless response[11] == "\x02"
 

--- a/modules/exploits/linux/misc/igel_command_injection.rb
+++ b/modules/exploits/linux/misc/igel_command_injection.rb
@@ -85,7 +85,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     connect_udp(true, 'RPORT' => 30005)
     udp_sock.put(probe)
-    res = udp_sock.recvfrom(65535, 0.5)
+    res = udp_sock.timed_recvfrom(65535, 0.5)
     disconnect_udp
 
     unless res && res[0]

--- a/modules/exploits/multi/upnp/libupnp_ssdp_overflow.rb
+++ b/modules/exploits/multi/upnp/libupnp_ssdp_overflow.rb
@@ -418,7 +418,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = nil
     1.upto(5) do
-      res, _, _ = udp_sock.recvfrom(65535, 1.0)
+      res, = udp_sock.timed_recvfrom(65535, 1.0)
       break if res and res =~ /^(Server|Location)/mi
 
       udp_sock.sendto(msearch, rhost, rport, 0)

--- a/modules/exploits/windows/brightstor/discovery_udp.rb
+++ b/modules/exploits/windows/brightstor/discovery_udp.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Exploit::Remote
     buf[1046, payload.encoded.length] = payload.encoded
 
     udp_sock.put(buf)
-    udp_sock.recvfrom(8192)
+    udp_sock.timed_recvfrom(8192)
 
     handler
     disconnect_udp

--- a/modules/exploits/windows/games/ut2004_secure.rb
+++ b/modules/exploits/windows/games/ut2004_secure.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def ut_version
     connect_udp
     udp_sock.put("\\basic\\")
-    res = udp_sock.recvfrom(8192)
+    res, = udp_sock.timed_recvfrom(8192)
     disconnect_udp
 
     if (res and (m = res.match(/\\gamever\\([0-9]{1,5})/)))

--- a/modules/exploits/windows/license/sentinel_lm7_udp.rb
+++ b/modules/exploits/windows/license/sentinel_lm7_udp.rb
@@ -63,7 +63,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def check
     connect_udp
     udp_sock.put("\x7a\x00\x00\x00\x00\x00")
-    res = udp_sock.recvfrom(8192)
+    res = udp_sock.timed_recvfrom(8192)
     disconnect_udp
 
     if (res and res[0] == 0x7a)
@@ -89,7 +89,7 @@ class MetasploitModule < Msf::Exploit::Remote
     buf[827, 5] = "\xe9" + [-829].pack('V')
 
     udp_sock.put(buf)
-    udp_sock.recvfrom(8192)
+    udp_sock.timed_recvfrom(8192)
 
     handler
     disconnect_udp

--- a/modules/exploits/windows/misc/crosschex_device_bof.rb
+++ b/modules/exploits/windows/misc/crosschex_device_bof.rb
@@ -70,8 +70,8 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     connect_udp
 
-    res, host, port = udp_sock.recvfrom(PACKET_LEN, datastore['TIMEOUT'].to_i > 0 ? datastore['TIMEOUT'].to_i : nil)
-    if res.empty?
+    res, = udp_sock.timed_recvfrom(PACKET_LEN, datastore['TIMEOUT'].to_i > 0 ? datastore['TIMEOUT'].to_i : nil)
+    if res.nil? || res.empty?
       fail_with(Failure::TimeoutExpired, 'Module timed out waiting for CrossChex broadcast')
     end
 

--- a/spec/lib/msf/base/sessions/modem_spec.rb
+++ b/spec/lib/msf/base/sessions/modem_spec.rb
@@ -195,10 +195,9 @@ RSpec.describe Msf::Sessions::Modem do
       recv_queue << nil
       chan = described_class.new(session, 4, conn, params)
 
-      data, host, port = chan.lsock.recvfrom(65535, 2)
+      data, addr = chan.lsock.recvfrom(65535)
       expect(data).to eq('response')
-      expect(host).to eq('8.8.8.8')
-      expect(port).to eq(53)
+      expect(addr).to eq(['AF_INET', 53, '8.8.8.8', '8.8.8.8'])
       chan.close
     end
 
@@ -207,10 +206,9 @@ RSpec.describe Msf::Sessions::Modem do
       recv_queue << nil
       chan = described_class.new(session, 4, conn, params)
 
-      data, host, port = chan.lsock.recvfrom(1, 2)
+      data, addr = chan.lsock.recvfrom(1)
       expect(data).to eq('r')
-      expect(host).to eq('8.8.8.8')
-      expect(port).to eq(53)
+      expect(addr).to eq(['AF_INET', 53, '8.8.8.8', '8.8.8.8'])
       chan.close
     end
 

--- a/spec/lib/msf/core/auxiliary/udp_scanner_spec.rb
+++ b/spec/lib/msf/core/auxiliary/udp_scanner_spec.rb
@@ -1,0 +1,50 @@
+# -*- coding: binary -*-
+
+require 'spec_helper'
+
+RSpec.describe Msf::Auxiliary::UDPScanner do
+  subject do
+    mod = Module.new
+    mod.extend described_class
+    mod.instance_variable_set(:@udp_sockets, {})
+    mod.instance_variable_set(:@udp_sockets_mutex, Mutex.new)
+    mod.instance_variable_set(:@results, {})
+    mod.define_singleton_method(:datastore) { { 'ScannerRecvQueueLimit' => 100 } }
+    mod.define_singleton_method(:inside_workspace_boundary?) { |_host| true }
+    allow(mod).to receive(:cleanup_udp_sockets)
+    mod
+  end
+
+  # A socket whose recvfrom raises, mimicking a connected UDP socket that received an
+  # ICMP port-unreachable for a closed port.
+  let(:refused_socket) do
+    sock = double('refused_socket')
+    allow(sock).to receive(:recvfrom).and_raise(::Errno::ECONNREFUSED)
+    sock
+  end
+
+  # A socket returning a valid response in the new stdlib-aligned shape:
+  #   [data, [address_family, port, hostname, host_ip]]
+  let(:responding_socket) do
+    sock = double('responding_socket')
+    allow(sock).to receive(:recvfrom).and_return(['response-data', ['AF_INET', 161, '192.0.2.5', '192.0.2.5']])
+    sock
+  end
+
+  describe '#scanner_recv' do
+    it 'swallows ECONNREFUSED raised by recvfrom instead of propagating it' do
+      allow(::IO).to receive(:select).and_return([[refused_socket], [], []], nil)
+
+      expect { subject.scanner_recv(0.1) }.not_to raise_error
+      expect(subject.scanner_recv(0.1)).to eq(0)
+      expect(subject.results).to be_empty
+    end
+
+    it 'continues processing other readable sockets after one raises ECONNREFUSED' do
+      allow(::IO).to receive(:select).and_return([[refused_socket, responding_socket], [], []], nil)
+
+      expect(subject.scanner_recv(0.1)).to eq(1)
+      expect(subject.results['192.0.2.5']).to eq(['response-data'])
+    end
+  end
+end

--- a/spec/lib/rex/post/meterpreter/channels/datagram_spec.rb
+++ b/spec/lib/rex/post/meterpreter/channels/datagram_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rex/socket/udp'
+require 'rex/post/meterpreter/channels/datagram'
+
+RSpec.describe Rex::Post::Meterpreter::Datagram do
+  subject(:channel) { described_class.new(nil, nil, nil, 0, nil) }
+
+  before do
+    channel.lsock.extend(Rex::Socket::Udp)
+    channel.lsock.initsock
+    channel.lsock.extend(described_class::SocketInterface)
+    channel.lsock.channel = channel
+  end
+
+  after do
+    channel.lsock.close unless channel.lsock.closed?
+    channel.rsock.close unless channel.rsock.closed?
+  end
+
+  describe 'SocketInterface#recvfrom_nonblock' do
+    it 'reads the synthetic sockaddr independently from the requested payload length' do
+      channel.rsock.syswrite('response')
+      channel.rsock.syswrite(Rex::Socket.to_sockaddr('192.0.2.53', 53))
+
+      data, host, port = channel.lsock.recvfrom(1, 2)
+
+      expect(data).to eq('r')
+      expect(host).to eq('192.0.2.53')
+      expect(port).to eq(53)
+    end
+  end
+end

--- a/spec/lib/rex/post/meterpreter/channels/datagram_spec.rb
+++ b/spec/lib/rex/post/meterpreter/channels/datagram_spec.rb
@@ -24,11 +24,10 @@ RSpec.describe Rex::Post::Meterpreter::Datagram do
       channel.rsock.syswrite('response')
       channel.rsock.syswrite(Rex::Socket.to_sockaddr('192.0.2.53', 53))
 
-      data, host, port = channel.lsock.recvfrom(1, 2)
+      data, addr = channel.lsock.recvfrom(1)
 
       expect(data).to eq('r')
-      expect(host).to eq('192.0.2.53')
-      expect(port).to eq(53)
+      expect(addr).to eq(['AF_INET', 53, '192.0.2.53', '192.0.2.53'])
     end
   end
 end

--- a/spec/lib/rex/proto/dns/resolver_spec.rb
+++ b/spec/lib/rex/proto/dns/resolver_spec.rb
@@ -7,12 +7,14 @@ require 'rex/socket/udp'
 RSpec.describe Rex::Proto::DNS::Resolver do
   subject(:resolver) { described_class.new(config_file: nil, nameservers: [], log_file: File::NULL) }
 
+  let(:udp_answer) { ['answer', ['AF_INET', 53, '192.0.2.53', '192.0.2.53']] }
+
   let(:socket) do
     double(
       'Rex::Socket::Udp',
       close: nil,
       closed?: false,
-      recvfrom: ['answer', '192.0.2.53', 53],
+      timed_recvfrom: udp_answer,
       write: nil
     )
   end
@@ -27,11 +29,11 @@ RSpec.describe Rex::Proto::DNS::Resolver do
 
       answer = resolver.send_udp(nil, 'query', [['192.0.2.53', {}]])
 
-      expect(answer).to eq(['answer', '192.0.2.53', 53])
+      expect(answer).to eq(udp_answer)
     end
 
     it 'closes the UDP socket after a timeout' do
-      allow(socket).to receive(:recvfrom).and_raise(Timeout::Error)
+      allow(socket).to receive(:timed_recvfrom).and_raise(Timeout::Error)
       expect(socket).to receive(:close)
 
       expect(resolver.send_udp(nil, 'query', [['192.0.2.53', {}]])).to be_nil

--- a/spec/modules/auxiliary/scanner/ipmi/ipmi_dumphashes_spec.rb
+++ b/spec/modules/auxiliary/scanner/ipmi/ipmi_dumphashes_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'IPMI Dump Hashes Scanner' do
   describe '#run_host' do
     it 'stops username enumeration when the host never answers the first open-session probe' do
       allow(udp_sock).to receive(:sendto)
-      allow(udp_sock).to receive(:recvfrom).and_return([nil, nil, nil])
+      allow(udp_sock).to receive(:timed_recvfrom).and_return(nil)
 
       expect(udp_sock).to receive(:sendto).exactly(3).times
 

--- a/spec/support/acceptance/session/java.rb
+++ b/spec/support/acceptance/session/java.rb
@@ -245,19 +245,16 @@ module Acceptance::Session::Java
         lines: {
           linux: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           osx: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           windows: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           }

--- a/spec/support/acceptance/session/mettle.rb
+++ b/spec/support/acceptance/session/mettle.rb
@@ -327,19 +327,16 @@ module Acceptance::Session::Mettle
         lines: {
           linux: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           osx: {
               known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           windows: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           }

--- a/spec/support/acceptance/session/php.rb
+++ b/spec/support/acceptance/session/php.rb
@@ -41,9 +41,9 @@ module Acceptance::Session::Php
             :windows,
             {
               skip: [
-                :meterpreter_runtime_version,
+                :session_runtime_version,
                 :==,
-                "php5.3"
+                "meterpreter/php5.3"
               ],
               reason: "Skip PHP 5.3 as the tests timeout - due to cmd_exec taking 15 seconds for each call. Caused by failure to detect feof correctly - https://github.com/rapid7/metasploit-payloads/blame/c7f7bc2fc0b86e17c3bc078149c71745c5e478b3/php/meterpreter/meterpreter.php#L1127-L1145"
             }
@@ -206,9 +206,9 @@ module Acceptance::Session::Php
             :windows,
             {
               skip: [
-                :meterpreter_runtime_version,
+                :session_runtime_version,
                 :==,
-                "php5.3"
+                "meterpreter/php5.3"
               ],
               reason: "Skip PHP 5.3 as the tests timeout - due to cmd_exec taking 15 seconds for each call. Caused by failure to detect feof correctly - https://github.com/rapid7/metasploit-payloads/blame/c7f7bc2fc0b86e17c3bc078149c71745c5e478b3/php/meterpreter/meterpreter.php#L1127-L1145"
             }
@@ -250,19 +250,22 @@ module Acceptance::Session::Php
         lines: {
           linux: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           osx: {
               known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           windows: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
+              # PHP 5.3 Meterpreter on a Windows host raises Errno::ENOTSOCK
+              # (WSAENOTSOCK) from the UDP channel recvfrom; PHP 7.4/8.3 are fine.
+              ["[-] [[UDP] Has the correct peer information] FAILED: [UDP] Has the correct peer information", { if: [:session_runtime_version, :==, "meterpreter/php5.3"] }],
+              ["[-] [[UDP] Has the correct peer information] Exception: Errno::ENOTSOCK", { if: [:session_runtime_version, :==, "meterpreter/php5.3"] }],
+              ["[-] [[UDP] Receives data from the peer] FAILED: [UDP] Receives data from the peer", { if: [:session_runtime_version, :==, "meterpreter/php5.3"] }],
+              ["[-] [[UDP] Receives data from the peer] Exception: Errno::ENOTSOCK", { if: [:session_runtime_version, :==, "meterpreter/php5.3"] }],
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           }

--- a/spec/support/acceptance/session/python.rb
+++ b/spec/support/acceptance/session/python.rb
@@ -262,19 +262,16 @@ module Acceptance::Session::Python
         lines: {
           linux: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           osx: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           },
           windows: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           }

--- a/spec/support/acceptance/session/windows_meterpreter.rb
+++ b/spec/support/acceptance/session/windows_meterpreter.rb
@@ -378,7 +378,6 @@ module Acceptance::Session::WindowsMeterpreter
           },
           windows: {
             known_failures: [
-              "[-] FAILED: [UDP] Has the correct peer information",
               *Acceptance::Session::Shared::SOCKET_CHANNEL_FLAKES
             ]
           }

--- a/test/modules/post/test/socket_channels.rb
+++ b/test/modules/post/test/socket_channels.rb
@@ -248,7 +248,6 @@ class MetasploitModule < Msf::Post
     end
 
     it '[UDP] Has the correct peer information' do
-      # this one is expected to fail because #recvfrom just returns a string address which is inconsistent
       client, server_client = udp_socket_pair
       data = Random.new.bytes(rand(10..100))
       # Now server can send to the client's address


### PR DESCRIPTION
## Description

This requires the changes from https://github.com/rapid7/rex-socket/pull/83 and incoporates them into the Metasploit framework to align the usage of `#recvfrom` on UDP sockets to behave the same as the standard library. This has the strong benefit of ensuring that developers do not need to worry about their socket being `UDPSocket` or `Rex::Socket::Udp` which by extension makes Metasploit compatible with libraries that need UDP sockets that have no knowledge of Rex.

There are three issues with Rex's `#recvfrom` vs the standard library

1. The arguments are different; the size should should be a required argument and the second parameter should be flags, not a timeout.
2. The shape of the return value is different, the standard library returns the address info as an array.
3. The standard library's method is blocking and does not support a timeout, the Rex version took a timeout parameter where flags should have been.

## Breaking Changes

https://github.com/rapid7/rex-socket/pull/83 is a breaking change. This PR brings framework inline so that nothing breakes on this side. There are no user-facing breaking changes.

## Reviewer Notes

It's not really practical to re-test every single module that uses UDP. That's the main reason that `#timed_recvfrom` was added, so methods could just be changed from `#recvfrom` -> `#timed_recvfrom` and not worry about points 1 and 3 from the list of issues above in the description section.

## Verification Steps

1. - [ ] Make sure the tests pass

I ran through multiple tests of the most important modules which covered the main patterns. The new `#timed_recvfrom` is used in place of the old `#recvfrom` where there was an expected timeout but the return value is aligned with the standard libraries `#recvfrom`.

Things I tested include

* `auxiliary/scanner/snmp/snmp_login`
* `auxiliary/gather/enum_dns`
* `auxiliary/scanner/ntp/timeroast`

## Test Evidence

```
msf auxiliary(gather/enum_dns) > use auxiliary/scanner/snmp/snmp_login 
msf auxiliary(scanner/snmp/snmp_login) > set RHOSTS 192.168.250.0/24
RHOSTS => 192.168.250.0/24
msf auxiliary(scanner/snmp/snmp_login) > set THREADS 10
THREADS => 10
msf auxiliary(scanner/snmp/snmp_login) > run
[+] 192.168.250.7:161 - Login Successful: internal (Access level: read-write); Proof (sysDescr.0): Brother NC-8800w, Firmware Ver.Z  ,MID 8C5-K8JFID 2
[+] 192.168.250.7:161 - Login Successful: public (Access level: read-write); Proof (sysDescr.0): Brother NC-8800w, Firmware Ver.Z  ,MID 8C5-K8JFID 2
[*] Scanned  29 of 256 hosts (11% complete)
[*] Scanned  52 of 256 hosts (20% complete)
[*] Scanned  77 of 256 hosts (30% complete)
[*] Scanned 103 of 256 hosts (40% complete)
[*] Error: 192.168.250.119: Errno::ECONNREFUSED Connection refused - recvfrom(2)
[*] Scanned 128 of 256 hosts (50% complete)
[*] Scanned 154 of 256 hosts (60% complete)
[*] Scanned 181 of 256 hosts (70% complete)
[*] Scanned 205 of 256 hosts (80% complete)
[*] Scanned 232 of 256 hosts (90% complete)
[*] Scanned 256 of 256 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/snmp/snmp_login) > use auxiliary/gather/enum_dns 
msf auxiliary(gather/enum_dns) > show options 

Module options (auxiliary/gather/enum_dns):

   Name         Current Setting                                                            Required  Description
   ----         ---------------                                                            --------  -----------
   DOMAIN       home.lan                                                                   yes       The target domain
   ENUM_A       true                                                                       yes       Enumerate DNS A record
   ENUM_AXFR    true                                                                       yes       Initiate a zone transfer against each NS record
   ENUM_BRT     false                                                                      yes       Brute force subdomains and hostnames via the supplied wordlist
   ENUM_CNAME   true                                                                       yes       Enumerate DNS CNAME record
   ENUM_MX      true                                                                       yes       Enumerate DNS MX record
   ENUM_NS      true                                                                       yes       Enumerate DNS NS record
   ENUM_RVL     false                                                                      yes       Reverse lookup a range of IP addresses
   ENUM_SOA     true                                                                       yes       Enumerate DNS SOA record
   ENUM_SRV     true                                                                       yes       Enumerate the most common SRV records
   ENUM_TLD     false                                                                      yes       Perform a TLD expansion by replacing the TLD with the IANA TLD list
   ENUM_TXT     true                                                                       yes       Enumerate DNS TXT record
   IPRANGE                                                                                 no        The target address range or CIDR identifier
   NS           192.168.250.4                                                              no        Specify the nameservers to use for queries, space separated
   Proxies                                                                                 no        A proxy chain of format type:host:port[,type:host:port][...]. Supported proxies: http, sapni, socks4, socks5, socks5h
   RPORT        53                                                                         yes       The target port (TCP)
   SEARCHLIST                                                                              no        DNS domain search list, comma separated
   STOP_WLDCRD  false                                                                      yes       Stops bruteforce enumeration if wildcard resolution is detected
   THREADS      1                                                                          no        Threads for ENUM_BRT
   WORDLIST     /home/smcintyre/Projects/metasploit-framework/data/wordlists/namelist.txt  no        Wordlist of subdomains


View the full module info with the info, or info -d command.

msf auxiliary(gather/enum_dns) > run
[*] Attempting DNS AXFR for home.lan from 192.168.250.4
^C[-] Stopping running against current target...
[*] Control-C again to force quit all targets.
^C[-] Auxiliary interrupted by the console user
[*] Auxiliary module execution completed
msf auxiliary(gather/enum_dns) > est ENUM_AXFR false
[-] Unknown command: est. Run the help command for more details.
msf auxiliary(gather/enum_dns) > set ENUM_AXFR false
ENUM_AXFR => false
msf auxiliary(gather/enum_dns) > run
[*] Querying DNS CNAME records for home.lan
[*] Querying DNS NS records for home.lan
[+] home.lan NS: dns-aux.home.lan
[+] home.lan NS: dns-pri.home.lan
[*] Querying DNS MX records for home.lan
[*] Querying DNS SOA records for home.lan
[+] home.lan SOA: dns.home.lan
[*] Querying DNS TXT records for home.lan
[*] Querying DNS SRV records for home.lan
[*] Auxiliary module execution completed
msf auxiliary(gather/enum_dns) > use auxiliary/scanner/ntp/timeroast 
msf auxiliary(scanner/ntp/timeroast) > show options 

Module options (auxiliary/scanner/ntp/timeroast):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   DELAY    20               yes       The delay in milliseconds between attempts.
   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
   RIDS                      yes       The RIDs to enumerate (e.g. 1000-2000).
   RPORT    123              yes       The target port (UDP)
   THREADS  1                yes       The number of concurrent threads (max one per host)
   TIMEOUT  5                yes       The timeout in seconds to wait at the end for replies.


View the full module info with the info, or info -d command.

msf auxiliary(scanner/ntp/timeroast) > set RHOSTS 192.168.159.10
RHOSTS => 192.168.159.10
msf auxiliary(scanner/ntp/timeroast) > set RIDS 1000-2000
RIDS => 1000-2000
msf auxiliary(scanner/ntp/timeroast) > run
[+] Hash for RID: 1001 - 1001:$sntp-ms$2ce861b855afa3d3e7a1954e4806da26$1c0100e900000000000a00264c4f434ceddaa204c19641f60000000000000000eddaa237ad9e3864eddaa237ad9e8fa2
```

## AI Usage Disclosure

I was assisted by Claude Opus during this development.



## Pre-Submission Checklist

- [x] Ran [`rubocop`](https://docs.metasploit.com/docs/development/quality/using-rubocop.html) on new files with no new offenses _(net new files only)_
- [x] Ran [`msftidy`](https://docs.metasploit.com/docs/development/quality/msftidy.html) on changed module files with no new offenses _(modules only)_
- [x] Ran [`msftidy_docs`](https://docs.metasploit.com/docs/development/quality/writing-module-documentation.html#before-you-submit-your-pr-msftidy_docsrb) on changed documentation files with no new offenses _(documentation files only)_
- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
