### PR TITLE
Fix undefined call to ArmBE to_linux_armbe_elf

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -19,6 +19,7 @@ module Msf::Util::EXE
   include Msf::Util::EXE::Linux::X86
   include Msf::Util::EXE::Linux::X64
   include Msf::Util::EXE::Linux::Armle
+  include Msf::Util::EXE::Linux::Armbe
   include Msf::Util::EXE::Linux::Aarch64
   include Msf::Util::EXE::Linux::Mipsle
   include Msf::Util::EXE::Linux::Mipsbe

--- a/lib/msf/util/exe/linux/armbe.rb
+++ b/lib/msf/util/exe/linux/armbe.rb
@@ -18,7 +18,7 @@ module Msf::Util::EXE::Linux::Armbe
     # @option           [String] :template
     # @return           [String] Returns an elf
     def to_linux_armbe_elf(framework, code, opts = {})
-      to_exe_elf(framework, opts, "template_armbe_linux.bin", code)
+      to_exe_elf(framework, opts, "template_armbe_linux.bin", code, true)
     end
 
     # Create a ARM Little Endian Linux ELF_DYN containing the payload provided in +code+
@@ -30,7 +30,7 @@ module Msf::Util::EXE::Linux::Armbe
     # @option           [String] :template
     # @return           [String] Returns an elf-so
     def to_linux_armbe_elf_dll(framework, code, opts = {})
-      to_exe_elf(framework, opts, "template_armbe_linux_dll.bin", code)
+      to_exe_elf(framework, opts, "template_armbe_linux_dll.bin", code, true)
     end
   end
 


### PR DESCRIPTION
## Description
This PR fixes the following issue:
```ruby
Msf::Util::EXE.to_executable_linux_armbe(self.framework, ...)
/Users/sjanusz/Programming/metasploit-framework/lib/msf/util/exe/linux.rb:67:in `to_executable_linux_armbe': undefined method `to_linux_armbe_elf' for module Msf::Util::EXE (NoMethodError)
```

## Before
```ruby
>> Msf::Util::EXE.to_executable_linux_armbe(self.framework, self.generate_simple(self.datastore))
/Users/sjanusz/Programming/metasploit-framework/lib/msf/util/exe/linux.rb:67:in `to_executable_linux_armbe': undefined method `to_linux_armbe_elf' for module Msf::Util::EXE (NoMethodError)
```

## After
```ruby
>> Msf::Util::EXE.to_executable_linux_armbe(self.framework, self.generate_simple(self.datastore))
=> "\x7FELF ... GENERATED PAYLOAD HERE"
```

## Verification Steps

- [ ] `bundle exec msfconsole -q`
- [ ] `use payload/cmd/linux/tftp/armbe/meterpreter_reverse_http`
- [ ] `set lhost 127.0.0.1`
- [ ] `irb`
- [ ] `Msf::Util::EXE.to_executable_linux_armbe(self.framework, self.generate_simple(self.datastore))`
