### PR TITLE
Wire ARCH_AARCH64 into to_executable_fmt for exe and exe-only

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -156,10 +156,8 @@ module Msf::Util::EXE
         case arch
         when ARCH_X86, nil
           to_winpe_only(framework, code, exeopts)
-        when ARCH_X64
+        when ARCH_X64, ARCH_AARCH64
           to_winpe_only(framework, code, exeopts, arch)
-        when ARCH_AARCH64
-            to_winaarch64pe(framework, code, exeopts)
         end
       when 'msi'
         case arch

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -136,7 +136,7 @@ module Msf::Util::EXE
         when ARCH_X64
           to_win64pe(framework, code, exeopts)
         when ARCH_AARCH64
-            to_winaarch64pe(framework, code, exeopts)
+          to_winaarch64pe(framework, code, exeopts)
         end
       when 'exe-service'
         case arch

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -135,6 +135,8 @@ module Msf::Util::EXE
           to_win32pe(framework, code, exeopts)
         when ARCH_X64
           to_win64pe(framework, code, exeopts)
+        when ARCH_AARCH64
+            to_winaarch64pe(framework, code, exeopts)
         end
       when 'exe-service'
         case arch
@@ -156,6 +158,8 @@ module Msf::Util::EXE
           to_winpe_only(framework, code, exeopts)
         when ARCH_X64
           to_winpe_only(framework, code, exeopts, arch)
+        when ARCH_AARCH64
+            to_winaarch64pe(framework, code, exeopts)
         end
       when 'msi'
         case arch


### PR DESCRIPTION
# Wire ARCH_AARCH64 into `to_executable_fmt` for `exe` and `exe-only` formats

## Summary

`Msf::Util::EXE::ClassMethods#to_executable_fmt` is missing `ARCH_AARCH64`
branches in its `'exe'` and `'exe-only'` cases. The helper
`to_winaarch64pe` (in `lib/msf/util/exe/windows/aarch64.rb`) is fully
implemented and the corresponding template
(`data/templates/template_aarch64_windows.exe`) ships with the
framework, but neither is reachable from msfvenom today because the
format dispatcher silently falls through when arch is AArch64 and
returns `nil`.

This means the existing `windows/aarch64/exec` payload — and any future
Windows AArch64 payload — cannot be wrapped into a PE via msfvenom:

```
$ ./msfvenom -p windows/aarch64/exec CMD=calc.exe -f exe -o exec.exe
[-] No platform was selected, choosing Msf::Module::Platform::Windows from the payload
[-] No arch selected, selecting arch: aarch64 from the payload
No encoder specified, outputting raw payload
Payload size: 360 bytes
Error: The payload could not be generated, check options
```

## Fix

Add the missing `when ARCH_AARCH64` branches to both `'exe'` and
`'exe-only'` cases, dispatching to the already-existing
`to_winaarch64pe` helper:

```ruby
when 'exe'
  case arch
  when ARCH_X86, nil
    to_win32pe(framework, code, exeopts)
  when ARCH_X64
    to_win64pe(framework, code, exeopts)
  when ARCH_AARCH64                         # <-- added
    to_winaarch64pe(framework, code, exeopts)
  end
```

Same two-line addition for `'exe-only'`. No other code paths touched.

## Verification

Before this PR:

```
$ ./msfvenom -p windows/aarch64/exec CMD=calc.exe -f exe -o exec.exe
Error: The payload could not be generated, check options
```

After this PR:

```
$ ./msfvenom -p windows/aarch64/exec CMD=calc.exe -f exe -o exec.exe
[*] Payload size: 360 bytes
[*] Final size of exe file: 6656 bytes
[*] Saved as: exec.exe

$ file exec.exe
exec.exe: PE32+ executable (console) Aarch64, for MS Windows
```

The resulting PE was executed on Windows 11 ARM64 (build 26200) and
correctly launched `calc.exe`.

`-f raw`, `-f c`, `-f hex`, and `-f bin` already worked because they do
not go through the EXE wrapper. This PR makes `-f exe` and `-f exe-only`
catch up to the same support level.

## Test plan

- [x] `./msfvenom -p windows/aarch64/exec CMD=calc.exe -f exe -o exec.exe` succeeds
- [x] `file exec.exe` reports a PE32+ AArch64 console executable
- [x] `exec.exe` runs and launches `calc.exe` on a Windows 11 ARM64 machine
- [x] `./msfvenom -p windows/aarch64/exec CMD=calc.exe -f exe-only -o exec_only.exe` succeeds
- [x] Existing x86 and x64 `-f exe` / `-f exe-only` paths are unaffected (regression check)

