### PR TITLE
Fixed issue #21572 - Catch NoDatabaseError on msfconsole exit

### DIFF
--- a/lib/msf/core/db_manager/connection.rb
+++ b/lib/msf/core/db_manager/connection.rb
@@ -121,7 +121,7 @@ module Msf::DBManager::Connection
         # calling `verify!` instead will ensure we are connected even if `active?` incorrectly returns false
         ApplicationRecord.connection.verify!
       end
-    rescue ActiveRecord::ConnectionNotEstablished, PG::ConnectionBad => error
+    rescue ActiveRecord::ConnectionNotEstablished, ActiveRecord::NoDatabaseError, PG::ConnectionBad => error
       false
     end
   end


### PR DESCRIPTION
This PR adds `ActiveRecord::NoDatabaseError` to the list of rescued exceptions inside the `connection_established?` check in `lib/msf/core/db_manager/connection.rb`.

Currently, if a user starts `msfconsole`, brings up a Docker Postgres database, preps it with `msfdb init` (targeting the `postgres` database instead of `msf`), and then tries to `exit` the console, the console crashes. This happens because PR #21430 updated the connection check to use `ApplicationRecord.connection.verify!`. When the database server is reachable but the specifically configured `msf` database does not exist, `verify!` throws an `ActiveRecord::NoDatabaseError`. 

Since this exception inherits from `ActiveRecord::StatementInvalid` rather than `ActiveRecord::ConnectionNotEstablished`, it bypassed the existing exception handlers and completely crashed the teardown sequence. Catching this specific error allows `connection_established?` to gracefully return `false` just like it does for unreachable hosts, so the console exits cleanly.

**Related Issue:** 
Fixes #21572

## Breaking Changes

None

## Reviewer Notes

This patches an exception inheritance gap caused by the transition to `.verify!` in #21430.

## Verification Steps

1. Start `msfconsole`.
2. In a separate terminal, start the msf docker database: `sudo docker run --rm -d -p 127.0.0.1:5433:5432 -e POSTGRES_PASSWORD="mysecretpassword" postgres:14`
3. Prep the database pointing specifically to `/postgres`: `bundle exec ./msfdb init --connection-string="postgres://postgres:mysecretpassword@127.0.0.1:5433/postgres"`
4. Back in the open `msfconsole` session, run `exit`.
5. Verify that the console exits  instead of throwing a stack trace with `[-] Error while running command exit: We could not find your database: msf.`

## Test Evidence

**Before this fix:**
```
msf6 > exit
[-] Error while running command exit: We could not find your database: msf. Available database configurations can be found in config/database.yml.
...
Call stack:
...lib/active_record/connection_adapters/postgresql_adapter.rb:63:in `rescue in new_client'
```

**After this fix:**
```
msf6 > exit
```
*(Clean shutdown)*

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Linux |
| **Ruby Version** | 3.3.8 |
| **Target Software/Hardware** | Metasploit Framework / msfconsole |
| **Docker Image / Vagrant Setup** | postgres:14 |

## AI Usage Disclosure

This PR fix was done with the help of an AI coding agent to speed up the work

## Pre-Submission Checklist

- [x] Ran [`rubocop`](https://docs.metasploit.com/docs/development/quality/using-rubocop.html) on new files with no new offenses _(net new files only)_
- [ ] Ran [`msftidy`](https://docs.metasploit.com/docs/development/quality/msftidy.html) on changed module files with no new offenses _(modules only)_
- [ ] Ran [`msftidy_docs`](https://docs.metasploit.com/docs/development/quality/writing-module-documentation.html#before-you-submit-your-pr-msftidy_docsrb) on changed documentation files with no new offenses _(documentation files only)_
- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)