### PR TITLE
FTP mixin: Check for complete response

### DIFF
--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -471,6 +471,37 @@ module Exploit::Remote::Ftp
       left << @ftpbuff
       @ftpbuff = ""
     end
+
+    unless left.empty?
+      # Handle ends without newlines
+      enlidx = left.rindex(0x0a.chr)
+      tail = ''
+      if enlidx != (left.length-1)
+        if not enlidx
+          tail = left
+          left = ''
+        else
+          tail = left.slice!((enlidx+1)..left.length)
+        end
+      end
+
+      rarr = left.split(/\r?\n/)
+      left = tail
+      rarr.each do |ln|
+        if !found_end
+          resp << ln << "\r\n"
+          found_end = true if ln.match?(/\A\d{3} /)
+        else
+          @ftpbuff << ln << "\r\n"
+        end
+      end
+      if found_end
+        @ftpbuff << left
+        print_status("FTP recv (buff): #{resp.inspect}") if datastore['FTPDEBUG']
+        return resp
+      end
+    end
+
     while true
       data = nsock.get_once(-1, ftp_timeout)
       if not data
@@ -499,17 +530,16 @@ module Exploit::Remote::Ftp
         if not found_end
           resp << ln
           resp << "\r\n"
-          if ln.length > 3 and ln[3,1] == ' ' and ln[0,3] =~ /\A\d{3}\z/
-            found_end = true
-          end
+          found_end = true if ln.match?(/\A\d{3} /)
         else
           left << ln
           left << "\r\n"
         end
       end
       if found_end
-        @ftpbuff << left
         print_status("FTP recv: #{resp.inspect}") if datastore['FTPDEBUG']
+        print_status("FTP buff: #{left.inspect}") if datastore['FTPDEBUG'] && !left.empty?
+        @ftpbuff << left
         return resp
       end
     end

--- a/spec/lib/msf/core/exploit/remote/ftp_recv_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ftp_recv_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper'
+require 'msf/core/exploit/remote/ftp'
+
+RSpec.describe Msf::Exploit::Remote::Ftp do
+  subject(:instance) do
+    mod = Msf::Exploit::Remote.allocate
+    mod.extend described_class
+    mod
+  end
+
+  let(:socket) { double('socket') }
+
+  before do
+    allow(instance).to receive(:datastore).and_return('FTPDEBUG' => false)
+    allow(instance).to receive(:ftp_timeout).and_return(1)
+    instance.instance_variable_set(:@ftpbuff, '')
+  end
+
+  describe '#recv_ftp_resp' do
+    context 'when @ftpbuff holds a complete response and the socket is idle' do
+      before do
+        instance.instance_variable_set(:@ftpbuff, "331 Please specify the password.\r\n")
+        allow(socket).to receive(:get_once).and_return(nil)
+      end
+
+      it 'returns the buffered response without reading from the socket' do
+        expect(instance.recv_ftp_resp(socket)).to eq("331 Please specify the password.\r\n")
+      end
+
+      it 'does not call get_once when @ftpbuff already contains a complete response' do
+        instance.recv_ftp_resp(socket)
+        expect(socket).not_to have_received(:get_once)
+      end
+
+      it 'leaves @ftpbuff empty after consuming a complete response' do
+        instance.recv_ftp_resp(socket)
+        expect(instance.instance_variable_get(:@ftpbuff)).to be_empty
+      end
+    end
+
+    context 'when @ftpbuff holds two complete responses (back-to-back burst)' do
+      before do
+        instance.instance_variable_set(:@ftpbuff, "331 Please specify the password.\r\n230 Login successful.\r\n")
+        allow(socket).to receive(:get_once).and_return(nil)
+      end
+
+      it 'returns only the first buffered response' do
+        expect(instance.recv_ftp_resp(socket)).to eq("331 Please specify the password.\r\n")
+      end
+
+      it 'keeps the second response in @ftpbuff for the next call' do
+        instance.recv_ftp_resp(socket)
+        expect(instance.instance_variable_get(:@ftpbuff)).to eq("230 Login successful.\r\n")
+      end
+    end
+
+    context 'when @ftpbuff holds only a partial response' do
+      before do
+        instance.instance_variable_set(:@ftpbuff, "220-Welcome to vsftpd\r\n")
+        allow(socket).to receive(:get_once).and_return("220 Ready.\r\n", nil)
+      end
+
+      it 'combines the buffered and socket data into one response' do
+        response = instance.recv_ftp_resp(socket)
+        expect(response).to include("220-Welcome to vsftpd\r\n")
+        expect(response).to include("220 Ready.\r\n")
+      end
+    end
+
+    context 'when @ftpbuff is empty and a single response arrives from the socket' do
+      before do
+        allow(socket).to receive(:get_once).and_return("220 (vsFTPd 2.3.4)\r\n", nil)
+      end
+
+      it 'returns the response from the socket normally' do
+        expect(instance.recv_ftp_resp(socket)).to eq("220 (vsFTPd 2.3.4)\r\n")
+      end
+    end
+
+    context 'when @ftpbuff holds a line left unterminated by a prior timeout mid multi-line response' do
+      before do
+        # First call: multi-line reply starts, then the socket goes idle mid-line.
+        # "220-more info" has no trailing \r\n -- it's an incomplete final line that
+        # was meant to be completed by bytes arriving on a later read.
+        allow(socket).to receive(:get_once).and_return("220-Welcome to vsftpd\r\n220-more info", nil)
+        instance.recv_ftp_resp(socket) # stashes the incomplete line in @ftpbuff, returns nil
+
+        # Second call: the rest of that same line, plus the terminator, arrives.
+        allow(socket).to receive(:get_once).and_return("rmation\r\n220 Ready.\r\n", nil)
+      end
+
+      it 'reassembles the split line without injecting a line break' do
+        response = instance.recv_ftp_resp(socket)
+        expect(response).to eq("220-Welcome to vsftpd\r\n220-more information\r\n220 Ready.\r\n")
+      end
+    end
+
+    context 'when FTPDEBUG is enabled' do
+      before do
+        allow(instance).to receive(:datastore).and_return('FTPDEBUG' => true)
+        allow(instance).to receive(:print_status)
+      end
+
+      context 'when the response comes from @ftpbuff' do
+        before do
+          instance.instance_variable_set(:@ftpbuff, "331 Please specify the password.\r\n")
+          allow(socket).to receive(:get_once).and_return(nil)
+        end
+
+        it 'prints FTP recv (buff): for the buffered response' do
+          instance.recv_ftp_resp(socket)
+          expect(instance).to have_received(:print_status).with('FTP recv (buff): "331 Please specify the password.\r\n"')
+        end
+      end
+
+      context 'when a burst delivers a surplus response alongside the first' do
+        before do
+          allow(socket).to receive(:get_once).and_return(
+            "220 (vsFTPd 2.3.4)\r\n331 Please specify the password.\r\n", nil
+          )
+        end
+
+        it 'prints FTP recv: for the returned response' do
+          instance.recv_ftp_resp(socket)
+          expect(instance).to have_received(:print_status).with('FTP recv: "220 (vsFTPd 2.3.4)\r\n"')
+        end
+
+        it 'prints FTP buff: for the surplus data' do
+          instance.recv_ftp_resp(socket)
+          expect(instance).to have_received(:print_status).with('FTP buff: "331 Please specify the password.\r\n"')
+        end
+
+        it 'prints FTP recv: before FTP buff:' do
+          order = []
+          allow(instance).to receive(:print_status) { |msg| order << msg }
+          instance.recv_ftp_resp(socket)
+          recv_idx = order.index { |m| m.start_with?('FTP recv:') }
+          buff_idx = order.index { |m| m.start_with?('FTP buff:') }
+          expect(recv_idx).to be < buff_idx
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/exploit/remote/ftp_recv_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ftp_recv_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'msf/core/exploit/remote/ftp'
 

--- a/spec/lib/msf/core/exploit/remote/ftp_recv_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ftp_recv_spec.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 
 require 'spec_helper'
 require 'msf/core/exploit/remote/ftp'


### PR DESCRIPTION
This has come from: https://github.com/rapid7/metasploit-framework/pull/21416 

Some FTP server/configurations may write multiple complete responses into a single TCP segment.
`recv_ftp_resp()` stores the response in `@ftpbuff`, and then returns the first response.  
On the next call to recv_ftp_resp(), it empty's @ftpbuff into `left`, but then called `get_once` unconditionally before inspecting `left`.
However, if the socket was idle at that point, get_once blocked until `ftp_timeout` expired and returned nil, thus dropping the buffered response.

This behaviour was seen with VSFTPD 2.3.4 in Metasploitable 2.

1.) `connect()` -> `recv_ftp_resp()` reads the 220 banner.
     The 331 response may arrive in the same TCP segment and is saved to `@ftpbuff`.
2.) `send_user()` sends `USER anonymous\r\n` -> `recv_ftp_resp()`
     `@ftpbuff` drains to `left`. 
     Socket is idle (server awaits `PASS`).
     `get_once` times out -> nil -> `connect_login()` fails on `/^(331|2)/` check.

Example: 

```console
$ ruby -r socket -e '
  [21, 2121].each do |port|
    begin
      s = TCPSocket.new("10.0.0.10", port)
      s.write("USER anonymous\r\n")
      sleep 0.1
      data = s.recv(4096)
      puts "Port #{port}: #{data.inspect}"
      s.close
    rescue => e
      puts "Port #{port}: #{e}"
    end
  end'
Port 21: "220 (vsFTPd 2.3.4)\r\n331 Please specify the password.\r\n"
Port 2121: "220 ProFTPD 1.3.1 Server (Debian) [::ffff:10.0.0.10]\r\n331 Password required for anonymous\r\n"
$
```     

## Demo

### Setup

_Will need to re-run this each time, isn't loop'd._

```console
$ ruby -r socket -e '
    s = TCPServer.new("127.0.0.1", 2121)
    puts "[i] Listening"
    c = s.accept
    c.write("220 vsFTPd 2.3.4\r\n331 Please specify the password.\r\n")
    puts "[+] Burst sent"
    sleep 5
    c.close'
[i] Listening
```

### Before

- Never sends `PASS [...]`

```console
$ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
$
$  ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ftp/ftp_anonymous;
set RHOSTS 127.0.0.1;
set RPORT 2121;
set FTPDEBUG true;
run'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 127.0.0.1
RPORT => 2121
FTPDEBUG => true
[*] 127.0.0.1:2121        - FTP recv: "220 vsFTPd 2.3.4\r\n"
[*] 127.0.0.1:2121        - FTP send: "USER anonymous\r\n"
[*] 127.0.0.1:2121        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_anonymous) >
```

### After

- Can see `331 [...]` & `PASS [...]`

```console
$ git status
On branch ftp_mixin2
Your branch is up to date with 'origin/ftp_mixin2'.

nothing to commit, working tree clean
$
$ ./msfconsole -q -x 'db_status; workspace -D; setg VERBOSE true;
use auxiliary/scanner/ftp/ftp_anonymous;
set RHOSTS 127.0.0.1;
set RPORT 2121;
set FTPDEBUG true;
run'
[*] Connected to msf. Connection type: postgresql.
[*] Deleted workspace: default
[*] Recreated the default workspace
VERBOSE => true
RHOSTS => 127.0.0.1
RPORT => 2121
FTPDEBUG => true
[*] 127.0.0.1:2121        - FTP recv: "220 vsFTPd 2.3.4\r\n"
[*] 127.0.0.1:2121        - FTP buff: "331 Please specify the password.\r\n"
[*] 127.0.0.1:2121        - FTP send: "USER anonymous\r\n"
[*] 127.0.0.1:2121        - FTP recv (buff): "331 Please specify the password.\r\n"
[*] 127.0.0.1:2121        - FTP send: "PASS mozilla@example.com\r\n"
[*] 127.0.0.1:2121        - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_anonymous) >
```