### PR TITLE
Add extra fields to MCP tools

### DIFF
--- a/lib/msf/core/mcp/metasploit/response_transformer.rb
+++ b/lib/msf/core/mcp/metasploit/response_transformer.rb
@@ -153,7 +153,9 @@ module Msf::MCP
             user: cred['user'],
             secret: cred['pass'],
             type: cred['type'],
-            updated_at: format_timestamp(cred['updated_at'])
+            updated_at: format_timestamp(cred['updated_at']),
+            realm_key: cred['realm_key'],
+            realm_value: cred['realm_value']
           }.compact
         end
       end

--- a/lib/msf/core/mcp/metasploit/response_transformer.rb
+++ b/lib/msf/core/mcp/metasploit/response_transformer.rb
@@ -89,18 +89,25 @@ module Msf::MCP
       def self.transform_services(response)
         return [] unless response.is_a?(Hash) && response['services'].is_a?(Array)
 
-        response['services'].map do |service|
-          {
-            host_address: service['host'],
-            created_at: format_timestamp(service['created_at']),
-            updated_at: format_timestamp(service['updated_at']),
-            port: service['port'],
-            protocol: service['proto'],
-            state: service['state'],
-            name: service['name'],
-            info: service['info'],
-          }.compact
-        end
+        response['services'].map { |service| transform_service(service) }
+      end
+
+      # Transform a single service, recursively transforming its parent services.
+      # @param service [Hash] Raw service data
+      # @return [Hash] Transformed service
+      def self.transform_service(service)
+        {
+          host_address: service['host'],
+          created_at: format_timestamp(service['created_at']),
+          updated_at: format_timestamp(service['updated_at']),
+          port: service['port'],
+          protocol: service['proto'],
+          state: service['state'],
+          name: service['name'],
+          info: service['info'],
+          resource: service['resource'],
+          parents: (service['parents'] || []).map { |parent| transform_service(parent) }
+        }.compact
       end
 
       # Transform vulnerabilities response
@@ -116,7 +123,8 @@ module Msf::MCP
             protocol: vuln['proto'],
             name: vuln['name'],
             references: parse_refs(vuln['refs']),
-            created_at: format_timestamp(vuln['time'])
+            created_at: format_timestamp(vuln['time']),
+            resource: vuln['resource']
           }.compact
         end
       end

--- a/lib/msf/core/mcp/tools/credential_info.rb
+++ b/lib/msf/core/mcp/tools/credential_info.rb
@@ -60,7 +60,9 @@ module Msf::MCP
                 user: { type: 'string' },
                 secret: { type: 'string' },
                 type: { type: 'string' },
-                updated_at: { type: 'string' }
+                updated_at: { type: 'string' },
+                realm_key: { type: 'string' },
+                realm_value: { type: 'string' }
               }
             }
           }

--- a/lib/msf/core/mcp/tools/note_info.rb
+++ b/lib/msf/core/mcp/tools/note_info.rb
@@ -74,7 +74,7 @@ module Msf::MCP
                 host: { type: 'string' },
                 service_name_or_port: { type: 'string' },
                 note_type: { type: 'string' },
-                data: { type: 'string' },
+                data: { type: ['object', 'string', 'null'] },
                 created_at: { type: 'string' }
               }
             }

--- a/lib/msf/core/mcp/tools/service_info.rb
+++ b/lib/msf/core/mcp/tools/service_info.rb
@@ -83,7 +83,9 @@ module Msf::MCP
                 protocol: { type: 'string' },
                 state: { type: 'string' },
                 name: { type: 'string' },
-                info: { type: 'string' }
+                info: { type: 'string' },
+                resource: { type: 'object' },
+                parents: { type: 'array', items: { type: 'object' } }
               }
             }
           }

--- a/lib/msf/core/mcp/tools/vulnerability_info.rb
+++ b/lib/msf/core/mcp/tools/vulnerability_info.rb
@@ -79,7 +79,8 @@ module Msf::MCP
                 protocol: { type: 'string' },
                 name: { type: 'string' },
                 references: { type: 'array', items: { type: 'string' } },
-                created_at: { type: 'string' }
+                created_at: { type: 'string' },
+                resource: { type: 'object' }
               }
             }
           }

--- a/spec/lib/msf/core/mcp/metasploit/response_transformer_spec.rb
+++ b/spec/lib/msf/core/mcp/metasploit/response_transformer_spec.rb
@@ -391,7 +391,9 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
             'user' => 'admin',
             'pass' => 'password123',
             'type' => 'password',
-            'updated_at' => 1609459200
+            'updated_at' => 1609459200,
+            'realm_key' => 'Active Directory Domain',
+            'realm_value' => 'msflab'
           }
         ]
       }
@@ -408,7 +410,9 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
         service_name: 'ssh',
         user: 'admin',
         secret: 'password123',
-        type: 'password'
+        type: 'password',
+        realm_key: 'Active Directory Domain',
+        realm_value: 'msflab'
       )
       expect(result[0][:updated_at]).to eq('2021-01-01T00:00:00Z')
     end

--- a/spec/lib/msf/core/mcp/metasploit/response_transformer_spec.rb
+++ b/spec/lib/msf/core/mcp/metasploit/response_transformer_spec.rb
@@ -363,6 +363,29 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
       # Note: 'critical' and 'seen' fields are not included in transform_notes output
     end
 
+    it 'passes through hash data unchanged' do
+      response = {
+        'notes' => [
+          {
+            'host' => '192.168.1.100',
+            'type' => 'host.comments',
+            'data' => { 'host_data' => 'This host is a honey pot' },
+            'time' => 1609459200
+          }
+        ]
+      }
+      result = described_class.transform_notes(response)
+
+      expect(result[0][:data]).to eq({ 'host_data' => 'This host is a honey pot' })
+    end
+
+    it 'handles nil data' do
+      response = { 'notes' => [{ 'host' => '192.168.1.1', 'type' => 'test', 'data' => nil }] }
+      result = described_class.transform_notes(response)
+
+      expect(result[0]).not_to have_key(:data)
+    end
+
     it 'handles nil input' do
       expect(described_class.transform_notes(nil)).to eq([])
     end

--- a/spec/lib/msf/core/mcp/metasploit/response_transformer_spec.rb
+++ b/spec/lib/msf/core/mcp/metasploit/response_transformer_spec.rb
@@ -247,6 +247,20 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
             'state' => 'open',
             'name' => 'http',
             'info' => 'Apache httpd 2.4.41',
+            'resource' => { 'path' => '/index.html' },
+            'parents' => [
+              {
+                'host' => '192.168.1.100',
+                'port' => 443,
+                'proto' => 'tcp',
+                'state' => 'open',
+                'name' => 'https',
+                'resource' => {},
+                'parents' => [],
+                'created_at' => 1609459200,
+                'updated_at' => 1640995200
+              }
+            ],
             'created_at' => 1609459200,
             'updated_at' => 1640995200
           }
@@ -264,8 +278,32 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
         protocol: 'tcp',
         state: 'open',
         name: 'http',
-        info: 'Apache httpd 2.4.41'
+        info: 'Apache httpd 2.4.41',
+        resource: { 'path' => '/index.html' }
       )
+    end
+
+    it 'recursively transforms parent services' do
+      result = described_class.transform_services(services_response)
+
+      parents = result[0][:parents]
+      expect(parents).to be_an(Array)
+      expect(parents.length).to eq(1)
+      expect(parents[0]).to include(
+        host_address: '192.168.1.100',
+        port: 443,
+        protocol: 'tcp',
+        name: 'https'
+      )
+      # nested parent has no parents of its own
+      expect(parents[0][:parents]).to eq([])
+    end
+
+    it 'defaults parents to an empty array when absent' do
+      response = { 'services' => [{ 'host' => '192.168.1.1', 'port' => 22, 'proto' => 'tcp' }] }
+      result = described_class.transform_services(response)
+
+      expect(result[0][:parents]).to eq([])
     end
 
     it 'handles nil input' do
@@ -288,6 +326,7 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
             'name' => 'MS17-010',
             'info' => 'SMB vulnerability',
             'refs' => 'CVE-2017-0144,MSB-2017-010',
+            'resource' => { 'dcerpc' => { 'pipe' => 'browser' } },
             'time' => 1609459200
           }
         ]
@@ -302,7 +341,8 @@ RSpec.describe Msf::MCP::Metasploit::ResponseTransformer do
         host: '192.168.1.100',
         port: 445,
         protocol: 'tcp',
-        name: 'MS17-010'
+        name: 'MS17-010',
+        resource: { 'dcerpc' => { 'pipe' => 'browser' } }
       )
       expect(result[0][:references]).to eq(['CVE-2017-0144', 'MSB-2017-010'])
       expect(result[0][:created_at]).to eq('2021-01-01T00:00:00Z')

--- a/spec/lib/msf/core/mcp/tools/credential_info_spec.rb
+++ b/spec/lib/msf/core/mcp/tools/credential_info_spec.rb
@@ -76,6 +76,8 @@ RSpec.describe Msf::MCP::Tools::CredentialInfo do
       expect(data_items[:user]).to eq({ type: 'string' })
       expect(data_items[:type]).to eq({ type: 'string' })
       expect(data_items[:updated_at]).to eq({ type: 'string' })
+      expect(data_items[:realm_key]).to eq({ type: 'string' })
+      expect(data_items[:realm_value]).to eq({ type: 'string' })
     end
   end
 

--- a/spec/lib/msf/core/mcp/tools/note_info_spec.rb
+++ b/spec/lib/msf/core/mcp/tools/note_info_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Msf::MCP::Tools::NoteInfo do
       expect(data_items[:host]).to eq({ type: 'string' })
       expect(data_items[:service_name_or_port]).to eq({ type: 'string' })
       expect(data_items[:note_type]).to eq({ type: 'string' })
-      expect(data_items[:data]).to eq({ type: 'string' })
+      expect(data_items[:data]).to eq({ type: ['object', 'string', 'null'] })
       expect(data_items[:created_at]).to eq({ type: 'string' })
     end
   end

--- a/spec/lib/msf/core/mcp/tools/service_info_spec.rb
+++ b/spec/lib/msf/core/mcp/tools/service_info_spec.rb
@@ -77,6 +77,8 @@ RSpec.describe Msf::MCP::Tools::ServiceInfo do
       expect(data_items[:host_address]).to eq({ type: 'string' })
       expect(data_items[:state]).to eq({ type: 'string' })
       expect(data_items[:info]).to eq({ type: 'string' })
+      expect(data_items[:resource]).to eq({ type: 'object' })
+      expect(data_items[:parents]).to eq({ type: 'array', items: { type: 'object' } })
     end
   end
 

--- a/spec/lib/msf/core/mcp/tools/vulnerability_info_spec.rb
+++ b/spec/lib/msf/core/mcp/tools/vulnerability_info_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Msf::MCP::Tools::VulnerabilityInfo do
       expect(data_items[:name]).to eq({ type: 'string' })
       expect(data_items[:references]).to eq({ type: 'array', items: { type: 'string' } })
       expect(data_items[:created_at]).to eq({ type: 'string' })
+      expect(data_items[:resource]).to eq({ type: 'object' })
     end
   end
 


### PR DESCRIPTION
## Description

This PR adds additional information to data returned through the MCP server. 

**Related Issue:** 
  * #21401
  * #21400
  * #21397


## Breaking Changes

This is not a breaking change.

## Reviewer Notes

## Verification Steps

1. - [ ] Configure the MCP server for a tool such as `claude` (the one used for testing
2. - [ ] Make sure there's some data in metasploit to query that shows the new fields
  * Run a module such as psexec that logs into something and registers a credential with an Active Directory domain
3. - [ ] Ask the LLM about AD credentials, e.g. "do I have any user credentials for the MSFLAB active directory domain?"
4. - [ ] Ask the LLM a question that uses the host data, e.g. "Are any windows hosts x64?"
5. - [ ] Ask the LLM a questoin about the host resources / services

Using claude code, you can use the Ctrl+O key to show the IO from the MCP tool which is useful to verify the shape of the data. You can also ask Claude to just verify the fields look right too.

## Test Evidence

*Test evidence includes tests for features that were dropped in this PR due to them being added in #21247.*

```
❯ What host is a honey pot?                                                                                                                                                                                                                                                               

  Called metasploit 2 times (ctrl+o to expand)
                                
● 192.168.159.132 (hostname ubuntu2404, Ubuntu 24.04) is the honey pot.

  Its host comment reads "This host is a honey pot", which is also recorded in a host.comments note. Worth treating it as a deception/monitoring trap — avoid interacting with it during engagements.

✻ Cogitated for 11s

❯ Do I have any user credentials for the MSFLAB active directory domain?                                                                                                                                                                                                                  

  Called metasploit (ctrl+o to expand)

● Yes — one credential matches the MSFLAB Active Directory domain:

  ┌──────────────┬──────────────────────────────────┐
  │    Field     │              Value               │
  ├──────────────┼──────────────────────────────────┤
  │ Username     │ smcintyre                        │
  ├──────────────┼──────────────────────────────────┤
  │ Password     │ Password1!                       │
  ├──────────────┼──────────────────────────────────┤
  │ Realm        │ msflab (Active Directory Domain) │
  ├──────────────┼──────────────────────────────────┤
  │ Host/Service │ 192.168.159.10 — smb/445 (tcp)   │
  └──────────────┴──────────────────────────────────┘

  Notes:
  - There's an identical credential stored with realm . (local/default realm) — same user/password against the same host.
  - There's also a smcintyre non-replayable hash ($6$..., a Linux SHA-512 crypt) with no realm — that's not an AD credential.

  So for the MSFLAB domain specifically, you have msflab\smcintyre : Password1!.

✻ Cooked for 8s

❯ Are any of the MS17-010 exploits noted as crash safe?                                                                                                                                                                                                                                   

  Called metasploit 3 times (ctrl+o to expand)

● No — neither MS17-010 exploit is noted as crash safe.

  Both exploit modules report Stability: ["unknown-stability"] in their notes metadata (no CRASH_SAFE flag on either):

  - exploit/windows/smb/ms17_010_eternalblue — Stability: unknown. Its description explicitly warns the opposite: "On some systems, this module may cause system instability and crashes, such as a BSOD or a reboot."
  - exploit/windows/smb/ms17_010_psexec (EternalRomance/Synergy/Champion) — Stability: unknown. Described as "more reliable than the EternalBlue exploit," but still not flagged crash safe.

  Practically, the psexec/EternalRomance chain is the safer of the two, but neither carries the CRASH_SAFE stability rating. Given the honey pot at 192.168.159.132, also worth noting these only matter for the Windows SMB targets anyway (e.g., the DC at 192.168.159.10).

✻ Worked for 16s

❯ Are any windows hosts x64?                                                                                                                                                                                                                                                              

● Yes. There's one Windows host, and it's x64:

  - 192.168.159.10 (DC) — Windows Server 2019, x64

  This comes from its host.os.session_fingerprint note (arch: x64). The only other host (192.168.159.132) is the Ubuntu honey pot.

✻ Baked for 7s

❯ Do I know of any services running on port 445?                                                                                                                                                                                                                                          

  Called metasploit (ctrl+o to expand)

● Yes — one SMB service on port 445:

  - 192.168.159.10 (DC) — 445/tcp open, smb
    - Info: "Module: exploit/windows/smb/psexec, last negotiated version: SMBv3 (dialect = 0x0311)"

  That's the Windows Server 2019 DC. SMBv3 (dialect 0x0311 = SMB 3.1.1) means it's a modern stack — consistent with it not being vulnerable to the MS17-010 exploits discussed earlier. You also have the msflab\smcintyre : Password1! credential for this same host/service if you need
  authenticated access.

✻ Cogitated for 8s
```

## Environment

I used a Windows Server 2019 as a target to populate some data, otherwise everything else was local using Claude Code.

## AI Usage Disclosure

Of course I used claude code to perform the tests. I also used claude to update the specs as necessary.



## Pre-Submission Checklist

- [x] Ran [`rubocop`](https://docs.metasploit.com/docs/development/quality/using-rubocop.html) on new files with no new offenses _(net new files only)_
- [x] Ran [`msftidy`](https://docs.metasploit.com/docs/development/quality/msftidy.html) on changed module files with no new offenses _(modules only)_
- [x] Ran [`msftidy_docs`](https://docs.metasploit.com/docs/development/quality/writing-module-documentation.html#before-you-submit-your-pr-msftidy_docsrb) on changed documentation files with no new offenses _(documentation files only)_
- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

