### PR TITLE
Implement immediate payload option validation on set calls

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/common.rb
+++ b/lib/msf/ui/console/command_dispatcher/common.rb
@@ -205,6 +205,23 @@ module Common
     path.gsub(regexp, '')
   end
 
+  # Import payload option definitions into a module's datastore so that
+  # typed validation (e.g. OptPort, OptAddressLocal) fires immediately
+  # on subsequent set calls rather than being deferred until show options
+  # triggers share_datastore.
+  #
+  # @param mod [Msf::Module] the exploit or evasion module
+  # @param payload_name [String, nil] the payload reference name to import from
+  def import_payload_options(mod, payload_name = nil)
+    payload_name ||= mod.datastore['PAYLOAD']
+    return unless payload_name
+
+    p = mod.framework.payloads.create(payload_name)
+    return unless p
+
+    mod.datastore.import_options(p.options)
+  end
+
 end
 
 end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2207,7 +2207,8 @@ class Core
     end
 
     # Set PAYLOAD
-    if name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?) && !clear
+    payload_changed = name.upcase == 'PAYLOAD' && active_module && (active_module.exploit? || active_module.evasion?) && !clear
+    if payload_changed
       value = trim_path(value, 'payload')
 
       index_from_list(payload_show_results, value) do |mod|
@@ -2243,6 +2244,11 @@ class Core
     rescue Msf::OptionValidateError => e
       print_error(e.message)
       elog('Exception encountered in cmd_set', error: e)
+    end
+
+    # Import payload options so validation applies immediately on subsequent set calls
+    if payload_changed
+      import_payload_options(active_module)
     end
 
     # Set PAYLOAD from TARGET

--- a/lib/msf/ui/console/command_dispatcher/modules.rb
+++ b/lib/msf/ui/console/command_dispatcher/modules.rb
@@ -928,6 +928,11 @@ module Msf
               print_status("No payload configured, defaulting to #{chosen_payload}") if chosen_payload
             end
 
+            # Import payload options so validation applies immediately on set calls
+            if (mod.exploit? || mod.evasion?) && mod.datastore['PAYLOAD']
+              import_payload_options(mod)
+            end
+
             if framework.features.enabled?(Msf::FeatureManager::DISPLAY_MODULE_ACTION) && mod.respond_to?(:actions) && mod.actions.size > 1
               print_status "Setting default action %grn#{mod.action.name}%clr - view all #{mod.actions.size} actions with the %grnshow actions%clr command"
             end

--- a/spec/lib/msf/ui/console/command_dispatcher/core_payload_options_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/core_payload_options_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
+  include_context 'Msf::DBManager'
+  include_context 'Msf::UIDriver'
+
+  subject(:core) do
+    described_class.new(driver)
+  end
+
+  describe '#cmd_set' do
+    context 'when setting PAYLOAD on an exploit module' do
+      let(:mod) do
+        mod_klass = Class.new(Msf::Exploit) do
+          def initialize
+            super(
+              'Name' => 'mock exploit for payload option import',
+              'Description' => 'mock exploit',
+              'Author' => ['Unknown'],
+              'License' => MSF_LICENSE,
+              'Arch' => ARCH_CMD,
+              'Platform' => ['unix'],
+              'Targets' => [['Automatic', {}]],
+              'DefaultTarget' => 0
+            )
+
+            register_options(
+              [
+                Msf::Opt::RHOSTS
+              ]
+            )
+          end
+        end
+        mod = mod_klass.new
+        allow(mod).to receive(:framework).and_return(framework)
+        mod
+      end
+
+      before(:each) do
+        allow(core).to receive(:active_module).and_return(mod)
+        allow(driver).to receive(:on_variable_set).and_return(true)
+        # Initialize the class variable that cmd_set references for payload index lookup
+        Msf::Ui::Console::CommandDispatcher::Modules.class_variable_set(:@@payload_show_results, [])
+      end
+
+      it 'imports payload options into the module datastore for immediate validation' do
+        # Before setting PAYLOAD, LHOST should not be in the module's options
+        expect(mod.datastore.options['LHOST']).to be_nil
+
+        core.cmd_set('PAYLOAD', 'generic/shell_reverse_tcp')
+
+        # After setting PAYLOAD, the payload's LHOST option should be registered
+        # so that subsequent set calls validate immediately
+        expect(mod.datastore.options['LHOST']).not_to be_nil
+      end
+
+      it 'validates payload options on subsequent set calls without requiring show options' do
+        core.cmd_set('PAYLOAD', 'generic/shell_reverse_tcp')
+
+        # Setting an invalid LPORT should trigger validation error
+        core.cmd_set('LPORT', 'not_a_port')
+        expect(@error.join).to match(/not valid for option/)
+      end
+
+      it 'updates payload options when switching to a different payload' do
+        core.cmd_set('PAYLOAD', 'generic/shell_reverse_tcp')
+        expect(mod.datastore.options['LHOST']).not_to be_nil
+
+        # Switch to a bind payload - LPORT should still be present
+        core.cmd_set('PAYLOAD', 'generic/shell_bind_tcp')
+        expect(mod.datastore.options['LPORT']).not_to be_nil
+      end
+    end
+  end
+end
+
+RSpec.describe Msf::Ui::Console::CommandDispatcher::Modules do
+  include_context 'Msf::DBManager'
+  include_context 'Msf::UIDriver'
+
+  subject(:modules_dispatcher) do
+    described_class.new(driver)
+  end
+
+  describe '#import_payload_options' do
+    let(:mod) do
+      mod_klass = Class.new(Msf::Exploit) do
+        def initialize
+          super(
+            'Name' => 'mock exploit for use-time payload import',
+            'Description' => 'mock exploit',
+            'Author' => ['Unknown'],
+            'License' => MSF_LICENSE,
+            'Arch' => ARCH_CMD,
+            'Platform' => ['unix'],
+            'Targets' => [['Automatic', {}]],
+            'DefaultTarget' => 0
+          )
+
+          register_options(
+            [
+              Msf::Opt::RHOSTS
+            ]
+          )
+        end
+      end
+      mod = mod_klass.new
+      allow(mod).to receive(:framework).and_return(framework)
+      mod
+    end
+
+    it 'imports reverse payload options into the module datastore' do
+      expect(mod.datastore.options['LHOST']).to be_nil
+
+      modules_dispatcher.import_payload_options(mod, 'generic/shell_reverse_tcp')
+
+      expect(mod.datastore.options['LHOST']).not_to be_nil
+      expect(mod.datastore.options['LPORT']).not_to be_nil
+    end
+
+    it 'imports bind payload options into the module datastore' do
+      modules_dispatcher.import_payload_options(mod, 'generic/shell_bind_tcp')
+
+      expect(mod.datastore.options['LPORT']).not_to be_nil
+    end
+
+    it 'does nothing when payload_name is nil and datastore has no PAYLOAD' do
+      modules_dispatcher.import_payload_options(mod, nil)
+
+      expect(mod.datastore.options['LHOST']).to be_nil
+      expect(mod.datastore.options['LPORT']).to be_nil
+    end
+
+    it 'uses the datastore PAYLOAD when no explicit name is given' do
+      mod.datastore['PAYLOAD'] = 'generic/shell_reverse_tcp'
+
+      modules_dispatcher.import_payload_options(mod)
+
+      expect(mod.datastore.options['LHOST']).not_to be_nil
+    end
+
+    it 'does nothing for an invalid payload name' do
+      modules_dispatcher.import_payload_options(mod, 'nonexistent/payload')
+
+      expect(mod.datastore.options['LHOST']).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Description

Payload option validation (LHOST, LPORT, etc.) was timing-dependent — it only fired on `set` calls after `show options` had been run, because `show options` triggers `share_datastore` which imports the payload's typed option definitions into the exploit module's datastore as a side effect. Before that call, `DataStore#[]=` skipped validation entirely since no option metadata was registered for payload keys.

This change eagerly imports payload option definitions when:
1. A user runs `set PAYLOAD <name>` on an exploit/evasion module
2. A module is loaded via `use` and a default payload is selected by `choose_payload`

After this fix, `set LPORT not_a_port` immediately reports a validation error regardless of whether `show options` has been called.

A shared `import_payload_options` helper is added to `CommandDispatcher::Common` to avoid duplicating the logic between `cmd_set` (core.rb) and `cmd_use` (modules.rb).

**Related Issue:** Related to #21552 (LHOST validation behavior)

## Verification Steps

1. - [ ] `msfconsole`
2. - [ ] `use exploit/multi/handler`
3. - [ ] `set PAYLOAD windows/meterpreter/reverse_tcp`
4. - [ ] `set LPORT not_a_port` — should immediately report validation error
5. - [ ] `set LHOST 192.0.2.1` — should succeed
6. - [ ] `use exploit/windows/smb/psexec`
7. - [ ] `set PAYLOAD windows/meterpreter/reverse_tcp`
8. - [ ] `set LPORT abc` — should immediately report validation error (previously this would silently succeed until `show options` was called first)

## Test Evidence

### Before
```
~/dev/metasploit-framework on  upstream-master! ⌚ 14:33:10
$ ./msfconsole -q                                                                                                                                                        ‹ruby-3.3.8@metasploit-framework›
[*] Using configured payload generic/shell_reverse_tcp
msf exploit(multi/handler) > set LPORT not_a_port
LPORT => not_a_port
msf exploit(multi/handler) >
```

### After
```
~/dev/metasploit-framework on  fix-option-validation! ⌚ 14:32:49
$ ./msfconsole -q                                                                                                                                                        ‹ruby-3.3.8@metasploit-framework›
[*] Using configured payload generic/shell_reverse_tcp
msf exploit(multi/handler) > set LPORT not_a_port
[-] The following options failed to validate: Value 'not_a_port' is not valid for option 'LPORT'.
LPORT => 4444
msf exploit(multi/handler) >
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS 26.5.1 |
| **Ruby Version** | 3.3.8 |
| **Target Software/Hardware** | Metasploit Framework console (msfconsole) |

## AI Usage Disclosure

Kiro

## Pre-Submission Checklist

- [x] Ran [`rubocop`](https://docs.metasploit.com/docs/development/quality/using-rubocop.html) on new files with no new offenses
- [ ] ~~Ran [`msftidy`](https://docs.metasploit.com/docs/development/quality/msftidy.html) on changed module files with no new offenses~~ _(not applicable — no module files changed)_
- [ ] ~~Included a corresponding documentation markdown file~~ _(not applicable)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

