### PR TITLE
Prevent file descriptor leaks in user input handling

### DIFF
--- a/lib/msf/base/sessions/hwbridge.rb
+++ b/lib/msf/base/sessions/hwbridge.rb
@@ -102,18 +102,18 @@ class HWBridge  < Rex::Post::HWBridge::Client
   # Initializes the console's I/O handles.
   #
   def init_ui(input, output)
-    self.user_input = input
-    self.user_output = output
+    super
+
     console.init_ui(input, output)
     console.set_log_source(log_source)
-
-    super
   end
 
   ##
   # :category: Msf::Session::Interactive implementors
   #
   # Resets the console's I/O handles.
+  # Does not call super - the session preserves its own user_input/user_output
+  # while only resetting the console's I/O.
   #
   def reset_ui
     console.unset_log_source

--- a/lib/msf/base/sessions/ldap.rb
+++ b/lib/msf/base/sessions/ldap.rb
@@ -108,18 +108,18 @@ class Msf::Sessions::LDAP
   # Initializes the console's I/O handles.
   #
   def init_ui(input, output)
-    self.user_input = input
-    self.user_output = output
+    super
+
     console.init_ui(input, output)
     console.set_log_source(log_source)
-
-    super
   end
 
   ##
   # :category: Msf::Session::Interactive implementors
   #
   # Resets the console's I/O handles.
+  # Does not call super - the session preserves its own user_input/user_output
+  # while only resetting the console's I/O.
   #
   def reset_ui
     console.unset_log_source

--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -370,18 +370,18 @@ class Meterpreter < Rex::Post::Meterpreter::Client
   # Initializes the console's I/O handles.
   #
   def init_ui(input, output)
-    self.user_input = input
-    self.user_output = output
+    super
+
     console.init_ui(input, output)
     console.set_log_source(log_source)
-
-    super
   end
 
   ##
   # :category: Msf::Session::Interactive implementors
   #
   # Resets the console's I/O handles.
+  # Does not call super - the session preserves its own user_input/user_output
+  # while only resetting the console's I/O.
   #
   def reset_ui
     console.unset_log_source

--- a/lib/msf/base/sessions/smb.rb
+++ b/lib/msf/base/sessions/smb.rb
@@ -95,18 +95,18 @@ class Msf::Sessions::SMB
   # Initializes the console's I/O handles.
   #
   def init_ui(input, output)
-    self.user_input = input
-    self.user_output = output
+    super
+
     console.init_ui(input, output)
     console.set_log_source(log_source)
-
-    super
   end
 
   ##
   # :category: Msf::Session::Interactive implementors
   #
   # Resets the console's I/O handles.
+  # Does not call super - the session preserves its own user_input/user_output
+  # while only resetting the console's I/O.
   #
   def reset_ui
     console.unset_log_source

--- a/lib/msf/base/sessions/sql.rb
+++ b/lib/msf/base/sessions/sql.rb
@@ -96,6 +96,8 @@ class Msf::Sessions::Sql
   end
 
   # Resets the console's I/O handles.
+  # Does not call super - the session preserves its own user_input/user_output
+  # while only resetting the console's I/O.
   #
   # @return [Object]
   def reset_ui

--- a/lib/rex/ui/subscriber.rb
+++ b/lib/rex/ui/subscriber.rb
@@ -127,6 +127,15 @@ module Subscriber
   # Sets the input and output handles.
   #
   def init_ui(input = nil, output = nil)
+    # Release FDs held by Input::Buffer socket pairs
+    if user_input && user_input != input && user_input.respond_to?(:close)
+      begin
+        user_input.close
+      rescue IOError, Errno::EBADF => e
+        elog("init_ui: failed to close old user_input: #{e}") if defined?(elog)
+      end
+    end
+
     self.user_input  = input
     self.user_output = output
   end
@@ -135,6 +144,15 @@ module Subscriber
   # Disables input/output
   #
   def reset_ui
+    # Release FDs held by Input::Buffer socket pairs
+    if user_input.respond_to?(:close)
+      begin
+        user_input.close
+      rescue IOError, Errno::EBADF => e
+        elog("reset_ui: failed to close user_input: #{e}") if defined?(elog)
+      end
+    end
+
     self.user_input  = nil
     self.user_output = nil
   end

--- a/spec/lib/rex/ui/subscriber_spec.rb
+++ b/spec/lib/rex/ui/subscriber_spec.rb
@@ -1,0 +1,337 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rex/ui/subscriber'
+require 'rex/ui/text/input/buffer'
+
+RSpec.describe Rex::Ui::Subscriber do
+  let(:subscriber_class) do
+    Class.new do
+      include Rex::Ui::Subscriber
+    end
+  end
+
+  let(:subscriber) { subscriber_class.new }
+
+  context 'closing handles on replacement' do
+    describe '#reset_ui' do
+      context 'when user_input responds to close' do
+        it 'calls close on the existing user_input before nilling' do
+          old_input = double('closeable_input')
+          allow(old_input).to receive(:close)
+
+          subscriber.init_ui(old_input, nil)
+          subscriber.reset_ui
+
+          expect(old_input).to have_received(:close)
+        end
+      end
+    end
+
+    describe '#init_ui' do
+      context 'when replacing user_input with a different closeable handle' do
+        it 'calls close on the old user_input before assigning the new one' do
+          old_input = double('old_closeable_input')
+          allow(old_input).to receive(:close)
+          new_input = double('new_input')
+
+          subscriber.init_ui(old_input, nil)
+          subscriber.init_ui(new_input, nil)
+
+          expect(old_input).to have_received(:close)
+        end
+      end
+    end
+
+    describe 'FD stability with real Input::Buffer instances' do
+      it 'does not grow FD count when calling init_ui repeatedly' do
+        initial_fd_count = Dir.glob('/dev/fd/*').count
+
+        5.times do
+          buffer = Rex::Ui::Text::Input::Buffer.new
+          subscriber.init_ui(buffer, nil)
+        end
+        subscriber.reset_ui
+
+        final_fd_count = Dir.glob('/dev/fd/*').count
+
+        # If handles are properly closed, FD count should not grow.
+        # On unfixed code, each Input::Buffer leaks a socket pair (2 FDs each).
+        expect(final_fd_count).to be <= initial_fd_count + 2
+      end
+    end
+  end
+
+  context 'Graceful close failure handling' do
+    describe '#reset_ui' do
+      it 'does not raise when user_input.close raises IOError' do
+        handle = double('already_closed')
+        allow(handle).to receive(:close).and_raise(IOError, 'closed stream')
+
+        subscriber.user_input = handle
+        expect { subscriber.reset_ui }.not_to raise_error
+      end
+
+      it 'does not raise when user_input.close raises Errno::EBADF' do
+        handle = double('bad_fd')
+        allow(handle).to receive(:close).and_raise(Errno::EBADF)
+
+        subscriber.user_input = handle
+        expect { subscriber.reset_ui }.not_to raise_error
+      end
+
+      it 'nils user_input even when close raises' do
+        handle = double('error_handle')
+        allow(handle).to receive(:close).and_raise(IOError)
+
+        subscriber.user_input = handle
+        subscriber.reset_ui
+
+        expect(subscriber.user_input).to be_nil
+      end
+
+      it 'nils user_output' do
+        output = double('output')
+        subscriber.user_output = output
+        subscriber.reset_ui
+
+        expect(subscriber.user_output).to be_nil
+      end
+    end
+
+    describe '#init_ui' do
+      it 'does not raise when old user_input.close raises IOError' do
+        old_input = double('already_closed')
+        allow(old_input).to receive(:close).and_raise(IOError, 'closed stream')
+        new_input = double('new_input')
+
+        subscriber.init_ui(old_input, nil)
+        expect { subscriber.init_ui(new_input, nil) }.not_to raise_error
+        expect(subscriber.user_input).to eq(new_input)
+      end
+
+      it 'does not raise when old user_input.close raises Errno::EBADF' do
+        old_input = double('bad_fd')
+        allow(old_input).to receive(:close).and_raise(Errno::EBADF)
+        new_input = double('new_input')
+
+        subscriber.init_ui(old_input, nil)
+        expect { subscriber.init_ui(new_input, nil) }.not_to raise_error
+        expect(subscriber.user_input).to eq(new_input)
+      end
+    end
+  end
+
+  context 'non-closeable and same-handle cases' do
+    describe '#reset_ui' do
+      context 'when user_input is nil' do
+        it 'does not raise' do
+          subscriber.user_input = nil
+          expect { subscriber.reset_ui }.not_to raise_error
+        end
+      end
+
+      context 'when user_input does not respond to close' do
+        it 'does not raise' do
+          non_closeable = Object.new
+          subscriber.user_input = non_closeable
+          expect { subscriber.reset_ui }.not_to raise_error
+        end
+      end
+    end
+
+    describe '#init_ui' do
+      context 'on a fresh subscriber with no existing handles' do
+        it 'assigns input and output handles correctly' do
+          input = double('input')
+          output = double('output')
+
+          subscriber.init_ui(input, output)
+
+          expect(subscriber.user_input).to eq(input)
+          expect(subscriber.user_output).to eq(output)
+        end
+      end
+
+      context 'when called with the same handle already assigned' do
+        it 'does not close the active handle' do
+          handle = double('closeable_handle', close: nil)
+          subscriber.user_input = handle
+
+          subscriber.init_ui(handle, nil)
+
+          expect(handle).not_to have_received(:close)
+          expect(subscriber.user_input).to eq(handle)
+        end
+      end
+
+      context 'when replacing a non-closeable handle with a new one' do
+        it 'does not raise' do
+          non_closeable = Object.new
+          subscriber.user_input = non_closeable
+
+          new_input = double('new_input')
+          expect { subscriber.init_ui(new_input, nil) }.not_to raise_error
+          expect(subscriber.user_input).to eq(new_input)
+        end
+      end
+    end
+  end
+
+  describe '#copy_ui' do
+    it 'copies input and output from another subscriber' do
+      source = subscriber_class.new
+      input = double('input')
+      output = double('output')
+      source.init_ui(input, output)
+
+      subscriber.copy_ui(source)
+
+      expect(subscriber.user_input).to eq(input)
+      expect(subscriber.user_output).to eq(output)
+    end
+
+    it 'closes existing closeable user_input when copying' do
+      old_input = double('old_input')
+      allow(old_input).to receive(:close)
+      subscriber.init_ui(old_input, nil)
+
+      source = subscriber_class.new
+      new_input = double('new_input')
+      source.init_ui(new_input, nil)
+
+      subscriber.copy_ui(source)
+
+      expect(old_input).to have_received(:close)
+    end
+  end
+
+  describe '#gets' do
+    it 'delegates to user_input.gets' do
+      input = double('input', gets: "hello\n")
+      subscriber.user_input = input
+
+      expect(subscriber.gets).to eq("hello\n")
+    end
+
+    it 'returns nil when user_input is nil' do
+      subscriber.user_input = nil
+      expect(subscriber.gets).to be_nil
+    end
+  end
+
+  describe Rex::Ui::Subscriber::Output do
+    let(:output) { double('output') }
+
+    before do
+      allow(output).to receive(:prompting?).and_return(false)
+      subscriber.user_output = output
+    end
+
+    describe '#print_line' do
+      it 'delegates to user_output.print_line' do
+        allow(output).to receive(:print_line)
+        subscriber.print_line('test message')
+        expect(output).to have_received(:print_line).with('test message')
+      end
+
+      it 'does nothing when user_output is nil' do
+        subscriber.user_output = nil
+        expect { subscriber.print_line('test') }.not_to raise_error
+      end
+    end
+
+    describe '#print_status' do
+      it 'delegates to user_output.print_status' do
+        allow(output).to receive(:print_status)
+        subscriber.print_status('status message')
+        expect(output).to have_received(:print_status).with('status message')
+      end
+
+      it 'does nothing when user_output is nil' do
+        subscriber.user_output = nil
+        expect { subscriber.print_status('test') }.not_to raise_error
+      end
+    end
+
+    describe '#print_error' do
+      it 'delegates to user_output.print_error' do
+        allow(output).to receive(:print_error)
+        subscriber.print_error('error message')
+        expect(output).to have_received(:print_error).with('error message')
+      end
+
+      it 'does nothing when user_output is nil' do
+        subscriber.user_output = nil
+        expect { subscriber.print_error('test') }.not_to raise_error
+      end
+    end
+
+    describe '#print_good' do
+      it 'delegates to user_output.print_good' do
+        allow(output).to receive(:print_good)
+        subscriber.print_good('good message')
+        expect(output).to have_received(:print_good).with('good message')
+      end
+
+      it 'does nothing when user_output is nil' do
+        subscriber.user_output = nil
+        expect { subscriber.print_good('test') }.not_to raise_error
+      end
+    end
+
+    describe '#print_warning' do
+      it 'delegates to user_output.print_warning' do
+        allow(output).to receive(:print_warning)
+        subscriber.print_warning('warning message')
+        expect(output).to have_received(:print_warning).with('warning message')
+      end
+
+      it 'does nothing when user_output is nil' do
+        subscriber.user_output = nil
+        expect { subscriber.print_warning('test') }.not_to raise_error
+      end
+    end
+
+    describe '#print' do
+      it 'delegates to user_output.print' do
+        allow(output).to receive(:print)
+        subscriber.print('raw text')
+        expect(output).to have_received(:print).with('raw text')
+      end
+
+      it 'does nothing when user_output is nil' do
+        subscriber.user_output = nil
+        expect { subscriber.print('test') }.not_to raise_error
+      end
+    end
+
+    describe '#flush' do
+      it 'delegates to user_output.flush' do
+        allow(output).to receive(:flush)
+        subscriber.flush
+        expect(output).to have_received(:flush)
+      end
+
+      it 'does nothing when user_output is nil' do
+        subscriber.user_output = nil
+        expect { subscriber.flush }.not_to raise_error
+      end
+    end
+
+    context 'when output is prompting' do
+      before do
+        allow(output).to receive(:prompting?).and_return(true)
+        allow(output).to receive(:prompting)
+        allow(output).to receive(:print_line)
+      end
+
+      it 'prints a blank line before print_line' do
+        subscriber.print_line('msg')
+        expect(output).to have_received(:prompting).with(false)
+        expect(output).to have_received(:print_line).with(no_args)
+        expect(output).to have_received(:print_line).with('msg')
+      end
+    end
+  end
+end


### PR DESCRIPTION


<!-- For trivial changes (typo fixes, comment corrections, minor doc edits): you may delete sections that don't apply. -->

<!-- PRs missing a description, verification steps, or test evidence will be closed. Each PR should address a single module, bug fix, or cohesive logical change. For full guidance, see CONTRIBUTING.md and the module acceptance guidelines linked below. If your PR is not yet complete, mark it as a draft or prefix the title with WIP. -->

## Description

fixes leaking file descriptors



<!-- Explain why this change is needed. What problem does it solve or what improvement does it provide? -->



<!-- Reference any related GitHub issue(s) below (e.g., "Fixes #1234" or "Related to #5678"). Delete this line if not applicable. -->

**Related Issue:** #21553 

## Breaking Changes

<!-- Does this PR change existing behavior, remove options, rename datastore settings, or alter API/mixin interfaces? If yes, describe what breaks and how users should adapt. Write "None" if not applicable. -->

None


## Verification Steps

Automated Tests
```
bundle exec rspec spec/lib/rex/ui/subscriber_spec.rb
```
All 40 examples should pass. The "FD stability with real Input::Buffer instances" test directly validates that repeated init_ui calls with socket-backed buffers do not leak file descriptors.

Manual Verification — FD Leak over RPC
Reproduces the issue from #21553 using a meterpreter bind payload in Docker.

 - [ ] Generate a meterpreter bind payload
`./msfvenom -p linux/x64/meterpreter/bind_tcp LPORT=4444 -f elf -o /tmp/mbind`
 
- [ ] Run it in a Docker container
`docker run --rm -d --name msf-target -p 4444:4444 -v /tmp/mbind:/mbind debian:bookworm-slim bash -c "chmod +x /mbind && /mbind"`

- [ ] Start msfrpcd (no SSL, foreground)
`./msfrpcd -P test -S -f -a 127.0.0.1`
 
- [ ] Connect to the bind payload via msfrpc
`./msfrpc -a 127.0.0.1 -S -P test -U msf`
In the IRB shell:

`rpc.call('module.execute', 'exploit', 'multi/handler', {'PAYLOAD' => 'linux/x64/meterpreter/bind_tcp', 'RHOST' => '127.0.0.1', 'LPORT' => '4444'})`
Wait a few seconds, confirm the session:

`rpc.call('session.list')`
 
- [ ] Record baseline FD count (separate terminal)
`lsof -p $(pgrep -f msfrpcd) | wc -l`
 
- [ ] Run repeated RPC interactions with pymetasploit3
`pip install pymetasploit3`
```
from pymetasploit3.msfrpc import MsfRpcClient
client = MsfRpcClient('test', ssl=False)
sid = list(client.sessions.list.keys())[0]
for i in range(20):
    shell = client.sessions.session(sid)
    shell.write('id')
    shell.read()
    print(f'Cycle {i+1}')
 ```
- [ ] Check FD count
`lsof -p $(pgrep -f msfrpcd) | wc -l`
Expected (with fix): FD count remains stable (no growth after initial settling).

Before fix: FD count grows by ~4 per cycle (2 TCP sockets + 2 FIFO pipes leaked each time).

 
- [ ] Cleanup
`docker rm -f msf-target`

## Test Evidence

```
~/dev/rex-socket on  fix-fd-leak! ⌚ 13:34:58
$ lsof -p $(pgrep -f msfrpcd) | wc -l                                                   ‹ruby-3.4.5›

     119
     
~/dev/metasploit-framework on  fix-fd-leak! ⌚ 13:36:45
$ python3 -c "                                                     ‹ruby-3.3.8@metasploit-framework›
from pymetasploit3.msfrpc import MsfRpcClient
client = MsfRpcClient('test', ssl=False)
sid = list(client.sessions.list.keys())[0]
for i in range(20):
    shell = client.sessions.session(sid)
    shell.write('id')
    shell.read()
    print(f'Cycle {i+1}')
"
Cycle 1
Cycle 2
Cycle 3
Cycle 4
Cycle 5
Cycle 6
Cycle 7
Cycle 8
Cycle 9
Cycle 10
Cycle 11
Cycle 12
Cycle 13
Cycle 14
Cycle 15
Cycle 16
Cycle 17
Cycle 18
Cycle 19
Cycle 20

~/dev/rex-socket on  fix-fd-leak! ⌚ 13:36:46
$ lsof -p $(pgrep -f msfrpcd) | wc -l                                                   ‹ruby-3.4.5›

     119
     
```

<!-- For new modules: include output from the module's `check` method (if applicable) AND successful exploitation or execution against a controlled lab/test environment target. -->

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS 26.5.1|
| **Ruby Version** | 3.3.8 |

## AI Usage Disclosure

Kiro



## Pre-Submission Checklist

- [x] Ran [`rubocop`](https://docs.metasploit.com/docs/development/quality/using-rubocop.html) on new files with no new offenses _(net new files only)_
- [x] Ran [`msftidy`](https://docs.metasploit.com/docs/development/quality/msftidy.html) on changed module files with no new offenses _(modules only)_
- [x] Ran [`msftidy_docs`](https://docs.metasploit.com/docs/development/quality/writing-module-documentation.html#before-you-submit-your-pr-msftidy_docsrb) on changed documentation files with no new offenses _(documentation files only)_
- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
