### PR TITLE
Fix SMB version crash on smb1

### DIFF
--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -915,15 +915,21 @@ module Msf
         client = simple.client if client.nil? && simple.present?
         client = client.client if client.is_a?(Rex::Proto::SMB::SimpleClient)
 
-        # simple is only set if the global option is true when calling #connect, which it is by default
-        if client.present?
+        if client.respond_to?(:socket)
+          peerhost = client.socket.peerhost
+          peerport = client.socket.peerport
+        elsif client.respond_to?(:dispatcher)
           peerhost = client.dispatcher.tcp_socket.peerhost
           peerport = client.dispatcher.tcp_socket.peerport
-          smb_version = client.respond_to?(:negotiated_smb_version) ? client.negotiated_smb_version : 1
-          info << ", last negotiated version: SMBv#{smb_version} (dialect = #{client.dialect})"
         else
           peerhost = rhost
           peerport = rport
+        end
+
+        # simple is only set if the global option is true when calling #connect, which it is by default
+        if client.present?
+          smb_version = client.respond_to?(:negotiated_smb_version) ? client.negotiated_smb_version : 1
+          info << ", last negotiated version: SMBv#{smb_version} (dialect = #{client.dialect})"
         end
 
         report_service(

--- a/spec/acceptance/smb_spec.rb
+++ b/spec/acceptance/smb_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'SMB sessions and SMB modules' do
           platforms: [:linux, :osx, :windows],
           targets: [:session, :rhost],
           skipped: false,
+          datastore: { 'MinRID' => 500, 'MaxRID' => 1001 },
           lines: {
             all: {
               required: [
@@ -86,9 +87,48 @@ RSpec.describe 'SMB sessions and SMB modules' do
             },
           }
         },
+        {
+          name: "auxiliary/scanner/smb/smb_version",
+          platforms: [:linux, :osx, :windows],
+          targets: [:rhost],
+          skipped: false,
+          lines: {
+            all: {
+              required: [
+                /SMB Detected \(versions:.*\) \(preferred dialect:.*\)/,
+              ]
+            },
+          }
+        },
       ]
     }
   }
+
+  # Build a v2/v3-only variant: copy the smb target/module_tests, inject SMB::ProtocolVersion
+  # into every datastore, and tighten the smb_version assertions.
+  tests[:smb_v2] = tests[:smb].merge(
+    target: tests[:smb][:target].merge(
+      datastore: tests[:smb][:target][:datastore].merge(
+        module: tests[:smb][:target][:datastore][:module].merge('SMB::ProtocolVersion' => '2,3')
+      )
+    ),
+    module_tests: tests[:smb][:module_tests].map do |test|
+      if test[:name] == "auxiliary/scanner/smb/smb_version"
+        test.merge(
+          datastore: (test[:datastore] || {}).merge('SMB::ProtocolVersion' => '2,3'),
+          lines: {
+            all: {
+              required: [
+                /SMB Detected \(versions:.*2.*3.*\) \(preferred dialect: SMB 3\.1\.1\)/,
+              ]
+            },
+          }
+        )
+      else
+        test.merge(datastore: (test[:datastore] || {}).merge('SMB::ProtocolVersion' => '2,3'))
+      end
+    end
+  )
 
   allure_test_environment = AllureRspec.configuration.environment_properties
 
@@ -337,7 +377,7 @@ RSpec.describe 'SMB sessions and SMB modules' do
                 end)
 
                 use_module = "use #{module_test[:name]}"
-                run_module = "run session=#{session_id} Verbose=true"
+                run_module = "run session=#{session_id} #{target.datastore_options(default_module_datastore: default_module_datastore.merge(module_test.fetch(:datastore, {})))} Verbose=true"
 
                 replication_commands << use_module
                 console.sendline(use_module)
@@ -357,7 +397,7 @@ RSpec.describe 'SMB sessions and SMB modules' do
             ) do
               with_test_harness(module_test) do |replication_commands|
                 use_module = "use #{module_test[:name]}"
-                run_module = "run #{target.datastore_options(default_module_datastore: default_module_datastore)} Verbose=true"
+                run_module = "run #{target.datastore_options(default_module_datastore: default_module_datastore.merge(module_test.fetch(:datastore, {})))} Verbose=true"
 
                 replication_commands << use_module
                 console.sendline(use_module)


### PR DESCRIPTION
Fix SMB version crash on SMB 1 introduced by https://github.com/rapid7/metasploit-framework/pull/21266

Before 🔴 

```
[*] [2026.06.12-02:32:08] 10.140.111.141:445 (SMB Version Detection) - Running module.
[*] [2026.06.12-02:32:08] [auxiliary/scanner/smb/smb_version] 10.140.111.141:445    - Force SMB1 since SMB fingerprint needs native_lm/native_os information
[-] [2026.06.12-02:32:08] [auxiliary/scanner/smb/smb_version] 10.140.111.141:445    - 10.140.111.141: NoMethodError undefined method `dispatcher' for an instance of Rex::Proto::SMB::Client
```

After 🟢 

```
[*] 10.140.113.233:445    - SMB Detected (versions: 1, 2) (preferred dialect: SMB 2.1) (signatures: optional) (uptime: 7w 3d 11h 8m 24s) (guid: {cbd0e727-e283-4589-b0ed-9c3291ab2318}) (authentication domain: VAGRANT-2008R2)
[+] 10.140.113.233:445    -   Host is running Windows 2008 R2  Standard  SP1  (build: 7601)
[*] 10.140.113.233:445    -   SMB signing is not required
[*] 10.140.113.233 - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/smb/smb_version) > 
```