### PR TITLE
Add Support for Windows .writable? in Post Mixin

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -247,11 +247,26 @@ module Msf::Post::File
   def writable?(path)
     verification_token = Rex::Text.rand_text_alpha_upper(8)
     if session.type == 'powershell'
+      if directory?(path)
+        tmp_file = "#{path}\\#{Rex::Text.rand_text_alpha(8)}.tmp"
+        return cmd_exec("$f=[System.IO.File]::Create('#{tmp_file}');if($?){$f.Close();[System.IO.File]::Delete('#{tmp_file}');echo #{verification_token}}").include?(verification_token)
+      end
       return false unless file?(path)
       return cmd_exec("$a=[System.IO.File]::OpenWrite('#{path}');if($?){echo #{verification_token}};$a.Close()").include?(verification_token)
     end
 
     if session.type == 'meterpreter' && session.platform == 'windows'
+      if directory?(path)
+        tmp_file = "#{path}\\#{Rex::Text.rand_text_alpha(8)}.tmp"
+        begin
+          fd = session.fs.file.new(tmp_file, 'wb')
+          fd.close
+          session.fs.file.rm(tmp_file)
+          return true
+        rescue ::Rex::Post::Meterpreter::RequestError
+          return false
+        end
+      end
       return false unless file?(path)
       begin
         fd = session.fs.file.new(path, 'wb')
@@ -263,6 +278,10 @@ module Msf::Post::File
     end
 
     if session.type == 'shell' && session.platform == 'windows'
+      if directory?(path)
+        tmp_file = "#{path}\\#{Rex::Text.rand_text_alpha(8)}.tmp"
+        return cmd_exec("type nul >> \"#{tmp_file}\" 2>nul && del \"#{tmp_file}\" && echo #{verification_token}").include?(verification_token)
+      end
       return false unless file?(path)
       return cmd_exec("type nul >> \"#{path}\" 2>nul && echo #{verification_token}").include?(verification_token)
     end

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -246,10 +246,27 @@ module Msf::Post::File
   #
   def writable?(path)
     verification_token = Rex::Text.rand_text_alpha_upper(8)
-    if session.type == 'powershell' && file?(path)
+    if session.type == 'powershell'
+      return false unless file?(path)
       return cmd_exec("$a=[System.IO.File]::OpenWrite('#{path}');if($?){echo #{verification_token}};$a.Close()").include?(verification_token)
     end
-    raise "`writable?' method does not support Windows systems" if session.platform == 'windows'
+
+    if session.type == 'meterpreter' && session.platform == 'windows'
+      return false unless file?(path)
+      begin
+        fd = session.fs.file.new(path, 'wb')
+        fd.close
+        return true
+      rescue ::Rex::Post::Meterpreter::RequestError
+        return false
+      end
+    end
+
+    if session.type == 'shell' && session.platform == 'windows'
+      return false unless file?(path)
+      return cmd_exec("type nul >> \"#{path}\" 2>nul && echo #{verification_token}").include?(verification_token)
+    end
+
 
     cmd_exec("(test -w '#{path}' || test -O '#{path}') && echo true").to_s.include? 'true'
   end

--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -245,49 +245,19 @@ module Msf::Post::File
   # @return [Boolean] true if +path+ exists and is writable
   #
   def writable?(path)
-    verification_token = Rex::Text.rand_text_alpha_upper(8)
     if session.type == 'powershell'
-      if directory?(path)
-        tmp_file = "#{path}\\#{Rex::Text.rand_text_alpha(8)}.tmp"
-        return cmd_exec("$f=[System.IO.File]::Create('#{tmp_file}');if($?){$f.Close();[System.IO.File]::Delete('#{tmp_file}');echo #{verification_token}}").include?(verification_token)
-      end
-      return false unless file?(path)
-      return cmd_exec("$a=[System.IO.File]::OpenWrite('#{path}');if($?){echo #{verification_token}};$a.Close()").include?(verification_token)
+      return _writable_powershell?(path)
     end
 
-    if session.type == 'meterpreter' && session.platform == 'windows'
-      if directory?(path)
-        tmp_file = "#{path}\\#{Rex::Text.rand_text_alpha(8)}.tmp"
-        begin
-          fd = session.fs.file.new(tmp_file, 'wb')
-          fd.close
-          session.fs.file.rm(tmp_file)
-          return true
-        rescue ::Rex::Post::Meterpreter::RequestError
-          return false
-        end
+    if session.platform == 'windows'
+      if session.type == 'meterpreter'
+        return _writable_windows_meterpreter?(path)
       end
-      return false unless file?(path)
-      begin
-        fd = session.fs.file.new(path, 'wb')
-        fd.close
-        return true
-      rescue ::Rex::Post::Meterpreter::RequestError
-        return false
-      end
+
+      return _writable_windows_shell?(path)
     end
 
-    if session.type == 'shell' && session.platform == 'windows'
-      if directory?(path)
-        tmp_file = "#{path}\\#{Rex::Text.rand_text_alpha(8)}.tmp"
-        return cmd_exec("type nul >> \"#{tmp_file}\" 2>nul && del \"#{tmp_file}\" && echo #{verification_token}").include?(verification_token)
-      end
-      return false unless file?(path)
-      return cmd_exec("type nul >> \"#{path}\" 2>nul && echo #{verification_token}").include?(verification_token)
-    end
-
-
-    cmd_exec("(test -w '#{path}' || test -O '#{path}') && echo true").to_s.include? 'true'
+    _writable_unix?(path)
   end
 
   #
@@ -745,7 +715,7 @@ module Msf::Post::File
   #
   # @param path [String] Absolute base path to search from (default: '/')
   # @param max_depth [Integer] Maximum directory depth to search (0 = base directory only)
-  # @param timeout [Integer] Maximum seconds for cmd_exec to wait (default: 15).
+  # @param timeout [Integer] Maximum seconds for create_process to wait (default: 15).
   #   Note: if the command times out, the remote find process may continue
   #   running and tie up the shell channel until it finishes.
   # @return [Array<String>, nil] Array of writable directory paths, or nil on failure
@@ -765,18 +735,12 @@ module Msf::Post::File
       print_warning("Large max_depth (#{max_depth}) may cause the find command to run for a long time and hang the session")
     end
 
-    escaped_path = session.escape_arg(path)
-    find_args = ["find #{escaped_path}"]
-    find_args << "-maxdepth #{max_depth}"
-    find_args << '-type d'
-    find_args << '-writable'
-
-    find_args << '2>/dev/null'
-    cmd = find_args.join(' ')
     exec_timeout = timeout > 0 ? timeout : 15
+    find_args = ['-maxdepth', max_depth.to_s, '-type', 'd', '-writable']
 
     begin
-      cmd_exec(cmd, nil, exec_timeout).to_s.lines.map(&:strip).select { |p| p.start_with?('/') }
+      output = create_process('find', args: [path] + find_args, time_out: exec_timeout)
+      output.to_s.lines.map(&:strip).select { |p| p.start_with?('/') }
     rescue ::StandardError => e
       elog("Failed to find writable directories in #{path}", error: e)
       print_error("Failed to find writable directories in #{path}")
@@ -785,6 +749,73 @@ module Msf::Post::File
   end
 
   protected
+
+  # Check writability via PowerShell session by attempting to create/open a file.
+  #
+  # @param path [String] Remote path to check
+  # @return [Boolean] true if +path+ is writable
+  def _writable_powershell?(path)
+    verification_token = Rex::Text.rand_text_alpha_upper(8)
+    if directory?(path)
+      tmp_file = "#{path}\\#{Rex::Text.rand_text_alpha(8)}.tmp"
+      script = "$f=[System.IO.File]::Create('#{tmp_file}');if($?){$f.Close();[System.IO.File]::Delete('#{tmp_file}');echo #{verification_token}}"
+      return create_process('powershell.exe', args: ['-NoProfile', '-Command', script]).to_s.include?(verification_token)
+    end
+    return false unless file?(path)
+
+    script = "$a=[System.IO.File]::OpenWrite('#{path}');if($?){echo #{verification_token}};$a.Close()"
+    create_process('powershell.exe', args: ['-NoProfile', '-Command', script]).to_s.include?(verification_token)
+  end
+
+  # Check writability on Windows via Meterpreter by attempting to open a file handle.
+  #
+  # @param path [String] Remote path to check
+  # @return [Boolean] true if +path+ is writable
+  def _writable_windows_meterpreter?(path)
+    if directory?(path)
+      tmp_file = "#{path}\\#{Rex::Text.rand_text_alpha(8)}.tmp"
+      begin
+        fd = session.fs.file.new(tmp_file, 'wb')
+        fd.close
+        session.fs.file.rm(tmp_file)
+        return true
+      rescue ::Rex::Post::Meterpreter::RequestError
+        return false
+      end
+    end
+    return false unless file?(path)
+
+    begin
+      fd = session.fs.file.new(path, 'wb')
+      fd.close
+      true
+    rescue ::Rex::Post::Meterpreter::RequestError
+      false
+    end
+  end
+
+  # Check writability on Windows via a shell session using cmd.exe redirects.
+  #
+  # @param path [String] Remote path to check
+  # @return [Boolean] true if +path+ is writable
+  def _writable_windows_shell?(path)
+    verification_token = Rex::Text.rand_text_alpha_upper(8)
+    if directory?(path)
+      tmp_file = "#{path}\\#{Rex::Text.rand_text_alpha(8)}.tmp"
+      return create_process('cmd.exe', args: ['/C', "type nul >> \"#{tmp_file}\" 2>nul && del \"#{tmp_file}\" && echo #{verification_token}"]).to_s.include?(verification_token)
+    end
+    return false unless file?(path)
+
+    create_process('cmd.exe', args: ['/C', "type nul >> \"#{path}\" 2>nul && echo #{verification_token}"]).to_s.include?(verification_token)
+  end
+
+  # Check writability on Unix using test(1) builtins.
+  #
+  # @param path [String] Remote path to check
+  # @return [Boolean] true if +path+ is writable
+  def _writable_unix?(path)
+    create_process('sh', args: ['-c', "(test -w '#{path}' || test -O '#{path}') && echo true"]).to_s.include?('true')
+  end
 
   def _append_file_powershell(file_name, data)
     _write_file_powershell(file_name, data, true)

--- a/spec/lib/msf/core/post/file_spec.rb
+++ b/spec/lib/msf/core/post/file_spec.rb
@@ -71,14 +71,13 @@ RSpec.describe Msf::Post::File do
       klass = Class.new do
         include described_mixin
         attr_accessor :session
-        def cmd_exec(*_args); ''; end
+        def create_process(*_args, **_kwargs); ''; end
         def print_warning(_msg); end
         def print_error(_msg); end
         def elog(*_args); end
       end
       obj = klass.allocate
       obj.session = double('session', platform: 'linux')
-      allow(obj.session).to receive(:escape_arg) { |arg| "'#{arg}'" }
       obj
     end
 
@@ -103,60 +102,60 @@ RSpec.describe Msf::Post::File do
     context 'on Unix' do
 
       it 'returns writable directories' do
-        allow(subject).to receive(:cmd_exec).and_return("/tmp\n/var/tmp\n")
+        allow(subject).to receive(:create_process).and_return("/tmp\n/var/tmp\n")
         expect(subject.find_writable_directories).to eq(['/tmp', '/var/tmp'])
       end
 
       it 'filters out non-absolute paths and error lines' do
-        allow(subject).to receive(:cmd_exec).and_return("/tmp\nfind: permission denied\n/var/tmp\n")
+        allow(subject).to receive(:create_process).and_return("/tmp\nfind: permission denied\n/var/tmp\n")
         expect(subject.find_writable_directories).to eq(['/tmp', '/var/tmp'])
       end
 
       it 'returns an empty array when no directories are found' do
-        allow(subject).to receive(:cmd_exec).and_return('')
+        allow(subject).to receive(:create_process).and_return('')
         expect(subject.find_writable_directories).to eq([])
       end
 
-      it 'passes the timeout to cmd_exec' do
-        expect(subject).to receive(:cmd_exec).with("find '/' -maxdepth 2 -type d -writable 2>/dev/null", nil, 15).and_return("/tmp\n")
+      it 'passes the timeout to create_process' do
+        expect(subject).to receive(:create_process).with('find', args: ['/', '-maxdepth', '2', '-type', 'd', '-writable'], time_out: 15).and_return("/tmp\n")
         subject.find_writable_directories
       end
 
-      it 'passes a custom timeout to cmd_exec' do
-        expect(subject).to receive(:cmd_exec).with("find '/' -maxdepth 2 -type d -writable 2>/dev/null", nil, 60).and_return("/tmp\n")
+      it 'passes a custom timeout to create_process' do
+        expect(subject).to receive(:create_process).with('find', args: ['/', '-maxdepth', '2', '-type', 'd', '-writable'], time_out: 60).and_return("/tmp\n")
         subject.find_writable_directories(timeout: 60)
       end
 
       it 'uses default timeout when timeout is 0' do
-        expect(subject).to receive(:cmd_exec).with("find '/' -maxdepth 2 -type d -writable 2>/dev/null", nil, 15).and_return("/tmp\n")
+        expect(subject).to receive(:create_process).with('find', args: ['/', '-maxdepth', '2', '-type', 'd', '-writable'], time_out: 15).and_return("/tmp\n")
         subject.find_writable_directories(timeout: 0)
       end
 
       it 'warns when max_depth is greater than 2' do
         expect(subject).to receive(:print_warning).with(/Large max_depth/)
-        allow(subject).to receive(:cmd_exec).and_return("/tmp\n")
+        allow(subject).to receive(:create_process).and_return("/tmp\n")
         subject.find_writable_directories(max_depth: 5)
       end
 
       it 'does not warn when max_depth is 2 or less' do
         expect(subject).not_to receive(:print_warning)
-        allow(subject).to receive(:cmd_exec).and_return("/tmp\n")
+        allow(subject).to receive(:create_process).and_return("/tmp\n")
         subject.find_writable_directories(max_depth: 2)
       end
 
       it 'passes -maxdepth 0 to search only the base directory' do
-        expect(subject).to receive(:cmd_exec).with("find '/' -maxdepth 0 -type d -writable 2>/dev/null", nil, 15).and_return("/\n")
+        expect(subject).to receive(:create_process).with('find', args: ['/', '-maxdepth', '0', '-type', 'd', '-writable'], time_out: 15).and_return("/\n")
         expect(subject.find_writable_directories(max_depth: 0)).to eq(['/'])
       end
 
       it 'uses custom path and max_depth' do
         allow(subject).to receive(:print_warning)
-        expect(subject).to receive(:cmd_exec).with("find '/var' -maxdepth 3 -type d -writable 2>/dev/null", nil, 15).and_return("/var/tmp\n")
+        expect(subject).to receive(:create_process).with('find', args: ['/var', '-maxdepth', '3', '-type', 'd', '-writable'], time_out: 15).and_return("/var/tmp\n")
         expect(subject.find_writable_directories(path: '/var', max_depth: 3)).to eq(['/var/tmp'])
       end
 
       it 'returns nil on failure' do
-        allow(subject).to receive(:cmd_exec).and_raise(RuntimeError, 'connection failed')
+        allow(subject).to receive(:create_process).and_raise(RuntimeError, 'connection failed')
         allow(subject).to receive(:print_error)
         allow(subject).to receive(:elog)
         expect(subject.find_writable_directories).to be_nil
@@ -171,6 +170,7 @@ RSpec.describe Msf::Post::File do
         include described_mixin
         attr_accessor :session
         def cmd_exec(_cmd); ''; end
+        def create_process(*_args, **_kwargs); ''; end
       end
       obj = klass.allocate
       obj.session = double('session')
@@ -190,21 +190,21 @@ RSpec.describe Msf::Post::File do
 
       it 'returns true when the file is writable' do
         allow(subject).to receive(:file?).with('C:\\writable.txt').and_return(true)
-        allow(subject).to receive(:cmd_exec).and_return('TESTTOKEN')
+        allow(subject).to receive(:create_process).and_return('TESTTOKEN')
         expect(subject.writable?('C:\\writable.txt')).to be true
       end
 
       it 'returns false when the file is not writable' do
         allow(subject).to receive(:file?).with('C:\\locked.txt').and_return(true)
-        allow(subject).to receive(:cmd_exec).and_return('')
+        allow(subject).to receive(:create_process).and_return('')
         expect(subject.writable?('C:\\locked.txt')).to be false
       end
 
       it 'returns true when the directory is writable' do
         allow(subject).to receive(:directory?).with('C:\\somedir').and_return(true)
         allow(Rex::Text).to receive(:rand_text_alpha).and_return('RANDFILE')
-        allow(subject).to receive(:cmd_exec)
-          .with('type nul >> "C:\\somedir\\RANDFILE.tmp" 2>nul && del "C:\\somedir\\RANDFILE.tmp" && echo TESTTOKEN')
+        allow(subject).to receive(:create_process)
+          .with('cmd.exe', args: ['/C', 'type nul >> "C:\\somedir\\RANDFILE.tmp" 2>nul && del "C:\\somedir\\RANDFILE.tmp" && echo TESTTOKEN'])
           .and_return('TESTTOKEN')
         expect(subject.writable?('C:\\somedir')).to be true
       end
@@ -212,7 +212,7 @@ RSpec.describe Msf::Post::File do
       it 'returns false when the directory is not writable' do
         allow(subject).to receive(:directory?).with('C:\\somedir').and_return(true)
         allow(Rex::Text).to receive(:rand_text_alpha).and_return('RANDFILE')
-        allow(subject).to receive(:cmd_exec).and_return('')
+        allow(subject).to receive(:create_process).and_return('')
         expect(subject.writable?('C:\\somedir')).to be false
       end
 
@@ -224,8 +224,8 @@ RSpec.describe Msf::Post::File do
 
       it 'issues the correct cmd.exe command' do
         allow(subject).to receive(:file?).with('C:\\test.txt').and_return(true)
-        expect(subject).to receive(:cmd_exec)
-          .with('type nul >> "C:\\test.txt" 2>nul && echo TESTTOKEN')
+        expect(subject).to receive(:create_process)
+          .with('cmd.exe', args: ['/C', 'type nul >> "C:\\test.txt" 2>nul && echo TESTTOKEN'])
           .and_return('')
         subject.writable?('C:\\test.txt')
       end
@@ -297,7 +297,7 @@ RSpec.describe Msf::Post::File do
 
       it 'returns true when the file is writable' do
         allow(subject).to receive(:file?).with('C:\\writable.txt').and_return(true)
-        allow(subject).to receive(:cmd_exec).and_return('TESTTOKEN')
+        allow(subject).to receive(:create_process).and_return('TESTTOKEN')
         expect(subject.writable?('C:\\writable.txt')).to be true
       end
 
@@ -310,8 +310,8 @@ RSpec.describe Msf::Post::File do
       it 'returns true when the directory is writable' do
         allow(subject).to receive(:directory?).with('C:\\somedir').and_return(true)
         allow(Rex::Text).to receive(:rand_text_alpha).and_return('RANDFILE')
-        allow(subject).to receive(:cmd_exec)
-          .with("$f=[System.IO.File]::Create('C:\\somedir\\RANDFILE.tmp');if($?){$f.Close();[System.IO.File]::Delete('C:\\somedir\\RANDFILE.tmp');echo TESTTOKEN}")
+        allow(subject).to receive(:create_process)
+          .with('powershell.exe', args: ['-NoProfile', '-Command', "$f=[System.IO.File]::Create('C:\\somedir\\RANDFILE.tmp');if($?){$f.Close();[System.IO.File]::Delete('C:\\somedir\\RANDFILE.tmp');echo TESTTOKEN}"])
           .and_return('TESTTOKEN')
         expect(subject.writable?('C:\\somedir')).to be true
       end
@@ -319,7 +319,7 @@ RSpec.describe Msf::Post::File do
       it 'returns false when the directory is not writable' do
         allow(subject).to receive(:directory?).with('C:\\somedir').and_return(true)
         allow(Rex::Text).to receive(:rand_text_alpha).and_return('RANDFILE')
-        allow(subject).to receive(:cmd_exec).and_return('')
+        allow(subject).to receive(:create_process).and_return('')
         expect(subject.writable?('C:\\somedir')).to be false
       end
     end
@@ -331,12 +331,12 @@ RSpec.describe Msf::Post::File do
       end
 
       it 'returns true when test -w succeeds' do
-        allow(subject).to receive(:cmd_exec).and_return('true')
+        allow(subject).to receive(:create_process).and_return('true')
         expect(subject.writable?('/tmp/file')).to be true
       end
 
       it 'returns false when test -w fails' do
-        allow(subject).to receive(:cmd_exec).and_return('')
+        allow(subject).to receive(:create_process).and_return('')
         expect(subject.writable?('/etc/shadow')).to be false
       end
     end

--- a/spec/lib/msf/core/post/file_spec.rb
+++ b/spec/lib/msf/core/post/file_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rex/text'
 
 RSpec.describe Msf::Post::File do
   subject do
@@ -159,6 +160,139 @@ RSpec.describe Msf::Post::File do
         allow(subject).to receive(:print_error)
         allow(subject).to receive(:elog)
         expect(subject.find_writable_directories).to be_nil
+      end
+    end
+  end
+
+  describe '#writable?' do
+    subject do
+      described_mixin = described_class
+      klass = Class.new do
+        include described_mixin
+        attr_accessor :session
+        def cmd_exec(_cmd); ''; end
+      end
+      obj = klass.allocate
+      obj.session = double('session')
+      obj
+    end
+
+    before(:each) do
+      allow(Rex::Text).to receive(:rand_text_alpha_upper).and_return('TESTTOKEN')
+    end
+
+    context 'on a Windows shell session' do
+      before(:each) do
+        allow(subject.session).to receive(:type).and_return('shell')
+        allow(subject.session).to receive(:platform).and_return('windows')
+      end
+
+      it 'returns true when the file is writable' do
+        allow(subject).to receive(:file?).with('C:\\writable.txt').and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('TESTTOKEN')
+        expect(subject.writable?('C:\\writable.txt')).to be true
+      end
+
+      it 'returns false when the file is not writable' do
+        allow(subject).to receive(:file?).with('C:\\locked.txt').and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('')
+        expect(subject.writable?('C:\\locked.txt')).to be false
+      end
+
+      it 'returns false for a directory without attempting the write check' do
+        allow(subject).to receive(:file?).with('C:\\somedir').and_return(false)
+        expect(subject).not_to receive(:cmd_exec)
+        expect(subject.writable?('C:\\somedir')).to be false
+      end
+
+      it 'returns false when the path does not exist' do
+        allow(subject).to receive(:file?).with('C:\\missing.txt').and_return(false)
+        expect(subject).not_to receive(:cmd_exec)
+        expect(subject.writable?('C:\\missing.txt')).to be false
+      end
+
+      it 'issues the correct cmd.exe command' do
+        allow(subject).to receive(:file?).with('C:\\test.txt').and_return(true)
+        expect(subject).to receive(:cmd_exec)
+          .with('type nul >> "C:\\test.txt" 2>nul && echo TESTTOKEN')
+          .and_return('')
+        subject.writable?('C:\\test.txt')
+      end
+    end
+
+    context 'on a Windows meterpreter session' do
+      let(:mock_fs)             { double('fs') }
+      let(:mock_fs_file)        { double('fs_file') }
+      let(:mock_fd)             { double('fd') }
+      let(:request_error_class) { Class.new(StandardError) }
+
+      before(:each) do
+        stub_const('Rex::Post::Meterpreter::RequestError', request_error_class)
+        allow(subject.session).to receive(:type).and_return('meterpreter')
+        allow(subject.session).to receive(:platform).and_return('windows')
+        allow(subject.session).to receive(:fs).and_return(mock_fs)
+        allow(mock_fs).to receive(:file).and_return(mock_fs_file)
+        allow(mock_fd).to receive(:close)
+      end
+
+      it 'returns true when the file is writable' do
+        allow(subject).to receive(:file?).with('C:\\writable.txt').and_return(true)
+        allow(mock_fs_file).to receive(:new).and_return(mock_fd)
+        expect(subject.writable?('C:\\writable.txt')).to be true
+      end
+
+      it 'returns false when opening the file raises a RequestError' do
+        allow(subject).to receive(:file?).with('C:\\locked.txt').and_return(true)
+        allow(mock_fs_file).to receive(:new).and_raise(request_error_class)
+        expect(subject.writable?('C:\\locked.txt')).to be false
+      end
+
+      it 'opens the file with write mode' do
+        allow(subject).to receive(:file?).with('C:\\test.txt').and_return(true)
+        expect(mock_fs_file).to receive(:new).with('C:\\test.txt', 'wb').and_return(mock_fd)
+        subject.writable?('C:\\test.txt')
+      end
+
+      it 'returns false for a non-file path' do
+        allow(subject).to receive(:file?).with('C:\\somedir').and_return(false)
+        expect(mock_fs_file).not_to receive(:new)
+        expect(subject.writable?('C:\\somedir')).to be false
+      end
+    end
+
+    context 'on a Windows PowerShell session' do
+      before(:each) do
+        allow(subject.session).to receive(:type).and_return('powershell')
+        allow(subject.session).to receive(:platform).and_return('windows')
+      end
+
+      it 'returns true when the file is writable' do
+        allow(subject).to receive(:file?).with('C:\\writable.txt').and_return(true)
+        allow(subject).to receive(:cmd_exec).and_return('TESTTOKEN')
+        expect(subject.writable?('C:\\writable.txt')).to be true
+      end
+
+      it 'returns false for a non-file path' do
+        allow(subject).to receive(:file?).with('C:\\somedir').and_return(false)
+        expect(subject).not_to receive(:cmd_exec)
+        expect(subject.writable?('C:\\somedir')).to be false
+      end
+    end
+
+    context 'on a Unix shell session' do
+      before(:each) do
+        allow(subject.session).to receive(:type).and_return('shell')
+        allow(subject.session).to receive(:platform).and_return('linux')
+      end
+
+      it 'returns true when test -w succeeds' do
+        allow(subject).to receive(:cmd_exec).and_return('true')
+        expect(subject.writable?('/tmp/file')).to be true
+      end
+
+      it 'returns false when test -w fails' do
+        allow(subject).to receive(:cmd_exec).and_return('')
+        expect(subject.writable?('/etc/shadow')).to be false
       end
     end
   end

--- a/spec/lib/msf/core/post/file_spec.rb
+++ b/spec/lib/msf/core/post/file_spec.rb
@@ -185,6 +185,7 @@ RSpec.describe Msf::Post::File do
       before(:each) do
         allow(subject.session).to receive(:type).and_return('shell')
         allow(subject.session).to receive(:platform).and_return('windows')
+        allow(subject).to receive(:directory?).and_return(false)
       end
 
       it 'returns true when the file is writable' do
@@ -199,16 +200,26 @@ RSpec.describe Msf::Post::File do
         expect(subject.writable?('C:\\locked.txt')).to be false
       end
 
-      it 'returns false for a directory without attempting the write check' do
-        allow(subject).to receive(:file?).with('C:\\somedir').and_return(false)
-        expect(subject).not_to receive(:cmd_exec)
+      it 'returns true when the directory is writable' do
+        allow(subject).to receive(:directory?).with('C:\\somedir').and_return(true)
+        allow(Rex::Text).to receive(:rand_text_alpha).and_return('RANDFILE')
+        allow(subject).to receive(:cmd_exec)
+          .with('type nul >> "C:\\somedir\\RANDFILE.tmp" 2>nul && del "C:\\somedir\\RANDFILE.tmp" && echo TESTTOKEN')
+          .and_return('TESTTOKEN')
+        expect(subject.writable?('C:\\somedir')).to be true
+      end
+
+      it 'returns false when the directory is not writable' do
+        allow(subject).to receive(:directory?).with('C:\\somedir').and_return(true)
+        allow(Rex::Text).to receive(:rand_text_alpha).and_return('RANDFILE')
+        allow(subject).to receive(:cmd_exec).and_return('')
         expect(subject.writable?('C:\\somedir')).to be false
       end
 
       it 'returns false when the path does not exist' do
-        allow(subject).to receive(:file?).with('C:\\missing.txt').and_return(false)
-        expect(subject).not_to receive(:cmd_exec)
-        expect(subject.writable?('C:\\missing.txt')).to be false
+        allow(subject).to receive(:directory?).with('C:\\missing').and_return(false)
+        allow(subject).to receive(:file?).with('C:\\missing').and_return(false)
+        expect(subject.writable?('C:\\missing')).to be false
       end
 
       it 'issues the correct cmd.exe command' do
@@ -233,6 +244,7 @@ RSpec.describe Msf::Post::File do
         allow(subject.session).to receive(:fs).and_return(mock_fs)
         allow(mock_fs).to receive(:file).and_return(mock_fs_file)
         allow(mock_fd).to receive(:close)
+        allow(subject).to receive(:directory?).and_return(false)
       end
 
       it 'returns true when the file is writable' do
@@ -254,8 +266,24 @@ RSpec.describe Msf::Post::File do
       end
 
       it 'returns false for a non-file path' do
+        allow(subject).to receive(:directory?).with('C:\\somedir').and_return(false)
         allow(subject).to receive(:file?).with('C:\\somedir').and_return(false)
         expect(mock_fs_file).not_to receive(:new)
+        expect(subject.writable?('C:\\somedir')).to be false
+      end
+
+      it 'returns true when the directory is writable' do
+        allow(subject).to receive(:directory?).with('C:\\somedir').and_return(true)
+        allow(Rex::Text).to receive(:rand_text_alpha).and_return('RANDFILE')
+        allow(mock_fs_file).to receive(:new).with('C:\\somedir\\RANDFILE.tmp', 'wb').and_return(mock_fd)
+        allow(mock_fs_file).to receive(:rm).with('C:\\somedir\\RANDFILE.tmp')
+        expect(subject.writable?('C:\\somedir')).to be true
+      end
+
+      it 'returns false when the directory is not writable' do
+        allow(subject).to receive(:directory?).with('C:\\somedir').and_return(true)
+        allow(Rex::Text).to receive(:rand_text_alpha).and_return('RANDFILE')
+        allow(mock_fs_file).to receive(:new).with('C:\\somedir\\RANDFILE.tmp', 'wb').and_raise(request_error_class)
         expect(subject.writable?('C:\\somedir')).to be false
       end
     end
@@ -264,6 +292,7 @@ RSpec.describe Msf::Post::File do
       before(:each) do
         allow(subject.session).to receive(:type).and_return('powershell')
         allow(subject.session).to receive(:platform).and_return('windows')
+        allow(subject).to receive(:directory?).and_return(false)
       end
 
       it 'returns true when the file is writable' do
@@ -273,8 +302,24 @@ RSpec.describe Msf::Post::File do
       end
 
       it 'returns false for a non-file path' do
+        allow(subject).to receive(:directory?).with('C:\\somedir').and_return(false)
         allow(subject).to receive(:file?).with('C:\\somedir').and_return(false)
-        expect(subject).not_to receive(:cmd_exec)
+        expect(subject.writable?('C:\\somedir')).to be false
+      end
+
+      it 'returns true when the directory is writable' do
+        allow(subject).to receive(:directory?).with('C:\\somedir').and_return(true)
+        allow(Rex::Text).to receive(:rand_text_alpha).and_return('RANDFILE')
+        allow(subject).to receive(:cmd_exec)
+          .with("$f=[System.IO.File]::Create('C:\\somedir\\RANDFILE.tmp');if($?){$f.Close();[System.IO.File]::Delete('C:\\somedir\\RANDFILE.tmp');echo TESTTOKEN}")
+          .and_return('TESTTOKEN')
+        expect(subject.writable?('C:\\somedir')).to be true
+      end
+
+      it 'returns false when the directory is not writable' do
+        allow(subject).to receive(:directory?).with('C:\\somedir').and_return(true)
+        allow(Rex::Text).to receive(:rand_text_alpha).and_return('RANDFILE')
+        allow(subject).to receive(:cmd_exec).and_return('')
         expect(subject.writable?('C:\\somedir')).to be false
       end
     end

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -298,10 +298,6 @@ class MetasploitModule < Msf::Post
         ret
       end
 
-      it 'should detect a non-writable file' do
-        !writable?('C:\\Windows\\System32\\config\\SAM')
-      end
-
       it 'should detect a writable directory' do
         mkdir(datastore['BaseDirectoryName'])
         ret = writable?(datastore['BaseDirectoryName'])
@@ -309,9 +305,6 @@ class MetasploitModule < Msf::Post
         ret
       end
 
-      it 'should detect a non-writable directory' do
-        !writable?('C:\\Windows\\System32\\config')
-      end
     end
   end
 

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -289,6 +289,32 @@ class MetasploitModule < Msf::Post
     end
   end
 
+  def test_writable
+    if session.platform == 'windows'
+      it 'should detect a writable file' do
+        write_file(datastore['BaseFileName'], 'test')
+        ret = writable?(datastore['BaseFileName'])
+        rm_f(datastore['BaseFileName'])
+        ret
+      end
+
+      it 'should detect a non-writable file' do
+        !writable?('C:\\Windows\\System32\\config\\SAM')
+      end
+
+      it 'should detect a writable directory' do
+        mkdir(datastore['BaseDirectoryName'])
+        ret = writable?(datastore['BaseDirectoryName'])
+        rm_rf(datastore['BaseDirectoryName'])
+        ret
+      end
+
+      it 'should detect a non-writable directory' do
+        !writable?('C:\\Windows\\System32\\config')
+      end
+    end
+  end
+
   def make_symlink(target, symlink)
     if session.platform == 'windows'
       cmd_exec("cmd.exe", "/c mklink #{directory?(target) ? '/D ' : ''}#{symlink} #{target}")


### PR DESCRIPTION
## Description

This adds support to the Post Mixin for Windows sessions to run the `.writable?` method. 

- Meterpreter sessions will try to open a write handle to the file via `session.fs.file.new(path, 'wb')`

- Shell sessions will try to append to the file via `type nul >> path`
  - This checks for FILE_APPEND_DATA and not GENERIC_WRITE. A file with append-but-not-write ACE (exotic, but possible) would return a false positive

## Reviewer Notes

Create two separates files to test. As a low privilege user, create the files in your home directory - avoid creating the files elsewhere like `C:\users\public` or `C:\` which will inherit unwanted privileges which will affected the test.

Create `writable.txt`: 
```
C:\Users\lowboi>echo test > writable.txt
```

Create `not_writable.txt`:
```
C:\Users\lowboi>echo test > not_writable.txt
```

Take away write privileges from your user by setting `(R)` read privs only: 
```
C:\Users\lowboi>icacls not_writable.txt /inheritance:r /grant:r "DESKTOP-0OPTL76\lowboi:(R)" "SYSTEM:(F)" "Administrators:(F)"
processed file: not_writable.txt
Successfully processed 1 files; Failed processing 0 files
```

Double check everything looks good: 
```
C:\Users\lowboi>icacls not_writable.txt
not_writable.txt BUILTIN\Administrators:(F)
                 NT AUTHORITY\SYSTEM:(F)
                 DESKTOP-0OPTL76\lowboi:(R)
```

From the GUI you should see:
<img width="915" height="614" alt="Screenshot 2026-06-15 at 12 37 48 PM" src="https://github.com/user-attachments/assets/7ca4501e-22ba-48d6-8854-a27b1b0fce34" />


## Verification Steps

- Establish a meterpreter session on the target
- Load any module that loads the Post::File mixin
- Drop into IRB
- test like so: 
```
msf exploit(windows/local/adobe_sandbox_adobecollabsync) > sessions -l

Active sessions
===============

  Id  Name  Type                     Information                               Connection
  --  ----  ----                     -----------                               ----------
  6         meterpreter x64/windows  DESKTOP-0OPTL76\lowboi @ DESKTOP-0OPTL76  192.168.1.68:4444 -> 192.168.1.150:50514 (192.168.1.150)

msf exploit(windows/local/adobe_sandbox_adobecollabsync) > irb
[*] Starting IRB shell...
[*] You are in exploit/windows/local/adobe_sandbox_adobecollabsync

>> writable?('c:\users\lowboi\not_writable.txt')
=> false
>> writable?('c:\users\lowboi\writable.txt')
=> true
```

- Establish a shell session on the target
- Load any module that loads the Post::File mixin
- Drop into IRB
- test like so: 
```
msf exploit(windows/local/adobe_sandbox_adobecollabsync) > sessions -l

Active sessions
===============

  Id  Name  Type               Information                                                      Connection
  --  ----  ----               -----------                                                      ----------
  5         shell cmd/windows  Shell Banner: Microsoft Windows [Version 10.0.19045.6466] -----  192.168.1.68:4444 -> 192.168.1.150:50370 (192.168.1.150)

msf exploit(windows/local/adobe_sandbox_adobecollabsync) > irb
[*] Starting IRB shell...
[*] You are in exploit/windows/local/adobe_sandbox_adobecollabsync

>> writable?('c:\users\lowboi\writable.txt')
=> true
>> writable?('c:\users\lowboi\not_writable.txt')
=> false
```



## Test Evidence
Evidence included in the verification steps. See the rspec output below: 
```
➜  metasploit-framework git:(feat/lib/post_windows_writable) ✗ bundle exec rspec spec/lib/msf/core/post/file_spec.rb
.Overriding user environment variable 'OPENSSL_CONF' to enable legacy functions.
Run options:
  include {:focus=>true}
  exclude {:acceptance=>true}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 16757
Msf::Post::File ........................................
Acceptance::DatastoreFormatting .......

Top 10 slowest examples (2.05 seconds, 19.0% of total time):
  Msf::Post::File#writable? on a Windows shell session returns false when the file is not writable
    0.2817 seconds ./spec/lib/msf/core/post/file_spec.rb:196
  Msf::Post::File#find_writable_directories on Unix returns an empty array when no directories are found
    0.26119 seconds ./spec/lib/msf/core/post/file_spec.rb:115
  Msf::Post::File#writable? on a Windows shell session returns true when the file is writable
    0.20451 seconds ./spec/lib/msf/core/post/file_spec.rb:190
  Msf::Post::File#find_writable_directories on Unix passes a custom timeout to cmd_exec
    0.19586 seconds ./spec/lib/msf/core/post/file_spec.rb:125
  Msf::Post::File#writable? on a Windows meterpreter session returns true when the file is writable
    0.19576 seconds ./spec/lib/msf/core/post/file_spec.rb:238
  Msf::Post::File#find_writable_directories raises an error for relative paths
    0.19185 seconds ./spec/lib/msf/core/post/file_spec.rb:95
  Msf::Post::File#_can_echo? should return false for "hello \"world\""
    0.19021 seconds ./spec/lib/msf/core/post/file_spec.rb:62
  Msf::Post::File#mkdir registers the directory for cleanup by default
    0.1872 seconds ./spec/lib/msf/core/post/file_spec.rb:34
  Msf::Post::File#writable? on a Windows PowerShell session returns true when the file is writable
    0.17541 seconds ./spec/lib/msf/core/post/file_spec.rb:269
  Msf::Post::File#find_writable_directories on Unix filters out non-absolute paths and error lines
    0.16756 seconds ./spec/lib/msf/core/post/file_spec.rb:110

Top 2 slowest example groups:
  Acceptance::DatastoreFormatting
    0.27547 seconds average (1.93 seconds / 7 examples) ./spec/support/acceptance/datastore_formatting_spec.rb:6
  Msf::Post::File
    0.22051 seconds average (8.82 seconds / 40 examples) ./spec/lib/msf/core/post/file_spec.rb:4

Finished in 10.82 seconds (files took 58.86 seconds to load)
47 examples, 0 failures

Randomized with seed 16757
Coverage report generated for RSpec to /Users/jheysel/rapid7/metasploit-framework/coverage.
Line Coverage: 18.55% (2510 / 13532)
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Windows 10 10.0.19045 N/A Build 19045 |
| **Ruby Version** | ruby 3.3.8 (2025-04-09 revision b200bad6cd) [x86_64-darwin24]|
| **Target Software/Hardware** | Windows|

## AI Usage Disclosure

Claude wrote the tests

## Pre-Submission Checklist

- [x] Ran [`rubocop`](https://docs.metasploit.com/docs/development/quality/using-rubocop.html) on new files with no new offenses _(net new files only)_
- [x] Ran [`msftidy`](https://docs.metasploit.com/docs/development/quality/msftidy.html) on changed module files with no new offenses _(modules only)_
- [x] Ran [`msftidy_docs`](https://docs.metasploit.com/docs/development/quality/writing-module-documentation.html#before-you-submit-your-pr-msftidy_docsrb) on changed documentation files with no new offenses _(documentation files only)_
- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
