### PR TITLE
Feature/panos CVE 2026 0265 scanner

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/panos_cve_2026_0265.md
+++ b/documentation/modules/auxiliary/scanner/http/panos_cve_2026_0265.md
@@ -1,0 +1,171 @@
+# PAN-OS GlobalProtect CVE-2026-0265 Vulnerability Checker
+
+## Overview
+
+This module safely detects systems affected by **CVE-2026-0265**, a vulnerability
+affecting **Palo Alto Networks PAN-OS GlobalProtect** when **Clientless
+Application Services (CAS)** authentication is enabled.
+
+The module performs a single anonymous request to the GlobalProtect
+prelogin endpoint and determines whether a target is affected by:
+
+1. Identifying whether the target is a GlobalProtect portal.
+2. Determining whether CAS authentication is enabled.
+3. Extracting the embedded PAN-OS version from the prelogin response.
+4. Comparing the version against the version and hotfix thresholds
+   published in the Palo Alto Networks security advisory.
+
+This module **does not** attempt exploitation, authentication bypass,
+session creation, or modification of the target system.
+
+## Vulnerability Detection Logic
+
+The detection process is intentionally passive.
+
+1. Perform an anonymous HTTP(S) GET request to:
+
+```
+/global-protect/prelogin.esp
+```
+
+2. Verify the target is a GlobalProtect portal.
+
+3. Determine whether CAS authentication is enabled by inspecting:
+
+```xml
+<cas-auth>yes</cas-auth>
+```
+
+4. Decode the embedded SAML/JWT token.
+
+5. Extract the embedded PAN-OS version:
+
+```
+PanOSversion
+```
+
+6. Compare the version against the advisory-defined version and hotfix
+thresholds.
+
+The module reports one of several possible states:
+
+| Status | Description |
+|---------|-------------|
+| **VULNERABLE** | Target version falls below the advisory-defined patched hotfix. |
+| **NOT VULNERABLE (PATCHED)** | Target version is patched. |
+| **NOT VULNERABLE (NOT-AFFECTED-NO-CAS)** | CAS authentication is not enabled. |
+| **NOT VULNERABLE (NOT-AFFECTED-NOT-GLOBALPROTECT)** | Target is not a GlobalProtect portal. |
+| **UNDETERMINED** | Version or configuration could not be reliably determined. |
+
+## Module Options
+
+| Option | Description |
+|---------|-------------|
+| RHOSTS | Target host(s). |
+| RPORT | Target HTTPS port (default: 443). |
+| SSL | Use HTTPS (default: true). |
+| TARGETURI | GlobalProtect prelogin endpoint. |
+| USERAGENT | User-Agent used for the anonymous probe. |
+| TIMEOUT | HTTP request timeout. |
+| RETRIES | Number of retries for transient failures or HTTP 503 responses. |
+
+## Usage
+
+Load the module:
+
+```text
+use auxiliary/scanner/http/panos_cve_2026_0265
+```
+
+Configure the target:
+
+```text
+set RHOSTS 10.10.10.6
+```
+
+Execute the scan:
+
+```text
+run
+```
+
+## Example Output
+
+### Vulnerable System
+
+```text
+[*] 10.10.10.6:443 - CAS enabled: Yes
+[*] 10.10.10.6:443 - PAN-OS version: 11.1.4
+[+] 10.10.10.6:443 - Status: VULNERABLE
+[*] 10.10.10.6:443 - 11.1.4 is below the advisory patched hotfix for this base.
+```
+
+### Patched System
+
+```text
+[*] 10.10.10.100:443 - CAS enabled: Yes
+[*] 10.10.10.100:443 - PAN-OS version: 11.2.7-h14
+[*] 10.10.10.100:443 - Status: NOT VULNERABLE (PATCHED)
+[*] 10.10.10.100:443 - 11.2.7-h14 is at or above the advisory patched hotfix for this base.
+```
+
+### CAS Disabled
+
+```text
+[*] 10.10.10.5:443 - CAS enabled: No
+[*] 10.10.10.5:443 - PAN-OS version: unknown
+[*] 10.10.10.5:443 - Status: NOT VULNERABLE (NOT-AFFECTED-NO-CAS)
+[*] 10.10.10.5:443 - prelogin response did not contain <cas-auth>yes</cas-auth>.
+```
+
+## Reporting
+
+When a vulnerable system is identified, the module reports the finding to
+the Metasploit database using `report_vuln`.
+
+Example:
+
+```text
+msf > vulns
+
+Timestamp                Host        Service    Name
+---------                ----        -------    ----
+2026-06-25 18:59:14 UTC  10.10.10.6  443/tcp    PAN-OS GlobalProtect CAS CVE-2026-0265
+```
+
+## Limitations
+
+This module performs passive detection only.
+
+It does **not**:
+
+- Exploit the vulnerability.
+- Attempt authentication.
+- Create or modify sessions.
+- Change firewall configuration.
+- Trigger the vulnerable code path.
+
+Detection depends on information exposed by the GlobalProtect prelogin
+endpoint and the advisory-defined version matrix.
+
+## Testing
+
+The module was validated against:
+
+- PAN-OS GlobalProtect with CAS enabled and vulnerable versions.
+- PAN-OS GlobalProtect with CAS enabled and patched versions.
+- PAN-OS GlobalProtect with CAS disabled.
+- Non-GlobalProtect / non-PAN-OS HTTPS services.
+
+Validation also included:
+
+- Ruby syntax (`ruby -c`)
+- `msftidy`
+- RuboCop
+- Metasploit database reporting
+
+## References
+
+- Palo Alto Networks Security Advisory: CVE-2026-0265
+- Bishop Fox CVE-2026-0265 Detection Utility
+- CVE-2026-0265

--- a/documentation/modules/auxiliary/scanner/http/panos_cve_2026_0265.md
+++ b/documentation/modules/auxiliary/scanner/http/panos_cve_2026_0265.md
@@ -1,171 +1,131 @@
-# PAN-OS GlobalProtect CVE-2026-0265 Vulnerability Checker
+## Vulnerable Application
 
-## Overview
+CVE-2026-0265 affects Palo Alto Networks PAN-OS GlobalProtect portals when Cloud Authentication Service (CAS)
+authentication is enabled and the PAN-OS version is within an affected release range.
 
-This module safely detects systems affected by **CVE-2026-0265**, a vulnerability
-affecting **Palo Alto Networks PAN-OS GlobalProtect** when **Clientless
-Application Services (CAS)** authentication is enabled.
+This module performs anonymous HTTP(S) GET requests to the GlobalProtect prelogin endpoint and uses the returned
+prelogin data to:
 
-The module performs a single anonymous request to the GlobalProtect
-prelogin endpoint and determines whether a target is affected by:
+1. Determine whether the listener is a GlobalProtect portal.
+2. Determine whether CAS authentication is enabled.
+3. Decode the embedded SAML/JWT token when present.
+4. Extract the `PanOSversion` value.
+5. Compare the version and hotfix level against the advisory-defined version matrix.
 
-1. Identifying whether the target is a GlobalProtect portal.
-2. Determining whether CAS authentication is enabled.
-3. Extracting the embedded PAN-OS version from the prelogin response.
-4. Comparing the version against the version and hotfix thresholds
-   published in the Palo Alto Networks security advisory.
+The module does not attempt authentication bypass, create a session, modify the request body, change firewall
+configuration, or exercise the vulnerable code path. A vulnerable result is based on the exposed configuration and
+version information.
 
-This module **does not** attempt exploitation, authentication bypass,
-session creation, or modification of the target system.
+The module uses the version and hotfix thresholds published by Palo Alto Networks and the detection logic from the
+Bishop Fox CVE-2026-0265 checker:
 
-## Vulnerability Detection Logic
+* [Palo Alto Networks CVE-2026-0265 Security Advisory](https://security.paloaltonetworks.com/CVE-2026-0265)
+* [Bishop Fox CVE-2026-0265 Detection Utility](https://github.com/BishopFox/CVE-2026-0265-check)
 
-The detection process is intentionally passive.
+The module has been tested against the following configurations:
 
-1. Perform an anonymous HTTP(S) GET request to:
+* PAN-OS 11.1.4 with CAS enabled.
+* PAN-OS 11.2.7-h14 with CAS enabled.
+* A GlobalProtect configuration with CAS disabled.
+* Non-GlobalProtect / non-PAN-OS HTTP(S) services.
+* A Python-based PAN-OS prelogin emulator for validating multiple version-response scenarios.
 
-```
-/global-protect/prelogin.esp
-```
 
-2. Verify the target is a GlobalProtect portal.
-
-3. Determine whether CAS authentication is enabled by inspecting:
-
-```xml
-<cas-auth>yes</cas-auth>
-```
-
-4. Decode the embedded SAML/JWT token.
-
-5. Extract the embedded PAN-OS version:
-
-```
-PanOSversion
-```
-
-6. Compare the version against the advisory-defined version and hotfix
-thresholds.
-
-The module reports one of several possible states:
+The scanner can return the following states:
 
 | Status | Description |
-|---------|-------------|
-| **VULNERABLE** | Target version falls below the advisory-defined patched hotfix. |
-| **NOT VULNERABLE (PATCHED)** | Target version is patched. |
-| **NOT VULNERABLE (NOT-AFFECTED-NO-CAS)** | CAS authentication is not enabled. |
-| **NOT VULNERABLE (NOT-AFFECTED-NOT-GLOBALPROTECT)** | Target is not a GlobalProtect portal. |
-| **UNDETERMINED** | Version or configuration could not be reliably determined. |
+|--------|-------------|
+| `VULNERABLE` | CAS is enabled and the PAN-OS version is below the applicable patched hotfix or patched base release. |
+| `NOT VULNERABLE (PATCHED)` | CAS is enabled and the PAN-OS version is at or above the applicable patched hotfix or patched base release. |
+| `NOT VULNERABLE (NOT-AFFECTED-SAAS)` | The detected build is a SaaS build and is not affected according to the advisory logic. |
+| `NOT VULNERABLE (NOT-AFFECTED-NO-CAS)` | The GlobalProtect prelogin response does not indicate CAS authentication is enabled. |
+| `NOT VULNERABLE (NOT-AFFECTED-NOT-GLOBALPROTECT)` | The response indicates the listener is not a GlobalProtect portal. |
+| `UNDETERMINED` | Status could not be determined because of network, parsing, mTLS, or client-version gating. |
 
-## Module Options
+## Verification Steps
 
-| Option | Description |
-|---------|-------------|
-| RHOSTS | Target host(s). |
-| RPORT | Target HTTPS port (default: 443). |
-| SSL | Use HTTPS (default: true). |
-| TARGETURI | GlobalProtect prelogin endpoint. |
-| USERAGENT | User-Agent used for the anonymous probe. |
-| TIMEOUT | HTTP request timeout. |
-| RETRIES | Number of retries for transient failures or HTTP 503 responses. |
+1. Configure or identify a PAN-OS GlobalProtect portal to test.
+1. Start `msfconsole`.
+1. Do: `use auxiliary/scanner/http/panos_cve_2026_0265`
+1. Do: `set RHOSTS <target>`
+1. If required, set `RPORT`, `SSL`, `TARGETURI`, `USERAGENT`, `TIMEOUT`, or `RETRY_TIMEOUT`.
+1. Do: `run`
+1. Verify that the module reports the CAS state, PAN-OS version when available, and vulnerability status.
 
-## Usage
+## Options
 
-Load the module:
+### USERAGENT
+
+The User-Agent sent with the anonymous prelogin request. The default is a browser-like Chrome User-Agent intended
+to allow the prelogin response to return the information required by the scanner.
+
+If the target uses client-version gating and the module returns an undetermined result, this option can be changed to
+a User-Agent appropriate for the environment.
+
+### TIMEOUT
+
+The HTTP request timeout in seconds. The default is `20`.
+
+### RETRY_TIMEOUT
+
+The maximum amount of time, in seconds, that the module will retry transient connection failures or HTTP `503`
+responses. The default is `15`.
+
+Retries use Metasploit's `Msf::Exploit::Retry.retry_until_truthy` helper and stop when a non-`503` HTTP response is
+received or the retry timeout expires.
+
+## Scenarios
+
+### PAN-OS 11.1.4 with CAS Enabled
+
+The following example shows a CAS-enabled PAN-OS 11.1.4 target. The module identifies the system as vulnerable and
+reports the applicable patched hotfix.
 
 ```text
-use auxiliary/scanner/http/panos_cve_2026_0265
-```
+msf auxiliary(scanner/http/panos_cve_2026_0265) > set RHOSTS 10.10.10.6
+RHOSTS => 10.10.10.6
+msf auxiliary(scanner/http/panos_cve_2026_0265) > run
 
-Configure the target:
-
-```text
-set RHOSTS 10.10.10.6
-```
-
-Execute the scan:
-
-```text
-run
-```
-
-## Example Output
-
-### Vulnerable System
-
-```text
 [*] 10.10.10.6:443 - CAS enabled: Yes
 [*] 10.10.10.6:443 - PAN-OS version: 11.1.4
 [+] 10.10.10.6:443 - Status: VULNERABLE
-[*] 10.10.10.6:443 - 11.1.4 is below the advisory patched hotfix for this base.
+[*] 10.10.10.6:443 - 11.1.4 is below the advisory patched hotfix 11.1.4-h33.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
 ```
 
-### Patched System
+### PAN-OS 11.2.7-h14 with CAS Enabled
+
+The following example shows a CAS-enabled PAN-OS 11.2.7-h14 target. The module identifies the system as patched and
+reports the applicable patched hotfix.
 
 ```text
-[*] 10.10.10.100:443 - CAS enabled: Yes
-[*] 10.10.10.100:443 - PAN-OS version: 11.2.7-h14
-[*] 10.10.10.100:443 - Status: NOT VULNERABLE (PATCHED)
-[*] 10.10.10.100:443 - 11.2.7-h14 is at or above the advisory patched hotfix for this base.
+msf auxiliary(scanner/http/panos_cve_2026_0265) > set RHOSTS 10.10.10.7
+RHOSTS => 10.10.10.7
+msf auxiliary(scanner/http/panos_cve_2026_0265) > run
+
+[*] 10.10.10.7:443 - CAS enabled: Yes
+[*] 10.10.10.7:443 - PAN-OS version: 11.2.7-h14
+[*] 10.10.10.7:443 - Status: NOT VULNERABLE (PATCHED)
+[*] 10.10.10.7:443 - 11.2.7-h14 is at or above the advisory patched hotfix 11.2.7-h13.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
 ```
 
-### CAS Disabled
+### GlobalProtect with CAS Disabled
+
+When the GlobalProtect prelogin response does not contain `<cas-auth>yes</cas-auth>`, the vulnerability does not
+apply to that listener and the module reports the target as not affected.
 
 ```text
+msf auxiliary(scanner/http/panos_cve_2026_0265) > set RHOSTS 10.10.10.5
+RHOSTS => 10.10.10.5
+msf auxiliary(scanner/http/panos_cve_2026_0265) > run
+
 [*] 10.10.10.5:443 - CAS enabled: No
 [*] 10.10.10.5:443 - PAN-OS version: unknown
 [*] 10.10.10.5:443 - Status: NOT VULNERABLE (NOT-AFFECTED-NO-CAS)
 [*] 10.10.10.5:443 - prelogin response did not contain <cas-auth>yes</cas-auth>.
+[*] Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
 ```
-
-## Reporting
-
-When a vulnerable system is identified, the module reports the finding to
-the Metasploit database using `report_vuln`.
-
-Example:
-
-```text
-msf > vulns
-
-Timestamp                Host        Service    Name
----------                ----        -------    ----
-2026-06-25 18:59:14 UTC  10.10.10.6  443/tcp    PAN-OS GlobalProtect CAS CVE-2026-0265
-```
-
-## Limitations
-
-This module performs passive detection only.
-
-It does **not**:
-
-- Exploit the vulnerability.
-- Attempt authentication.
-- Create or modify sessions.
-- Change firewall configuration.
-- Trigger the vulnerable code path.
-
-Detection depends on information exposed by the GlobalProtect prelogin
-endpoint and the advisory-defined version matrix.
-
-## Testing
-
-The module was validated against:
-
-- PAN-OS GlobalProtect with CAS enabled and vulnerable versions.
-- PAN-OS GlobalProtect with CAS enabled and patched versions.
-- PAN-OS GlobalProtect with CAS disabled.
-- Non-GlobalProtect / non-PAN-OS HTTPS services.
-
-Validation also included:
-
-- Ruby syntax (`ruby -c`)
-- `msftidy`
-- RuboCop
-- Metasploit database reporting
-
-## References
-
-- Palo Alto Networks Security Advisory: CVE-2026-0265
-- Bishop Fox CVE-2026-0265 Detection Utility
-- CVE-2026-0265

--- a/documentation/modules/auxiliary/scanner/http/panos_cve_2026_0265.md
+++ b/documentation/modules/auxiliary/scanner/http/panos_cve_2026_0265.md
@@ -48,7 +48,7 @@ The scanner can return the following states:
 1. Start `msfconsole`.
 1. Do: `use auxiliary/scanner/http/panos_cve_2026_0265`
 1. Do: `set RHOSTS <target>`
-1. If required, set `RPORT`, `SSL`, `TARGETURI`, `USERAGENT`, `TIMEOUT`, or `RETRY_TIMEOUT`.
+1. If required, set `RPORT`, `SSL`, `TARGETURI`, `USERAGENT`, or `RETRY_TIMEOUT`.
 1. Do: `run`
 1. Verify that the module reports the CAS state, PAN-OS version when available, and vulnerability status.
 
@@ -62,14 +62,12 @@ to allow the prelogin response to return the information required by the scanner
 If the target uses client-version gating and the module returns an undetermined result, this option can be changed to
 a User-Agent appropriate for the environment.
 
-### TIMEOUT
-
-The HTTP request timeout in seconds. The default is `20`.
-
 ### RETRY_TIMEOUT
 
 The maximum amount of time, in seconds, that the module will retry transient connection failures or HTTP `503`
 responses. The default is `15`.
+
+The value must be greater than `0`. Non-positive values generate a warning and cause the module to use the default of `15` seconds.
 
 Retries use Metasploit's `Msf::Exploit::Retry.retry_until_truthy` helper and stop when a non-`503` HTTP response is
 received or the retry timeout expires.

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -1,0 +1,302 @@
+##
+##
+# CVE-2026-0265 PAN-OS GlobalProtect CAS Exposure and Version Scanner
+#
+# Safe scanner: no authentication bypass attempted, no session creation,
+# no body modification, and no firewall state changes.
+#
+# Detection logic derived from:
+# https://github.com/BishopFox/CVE-2026-0265-check
+#
+# Copyright (c) Bishop Fox
+# Original utility released under the MIT License.
+#
+# This Metasploit module is distributed under the Metasploit Framework license.
+##
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  DEFAULT_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ' \
+                       '(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36'
+
+  # Per-base patched-hotfix cutoffs from Bishop Fox scanner / PA advisory logic.
+  # Any hotfix strictly below the listed value on the same base is vulnerable.
+  ADVISORY_PATCHED_HOTFIX = {
+    [10, 2, 4 ] => 44,
+    [10, 2, 7 ] => 34,
+    [10, 2, 10] => 36,
+    [10, 2, 13] => 21,
+    [10, 2, 16] => 7,
+    [10, 2, 18] => 6,
+    [11, 1, 4 ] => 33,
+    [11, 1, 6 ] => 32,
+    [11, 1, 7 ] => 6,
+    [11, 1, 10] => 25,
+    [11, 1, 13] => 5,
+    [11, 2, 4 ] => 17,
+    [11, 2, 7 ] => 13,
+    [11, 2, 10] => 6,
+    [12, 1, 4 ] => 5
+  }.freeze
+
+  # Train-base floors: anything >= this base in the train is patched.
+  ADVISORY_BASE_FLOOR = {
+    [11, 1] => 15,
+    [11, 2] => 12,
+    [12, 1] => 7
+  }.freeze
+
+  UNAFFECTED_TRAINS = [
+    [8, 1],
+    [9, 1]
+  ].freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'PAN-OS GlobalProtect CAS CVE-2026-0265 Vulnerability Checker',
+        'Description' => %q{
+          This module checks a PAN-OS GlobalProtect portal for CVE-2026-0265
+          using the Bishop Fox scanner decision flow. It performs a single
+          anonymous GET request to the GlobalProtect prelogin endpoint, checks
+          whether CAS authentication is enabled, decodes the embedded SAML/JWT
+          token when present, extracts PanOSversion, and compares it against
+          the advisory version matrix.
+        },
+        'Author' => [
+          'Bishop Fox Team X', # original scanner logic
+          'Rapid7 Research / Deral Heiland adaptation' # Metasploit port workflow
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-0265'],
+          ['URL', 'https://security.paloaltonetworks.com/CVE-2026-0265']
+        ],
+        'DisclosureDate' => '2026-05-21',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(443),
+        OptBool.new('SSL', [true, 'Use SSL/TLS', true]),
+        OptString.new('TARGETURI', [true, 'GlobalProtect prelogin endpoint path', '/global-protect/prelogin.esp']),
+        OptString.new('USERAGENT', [true, 'User-Agent used for the prelogin probe', DEFAULT_USER_AGENT]),
+        OptInt.new('TIMEOUT', [true, 'HTTP request timeout in seconds', 20]),
+        OptInt.new('RETRIES', [true, 'Number of retries for transient failures or HTTP 503', 3])
+      ]
+    )
+  end
+
+  def run_host(ip)
+    finding = scan_target
+    target = target_label(ip)
+
+    print_status("#{target} - CAS enabled: #{finding[:cas_enabled]}")
+    print_status("#{target} - PAN-OS version: #{finding[:panos_version] || 'unknown'}")
+
+    case finding[:verdict]
+    when 'VULNERABLE'
+      print_good("#{target} - Status: VULNERABLE")
+      print_status("#{target} - #{finding[:note]}") if finding[:note]
+      report_vulnerability(ip, finding)
+    when 'PATCHED', 'NOT-AFFECTED-SAAS', 'NOT-AFFECTED-NO-CAS', 'NOT-AFFECTED-NOT-GLOBALPROTECT'
+      print_status("#{target} - Status: NOT VULNERABLE (#{finding[:verdict]})")
+      print_status("#{target} - #{finding[:note]}") if finding[:note]
+    else
+      print_warning("#{target} - Status: UNDETERMINED (#{finding[:verdict]})")
+      print_warning("#{target} - #{finding[:error]}") if finding[:error]
+      print_status("#{target} - #{finding[:note]}") if finding[:note]
+    end
+  rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError => e
+    print_error("#{target_label(ip)} - Status: UNDETERMINED (network error: #{e.class}: #{e.message})")
+  rescue ::StandardError => e
+    print_error("#{target_label(ip)} - Status: UNDETERMINED (module error: #{e.class}: #{e.message})")
+  end
+
+  def target_label(ip)
+    "#{ip}:#{datastore['RPORT']}"
+  end
+
+  def scan_target
+    res = fetch_prelogin
+    return error_finding('UNDETERMINED-ERROR', 'No HTTP response received') unless res
+
+    body = res.body.to_s
+
+    if body.include?('GlobalProtect portal does not exist')
+      return {
+        verdict: 'NOT-AFFECTED-NOT-GLOBALPROTECT',
+        cas_enabled: 'No',
+        panos_version: nil,
+        note: 'Response indicates this listener is not a GlobalProtect portal.'
+      }
+    end
+
+    if body.include?('Valid client certificate is required')
+      return {
+        verdict: 'UNDETERMINED-MTLS-GATED',
+        cas_enabled: 'Unknown',
+        panos_version: nil,
+        note: 'mTLS gate hides the authentication profile configuration.'
+      }
+    end
+
+    if body.include?('CAS is not supported by the client')
+      return {
+        verdict: 'UNDETERMINED-VERSION-GATED',
+        cas_enabled: 'Yes',
+        panos_version: nil,
+        note: 'CAS is attached but the probe was User-Agent/client-version gated.'
+      }
+    end
+
+    cas_auth_value = body[%r{<cas-auth>([^<]*)</cas-auth>}i, 1]
+    unless cas_auth_value == 'yes'
+      return {
+        verdict: 'NOT-AFFECTED-NO-CAS',
+        cas_enabled: 'No',
+        panos_version: nil,
+        note: 'prelogin response did not contain <cas-auth>yes</cas-auth>.'
+      }
+    end
+
+    claims = decode_token_from_prelogin(body)
+    unless claims
+      return error_finding('UNDETERMINED-ERROR', 'cas-auth=yes but Token decode from prelogin response failed', 'Yes')
+    end
+
+    panos_version = claims['PanOSversion']
+    verdict = advisory_verdict_for_version(panos_version.to_s)
+
+    if verdict == 'ERROR'
+      return error_finding(
+        'UNDETERMINED-ERROR',
+        "PanOSversion=#{panos_version.inspect} could not be parsed against advisory matrix",
+        'Yes',
+        panos_version
+      )
+    end
+
+    note = case verdict
+           when 'VULNERABLE'
+             "#{panos_version} is below the advisory patched hotfix for this base."
+           when 'PATCHED'
+             "#{panos_version} is at or above the advisory patched hotfix for this base."
+           when 'NOT-AFFECTED-SAAS'
+             '.saas builds are not affected per advisory logic.'
+           end
+
+    {
+      verdict: verdict,
+      cas_enabled: 'Yes',
+      panos_version: panos_version,
+      note: note
+    }
+  end
+
+  def fetch_prelogin
+    last_res = nil
+    attempts = datastore['RETRIES'].to_i + 1
+
+    attempts.times do |attempt|
+      res = send_request_cgi(
+        {
+          'method' => 'GET',
+          'uri' => normalize_uri(datastore['TARGETURI']),
+          'headers' => {
+            'User-Agent' => datastore['USERAGENT']
+          }
+        },
+        datastore['TIMEOUT'].to_i
+      )
+
+      return res if res && res.code != 503
+
+      last_res = res
+      Rex.sleep([attempt, 4].min) if attempt < attempts - 1
+    rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError
+      Rex.sleep([attempt, 4].min) if attempt < attempts - 1
+      raise if attempt == attempts - 1
+    end
+
+    last_res
+  end
+
+  def decode_token_from_prelogin(body)
+    saml_request = body[%r{<saml-request>([^<]+)</saml-request>}i, 1]
+    return nil unless saml_request
+
+    html_form = Rex::Text.decode_base64(saml_request.strip).to_s
+    token = html_form[/name="Token"\s+value="([^"]+)"/, 1]
+    return nil unless token
+
+    parts = token.split('.')
+    return nil unless parts.length == 3
+
+    payload_json = base64url_decode(parts[1])
+    JSON.parse(payload_json)
+  rescue ::StandardError
+    nil
+  end
+
+  def base64url_decode(value)
+    padded = value + ('=' * ((4 - value.length % 4) % 4))
+    Rex::Text.decode_base64(padded.tr('-_', '+/'))
+  end
+
+  def advisory_verdict_for_version(panos_version)
+    return 'ERROR' if panos_version.empty?
+    return 'NOT-AFFECTED-SAAS' if panos_version.include?('.saas')
+
+    match = panos_version.match(/^(\d+)\.(\d+)\.(\d+)(?:-h(\d+))?$/)
+    return 'ERROR' unless match
+
+    maj = match[1].to_i
+    min = match[2].to_i
+    pat = match[3].to_i
+    hf = match[4] ? match[4].to_i : 0
+
+    return 'PATCHED' if UNAFFECTED_TRAINS.include?([maj, min])
+
+    floor = ADVISORY_BASE_FLOOR[[maj, min]]
+    return 'PATCHED' if floor && pat >= floor
+
+    cutoff = ADVISORY_PATCHED_HOTFIX[[maj, min, pat]]
+    return hf >= cutoff ? 'PATCHED' : 'VULNERABLE' if cutoff
+
+    return 'VULNERABLE' if [[10, 2], [11, 1], [11, 2], [12, 1]].include?([maj, min])
+
+    'PATCHED'
+  end
+
+  def error_finding(verdict, error, cas_enabled = 'Unknown', panos_version = nil)
+    {
+      verdict: verdict,
+      cas_enabled: cas_enabled,
+      panos_version: panos_version,
+      error: error
+    }
+  end
+
+  def report_vulnerability(ip, finding)
+    report_vuln(
+      host: ip,
+      port: datastore['RPORT'],
+      proto: 'tcp',
+      name: 'PAN-OS GlobalProtect CAS CVE-2026-0265',
+      refs: references,
+      info: "CAS enabled: #{finding[:cas_enabled]}, PAN-OS version: #{finding[:panos_version]}, verdict: #{finding[:verdict]}"
+    )
+  end
+end

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -273,7 +273,7 @@ class MetasploitModule < Msf::Auxiliary
     return 'PATCHED' if floor && pat >= floor
 
     cutoff = ADVISORY_PATCHED_HOTFIX[[maj, min, pat]]
-    return hf >= cutoff ? 'PATCHED' : 'VULNERABLE' if cutoff
+    return (hf >= cutoff ? 'PATCHED' : 'VULNERABLE') if cutoff
 
     return 'VULNERABLE' if [[10, 2], [11, 1], [11, 2], [12, 1]].include?([maj, min])
 

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -221,8 +221,7 @@ class MetasploitModule < Msf::Auxiliary
           'headers' => {
             'User-Agent' => datastore['USERAGENT']
           }
-        },
-        datastore['TIMEOUT'].to_i
+        }
       )
 
       return res if res && res.code != 503

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -194,7 +194,7 @@ class MetasploitModule < Msf::Auxiliary
            when 'PATCHED'
              "#{panos_version} is at or above the advisory patched hotfix for this base."
            when 'NOT-AFFECTED-SAAS'
-             '.saas builds are not affected per advisory logic.'
+             'SaaS builds are not affected per advisory logic.'
            end
 
     {

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Auxiliary
         finding[:error] || finding[:note] || "Unable to determine vulnerability status (#{finding[:verdict]})."
       )
     end
-  rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError => e
+  rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError, ::Errno::EPIPE, ::Errno::ECONNRESET => e
     reason = "Network error: #{e.class}: #{e.message}"
     print_error("#{target_label(ip)} - Status: UNDETERMINED (#{reason})")
     Exploit::CheckCode::Unknown(reason)

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -99,6 +99,10 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def run_host(ip)
+    check_host(ip)
+  end
+  
+  def check_host(ip)
     finding = scan_target
     target = target_label(ip)
 

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -103,8 +103,6 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(443),
-        OptBool.new('SSL', [true, 'Use SSL/TLS', true]),
         OptString.new('TARGETURI', [true, 'GlobalProtect prelogin endpoint path', '/global-protect/prelogin.esp']),
         OptString.new('USERAGENT', [true, 'User-Agent used for the prelogin probe', DEFAULT_USER_AGENT]),
         OptInt.new('RETRY_TIMEOUT', [true, 'Maximum time in seconds to retry transient failures or HTTP 503 responses', DEFAULT_RETRY_TIMEOUT])

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -125,7 +125,7 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def target_label(ip)
-    "#{ip}:#{datastore['RPORT']}"
+    Rex::Socket.to_authority(ip, datastore['RPORT'])
   end
 
   def scan_target

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -271,7 +271,7 @@ class MetasploitModule < Msf::Auxiliary
       )
 
       res if res && res.code != 503
-    rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError => e
+    rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError, ::Errno::EPIPE, ::Errno::ECONNRESET => e
       vprint_warning("Transient request failure: #{e.class}: #{e.message}")
       nil
     end

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -87,7 +87,8 @@ class MetasploitModule < Msf::Auxiliary
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2026-0265'],
-          ['URL', 'https://security.paloaltonetworks.com/CVE-2026-0265']
+          ['URL', 'https://security.paloaltonetworks.com/CVE-2026-0265'],
+          ['URL', 'https://github.com/BishopFox/CVE-2026-0265-check']
         ],
         'DisclosureDate' => '2026-05-21',
         'Notes' => {

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -66,6 +66,8 @@ class MetasploitModule < Msf::Auxiliary
     [9, 1]
   ].freeze
 
+  DEFAULT_RETRY_TIMEOUT = 15
+
   def initialize(info = {})
     super(
       update_info(
@@ -105,8 +107,7 @@ class MetasploitModule < Msf::Auxiliary
         OptBool.new('SSL', [true, 'Use SSL/TLS', true]),
         OptString.new('TARGETURI', [true, 'GlobalProtect prelogin endpoint path', '/global-protect/prelogin.esp']),
         OptString.new('USERAGENT', [true, 'User-Agent used for the prelogin probe', DEFAULT_USER_AGENT]),
-        OptInt.new('TIMEOUT', [true, 'HTTP request timeout in seconds', 20]),
-        OptInt.new('RETRY_TIMEOUT', [true, 'Maximum time in seconds to retry transient failures or HTTP 503 responses', 15])
+        OptInt.new('RETRY_TIMEOUT', [true, 'Maximum time in seconds to retry transient failures or HTTP 503 responses', DEFAULT_RETRY_TIMEOUT])
       ]
     )
   end
@@ -251,7 +252,14 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def fetch_prelogin
-    retry_until_truthy(timeout: datastore['RETRY_TIMEOUT'].to_i) do
+    retry_timeout = datastore['RETRY_TIMEOUT'].to_i
+
+    unless retry_timeout.positive?
+      print_warning("RETRY_TIMEOUT must be greater than 0; using the default of #{DEFAULT_RETRY_TIMEOUT} seconds.")
+      retry_timeout = DEFAULT_RETRY_TIMEOUT
+    end
+
+    retry_until_truthy(timeout: retry_timeout) do
       res = send_request_cgi(
         {
           'method' => 'GET',

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -17,6 +17,7 @@
 
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Retry
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
@@ -62,8 +63,9 @@ class MetasploitModule < Msf::Auxiliary
         'Name' => 'PAN-OS GlobalProtect CAS CVE-2026-0265 Vulnerability Checker',
         'Description' => %q{
           This module checks a PAN-OS GlobalProtect portal for CVE-2026-0265
-          using the Bishop Fox scanner decision flow. It performs a single
-          anonymous GET request to the GlobalProtect prelogin endpoint, checks
+          using the Bishop Fox scanner decision flow. It performs anonymous
+          GET requests to the GlobalProtect prelogin endpoint, retrying transient
+          failures and HTTP 503 responses, then checks
           whether CAS authentication is enabled, decodes the embedded SAML/JWT
           token when present, extracts PanOSversion, and compares it against
           the advisory version matrix.
@@ -93,7 +95,7 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('TARGETURI', [true, 'GlobalProtect prelogin endpoint path', '/global-protect/prelogin.esp']),
         OptString.new('USERAGENT', [true, 'User-Agent used for the prelogin probe', DEFAULT_USER_AGENT]),
         OptInt.new('TIMEOUT', [true, 'HTTP request timeout in seconds', 20]),
-        OptInt.new('RETRIES', [true, 'Number of retries for transient failures or HTTP 503', 3])
+        OptInt.new('RETRY_TIMEOUT', [true, 'Maximum time in seconds to retry transient failures or HTTP 503 responses', 15])
       ]
     )
   end
@@ -114,18 +116,34 @@ class MetasploitModule < Msf::Auxiliary
       print_good("#{target} - Status: VULNERABLE")
       print_status("#{target} - #{finding[:note]}") if finding[:note]
       report_vulnerability(ip, finding)
+
+      Exploit::CheckCode::Appears(
+        finding[:note] || "CAS is enabled and PAN-OS #{finding[:panos_version]} is in an affected version range."
+      )
     when 'PATCHED', 'NOT-AFFECTED-SAAS', 'NOT-AFFECTED-NO-CAS', 'NOT-AFFECTED-NOT-GLOBALPROTECT'
       print_status("#{target} - Status: NOT VULNERABLE (#{finding[:verdict]})")
       print_status("#{target} - #{finding[:note]}") if finding[:note]
+
+      Exploit::CheckCode::Safe(
+        finding[:note] || "The target is not affected (#{finding[:verdict]})."
+      )
     else
       print_warning("#{target} - Status: UNDETERMINED (#{finding[:verdict]})")
       print_warning("#{target} - #{finding[:error]}") if finding[:error]
       print_status("#{target} - #{finding[:note]}") if finding[:note]
+
+      Exploit::CheckCode::Unknown(
+        finding[:error] || finding[:note] || "Unable to determine vulnerability status (#{finding[:verdict]})."
+      )
     end
   rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError => e
-    print_error("#{target_label(ip)} - Status: UNDETERMINED (network error: #{e.class}: #{e.message})")
+    reason = "Network error: #{e.class}: #{e.message}"
+    print_error("#{target_label(ip)} - Status: UNDETERMINED (#{reason})")
+    Exploit::CheckCode::Unknown(reason)
   rescue ::StandardError => e
-    print_error("#{target_label(ip)} - Status: UNDETERMINED (module error: #{e.class}: #{e.message})")
+    reason = "Module error: #{e.class}: #{e.message}"
+    print_error("#{target_label(ip)} - Status: UNDETERMINED (#{reason})")
+    Exploit::CheckCode::Unknown(reason)
   end
 
   def target_label(ip)
@@ -210,30 +228,24 @@ class MetasploitModule < Msf::Auxiliary
   end
 
   def fetch_prelogin
-    last_res = nil
-    attempts = datastore['RETRIES'].to_i + 1
-
-    attempts.times do |attempt|
-      res = send_request_cgi(
-        {
-          'method' => 'GET',
-          'uri' => normalize_uri(datastore['TARGETURI']),
-          'headers' => {
-            'User-Agent' => datastore['USERAGENT']
+    retry_until_truthy(timeout: datastore['RETRY_TIMEOUT'].to_i) do
+      begin
+        res = send_request_cgi(
+          {
+            'method' => 'GET',
+            'uri' => normalize_uri(datastore['TARGETURI']),
+            'headers' => {
+              'User-Agent' => datastore['USERAGENT']
+            }
           }
-        }
-      )
+        )
 
-      return res if res && res.code != 503
-
-      last_res = res
-      Rex.sleep([attempt, 4].min) if attempt < attempts - 1
-    rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError
-      Rex.sleep([attempt, 4].min) if attempt < attempts - 1
-      raise if attempt == attempts - 1
+        res if res && res.code != 503
+      rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError => e
+        vprint_warning("Transient request failure: #{e.class}: #{e.message}")
+        nil
+      end
     end
-
-    last_res
   end
 
   def decode_token_from_prelogin(body)
@@ -247,15 +259,10 @@ class MetasploitModule < Msf::Auxiliary
     parts = token.split('.')
     return nil unless parts.length == 3
 
-    payload_json = base64url_decode(parts[1])
+    payload_json = Rex::Text.decode_base64url(parts[1])
     JSON.parse(payload_json)
   rescue ::StandardError
     nil
-  end
-
-  def base64url_decode(value)
-    padded = value + ('=' * ((4 - value.length % 4) % 4))
-    Rex::Text.decode_base64(padded.tr('-_', '+/'))
   end
 
   def advisory_verdict_for_version(panos_version)

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -103,7 +103,7 @@ class MetasploitModule < Msf::Auxiliary
   def run_host(ip)
     check_host(ip)
   end
-  
+
   def check_host(ip)
     finding = scan_target
     target = target_label(ip)
@@ -229,22 +229,20 @@ class MetasploitModule < Msf::Auxiliary
 
   def fetch_prelogin
     retry_until_truthy(timeout: datastore['RETRY_TIMEOUT'].to_i) do
-      begin
-        res = send_request_cgi(
-          {
-            'method' => 'GET',
-            'uri' => normalize_uri(datastore['TARGETURI']),
-            'headers' => {
-              'User-Agent' => datastore['USERAGENT']
-            }
+      res = send_request_cgi(
+        {
+          'method' => 'GET',
+          'uri' => normalize_uri(datastore['TARGETURI']),
+          'headers' => {
+            'User-Agent' => datastore['USERAGENT']
           }
-        )
+        }
+      )
 
-        res if res && res.code != 503
-      rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError => e
-        vprint_warning("Transient request failure: #{e.class}: #{e.message}")
-        nil
-      end
+      res if res && res.code != 503
+    rescue ::Rex::ConnectionError, ::Timeout::Error, ::EOFError => e
+      vprint_warning("Transient request failure: #{e.class}: #{e.message}")
+      nil
     end
   end
 

--- a/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
+++ b/modules/auxiliary/scanner/http/panos_cve_2026_0265.rb
@@ -51,6 +51,16 @@ class MetasploitModule < Msf::Auxiliary
     [12, 1] => 7
   }.freeze
 
+  # Highest base release represented by the advisory matrix for each affected train.
+  # A later base release is presumed patched so future releases do not fall through
+  # to the affected-train fallback below.
+  ADVISORY_LAST_KNOWN_BASE = {
+    [10, 2] => 18,
+    [11, 1] => 15,
+    [11, 2] => 12,
+    [12, 1] => 7
+  }.freeze
+
   UNAFFECTED_TRAINS = [
     [8, 1],
     [9, 1]
@@ -210,11 +220,23 @@ class MetasploitModule < Msf::Auxiliary
       )
     end
 
+    patch_reference = advisory_patch_reference_for_version(panos_version.to_s)
+
     note = case verdict
            when 'VULNERABLE'
-             "#{panos_version} is below the advisory patched hotfix for this base."
+             if patch_reference && patch_reference[:type] == :hotfix
+               "#{panos_version} is below the advisory patched hotfix #{patch_reference[:version]}."
+             else
+               "#{panos_version} is within an affected PAN-OS release train."
+             end
            when 'PATCHED'
-             "#{panos_version} is at or above the advisory patched hotfix for this base."
+             if patch_reference && patch_reference[:type] == :hotfix
+               "#{panos_version} is at or above the advisory patched hotfix #{patch_reference[:version]}."
+             elsif patch_reference && patch_reference[:type] == :base
+               "#{panos_version} is at or above the advisory patched base release #{patch_reference[:version]}."
+             else
+               "#{panos_version} is not affected per advisory version logic."
+             end
            when 'NOT-AFFECTED-SAAS'
              'SaaS builds are not affected per advisory logic.'
            end
@@ -263,6 +285,23 @@ class MetasploitModule < Msf::Auxiliary
     nil
   end
 
+  def advisory_patch_reference_for_version(panos_version)
+    match = panos_version.match(/^(\d+)\.(\d+)\.(\d+)(?:-h(\d+))?$/)
+    return nil unless match
+
+    maj = match[1].to_i
+    min = match[2].to_i
+    pat = match[3].to_i
+
+    floor = ADVISORY_BASE_FLOOR[[maj, min]]
+    return { type: :base, version: "#{maj}.#{min}.#{floor}" } if floor && pat >= floor
+
+    cutoff = ADVISORY_PATCHED_HOTFIX[[maj, min, pat]]
+    return { type: :hotfix, version: "#{maj}.#{min}.#{pat}-h#{cutoff}" } if cutoff
+
+    nil
+  end
+
   def advisory_verdict_for_version(panos_version)
     return 'ERROR' if panos_version.empty?
     return 'NOT-AFFECTED-SAAS' if panos_version.include?('.saas')
@@ -282,6 +321,9 @@ class MetasploitModule < Msf::Auxiliary
 
     cutoff = ADVISORY_PATCHED_HOTFIX[[maj, min, pat]]
     return (hf >= cutoff ? 'PATCHED' : 'VULNERABLE') if cutoff
+
+    last_known_base = ADVISORY_LAST_KNOWN_BASE[[maj, min]]
+    return 'PATCHED' if last_known_base && pat > last_known_base
 
     return 'VULNERABLE' if [[10, 2], [11, 1], [11, 2], [12, 1]].include?([maj, min])
 


### PR DESCRIPTION
## Description

This PR adds a new Metasploit auxiliary scanner module for safely detecting
CVE-2026-0265 affecting PAN-OS GlobalProtect portals when Clientless
Application Services (CAS) authentication is enabled.

The module performs a single anonymous request to the GlobalProtect
prelogin endpoint and determines whether a target is affected without
attempting exploitation, authentication bypass, session creation, or
modification of the target.

Detection is based on the public Palo Alto Networks security advisory and
the Bishop Fox CVE-2026-0265 detection utility. The module:

- Detects whether the target is a GlobalProtect portal
- Determines whether CAS authentication is enabled
- Extracts the embedded PAN-OS version from the prelogin response
- Compares the version against the advisory-defined patch and hotfix matrix
- Reports vulnerable systems to the Metasploit database using `report_vuln`

This module is intended as a safe vulnerability detection utility and does
not exploit the vulnerability.

**Related Issue:**

None

## Breaking Changes

None

## Reviewer Notes

The module was tested against real PAN-OS systems representing vulnerable,
patched, and non-applicable configurations.

The implementation follows the public vendor advisory decision logic and
the Bishop Fox reference implementation while adapting it to Metasploit's
Auxiliary::Scanner framework.

## Verification Steps

1. Load the module:

   ```
   use auxiliary/scanner/http/panos_cve_2026_0265
   ```

2. Configure the target:

   ```
   set RHOSTS <target>
   ```

3. Execute:

   ```
   run
   ```

4. Verify expected results:

   - Vulnerable systems report:

     ```
     Status: VULNERABLE
     ```

   - Patched systems report:

     ```
     Status: NOT VULNERABLE (PATCHED)
     ```

   - Systems with CAS disabled report:

     ```
     Status: NOT VULNERABLE (NOT-AFFECTED-NO-CAS)
     ```

   - Vulnerable targets are recorded in the Metasploit database.

## Test Evidence

Successfully tested against:

- PAN-OS GlobalProtect with CAS enabled and vulnerable version
- PAN-OS GlobalProtect with CAS enabled and patched version
- PAN-OS GlobalProtect with CAS disabled
- Non-GlobalProtect / non-PAN-OS HTTPS target

Validation completed:

- Module loads successfully in msfconsole
- Ruby syntax (`ruby -c`)
- `msftidy`
- RuboCop
- Vulnerability reporting (`report_vuln`)
- Manual verification of expected output

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Ubuntu 25.10 (ARM64) |
| **Target Software/Hardware** | PAN-OS GlobalProtect Portal (multiple versions including vulnerable, patched, and CAS-disabled systems) |

## AI Usage Disclosure

OpenAI ChatGPT was used as a development assistant to discuss implementation approaches, review Ruby code, improve documentation, and refine module formatting. The module logic, testing, validation, and final code review were performed by the submitter.

## Pre-Submission Checklist

- [x Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(not applicable)_
- [x] Read the CONTRIBUTING.md and module acceptance guidelines