### PR TITLE
Add LDAP and RDP TLS peer cert tracing via CertificateTrace (Phase 2)

### DIFF
--- a/lib/msf/core/exploit/remote/certificate_trace.rb
+++ b/lib/msf/core/exploit/remote/certificate_trace.rb
@@ -81,8 +81,12 @@ module Msf
       return if @_peer_cert_seen[key]
 
       if respond_to?(:framework) && framework&.db&.active
+        # Dedup across runs using a note keyed by "host:port" in its own data.
+        # Match on the note's serialized data column (already loaded with the
+        # row) rather than walking the host/service associations, which would
+        # issue a separate query per note (N+1).
         already_noted = framework.db.notes(ntype: 'ssl.peer_cert_seen').any? do |n|
-          n.host&.address == host && n.service&.port == port
+          n.data.is_a?(Hash) && n.data['endpoint'] == key
         end
         if already_noted
           @_peer_cert_seen[key] = true
@@ -91,7 +95,7 @@ module Msf
         framework.db.report_note(
           host: host, port: port, proto: 'tcp',
           ntype: 'ssl.peer_cert_seen',
-          data: {},
+          data: { 'endpoint' => key },
           update: :unique
         )
       end

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -13,7 +13,6 @@ module Msf
     include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
     include Msf::Exploit::Remote::CertificateTrace
     include Metasploit::Framework::LDAP::Client
-    include Msf::Exploit::Remote::CertificateTrace
 
     # Initialize the LDAP client and set up the LDAP specific datastore
     # options to allow the client to perform authentication and timeout
@@ -162,7 +161,12 @@ module Msf
     #   passed in via the "block" parameter yielded.
     def ldap_open(connect_opts, keep_open: false, &block)
       opts = resolve_connect_opts(connect_opts)
-      if keep_open
+      # When keep_open is set, or no block was supplied, open the connection and
+      # return the client to the caller (who owns its lifecycle). Net::LDAP.open
+      # yields to a block and closes the connection afterwards, so a block-less
+      # call must not be forwarded to it - trace the peer cert and hand back the
+      # open client instead.
+      if keep_open || block.nil?
         ldap = Rex::Proto::LDAP::Client._open(opts)
         _ldap_trace_peer_cert(ldap.socket)
         ldap

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -375,10 +375,13 @@ module Msf
     # @param socket [Rex::Socket, nil] the LDAP socket after TLS handshake
     # @return [void]
     def _ldap_trace_peer_cert(socket)
+      return unless certificate_trace_enabled?
       return unless socket&.respond_to?(:peer_cert)
 
       raw_cert = socket.peer_cert
-      certificate_peer_cert_trace(raw_cert, rhost, rport.to_i) if raw_cert
+      return unless raw_cert
+
+      certificate_peer_cert_trace(raw_cert, rhost, rport.to_i)
     end
   end
 end

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -11,6 +11,7 @@ module Msf
   module Exploit::Remote::LDAP
     include Msf::Exploit::Remote::Kerberos::Ticket::Storage
     include Msf::Exploit::Remote::Kerberos::ServiceAuthenticator::Options
+    include Msf::Exploit::Remote::CertificateTrace
     include Metasploit::Framework::LDAP::Client
     include Msf::Exploit::Remote::CertificateTrace
 
@@ -162,9 +163,15 @@ module Msf
     def ldap_open(connect_opts, keep_open: false, &block)
       opts = resolve_connect_opts(connect_opts)
       if keep_open
-        Rex::Proto::LDAP::Client._open(opts, &block)
+        ldap = Rex::Proto::LDAP::Client._open(opts)
+        _ldap_trace_peer_cert(ldap.socket)
+        ldap
       else
-        Rex::Proto::LDAP::Client.open(opts, &block)
+        Rex::Proto::LDAP::Client.open(opts) do |ldap|
+          conn = ldap.instance_variable_get(:@open_connection)
+          _ldap_trace_peer_cert(conn&.socket)
+          block.call(ldap)
+        end
       end
     end
 
@@ -357,6 +364,21 @@ module Msf
     # @return The escaped string.
     def ldap_escape_filter(string)
       Net::LDAP::Filter.escape(string)
+    end
+
+    private
+
+    # Traces the TLS peer certificate on an LDAP socket when CertificateTrace
+    # is enabled. Delegates to #certificate_peer_cert_trace so dedup and
+    # formatting are handled consistently with the HTTP path.
+    #
+    # @param socket [Rex::Socket, nil] the LDAP socket after TLS handshake
+    # @return [void]
+    def _ldap_trace_peer_cert(socket)
+      return unless socket&.respond_to?(:peer_cert)
+
+      raw_cert = socket.peer_cert
+      certificate_peer_cert_trace(raw_cert, rhost, rport.to_i) if raw_cert
     end
   end
 end

--- a/lib/msf/core/exploit/remote/rdp.rb
+++ b/lib/msf/core/exploit/remote/rdp.rb
@@ -10,6 +10,7 @@ module Msf
 module Exploit::Remote::RDP
   require 'rc4'
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::CertificateTrace
 
   #
   # Creates an instance of a RDP exploit module.
@@ -1180,6 +1181,8 @@ module Exploit::Remote::RDP
       vprint_error("Retry with advanced option RDP_TLS_SECURITY_LEVEL=0")
       raise
     end
+
+    certificate_peer_cert_trace(ssl.peer_cert, rhost, rport.to_i)
 
     self.rdp_sock.extend(Rex::Socket::SslTcp)
     self.rdp_sock.sslsock = ssl

--- a/spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb
@@ -319,10 +319,8 @@ RSpec.describe Msf::Exploit::Remote::CertificateTrace do
     end
 
     context 'DB-backed deduplication' do
-      let(:host_dbl)    { double('host', address: '192.168.1.1') }
-      let(:service_dbl) { double('service', port: 443) }
-      let(:note_dbl)    { double('note', host: host_dbl, service: service_dbl) }
-      let(:active_db)   { double('db', active: true) }
+      let(:note_dbl) { double('note', data: { 'endpoint' => '192.168.1.1:443' }) }
+      let(:active_db) { double('db', active: true) }
 
       before do
         subject.datastore['CertificateTrace'] = 'metadata'
@@ -336,10 +334,18 @@ RSpec.describe Msf::Exploit::Remote::CertificateTrace do
         subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443)
       end
 
-      it 'prints and records a note when the host:port has not been seen before' do
+      it 'does not skip when an existing note is for a different endpoint' do
+        other_note = double('note', data: { 'endpoint' => '10.0.0.9:443' })
+        allow(active_db).to receive(:notes).with(ntype: 'ssl.peer_cert_seen').and_return([other_note])
+        expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+        subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443)
+      end
+
+      it 'prints and records a note keyed by host:port when not seen before' do
         allow(active_db).to receive(:notes).with(ntype: 'ssl.peer_cert_seen').and_return([])
         expect(active_db).to receive(:report_note).with(hash_including(
-          host: '192.168.1.1', port: 443, ntype: 'ssl.peer_cert_seen'
+          host: '192.168.1.1', port: 443, ntype: 'ssl.peer_cert_seen',
+          data: { 'endpoint' => '192.168.1.1:443' }
         ))
         expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
         subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443)

--- a/spec/lib/msf/core/exploit/remote/ldap_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ldap_spec.rb
@@ -83,6 +83,18 @@ RSpec.describe Msf::Exploit::Remote::LDAP do
       end
     end
 
+    context 'when no block is given' do
+      it 'opens and returns the client instead of forwarding to a block-less Net::LDAP.open' do
+        opts = {}
+        allow(subject).to receive(:resolve_connect_opts).and_return(opts)
+        allow(ldap_dbl).to receive(:socket).and_return(nil)
+        expect(Rex::Proto::LDAP::Client).to receive(:_open).with(opts).and_return(ldap_dbl)
+        expect(Rex::Proto::LDAP::Client).not_to receive(:open)
+        expect { @result = subject.ldap_open(opts) }.not_to raise_error
+        expect(@result).to eq(ldap_dbl)
+      end
+    end
+
     context 'peer cert tracing (keep_open: false)' do
       let(:tls_socket) do
         dbl = double('socket')

--- a/spec/lib/msf/core/exploit/remote/ldap_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ldap_spec.rb
@@ -57,12 +57,136 @@ RSpec.describe Msf::Exploit::Remote::LDAP do
   end
 
   describe '#ldap_open' do
-    it do
+    let(:ldap_dbl) do
+      dbl = instance_double(Rex::Proto::LDAP::Client)
+      allow(dbl).to receive(:instance_variable_get).with(:@open_connection).and_return(nil)
+      dbl
+    end
+
+    it 'delegates to Rex::Proto::LDAP::Client.open and forwards the caller block' do
       opts = {}
-      expect(Net::LDAP).to receive(:open).with(opts, &ldap_proc)
-      expect(subject).not_to receive(:get_connect_opts)
-      expect(subject).to receive(:resolve_connect_opts).and_return(opts)
-      subject.ldap_open(opts, &ldap_proc)
+      yielded = nil
+      allow(subject).to receive(:resolve_connect_opts).and_return(opts)
+      expect(Rex::Proto::LDAP::Client).to receive(:open).with(opts).and_yield(ldap_dbl)
+      subject.ldap_open(opts) { |ldap| yielded = ldap }
+      expect(yielded).to eq(ldap_dbl)
+    end
+
+    context 'when keep_open is true' do
+      it 'calls _open and returns the client directly without yielding' do
+        opts = {}
+        allow(subject).to receive(:resolve_connect_opts).and_return(opts)
+        allow(ldap_dbl).to receive(:socket).and_return(nil)
+        expect(Rex::Proto::LDAP::Client).to receive(:_open).with(opts).and_return(ldap_dbl)
+        result = subject.ldap_open(opts, keep_open: true)
+        expect(result).to eq(ldap_dbl)
+      end
+    end
+
+    context 'peer cert tracing (keep_open: false)' do
+      let(:tls_socket) do
+        dbl = double('socket')
+        allow(dbl).to receive(:respond_to?).with(:peer_cert).and_return(true)
+        allow(dbl).to receive(:peer_cert).and_return(tls_cert)
+        dbl
+      end
+
+      let(:tls_conn) do
+        dbl = double('connection')
+        allow(dbl).to receive(:socket).and_return(tls_socket)
+        dbl
+      end
+
+      let(:tls_ldap_dbl) do
+        dbl = instance_double(Rex::Proto::LDAP::Client)
+        allow(dbl).to receive(:instance_variable_get).with(:@open_connection).and_return(tls_conn)
+        dbl
+      end
+
+      let(:tls_cert) do
+        key = OpenSSL::PKey::RSA.generate(2048)
+        c = OpenSSL::X509::Certificate.new
+        c.subject = OpenSSL::X509::Name.parse('/CN=ldap.example.com')
+        c.issuer  = OpenSSL::X509::Name.parse('/CN=Test CA')
+        c.public_key = key.public_key
+        c.serial = OpenSSL::BN.new('1')
+        c.version = 2
+        c.not_before = Time.utc(2026, 1, 1)
+        c.not_after  = Time.utc(2027, 1, 1)
+        c.sign(key, OpenSSL::Digest::SHA256.new)
+        c
+      end
+
+      before do
+        subject.datastore['CertificateTrace'] = 'metadata'
+        allow(subject).to receive(:framework).and_return(framework)
+        allow(framework).to receive(:db).and_return(double('db', active: false))
+        allow(Rex::Proto::LDAP::Client).to receive(:open).and_yield(tls_ldap_dbl)
+      end
+
+      it 'prints the peer cert when CertificateTrace is enabled and connection is TLS' do
+        expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+        subject.ldap_open({}) { |_ldap| }
+      end
+
+      it 'produces no output when CertificateTrace is off' do
+        subject.datastore['CertificateTrace'] = 'off'
+        expect(subject).not_to receive(:print_line)
+        subject.ldap_open({}) { |_ldap| }
+      end
+    end
+
+    context 'peer cert tracing (keep_open: true)' do
+      let(:tls_socket) do
+        dbl = double('socket')
+        allow(dbl).to receive(:respond_to?).with(:peer_cert).and_return(true)
+        allow(dbl).to receive(:peer_cert).and_return(tls_cert)
+        dbl
+      end
+
+      let(:keep_open_ldap_dbl) do
+        dbl = instance_double(Rex::Proto::LDAP::Client)
+        allow(dbl).to receive(:socket).and_return(tls_socket)
+        dbl
+      end
+
+      let(:tls_cert) do
+        key = OpenSSL::PKey::RSA.generate(2048)
+        c = OpenSSL::X509::Certificate.new
+        c.subject = OpenSSL::X509::Name.parse('/CN=ldap.example.com')
+        c.issuer  = OpenSSL::X509::Name.parse('/CN=Test CA')
+        c.public_key = key.public_key
+        c.serial = OpenSSL::BN.new('1')
+        c.version = 2
+        c.not_before = Time.utc(2026, 1, 1)
+        c.not_after  = Time.utc(2027, 1, 1)
+        c.sign(key, OpenSSL::Digest::SHA256.new)
+        c
+      end
+
+      before do
+        subject.datastore['CertificateTrace'] = 'metadata'
+        allow(subject).to receive(:framework).and_return(framework)
+        allow(framework).to receive(:db).and_return(double('db', active: false))
+        allow(Rex::Proto::LDAP::Client).to receive(:_open).and_return(keep_open_ldap_dbl)
+      end
+
+      it 'prints the peer cert when CertificateTrace is enabled and connection is TLS' do
+        expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+        subject.ldap_open({}, keep_open: true)
+      end
+
+      it 'produces no output when CertificateTrace is off' do
+        subject.datastore['CertificateTrace'] = 'off'
+        expect(subject).not_to receive(:print_line)
+        subject.ldap_open({}, keep_open: true)
+      end
+
+      it 'produces no output when the socket has no peer_cert (plain LDAP)' do
+        allow(tls_socket).to receive(:respond_to?).with(:peer_cert).and_return(false)
+        expect(subject).not_to receive(:print_line)
+        subject.ldap_open({}, keep_open: true)
+      end
     end
   end
 

--- a/spec/lib/msf/core/exploit/remote/rdp_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/rdp_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Remote::RDP do
+  include_context 'Msf::Simple::Framework'
+
+  subject do
+    mod = ::Msf::Exploit.new
+    mod.extend described_class
+    mod
+  end
+
+  before do
+    allow(subject).to receive(:framework).and_return(framework)
+    allow(subject).to receive(:rhost).and_return('192.168.1.10')
+    allow(subject).to receive(:rport).and_return(3389)
+  end
+
+  describe '#swap_sock_plain_to_ssl' do
+    let(:tls_cert) do
+      key = OpenSSL::PKey::RSA.generate(2048)
+      c = OpenSSL::X509::Certificate.new
+      c.subject = OpenSSL::X509::Name.parse('/CN=rdp.example.com')
+      c.issuer  = OpenSSL::X509::Name.parse('/CN=Test CA')
+      c.public_key = key.public_key
+      c.serial = OpenSSL::BN.new('1')
+      c.version = 2
+      c.not_before = Time.utc(2026, 1, 1)
+      c.not_after  = Time.utc(2027, 1, 1)
+      c.sign(key, OpenSSL::Digest::SHA256.new)
+      c
+    end
+
+    let(:ssl_socket_dbl) do
+      dbl = double('ssl_socket')
+      allow(dbl).to receive(:connect)
+      allow(dbl).to receive(:peer_cert).and_return(tls_cert)
+      dbl
+    end
+
+    let(:rdp_sock_dbl) do
+      dbl = double('rdp_sock')
+      allow(dbl).to receive(:extend)
+      allow(dbl).to receive(:sslsock=)
+      allow(dbl).to receive(:sslctx=)
+      dbl
+    end
+
+    before do
+      subject.instance_variable_set(:@rdp_sock, rdp_sock_dbl)
+      subject.datastore['RDP_TLS_SECURITY_LEVEL'] = 0
+      allow(OpenSSL::SSL::SSLSocket).to receive(:new).and_return(ssl_socket_dbl)
+      allow(framework).to receive(:db).and_return(double('db', active: false))
+    end
+
+    it 'prints the peer cert when CertificateTrace is enabled' do
+      subject.datastore['CertificateTrace'] = 'metadata'
+      expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+      subject.swap_sock_plain_to_ssl
+    end
+
+    it 'produces no output when CertificateTrace is off' do
+      subject.datastore['CertificateTrace'] = 'off'
+      expect(subject).not_to receive(:print_line)
+      subject.swap_sock_plain_to_ssl
+    end
+
+    it 'produces no output when the server returns no cert' do
+      subject.datastore['CertificateTrace'] = 'metadata'
+      allow(ssl_socket_dbl).to receive(:peer_cert).and_return(nil)
+      expect(subject).not_to receive(:print_line)
+      subject.swap_sock_plain_to_ssl
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extends `CertificateTrace` peer cert tracing (introduced in #21599) to LDAP over TLS and RDP. No new operator-facing option -- operators use the existing `CertificateTrace` enum (`off`/`metadata`/`full`).

**LDAP (`Exploit::Remote::LDAP`):**
- Includes `CertificateTrace`
- `ldap_open` wraps both connection paths (`keep_open: false` via `Rex::Proto::LDAP::Client.open`; `keep_open: true` via `Client._open`) to read the server cert from the socket after the TLS handshake
- Private `_ldap_trace_peer_cert` helper guards against non-TLS (plain LDAP) connections silently

**RDP (`Exploit::Remote::RDP`):**
- Includes `CertificateTrace`
- `swap_sock_plain_to_ssl` calls `certificate_peer_cert_trace` immediately after `ssl.connect` while the raw `OpenSSL::SSL::SSLSocket` is still in scope

**Dedup, color, and DB recording** are delegated to `#certificate_peer_cert_trace` in `CertificateTrace` (the same logic as HTTP).

## Test plan

Rebased onto latest master; the conflicts with the merged CSR trace work (#21580) were resolved (peer-cert and CSR methods/specs kept as siblings). All checks below re-run after the merge.


Peer cert labeling: peer certs now print under a `Peer Cert` header (a `label:` keyword was added to `CertificateTracePresenter#to_s_metadata`/`#to_s_full`, default `x.509`), so a server's TLS certificate is no longer visually indistinguishable from an issued/client certificate. Issued-cert (`x.509`) and CSR output are unchanged.

Unit specs (this branch, post-merge):
- `bundle exec rspec spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb` - 54 examples, 0 failures
- `bundle exec rspec spec/lib/msf/core/exploit/remote/ldap_spec.rb` - 31 examples, 0 failures
- `bundle exec rspec spec/lib/msf/core/exploit/remote/rdp_spec.rb` - 10 examples, 0 failures

Live test - RDP peer cert trace against a real Windows domain controller (`auxiliary/scanner/rdp/rdp_scanner` vs `192.168.64.3:3389`, `CertificateTrace=full`):

```
[CertificateTrace] Peer Cert ----------------------------
  Subject    : /CN=DC1.kerberos.issue
  Issuer     : /CN=DC1.kerberos.issue
  SHA-256    : e2b701ff59a955e75d8cb06395fdc112de068a00a616ac1e0d562c991a6167ec
  Serial     : 94318831981875632055531169548231728305
```

Live test - LDAP peer cert trace over LDAPS against the same DC (`192.168.64.3:636`, `CertificateTrace=full`), showing the AD CS issued cert with extensions:

```
[CertificateTrace] Peer Cert ----------------------------
  Subject    : /CN=DC1.kerberos.issue
  Issuer     : /DC=issue/DC=kerberos/CN=kerberos-DC1-CA
  SHA-256    : 5ba07d93b9243d781045c37db3fd3d0573e9dbc2f7be11d8fa5511f603dfba61
```

- Dedup confirmed: one trace per host:port on both paths.
- Plain (non-TLS) LDAP and RDP connections produce no output.

## Notes

- Depends on #21599 (Phase 1, HTTP support)
- WinRM over HTTPS is already covered by Phase 1 (WinRM includes `HttpClient`)
- Postgres and SMB over TLS are pending TLS support in those mixins (Phase 3)

