### PR TITLE
FTP mixin: Report if host is up but service doesn't match

### DIFF
--- a/lib/msf/core/exploit/remote/ftp.rb
+++ b/lib/msf/core/exploit/remote/ftp.rb
@@ -116,6 +116,20 @@ module Exploit::Remote::Ftp
 
         report_host({ host: rhost }.merge(os_info)) unless os_info.empty?
       end
+    else
+      report_service(
+        host: rhost,
+        port: rport,
+        proto: 'tcp',
+        name: 'unknown',
+        info: Rex::Text.to_hex_ascii((self.banner || @ftpbuff).to_s.strip).presence || 'Non-FTP service',
+        parents: {
+          host: rhost,
+          port: rport,
+          proto: 'tcp',
+          name: 'tcp'
+        }
+      )
     end
 
     # Return the file descriptor to the caller


### PR DESCRIPTION
This has come from: #21416

When `ftp_version` (or any module using the FTP mixin) connects to an open port that responds with a non-FTP banner, the greeting fails to match `/^(120|220)[\s-]/`.
Currently, the connection simply closes with nothing added to the workspace.

This uses `report_service()` to update the workspace with the unknown service (and also host).

## Demo

### Before

- Nothing recorded when a non-FTP service responds

```console
$ git status
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
$
$ ./msfconsole -q -x 'workspace -D;
use auxiliary/scanner/ftp/ftp_version;
set RHOSTS 10.0.0.10;
set RPORT 22;
run'
[*] Deleted workspace: default
[*] Recreated the default workspace
RHOSTS => 10.0.0.10
RPORT => 22
[*] 10.0.0.10:22          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_version) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  0      0         0      0      0      0

msf auxiliary(scanner/ftp/ftp_version) >
```

#### After

- Host and service recorded with banner info

```console
$ git status
On branch ftp_mixin3
Your branch is up to date with 'origin/ftp_mixin3'.

nothing to commit, working tree clean
$
$ ./msfconsole -q -x 'workspace -D;
use auxiliary/scanner/ftp/ftp_version;
set RHOSTS 10.0.0.10;
set RPORT 22;
run;'
[*] Deleted workspace: default
[*] Recreated the default workspace
RHOSTS => 10.0.0.10
RPORT => 22
[*] 10.0.0.10:22          - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/ftp/ftp_version) > workspace -v

Workspaces
==========

current  name     hosts  services  vulns  creds  loots  notes
-------  ----     -----  --------  -----  -----  -----  -----
*        default  1      2         0      0      0      0

msf auxiliary(scanner/ftp/ftp_version) > hosts

Hosts
=====

address    mac  name  os_name  os_flavor  os_sp  purpose  info  comments
-------    ---  ----  -------  ---------  -----  -------  ----  --------
10.0.0.10             Unknown                    device

msf auxiliary(scanner/ftp/ftp_version) > services
Services
========

host       port  proto  name     state  info             resource  parents
----       ----  -----  ----     -----  ----             --------  -------
10.0.0.10  22    tcp    unknown  open   Non-FTP service  {}        tcp (22/tcp)
10.0.0.10  22    tcp    tcp      open                    {}

msf auxiliary(scanner/ftp/ftp_version) >
```
