### PR TITLE
Add Splunk PostgreSQL sidecar unauthenticated file operation scanner (CVE-2026-20253)

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.md
@@ -15,19 +15,19 @@ execution via PostgreSQL's `lo_export`.
 
 Affected versions:
 
-- **10.0.0 – 10.0.6** (fixed in **10.0.7**)
-- **10.2.0 – 10.2.3** (fixed in **10.2.4**)
+- **10.0.0 - 10.0.6** (fixed in **10.0.7**)
+- **10.2.0 - 10.2.3** (fixed in **10.2.4**)
 - 10.4.0 and later are not affected; Splunk Cloud Platform is not affected.
 
-This module is **detection only** — it mirrors the public watchTowr detection
+This module is **detection only** -- it mirrors the public watchTowr detection
 artifact and never creates, truncates, or reads a file. It sends a POST to the
 recovery endpoint with a non-Splunk (Basic) `Authorization` header:
 
 - An affected build passes its (absent) authorization check and fails to decode
-  the empty body → **HTTP 400 `Failed to decode request`** → reported vulnerable.
-- A patched build rejects the Basic header → **HTTP 401 `Authorization header
-  must use Splunk token`** → reported not vulnerable.
-- Any other response → the sidecar endpoint is not present (not vulnerable, or
+  the empty body -> **HTTP 400 `Failed to decode request`** -> reported vulnerable.
+- A patched build rejects the Basic header -> **HTTP 401 `Authorization header
+  must use Splunk token`** -> reported not vulnerable.
+- Any other response -> the sidecar endpoint is not present (not vulnerable, or
   not Splunk Web).
 
 The Basic header is required: an unauthenticated request returns HTTP 401 on both
@@ -72,7 +72,7 @@ The locale segment Splunk Web places in its URLs (e.g. `en-US`, `en-GB`). The
 recovery endpoint is reached through `/<locale>/splunkd/__raw/...`. Default:
 `en-US`.
 
-## Scenario
+## Scenarios
 
 ```
 msf6 auxiliary(scanner/http/splunk_postgres_sidecar_scanner) > set RHOSTS 127.0.0.1

--- a/documentation/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.md
@@ -79,7 +79,7 @@ msf6 auxiliary(scanner/http/splunk_postgres_sidecar_scanner) > set RHOSTS 127.0.
 msf6 auxiliary(scanner/http/splunk_postgres_sidecar_scanner) > set RPORT 8000
 msf6 auxiliary(scanner/http/splunk_postgres_sidecar_scanner) > run
 
-[+] 127.0.0.1:8000 - Vulnerable: the PostgreSQL sidecar recovery endpoint accepted an unauthenticated request (CVE-2026-20253)
+[+] 127.0.0.1:8000 - Vulnerable: a non-Splunk Basic credential bypassed authorization on the PostgreSQL sidecar recovery endpoint (CVE-2026-20253)
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 ```

--- a/documentation/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.md
+++ b/documentation/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.md
@@ -1,0 +1,91 @@
+## Vulnerable Application
+
+[Splunk Enterprise](https://www.splunk.com/) 10.x ships a PostgreSQL "sidecar"
+service that backs the Edge Processor, OpAmp, and SPL2 data-pipeline features. A
+recovery endpoint exposed by that service through Splunk Web,
+
+```
+POST /<locale>/splunkd/__raw/v1/postgres/recovery/backup
+```
+
+performs **no authorization** ([CVE-2026-20253](https://advisory.splunk.com/advisories/SVD-2026-0603),
+CVSS 9.8, CWE-306). An unauthenticated attacker can invoke arbitrary file
+create/truncate operations, which researchers have chained to remote code
+execution via PostgreSQL's `lo_export`.
+
+Affected versions:
+
+- **10.0.0 – 10.0.6** (fixed in **10.0.7**)
+- **10.2.0 – 10.2.3** (fixed in **10.2.4**)
+- 10.4.0 and later are not affected; Splunk Cloud Platform is not affected.
+
+This module is **detection only** — it mirrors the public watchTowr detection
+artifact and never creates, truncates, or reads a file. It sends a POST to the
+recovery endpoint with a non-Splunk (Basic) `Authorization` header:
+
+- An affected build passes its (absent) authorization check and fails to decode
+  the empty body → **HTTP 400 `Failed to decode request`** → reported vulnerable.
+- A patched build rejects the Basic header → **HTTP 401 `Authorization header
+  must use Splunk token`** → reported not vulnerable.
+- Any other response → the sidecar endpoint is not present (not vulnerable, or
+  not Splunk Web).
+
+The Basic header is required: an unauthenticated request returns HTTP 401 on both
+affected and patched builds, so it does not discriminate.
+
+### Setup with Docker
+
+Splunk Enterprise 10.x bundles the PostgreSQL sidecar in the official image; no
+extra configuration is needed to reproduce the endpoint.
+
+Vulnerable:
+
+```
+docker run -d --name splunk-vuln -p 8000:8000 \
+  -e SPLUNK_GENERAL_TERMS=--accept-sgt-current-at-splunk-com \
+  -e SPLUNK_START_ARGS=--accept-license \
+  -e SPLUNK_PASSWORD=Changeme123 \
+  splunk/splunk:10.2.3
+```
+
+Patched (for the negative case): same command with `splunk/splunk:10.2.4`.
+
+## Verification Steps
+
+1. Start `msfconsole`.
+2. `use auxiliary/scanner/http/splunk_postgres_sidecar_scanner`
+3. `set RHOSTS <target>`
+4. (If Splunk Web is HTTPS) `set SSL true` and adjust `RPORT`.
+5. `run`
+6. A vulnerable host prints a `[+]` and a reported vuln; a patched host prints a
+   `[*] Not vulnerable` status.
+
+## Options
+
+### TARGETURI
+
+The base path to Splunk Web. Default: `/`.
+
+### LOCALE
+
+The locale segment Splunk Web places in its URLs (e.g. `en-US`, `en-GB`). The
+recovery endpoint is reached through `/<locale>/splunkd/__raw/...`. Default:
+`en-US`.
+
+## Scenario
+
+```
+msf6 auxiliary(scanner/http/splunk_postgres_sidecar_scanner) > set RHOSTS 127.0.0.1
+msf6 auxiliary(scanner/http/splunk_postgres_sidecar_scanner) > set RPORT 8000
+msf6 auxiliary(scanner/http/splunk_postgres_sidecar_scanner) > run
+
+[+] 127.0.0.1:8000 - Vulnerable: the PostgreSQL sidecar recovery endpoint accepted an unauthenticated request (CVE-2026-20253)
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+Against a patched (10.2.4) instance:
+
+```
+[*] 127.0.0.1:8000 - Not vulnerable: the recovery endpoint requires a Splunk token (patched)
+```

--- a/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.rb
+++ b/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
-    if res.code == 400 && res.body.to_s.include?('Failed to decode')
+    if res.code == 400 && res.body.to_s.include?('Failed to decode request')
       print_good("#{peer} - Vulnerable: the PostgreSQL sidecar recovery endpoint accepted an unauthenticated request (CVE-2026-20253)")
       report_vuln(
         host: rhost,
@@ -93,7 +93,7 @@ class MetasploitModule < Msf::Auxiliary
         info: 'Unauthenticated access to /splunkd/__raw/v1/postgres/recovery/backup (HTTP 400 "Failed to decode request")',
         refs: references
       )
-    elsif res.code == 401
+    elsif res.code == 401 && res.body.to_s.include?('Splunk token')
       print_status("#{peer} - Not vulnerable: the recovery endpoint requires a Splunk token (patched)")
     else
       vprint_status("#{peer} - PostgreSQL sidecar recovery endpoint not detected (HTTP #{res.code}); likely not installed or not Splunk Web")

--- a/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.rb
+++ b/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.rb
@@ -1,0 +1,102 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Splunk Enterprise PostgreSQL Sidecar Unauthenticated File Operation Scanner',
+        'Description' => %q{
+          This module detects Splunk Enterprise servers affected by
+          CVE-2026-20253. Splunk Enterprise 10.x ships a PostgreSQL "sidecar"
+          service (used by Edge Processor, OpAmp, and SPL2 data pipelines) whose
+          recovery endpoint, reachable through Splunk Web at
+          /<locale>/splunkd/__raw/v1/postgres/recovery/backup, performs no
+          authorization. An unauthenticated, network-adjacent attacker can invoke
+          arbitrary file create/truncate operations, which has been shown to chain
+          to remote code execution via PostgreSQL's lo_export.
+
+          Affected versions are 10.0.0 through 10.0.6 (fixed in 10.0.7) and 10.2.0
+          through 10.2.3 (fixed in 10.2.4); 10.4.0 and later are not affected.
+          Splunk Cloud Platform does not use Postgres sidecars and is not affected.
+
+          The module sends a benign request that mirrors the watchTowr detection
+          artifact: a POST to the recovery endpoint carrying a non-Splunk
+          (Basic) Authorization header. An affected build accepts the request past
+          authorization and fails decoding the (empty) body with HTTP 400
+          "Failed to decode request"; a patched build rejects the Basic header
+          with HTTP 401 "Authorization header must use Splunk token". The module
+          does not create, truncate, or read any file.
+        },
+        'Author' => [
+          'Piotr Bazydlo', # CVE-2026-20253 detection artifact (watchTowr)
+          'Kenneth LaCroix' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2026-20253'],
+          ['URL', 'https://advisory.splunk.com/advisories/SVD-2026-0603'],
+          ['URL', 'https://github.com/watchtowrlabs/watchTowr-vs-Splunk-CVE-2026-20253']
+        ],
+        'DisclosureDate' => '2026-06-10',
+        'License' => MSF_LICENSE,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        },
+        'DefaultOptions' => { 'RPORT' => 8000, 'SSL' => false }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to Splunk Web', '/']),
+        OptString.new('LOCALE', [true, 'The Splunk Web locale segment present in URLs', 'en-US'])
+      ]
+    )
+  end
+
+  # The recovery endpoint, reached through the Splunk Web __raw proxy. A
+  # non-Splunk (Basic) credential is enough to pass an affected server's
+  # (absent) authorization check; "dag:" is the credential used by the public
+  # detection artifact.
+  def probe
+    send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, datastore['LOCALE'], 'splunkd', '__raw', 'v1', 'postgres', 'recovery', 'backup'),
+        'headers' => { 'Authorization' => 'Basic ZGFnOg==' }
+      }
+    )
+  end
+
+  def run_host(_ip)
+    res = probe
+    unless res
+      vprint_error("#{peer} - No response from the Splunk Web recovery endpoint")
+      return
+    end
+
+    if res.code == 400 && res.body.to_s.include?('Failed to decode')
+      print_good("#{peer} - Vulnerable: the PostgreSQL sidecar recovery endpoint accepted an unauthenticated request (CVE-2026-20253)")
+      report_vuln(
+        host: rhost,
+        port: rport,
+        name: name,
+        info: 'Unauthenticated access to /splunkd/__raw/v1/postgres/recovery/backup (HTTP 400 "Failed to decode request")',
+        refs: references
+      )
+    elsif res.code == 401
+      print_status("#{peer} - Not vulnerable: the recovery endpoint requires a Splunk token (patched)")
+    else
+      vprint_status("#{peer} - PostgreSQL sidecar recovery endpoint not detected (HTTP #{res.code}); likely not installed or not Splunk Web")
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.rb
+++ b/modules/auxiliary/scanner/http/splunk_postgres_sidecar_scanner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -63,40 +65,63 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
-  # The recovery endpoint, reached through the Splunk Web __raw proxy. A
-  # non-Splunk (Basic) credential is enough to pass an affected server's
-  # (absent) authorization check; "dag:" is the credential used by the public
-  # detection artifact.
-  def probe
+  # POST to the recovery endpoint, reached through the Splunk Web __raw proxy.
+  # Pass the Basic credential ("dag:", the value used by the public detection
+  # artifact) to reach the recovery endpoint past an affected server's (absent)
+  # authorization check; an empty header set is the unauthenticated control.
+  def probe(extra_headers = {})
     send_request_cgi(
       {
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path, datastore['LOCALE'], 'splunkd', '__raw', 'v1', 'postgres', 'recovery', 'backup'),
-        'headers' => { 'Authorization' => 'Basic ZGFnOg==' }
+        'headers' => extra_headers
       }
     )
   end
 
+  # Confirm the target is Splunk Web before interpreting the recovery-endpoint
+  # behaviour, and register it as a service.
+  def fingerprint_splunk_web
+    res = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path, datastore['LOCALE'], 'account', 'login'))
+    return false unless res
+    return false unless res.headers['Server'].to_s.include?('Splunkd') ||
+                        res.get_cookies.to_s.include?('splunkweb') ||
+                        res.body.to_s.include?('Splunk')
+
+    report_service(host: rhost, port: rport, proto: 'tcp', name: (ssl ? 'https' : 'http'), info: 'Splunk Web')
+    true
+  end
+
   def run_host(_ip)
-    res = probe
-    unless res
+    fingerprint_splunk_web
+
+    # Control: with no Authorization header the Splunk Web __raw proxy returns
+    # HTTP 401 on both affected and patched builds, so a bare 400 is not by
+    # itself a bypass signal.
+    control = probe
+    # Bypass: a non-Splunk Basic credential passes an affected server's (absent)
+    # authorization check and reaches the recovery endpoint, which fails to
+    # decode the empty body (HTTP 400 "Failed to decode request").
+    bypass = probe('Authorization' => 'Basic ZGFnOg==')
+
+    unless control && bypass
       vprint_error("#{peer} - No response from the Splunk Web recovery endpoint")
       return
     end
 
-    if res.code == 400 && res.body.to_s.include?('Failed to decode request')
-      print_good("#{peer} - Vulnerable: the PostgreSQL sidecar recovery endpoint accepted an unauthenticated request (CVE-2026-20253)")
+    if control.code == 401 && bypass.code == 400 && bypass.body.to_s.include?('Failed to decode request')
+      print_good("#{peer} - Vulnerable: a non-Splunk Basic credential bypassed authorization on the PostgreSQL sidecar recovery endpoint (CVE-2026-20253)")
       report_vuln(
         host: rhost,
         port: rport,
         name: name,
-        info: 'Unauthenticated access to /splunkd/__raw/v1/postgres/recovery/backup (HTTP 400 "Failed to decode request")',
+        info: 'Auth bypass on /splunkd/__raw/v1/postgres/recovery/backup: no-auth -> HTTP 401, Basic-auth -> HTTP 400 "Failed to decode request"',
         refs: references
       )
-    elsif res.code == 401 && res.body.to_s.include?('Splunk token')
+    elsif bypass.code == 401 && bypass.body.to_s.include?('Splunk token')
       print_status("#{peer} - Not vulnerable: the recovery endpoint requires a Splunk token (patched)")
     else
-      vprint_status("#{peer} - PostgreSQL sidecar recovery endpoint not detected (HTTP #{res.code}); likely not installed or not Splunk Web")
+      vprint_status("#{peer} - Auth-bypass signature not present (control HTTP #{control.code}, bypass HTTP #{bypass.code}); not confirmed vulnerable")
     end
   end
 end


### PR DESCRIPTION
## Overview

Adds a detection module for **CVE-2026-20253** (CVSS 9.8, CWE-306), an
unauthenticated file-operation flaw in the Splunk Enterprise 10.x PostgreSQL
sidecar service ([SVD-2026-0603](https://advisory.splunk.com/advisories/SVD-2026-0603)).

The sidecar (backing Edge Processor / OpAmp / SPL2 data pipelines) exposes a
recovery endpoint through Splunk Web,
`POST /<locale>/splunkd/__raw/v1/postgres/recovery/backup`, that performs no
authorization. An unauthenticated attacker can create/truncate arbitrary files,
which has been chained to RCE via PostgreSQL `lo_export`.

Affected: 10.0.0–10.0.6 (fixed 10.0.7) and 10.2.0–10.2.3 (fixed 10.2.4); 10.4.0+
and Splunk Cloud are unaffected.

This is **detection only** (mirrors the public watchTowr artifact); it never
creates, truncates, or reads a file. It POSTs to the endpoint with a non-Splunk
(Basic) `Authorization` header:

- affected → HTTP **400 `Failed to decode request`** (request passed the absent
  authz check) → reported vulnerable
- patched → HTTP **401 `Authorization header must use Splunk token`** → not
  vulnerable
- otherwise → sidecar not present

The Basic header is required: an unauthenticated request returns 401 on both
affected and patched builds, so it does not discriminate.

## Verification

Lab: official `splunk/splunk:10.2.3` (vulnerable) and `:10.2.4` (patched)
containers (the sidecar ships in the stock image; no extra config needed).

- [x] `ruby -c` passes; module loads in `msfconsole`
- [x] `run` against 10.2.3 → **Vulnerable** (HTTP 400 `Failed to decode request`)
- [x] `run` against 10.2.4 → **Not vulnerable** (HTTP 401, token required)

```
msf6 auxiliary(scanner/http/splunk_postgres_sidecar_scanner) > run
[+] 127.0.0.1:18000 - Vulnerable: the PostgreSQL sidecar recovery endpoint accepted an unauthenticated request (CVE-2026-20253)
[*] 127.0.0.1:28000 - Not vulnerable: the recovery endpoint requires a Splunk token (patched)
```
