### PR TITLE
Change AGENTS.md Wording for Scenarios Section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Metasploit Framework is an open-source penetration testing and exploitation fram
 - License new code with `MSF_LICENSE` (the project default, defined in `lib/msf/core/constants.rb`)
 - When overriding `cleanup`, always call `super` to ensure the parent mixin chain cleans up connections and sessions properly
 - When possible don't set a default payload (`DefaultOptions` with `'PAYLOAD'`) in modules — let the framework choose the most appropriate payload automatically
-- New modules require an associated markdown file in the `documentation/modules` folder with the same structure, including steps to set up the vulnerable environment for testing. NEVER add content into the Scenarios section, this must be filled out by a human at all times. Follow `documentation/modules/module_doc_template.md` as a template.
+- New modules require an associated markdown file in the `documentation/modules` folder with the same structure, including steps to set up the vulnerable environment for testing. The Scenarios section must be filled out by a human at all times. Follow `documentation/modules/module_doc_template.md` as a template.
 - Module descriptions or documentation should list the range of vulnerable versions and the fixed version of the affected software, when known
 - Module descriptions should only use ASCII characters
 - `report_service` method called when a service can be reported


### PR DESCRIPTION
## Description

The AGENTS.md file is used by copilot to review PRs. The file was instructing AI to "NEVER fill in the scenarios section, leave it for a human to fill in". Copilot has been flagging every filled in scenarios section as incorrect: 


<img width="765" height="416" alt="Screenshot 2026-06-23 at 10 20 36 AM" src="https://github.com/user-attachments/assets/a8535c75-f61a-4dd3-ae0b-fb2ae62c3892" />

https://github.com/rapid7/metasploit-framework/pull/21566#discussion_r3444224468


This PR changes the wording in the AGENTS.md file to hopefully remediate this. 


## Breaking Changes

None

## Reviewer Notes

Let me know what you think! Could the wording be adjusted?

## Verification Steps

Run a local copilot review using the AGENTS.md file and ensure it does not flag a filled in scenarios section as being incorrect