### PR TITLE
Add CSR tracing to CertificateTrace for AD CS enrollment

### DIFF
--- a/lib/msf/core/exploit/remote/cert_request.rb
+++ b/lib/msf/core/exploit/remote/cert_request.rb
@@ -120,6 +120,10 @@ module Msf
     def with_adcs_certificate_request(opts, &block)
       csr, private_key, attributes = create_csr(opts)
 
+      # When the including module also mixes in Exploit::Remote::CertificateTrace
+      # and tracing is enabled, surface the CSR before it leaves the host.
+      certificate_csr_trace(csr, attributes) if respond_to?(:certificate_csr_trace)
+
       vprint_status('Submitting the certificate signing request to the target...')
       certificate = block.call(csr, attributes)
       return unless certificate

--- a/lib/msf/core/exploit/remote/certificate_trace.rb
+++ b/lib/msf/core/exploit/remote/certificate_trace.rb
@@ -62,6 +62,35 @@ module Msf
       print_line(certificate_trace_colorize(output))
     end
 
+    # Dispatches a certificate signing request (CSR) trace at the configured
+    # verbosity level, mirroring #certificate_trace for the request side of an
+    # enrollment (e.g. AD CS / MS-ICPR). Intended to be called with the CSR and
+    # enrollment attributes just before the request is submitted to the CA.
+    #
+    # @param csr [OpenSSL::X509::Request, String, #to_der]
+    # @param attributes [Hash] enrollment request attributes (e.g.
+    #   'CertificateTemplate', 'SAN') as returned by CertRequest#create_csr
+    # @return [void]
+    def certificate_csr_trace(csr, attributes = {})
+      return unless certificate_trace_enabled?
+
+      mode = datastore['CertificateTrace']
+      presenter = Msf::Trace::CertificateTracePresenter.new
+
+      output = case mode
+               when 'metadata'
+                 presenter.to_s_csr_metadata(csr)
+               when 'full'
+                 presenter.to_s_csr_full(csr, attributes)
+               else
+                 vprint_warning("Unknown CertificateTrace mode: #{mode}")
+                 nil
+               end
+      return unless output
+
+      print_line(certificate_trace_colorize(output))
+    end
+
     private
 
     # Wraps +text+ in the configured certificate trace color escape sequences.

--- a/lib/msf/core/exploit/remote/certificate_trace.rb
+++ b/lib/msf/core/exploit/remote/certificate_trace.rb
@@ -77,10 +77,14 @@ module Msf
       mode = datastore['CertificateTrace']
       presenter = Msf::Trace::CertificateTracePresenter.new
 
-      output = if mode == 'metadata'
+      output = case mode
+               when 'metadata'
                  presenter.to_s_csr_metadata(csr)
-               else
+               when 'full'
                  presenter.to_s_csr_full(csr, attributes)
+               else
+                 vprint_warning("Unknown CertificateTrace mode: #{mode}")
+                 nil
                end
       return unless output
 

--- a/lib/msf/core/exploit/remote/certificate_trace.rb
+++ b/lib/msf/core/exploit/remote/certificate_trace.rb
@@ -77,14 +77,10 @@ module Msf
       mode = datastore['CertificateTrace']
       presenter = Msf::Trace::CertificateTracePresenter.new
 
-      output = case mode
-               when 'metadata'
+      output = if mode == 'metadata'
                  presenter.to_s_csr_metadata(csr)
-               when 'full'
-                 presenter.to_s_csr_full(csr, attributes)
                else
-                 vprint_warning("Unknown CertificateTrace mode: #{mode}")
-                 nil
+                 presenter.to_s_csr_full(csr, attributes)
                end
       return unless output
 

--- a/lib/msf/core/trace/certificate_trace_presenter.rb
+++ b/lib/msf/core/trace/certificate_trace_presenter.rb
@@ -16,6 +16,13 @@ module Msf
     #   presenter = Msf::Trace::CertificateTracePresenter.new(cert)
     #   mod.print_line(presenter.to_s_metadata)
     #   mod.print_line(presenter.to_s_full)
+    #
+    #   # CSR mode - present a certificate signing request before it is submitted
+    #   # (e.g. the AD CS / MS-ICPR enrollment flow). +attributes+ is the enrollment
+    #   # attribute hash returned alongside the CSR by CertRequest#create_csr.
+    #   presenter = Msf::Trace::CertificateTracePresenter.new
+    #   mod.print_line(presenter.to_s_csr_metadata(csr))
+    #   mod.print_line(presenter.to_s_csr_full(csr, attributes))
     class CertificateTracePresenter
 
       SEPARATOR = ('[CertificateTrace] ' + ('-' * 38)).freeze
@@ -88,8 +95,26 @@ module Msf
         nil
       end
 
-      # @param cert [OpenSSL::X509::Certificate, OpenSSL::PKCS12, String]
-      def initialize(cert)
+      # Attempt to coerce input into an OpenSSL::X509::Request (CSR).
+      # Accepts a live request object (the type CertRequest#create_csr returns is
+      # a plain OpenSSL::X509::Request) or raw DER/PEM bytes. Anything else - for
+      # example the CMC ContentInfo wrapper produced for on-behalf-of enrollments -
+      # is returned as nil so the caller silently skips the trace.
+      #
+      # @param csr [OpenSSL::X509::Request, String, #to_der]
+      # @return [OpenSSL::X509::Request, nil]
+      def self.coerce_csr(csr)
+        return csr if csr.is_a?(OpenSSL::X509::Request)
+        return OpenSSL::X509::Request.new(csr) if csr.is_a?(String)
+        return OpenSSL::X509::Request.new(csr.to_der) if csr.respond_to?(:to_der)
+
+        nil
+      rescue OpenSSL::X509::RequestError, OpenSSL::ASN1::ASN1Error
+        nil
+      end
+
+      # @param cert [OpenSSL::X509::Certificate, OpenSSL::PKCS12, String, nil]
+      def initialize(cert = nil)
         @cert = self.class.coerce(cert)
       end
 
@@ -152,7 +177,104 @@ module Msf
         lines.join("\n")
       end
 
+      # Returns a formatted CSR metadata string: subject, public key, signature
+      # algorithm. Mirrors #to_s_metadata for the request side of an enrollment.
+      #
+      # @param csr [OpenSSL::X509::Request, String, #to_der]
+      # @return [String, nil] nil if the CSR could not be parsed
+      def to_s_csr_metadata(csr)
+        csr = self.class.coerce_csr(csr)
+        return nil unless csr
+
+        lines = [SEPARATOR, "  CSR Subject : #{csr.subject}"]
+
+        public_key = csr_public_key(csr)
+        lines << "  CSR Pub Key : #{format_public_key(public_key)}" if public_key
+
+        sig_alg = csr_signature_algorithm(csr)
+        lines << "  CSR Sig Alg : #{sig_alg}" if sig_alg
+
+        lines.join("\n")
+      rescue StandardError
+        nil
+      end
+
+      # Returns a formatted full CSR string: metadata plus the requested template
+      # and SAN (taken from the enrollment +attributes+ hash) and any extensions
+      # carried in the CSR's PKCS#9 extensionRequest attribute.
+      #
+      # @param csr [OpenSSL::X509::Request, String, #to_der]
+      # @param attributes [Hash] enrollment request attributes from
+      #   CertRequest#create_csr (e.g. 'CertificateTemplate', 'SAN')
+      # @return [String, nil] nil if the CSR could not be parsed
+      def to_s_csr_full(csr, attributes = {})
+        csr = self.class.coerce_csr(csr)
+        base = to_s_csr_metadata(csr)
+        return nil unless base
+
+        attributes ||= {}
+        lines = [base]
+
+        template = attributes['CertificateTemplate'] || attributes[:CertificateTemplate]
+        lines << "  Req Template : #{template}" if template
+
+        san = attributes['SAN'] || attributes[:SAN]
+        lines << "  Req SAN      : #{san}" if san
+
+        # subjectAltName is already surfaced above as the friendly "Req SAN" line;
+        # drop it from the raw dump so we don't repeat it as an opaque hex blob.
+        extensions = csr_extensions(csr).reject { |e| e.oid == 'subjectAltName' }
+        if extensions.any?
+          lines << '  Req Extns    :'
+          extensions.each do |e|
+            label = EXTENSION_OID_NAMES[normalize_oid(e.oid)] || e.oid
+            lines << "    #{label} : #{format_extension(e)}"
+          end
+        end
+
+        lines.join("\n")
+      end
+
       private
+
+      # @param csr [OpenSSL::X509::Request]
+      # @return [OpenSSL::PKey::PKey, nil]
+      def csr_public_key(csr)
+        csr.public_key
+      rescue StandardError
+        nil
+      end
+
+      # @param csr [OpenSSL::X509::Request]
+      # @return [String, nil]
+      def csr_signature_algorithm(csr)
+        csr.signature_algorithm
+      rescue StandardError
+        nil
+      end
+
+      # Extract the X.509v3 extensions a CSR requests via its PKCS#9
+      # extensionRequest attribute (OpenSSL::X509::Request exposes no #extensions
+      # of its own). The attribute value is a SET containing a SEQUENCE OF
+      # Extension; rebuild each as an OpenSSL::X509::Extension so the shared
+      # #format_extension / EXTENSION_OID_NAMES handling applies unchanged.
+      #
+      # @param csr [OpenSSL::X509::Request]
+      # @return [Array<OpenSSL::X509::Extension>]
+      def csr_extensions(csr)
+        return [] unless csr.respond_to?(:attributes)
+
+        ext_req = csr.attributes.find { |a| %w[extReq extensionRequest].include?(a.oid) }
+        return [] unless ext_req
+
+        ext_req.value.value.flat_map do |seq|
+          next [] unless seq.respond_to?(:value) && seq.value.is_a?(Array)
+
+          seq.value.map { |ext_asn1| OpenSSL::X509::Extension.new(ext_asn1.to_der) }
+        end
+      rescue StandardError
+        []
+      end
 
       def subject_cn
         @cert.subject.to_a.find { |name, _, _| name == 'CN' }&.dig(1)

--- a/lib/msf/core/trace/certificate_trace_presenter.rb
+++ b/lib/msf/core/trace/certificate_trace_presenter.rb
@@ -25,7 +25,7 @@ module Msf
     #   mod.print_line(presenter.to_s_csr_full(csr, attributes))
     class CertificateTracePresenter
 
-      SEPARATOR = ('[CertificateTrace] ' + ('-' * 38)).freeze
+      SEPARATOR_WIDTH = 57 # '[CertificateTrace] ' (19) + 38 dashes, preserved
 
       # OIDs surfaced as named fields in to_s_full; excluded from the raw extension dump.
       NAMED_OIDS = %w[subjectAltName extendedKeyUsage keyUsage].freeze
@@ -127,7 +127,7 @@ module Msf
         fingerprint = OpenSSL::Digest::SHA256.hexdigest(@cert.to_der)
 
         [
-          SEPARATOR,
+          trace_separator('x.509'),
           "  Subject    : #{@cert.subject}",
           "  Issuer     : #{@cert.issuer}",
           "  Not Before : #{@cert.not_before}",
@@ -186,13 +186,13 @@ module Msf
         csr = self.class.coerce_csr(csr)
         return nil unless csr
 
-        lines = [SEPARATOR, "  CSR Subject : #{csr.subject}"]
+        lines = [trace_separator('CSR'), "  Subject    : #{csr.subject}"]
 
         public_key = csr_public_key(csr)
-        lines << "  CSR Pub Key : #{format_public_key(public_key)}" if public_key
+        lines << "  Public Key : #{format_public_key(public_key)}" if public_key
 
         sig_alg = csr_signature_algorithm(csr)
-        lines << "  CSR Sig Alg : #{sig_alg}" if sig_alg
+        lines << "  Sig Alg    : #{sig_alg}" if sig_alg
 
         lines.join("\n")
       rescue StandardError
@@ -444,6 +444,11 @@ module Msf
         s = s.b.force_encoding('UTF-8')
         s = s.scrub('?') unless s.valid_encoding?
         s.delete("\u0000")
+      end
+
+      def trace_separator(label)
+        prefix = "[CertificateTrace] #{label} "
+        prefix + ('-' * [SEPARATOR_WIDTH - prefix.length, 0].max)
       end
 
       def format_public_key(pk)

--- a/spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb
@@ -181,4 +181,57 @@ RSpec.describe Msf::Exploit::Remote::CertificateTrace do
       end
     end
   end
+
+  describe '#certificate_csr_trace' do
+    let(:csr) do
+      req = OpenSSL::X509::Request.new
+      req.subject = OpenSSL::X509::Name.parse('/CN=Administrator')
+      req.public_key = key.public_key
+      req.sign(key, OpenSSL::Digest::SHA256.new)
+      req
+    end
+
+    context 'when tracing is off' do
+      it 'produces no output' do
+        subject.datastore['CertificateTrace'] = 'off'
+        expect(subject).not_to receive(:print_line)
+        subject.certificate_csr_trace(csr)
+      end
+    end
+
+    context 'when mode is metadata' do
+      before { subject.datastore['CertificateTrace'] = 'metadata' }
+
+      it 'prints a line containing [CertificateTrace]' do
+        expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+        subject.certificate_csr_trace(csr)
+      end
+    end
+
+    context 'when mode is full' do
+      before { subject.datastore['CertificateTrace'] = 'full' }
+
+      it 'prints a line containing [CertificateTrace]' do
+        expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+        subject.certificate_csr_trace(csr)
+      end
+    end
+
+    context 'when mode is unknown' do
+      it 'emits a warning and produces no output' do
+        subject.datastore.update_value('CertificateTrace', 'bogus')
+        expect(subject).not_to receive(:print_line)
+        expect(subject).to receive(:vprint_warning).with(include('bogus'))
+        subject.certificate_csr_trace(csr)
+      end
+    end
+
+    context 'with an invalid CSR' do
+      it 'produces no output and does not raise' do
+        subject.datastore['CertificateTrace'] = 'full'
+        expect(subject).not_to receive(:print_line)
+        expect { subject.certificate_csr_trace('not a csr') }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
+++ b/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
@@ -400,4 +400,124 @@ RSpec.describe Msf::Trace::CertificateTracePresenter do
       end
     end
   end
+
+  # ── CSR presentation ─────────────────────────────────────────────────────────
+  # A real certificate signing request built through the same helper the
+  # MS-ICPR / AD CS enrollment flow uses (Rex::Proto::X509::Request.build_csr),
+  # carrying a UPN SAN and an application-policy (EKU) extension.
+  describe 'CSR presentation' do
+    let(:csr) do
+      Rex::Proto::X509::Request.build_csr(
+        cn: 'Administrator',
+        private_key: key,
+        dns: 'dc.contoso.local',
+        msext_upn: 'administrator@contoso.local',
+        algorithm: 'SHA256',
+        application_policies: ['1.3.6.1.5.5.7.3.2']
+      )
+    end
+
+    let(:attributes) do
+      { 'CertificateTemplate' => 'User', 'SAN' => 'dns=dc.contoso.local&upn=administrator@contoso.local' }
+    end
+
+    describe '.coerce_csr' do
+      it 'passes through an existing OpenSSL::X509::Request unchanged' do
+        expect(described_class.coerce_csr(csr)).to equal(csr)
+      end
+
+      it 'coerces DER bytes to an OpenSSL::X509::Request' do
+        expect(described_class.coerce_csr(csr.to_der)).to be_a(OpenSSL::X509::Request)
+      end
+
+      it 'returns nil for invalid input' do
+        expect(described_class.coerce_csr('not a csr')).to be_nil
+      end
+
+      it 'returns nil for an unrelated object' do
+        expect(described_class.coerce_csr(Object.new)).to be_nil
+      end
+    end
+
+    describe '#to_s_csr_metadata' do
+      subject { described_class.new.to_s_csr_metadata(csr) }
+
+      it 'includes the CertificateTrace separator' do
+        expect(subject).to include('[CertificateTrace]')
+      end
+
+      it 'includes the CSR subject' do
+        expect(subject).to include('CSR Subject')
+        expect(subject).to include('Administrator')
+      end
+
+      it 'renders the public key as algorithm and bit size, not raw PEM' do
+        expect(subject).to include('CSR Pub Key')
+        expect(subject).to include('RSA-2048')
+        expect(subject).not_to include('-----BEGIN')
+      end
+
+      it 'includes the signature algorithm' do
+        expect(subject).to include('CSR Sig Alg')
+      end
+
+      it 'accepts DER bytes without raising' do
+        expect { described_class.new.to_s_csr_metadata(csr.to_der) }.not_to raise_error
+      end
+
+      it 'returns nil when the CSR cannot be parsed' do
+        expect(described_class.new.to_s_csr_metadata('garbage')).to be_nil
+      end
+
+      it 'returns nil for a nil CSR' do
+        expect(described_class.new.to_s_csr_metadata(nil)).to be_nil
+      end
+    end
+
+    describe '#to_s_csr_full' do
+      subject { described_class.new.to_s_csr_full(csr, attributes) }
+
+      it 'includes everything from metadata' do
+        expect(subject).to include('CSR Subject')
+        expect(subject).to include('RSA-2048')
+      end
+
+      it 'includes the requested certificate template from attributes' do
+        expect(subject).to include('Req Template')
+        expect(subject).to include('User')
+      end
+
+      it 'includes the requested SAN from attributes' do
+        expect(subject).to include('Req SAN')
+        expect(subject).to include('administrator@contoso.local')
+      end
+
+      it 'decodes the requested application-policy extension to a friendly EKU label' do
+        expect(subject).to include('Req Extns')
+        expect(subject).to include('1.3.6.1.5.5.7.3.2 (Client Authentication)')
+      end
+
+      it 'does not emit non-printable bytes in the requested-extensions block' do
+        ext_lines = subject.lines.select { |l| l.start_with?('    ') }.map(&:chomp).join
+        expect(ext_lines).not_to match(/[^[:print:]\t]/)
+      end
+
+      it 'does not repeat subjectAltName as a raw hex blob in the extensions block' do
+        ext_lines = subject.lines.select { |l| l.start_with?('    ') }.join
+        expect(ext_lines).not_to include('subjectAltName')
+      end
+
+      it 'omits the template line when attributes carry no template' do
+        expect(described_class.new.to_s_csr_full(csr, {})).not_to include('Req Template')
+      end
+
+      it 'tolerates a nil attributes hash' do
+        expect { described_class.new.to_s_csr_full(csr, nil) }.not_to raise_error
+      end
+
+      it 'returns nil when the CSR cannot be parsed' do
+        expect(described_class.new.to_s_csr_full('garbage', attributes)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
+++ b/spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb
@@ -80,8 +80,8 @@ RSpec.describe Msf::Trace::CertificateTracePresenter do
       expect(subject).to be_a(String)
     end
 
-    it 'includes the separator' do
-      expect(subject).to include('[CertificateTrace]')
+    it 'includes the x.509-labelled separator' do
+      expect(subject).to include('[CertificateTrace] x.509')
     end
 
     it 'includes subject' do
@@ -442,23 +442,23 @@ RSpec.describe Msf::Trace::CertificateTracePresenter do
     describe '#to_s_csr_metadata' do
       subject { described_class.new.to_s_csr_metadata(csr) }
 
-      it 'includes the CertificateTrace separator' do
-        expect(subject).to include('[CertificateTrace]')
+      it 'includes the CSR-labelled separator' do
+        expect(subject).to include('[CertificateTrace] CSR')
       end
 
       it 'includes the CSR subject' do
-        expect(subject).to include('CSR Subject')
+        expect(subject).to include('Subject')
         expect(subject).to include('Administrator')
       end
 
       it 'renders the public key as algorithm and bit size, not raw PEM' do
-        expect(subject).to include('CSR Pub Key')
+        expect(subject).to include('Public Key')
         expect(subject).to include('RSA-2048')
         expect(subject).not_to include('-----BEGIN')
       end
 
       it 'includes the signature algorithm' do
-        expect(subject).to include('CSR Sig Alg')
+        expect(subject).to include('Sig Alg')
       end
 
       it 'accepts DER bytes without raising' do
@@ -478,7 +478,7 @@ RSpec.describe Msf::Trace::CertificateTracePresenter do
       subject { described_class.new.to_s_csr_full(csr, attributes) }
 
       it 'includes everything from metadata' do
-        expect(subject).to include('CSR Subject')
+        expect(subject).to include('Subject')
         expect(subject).to include('RSA-2048')
       end
 


### PR DESCRIPTION
## Summary

Follow-up to #21198. That PR landed the \`CertificateTracePresenter\` and the \`CertificateTrace\` option, but the \`csr\` mode was dropped before merge (commit \`697ed9be44\`) because nothing passed a real CSR to the presenter the enum value just fell through to \`to_s_full\`.

A real CSR **is** available in the AD CS / MS-ICPR enrollment flow (\`CertRequest#create_csr\`), so this PR restores CSR printing and wires it into that path. When \`CertificateTrace\` is enabled on \`icpr_cert\` (which already mixes in \`CertificateTrace\`), the request-signing certificate is now surfaced before it is submitted to the CA.

## What's included

- **\`CertificateTracePresenter\`**: \`to_s_csr_metadata\` / \`to_s_csr_full\` (plus a \`coerce_csr\` helper). The full mode reuses the existing extension formatters to decode the requested certificate template, SAN, and application-policy (EKU) OIDs. The cert path is unchanged.
- **\`Exploit::Remote::CertificateTrace#certificate_csr_trace\`**: mirrors \`certificate_trace\`, honoring the existing \`off\` / \`metadata\` / \`full\` verbosity modes and the \`CertificateTraceColors\` option. Unknown modes emit \`vprint_warning\` and produce no output (same behaviour as \`certificate_trace\`).
- **\`CertRequest#with_adcs_certificate_request\`**: emits the CSR trace just before submission, guarded by \`respond_to?(:certificate_csr_trace)\` so \`CertRequest\` stays independent of the trace mixin.
- \`SEPARATOR\` constant replaced with \`SEPARATOR_WIDTH\` + \`trace_separator(label)\` so the separator header identifies the block type (\`CSR\` or \`x.509\`).
- Specs for CSR coercion, metadata/full rendering, and \`certificate_csr_trace\` dispatch (off/metadata/full/unknown/invalid-input).

## Sample output

\`CertificateTrace metadata\` against a live AD CS enrollment:

```
[CertificateTrace] CSR ----------------------------------
  Subject    : /CN=labuser
  Public Key : RSA-2048
  Sig Alg    : sha256WithRSAEncryption
[+] The requested certificate was issued.
[CertificateTrace] x.509 --------------------------------
  Subject    : /DC=issue/DC=kerberos/CN=Users/CN=labuser
  Issuer     : /DC=issue/DC=kerberos/CN=kerberos-DC1-CA
  Not Before : 2026-06-26 06:18:47 UTC
  Not After  : 2027-06-26 06:18:47 UTC
  SHA-256    : a6c618026ff56312ac9ccff0830d10caba7d3b1a4fc86a796f14ff96cf43575e
```

\`CertificateTrace full\` additionally shows \`Req Template\`, \`Req SAN\`, requested extensions, and the full x.509 detail block. \`CertificateTrace off\` produces no output.

## Verification steps

1. [x] \`bundle exec rspec spec/lib/msf/core/trace/certificate_trace_presenter_spec.rb\` - 73 examples, 0 failures
2. [x] \`bundle exec rspec spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb\` - 34 examples, 0 failures (includes \`certificate_csr_trace\` off/metadata/full/unknown/invalid coverage)
3. [x] \`use auxiliary/admin/dcerpc/icpr_cert\` against a live Windows Server 2022 AD CS CA with \`CertificateTrace full\` - CSR block printed before issued certificate (see lab validation comment below)
4. [x] \`CertificateTrace metadata\` prints only subject, public key, and signature algorithm
5. [x] \`CertificateTrace off\` produces no output