### PR TITLE
Add Postgres TLS support and peer cert tracing via CertificateTrace (Phase 3)

### DIFF
--- a/lib/msf/core/exploit/remote/certificate_trace.rb
+++ b/lib/msf/core/exploit/remote/certificate_trace.rb
@@ -82,7 +82,8 @@ module Msf
       key = "#{host}:#{port}"
       return if @_peer_cert_seen[key]
 
-      if respond_to?(:framework) && framework&.db&.active
+      db_active = respond_to?(:framework) && framework&.db&.active
+      if db_active
         # Dedup across runs using a note keyed by "host:port" in its own data.
         # Match on the note's serialized data column (already loaded with the
         # row) rather than walking the host/service associations, which would
@@ -94,15 +95,7 @@ module Msf
           @_peer_cert_seen[key] = true
           return
         end
-        framework.db.report_note(
-          host: host, port: port, proto: 'tcp',
-          ntype: 'ssl.peer_cert_seen',
-          data: { 'endpoint' => key },
-          update: :unique
-        )
       end
-
-      @_peer_cert_seen[key] = true
 
       mode = datastore['CertificateTrace']
       presenter = Msf::Trace::CertificateTracePresenter.new(cert)
@@ -118,6 +111,19 @@ module Msf
                  nil
                end
       return unless output
+
+      # Only record the endpoint as seen once we have actually produced output,
+      # so an unknown mode or a render failure does not permanently suppress
+      # future tracing for this host:port.
+      @_peer_cert_seen[key] = true
+      if db_active
+        framework.db.report_note(
+          host: host, port: port, proto: 'tcp',
+          ntype: 'ssl.peer_cert_seen',
+          data: { 'endpoint' => key },
+          update: :unique
+        )
+      end
 
       print_line(certificate_trace_colorize(output))
 

--- a/lib/msf/core/exploit/remote/certificate_trace.rb
+++ b/lib/msf/core/exploit/remote/certificate_trace.rb
@@ -120,6 +120,20 @@ module Msf
       return unless output
 
       print_line(certificate_trace_colorize(output))
+
+      return unless mode == 'full'
+
+      # When chain is provided, print each intermediate / root CA cert that the
+      # server included in the handshake. chain[0] is the leaf (already printed),
+      # so we start from chain[1].
+      chain_certs = Array(chain).drop(1)
+      chain_certs.each_with_index do |chain_cert, idx|
+        chain_presenter = Msf::Trace::CertificateTracePresenter.new(chain_cert)
+        chain_output = chain_presenter.to_s_full(label: "Chain #{idx + 1}/#{chain_certs.length}")
+        next unless chain_output
+
+        print_line(certificate_trace_colorize(chain_output))
+      end
     end
 
     # Dispatches a certificate signing request (CSR) trace at the configured
@@ -149,22 +163,6 @@ module Msf
       return unless output
 
       print_line(certificate_trace_colorize(output))
-
-      return unless mode == 'full'
-
-      # When chain is provided, print each intermediate / root CA cert that the
-      # server included in the handshake. chain[0] is the leaf (already printed),
-      # so we start from chain[1].
-      chain_certs = Array(chain).drop(1)
-      chain_certs.each_with_index do |chain_cert, idx|
-        chain_presenter = Msf::Trace::CertificateTracePresenter.new(chain_cert)
-        chain_output = chain_presenter.to_s_full
-        next unless chain_output
-
-        chain_header = "[CertificateTrace] Chain #{idx + 1}/#{chain_certs.length} #{'-' * 28}"
-        chain_output = chain_output.sub(Msf::Trace::CertificateTracePresenter::SEPARATOR, chain_header)
-        print_line(certificate_trace_colorize(chain_output))
-      end
     end
 
     private

--- a/lib/msf/core/exploit/remote/certificate_trace.rb
+++ b/lib/msf/core/exploit/remote/certificate_trace.rb
@@ -71,8 +71,10 @@ module Msf
     # @param cert [OpenSSL::X509::Certificate, String] peer certificate or DER bytes
     # @param host [String] remote hostname or IP
     # @param port [Integer] remote port
+    # @param chain [Array<OpenSSL::X509::Certificate>, nil] the certificates the
+    #   server presented (leaf first); intermediates/roots are printed in full mode
     # @return [void]
-    def certificate_peer_cert_trace(cert, host, port)
+    def certificate_peer_cert_trace(cert, host, port, chain: nil)
       return unless certificate_trace_enabled?
       return if cert.nil?
 
@@ -147,6 +149,22 @@ module Msf
       return unless output
 
       print_line(certificate_trace_colorize(output))
+
+      return unless mode == 'full'
+
+      # When chain is provided, print each intermediate / root CA cert that the
+      # server included in the handshake. chain[0] is the leaf (already printed),
+      # so we start from chain[1].
+      chain_certs = Array(chain).drop(1)
+      chain_certs.each_with_index do |chain_cert, idx|
+        chain_presenter = Msf::Trace::CertificateTracePresenter.new(chain_cert)
+        chain_output = chain_presenter.to_s_full
+        next unless chain_output
+
+        chain_header = "[CertificateTrace] Chain #{idx + 1}/#{chain_certs.length} #{'-' * 28}"
+        chain_output = chain_output.sub(Msf::Trace::CertificateTracePresenter::SEPARATOR, chain_header)
+        print_line(certificate_trace_colorize(chain_output))
+      end
     end
 
     private

--- a/lib/msf/core/exploit/remote/http_client.rb
+++ b/lib/msf/core/exploit/remote/http_client.rb
@@ -425,7 +425,10 @@ module Exploit::Remote::HttpClient
 
     if c.conn&.respond_to?(:peer_cert)
       raw_cert = c.conn.peer_cert
-      certificate_peer_cert_trace(raw_cert, opts['rhost'] || rhost, (opts['rport'] || rport).to_i) if raw_cert
+      if raw_cert
+        raw_chain = c.conn.peer_cert_chain if c.conn.respond_to?(:peer_cert_chain)
+        certificate_peer_cert_trace(raw_cert, opts['rhost'] || rhost, (opts['rport'] || rport).to_i, chain: raw_chain)
+      end
     end
 
     disconnect(c) if disconnect

--- a/lib/msf/core/exploit/remote/ldap.rb
+++ b/lib/msf/core/exploit/remote/ldap.rb
@@ -385,7 +385,8 @@ module Msf
       raw_cert = socket.peer_cert
       return unless raw_cert
 
-      certificate_peer_cert_trace(raw_cert, rhost, rport.to_i)
+      chain = socket.peer_cert_chain if socket.respond_to?(:peer_cert_chain)
+      certificate_peer_cert_trace(raw_cert, rhost, rport.to_i, chain: chain)
     end
   end
 end

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -15,6 +15,7 @@ module Exploit::Remote::Postgres
   require 'metasploit/framework/tcp/client'
   include Msf::Db::PostgresPR
   include Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::CertificateTrace
 
   # @!attribute [rw] postgres_conn
   #   @return [::Msf::Db::PostgresPR::Connection]
@@ -97,6 +98,7 @@ module Exploit::Remote::Postgres
     ip = opts[:server]         || datastore['RHOST']
     port = opts[:port]         || datastore['RPORT']
     proxies = opts[:proxies]   || datastore['Proxies']
+    ssl = opts.key?(:ssl) ? opts[:ssl] : datastore['SSL']
     uri = "tcp://#{ip}:#{port}"
 
     if Rex::Socket.is_ipv6?(ip)
@@ -105,7 +107,7 @@ module Exploit::Remote::Postgres
 
     verbose = opts[:verbose] || datastore['VERBOSE']
     begin
-      self.postgres_conn = Connection.new(db,username,password,uri,proxies)
+      self.postgres_conn = Connection.new(db, username, password, uri, proxies, ssl)
     rescue RuntimeError => e
       case e.to_s.split("\t")[1]
       when "C3D000"
@@ -124,6 +126,7 @@ module Exploit::Remote::Postgres
     end
     if self.postgres_conn
       print_good "#{self.postgres_conn.peerhost}:#{self.postgres_conn.peerport} Postgres - Logged in to '#{db}' with '#{username}':'#{password}'" if verbose
+      certificate_peer_cert_trace(postgres_conn.conn&.peer_cert, ip, port.to_i)
       return :connected
     end
   end

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -126,7 +126,11 @@ module Exploit::Remote::Postgres
     end
     if self.postgres_conn
       print_good "#{self.postgres_conn.peerhost}:#{self.postgres_conn.peerport} Postgres - Logged in to '#{db}' with '#{username}':'#{password}'" if verbose
-      certificate_peer_cert_trace(postgres_conn.conn&.peer_cert, ip, port.to_i)
+      pg_socket = postgres_conn.conn
+      certificate_peer_cert_trace(
+        pg_socket&.peer_cert, ip, port.to_i,
+        chain: pg_socket.respond_to?(:peer_cert_chain) ? pg_socket.peer_cert_chain : nil
+      )
       return :connected
     end
   end

--- a/lib/msf/core/exploit/remote/postgres.rb
+++ b/lib/msf/core/exploit/remote/postgres.rb
@@ -127,10 +127,12 @@ module Exploit::Remote::Postgres
     if self.postgres_conn
       print_good "#{self.postgres_conn.peerhost}:#{self.postgres_conn.peerport} Postgres - Logged in to '#{db}' with '#{username}':'#{password}'" if verbose
       pg_socket = postgres_conn.conn
-      certificate_peer_cert_trace(
-        pg_socket&.peer_cert, ip, port.to_i,
-        chain: pg_socket.respond_to?(:peer_cert_chain) ? pg_socket.peer_cert_chain : nil
-      )
+      if pg_socket&.respond_to?(:peer_cert)
+        certificate_peer_cert_trace(
+          pg_socket.peer_cert, ip, port.to_i,
+          chain: pg_socket.respond_to?(:peer_cert_chain) ? pg_socket.peer_cert_chain : nil
+        )
+      end
       return :connected
     end
   end

--- a/lib/msf/core/exploit/remote/rdp.rb
+++ b/lib/msf/core/exploit/remote/rdp.rb
@@ -1182,7 +1182,7 @@ module Exploit::Remote::RDP
       raise
     end
 
-    certificate_peer_cert_trace(ssl.peer_cert, rhost, rport.to_i)
+    certificate_peer_cert_trace(ssl.peer_cert, rhost, rport.to_i, chain: ssl.peer_cert_chain)
 
     self.rdp_sock.extend(Rex::Socket::SslTcp)
     self.rdp_sock.sslsock = ssl

--- a/spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb
@@ -277,6 +277,18 @@ RSpec.describe Msf::Exploit::Remote::CertificateTrace do
         expect(subject).to receive(:vprint_warning).with(include('bogus'))
         subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443)
       end
+
+      it 'does not suppress a later valid trace of the same host:port when it produced no output' do
+        allow(subject).to receive(:vprint_warning)
+        subject.datastore.update_value('CertificateTrace', 'bogus')
+        subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443)
+
+        # A run with a valid mode must still trace: the endpoint should not have
+        # been marked seen when nothing was rendered.
+        subject.datastore.update_value('CertificateTrace', 'metadata')
+        expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+        subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443)
+      end
     end
 
     context 'with raw DER bytes' do

--- a/spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb
@@ -377,6 +377,57 @@ RSpec.describe Msf::Exploit::Remote::CertificateTrace do
         subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443)
       end
     end
+
+    context 'cert chain (full mode)' do
+      let(:ca_key) { OpenSSL::PKey::RSA.generate(2048) }
+
+      let(:intermediate_cert) do
+        c = OpenSSL::X509::Certificate.new
+        c.subject = OpenSSL::X509::Name.parse('/CN=Intermediate CA/O=MSF Lab')
+        c.issuer  = OpenSSL::X509::Name.parse('/CN=Root CA')
+        c.public_key = ca_key.public_key
+        c.serial = OpenSSL::BN.new('10')
+        c.version = 2
+        c.not_before = Time.utc(2025, 1, 1)
+        c.not_after  = Time.utc(2030, 1, 1)
+        c.sign(ca_key, OpenSSL::Digest::SHA256.new)
+        c
+      end
+
+      before { subject.datastore['CertificateTrace'] = 'full' }
+
+      it 'prints chain certs when chain has more than one cert' do
+        chain = [peer_cert, intermediate_cert]
+        # leaf + 1 chain cert = 2 print_line calls
+        expect(subject).to receive(:print_line).twice
+        subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443, chain: chain)
+      end
+
+      it 'uses "Chain N/M" header for intermediate certs' do
+        chain = [peer_cert, intermediate_cert]
+        received = []
+        allow(subject).to receive(:print_line) { |s| received << s }
+        subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443, chain: chain)
+        expect(received.last).to include('Chain 1/1')
+      end
+
+      it 'does not print chain certs in metadata mode' do
+        subject.datastore['CertificateTrace'] = 'metadata'
+        chain = [peer_cert, intermediate_cert]
+        expect(subject).to receive(:print_line).once
+        subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443, chain: chain)
+      end
+
+      it 'prints only the leaf when chain is nil' do
+        expect(subject).to receive(:print_line).once
+        subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443, chain: nil)
+      end
+
+      it 'prints only the leaf when chain has only one cert (the leaf itself)' do
+        expect(subject).to receive(:print_line).once
+        subject.certificate_peer_cert_trace(peer_cert, '192.168.1.1', 443, chain: [peer_cert])
+      end
+    end
   end
 
   describe '#certificate_csr_trace' do

--- a/spec/lib/msf/core/exploit/remote/ldap_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/ldap_spec.rb
@@ -99,7 +99,9 @@ RSpec.describe Msf::Exploit::Remote::LDAP do
       let(:tls_socket) do
         dbl = double('socket')
         allow(dbl).to receive(:respond_to?).with(:peer_cert).and_return(true)
+        allow(dbl).to receive(:respond_to?).with(:peer_cert_chain).and_return(true)
         allow(dbl).to receive(:peer_cert).and_return(tls_cert)
+        allow(dbl).to receive(:peer_cert_chain).and_return([tls_cert])
         dbl
       end
 
@@ -152,7 +154,9 @@ RSpec.describe Msf::Exploit::Remote::LDAP do
       let(:tls_socket) do
         dbl = double('socket')
         allow(dbl).to receive(:respond_to?).with(:peer_cert).and_return(true)
+        allow(dbl).to receive(:respond_to?).with(:peer_cert_chain).and_return(true)
         allow(dbl).to receive(:peer_cert).and_return(tls_cert)
+        allow(dbl).to receive(:peer_cert_chain).and_return([tls_cert])
         dbl
       end
 

--- a/spec/lib/msf/core/exploit/remote/postgres_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/postgres_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit::Remote::Postgres do
+  include_context 'Msf::Simple::Framework'
+
+  subject do
+    mod = ::Msf::Exploit.new
+    mod.extend described_class
+    mod
+  end
+
+  before do
+    allow(subject).to receive(:framework).and_return(framework)
+    subject.datastore['RHOST'] = '192.168.1.20'
+    subject.datastore['RPORT'] = 5432
+    subject.datastore['DATABASE'] = 'template1'
+    subject.datastore['USERNAME'] = 'postgres'
+    subject.datastore['PASSWORD'] = 'postgres'
+  end
+
+  describe '#postgres_login' do
+    let(:tls_cert) do
+      key = OpenSSL::PKey::RSA.generate(2048)
+      c = OpenSSL::X509::Certificate.new
+      c.subject = OpenSSL::X509::Name.parse('/CN=pg.example.com')
+      c.issuer  = OpenSSL::X509::Name.parse('/CN=Test CA')
+      c.public_key = key.public_key
+      c.serial = OpenSSL::BN.new('1')
+      c.version = 2
+      c.not_before = Time.utc(2026, 1, 1)
+      c.not_after  = Time.utc(2027, 1, 1)
+      c.sign(key, OpenSSL::Digest::SHA256.new)
+      c
+    end
+
+    let(:ssl_socket_dbl) do
+      dbl = double('ssl_socket')
+      allow(dbl).to receive(:peer_cert).and_return(tls_cert)
+      dbl
+    end
+
+    let(:pg_conn_dbl) do
+      dbl = double('pg_connection')
+      allow(dbl).to receive(:peerhost).and_return('192.168.1.20')
+      allow(dbl).to receive(:peerport).and_return(5432)
+      allow(dbl).to receive(:conn).and_return(ssl_socket_dbl)
+      dbl
+    end
+
+    before do
+      allow(::Msf::Db::PostgresPR::Connection).to receive(:new).and_return(pg_conn_dbl)
+      allow(framework).to receive(:db).and_return(double('db', active: false))
+    end
+
+    context 'SSL peer cert tracing' do
+      before { subject.datastore['SSL'] = true }
+
+      it 'prints the peer cert when CertificateTrace is enabled' do
+        subject.datastore['CertificateTrace'] = 'metadata'
+        expect(subject).to receive(:print_line).with(include('[CertificateTrace]'))
+        subject.postgres_login
+      end
+
+      it 'produces no output when CertificateTrace is off' do
+        subject.datastore['CertificateTrace'] = 'off'
+        expect(subject).not_to receive(:print_line)
+        expect(subject.postgres_login).to eq(:connected)
+      end
+
+      it 'passes ssl: true through to Connection.new' do
+        expect(::Msf::Db::PostgresPR::Connection).to receive(:new).with(
+          anything, anything, anything, anything, anything, true
+        ).and_return(pg_conn_dbl)
+        subject.postgres_login
+      end
+    end
+
+    context 'plain connection (SSL disabled)' do
+      before { subject.datastore['SSL'] = false }
+
+      it 'produces no output even when CertificateTrace is enabled (no peer_cert)' do
+        allow(ssl_socket_dbl).to receive(:peer_cert).and_return(nil)
+        subject.datastore['CertificateTrace'] = 'metadata'
+        expect(subject).not_to receive(:print_line)
+        expect(subject.postgres_login).to eq(:connected)
+      end
+
+      it 'passes ssl: false through to Connection.new' do
+        expect(::Msf::Db::PostgresPR::Connection).to receive(:new).with(
+          anything, anything, anything, anything, anything, false
+        ).and_return(pg_conn_dbl)
+        subject.postgres_login
+      end
+    end
+
+    context 'opts[:ssl] override' do
+      it 'respects an explicit ssl: true passed in opts even when datastore SSL is false' do
+        subject.datastore['SSL'] = false
+        expect(::Msf::Db::PostgresPR::Connection).to receive(:new).with(
+          anything, anything, anything, anything, anything, true
+        ).and_return(pg_conn_dbl)
+        subject.postgres_login(ssl: true)
+      end
+    end
+
+    context 'when login fails' do
+      it 'returns :error_credentials on bad password without calling certificate_peer_cert_trace' do
+        allow(::Msf::Db::PostgresPR::Connection).to receive(:new).and_raise(RuntimeError, "auth\tC28000")
+        expect(subject).not_to receive(:certificate_peer_cert_trace)
+        expect(subject.postgres_login).to eq(:error_credentials)
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/exploit/remote/rdp_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/rdp_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Msf::Exploit::Remote::RDP do
       dbl = double('ssl_socket')
       allow(dbl).to receive(:connect)
       allow(dbl).to receive(:peer_cert).and_return(tls_cert)
+      allow(dbl).to receive(:peer_cert_chain).and_return([tls_cert])
       dbl
     end
 


### PR DESCRIPTION
## Summary

Extends `CertificateTrace` peer cert tracing to PostgreSQL over TLS, and fixes a long-standing gap where the Postgres mixin accepted an `SSL` datastore option (registered via the included `Exploit::Remote::Tcp`) but never passed it through to the underlying connection.

**Changes:**
- `Exploit::Remote::Postgres` now includes `CertificateTrace`
- `postgres_login` extracts `ssl` from `opts[:ssl]` or `datastore['SSL']` and passes it as the 6th argument to `Connection.new`, activating the `starttls` path in `postgres-pr` when SSL is requested
- After a successful login, `certificate_peer_cert_trace` is called with `postgres_conn.conn.peer_cert` -- guarded by `respond_to?(:peer_cert)` so plain TCP connections are a silent no-op
- Callers can override with `opts[:ssl]: true/false` independent of the datastore

**No new options introduced.** The `SSL` bool was already registered by `Exploit::Remote::Tcp`; this PR just wires it through.

## Test plan

Rebased onto latest master; the conflicts with the merged CSR trace work (#21580) were resolved.

Chain header rendering: chain members are printed by passing `label: "Chain N/M"` to `CertificateTracePresenter#to_s_full`. This relies on the same `label:` keyword described below (default `x.509`), so there is no dependency on presenter separator internals and the header pads to the presenter's separator width for any chain length. (An earlier revision referenced `CertificateTracePresenter::SEPARATOR`, a constant #21580 removed; that path is gone.)

Peer cert labeling: peer certs now print under a `Peer Cert` header (a `label:` keyword was added to `CertificateTracePresenter#to_s_metadata`/`#to_s_full`, default `x.509`), so a server's TLS certificate is no longer visually indistinguishable from an issued/client certificate. Issued-cert (`x.509`) and CSR output are unchanged.

Unit specs (this branch, post-merge):
- `bundle exec rspec spec/lib/msf/core/exploit/remote/certificate_trace_spec.rb` - 62 examples, 0 failures (includes 5 `cert chain (full mode)` examples)
- `bundle exec rspec spec/lib/msf/core/exploit/remote/ldap_spec.rb` - 32 examples, 0 failures
- `bundle exec rspec spec/lib/msf/core/exploit/remote/rdp_spec.rb` - 10 examples, 0 failures
- `bundle exec rspec spec/lib/msf/core/exploit/remote/postgres_spec.rb` - 14 examples, 0 failures

Live test - Postgres peer cert trace over TLS (`auxiliary/admin/postgres/postgres_sql` vs a local PostgreSQL 14 with `ssl=on`, `SSL true`, `CertificateTrace=full`). The SQL query succeeds and the cert traces:

```
[CertificateTrace] Peer Cert ----------------------------
  Subject    : /CN=localhost/O=MSF Lab/C=US
  Issuer     : /CN=MSF Lab Root CA/O=MSF Lab/C=US
  SHA-256    : b3c6c44dd77622d1c73bddcfb2ba1cae5b7655371daf5909dfdd44fcb8bf88b1
  Public Key : RSA-2048
  Identity   : localhost (Subject CN)
  SAN        : DNS:localhost, IP Address:127.0.0.1
  EKU        : TLS Web Server Authentication
  Key Usage  : Digital Signature, Key Encipherment
```

Live test - full cert chain rendering. Postgres was configured to present a CA-signed server cert (leaf + issuing CA). In `full` mode the intermediate is printed under a `Chain N/M` header (leaf under `Peer Cert`), confirming the chain rendering at runtime:

```
[CertificateTrace] Chain 1/1 ----------------------------
  Subject    : /CN=MSF Lab Root CA/O=MSF Lab/C=US
  Issuer     : /CN=MSF Lab Root CA/O=MSF Lab/C=US
  Not Before : 2026-07-09 14:04:51 UTC
  Not After  : 2036-07-06 14:04:51 UTC
  SHA-256    : 8edf93a8b0535b8529e8a691c26757aa82e8f9b905970c71d0423899923770c0
  Serial     : 70724844633869769291751631124338764489961695300
  Version    : v3
  Public Key : RSA-2048
  Identity   : MSF Lab Root CA (Subject CN)
  Extensions :
    subjectKeyIdentifier : B7:08:CF:B7:D0:8D:5B:DB:15:2F:0E:6E:80:46:67:1D:6A:09:BC:73
    authorityKeyIdentifier : B7:08:CF:B7:D0:8D:5B:DB:15:2F:0E:6E:80:46:67:1D:6A:09:BC:73
    basicConstraints : CA:TRUE
```

- Dedup confirmed: one trace per host:port (DB-backed note when a database is connected, in-memory otherwise).
- Plain connections (`SSL false`, no peer cert) produce no output.

## Notes

- Depends on #21607 (Phase 2, LDAP + RDP)
- Depends on #21599 (Phase 1, HTTP)
- SMB over TLS remains pending -- TLS is not yet implemented in Rex SMB



