### PR TITLE
Also catch ECONNRESET from UDP sockets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -551,7 +551,7 @@ GEM
       metasm
       rex-core
       rex-text
-    rex-socket (0.1.69)
+    rex-socket (0.1.70)
       dnsruby
       rex-core
     rex-sslscan (0.1.13)

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -148,7 +148,7 @@ module Auxiliary::UDPScanner
 
       retry
 
-    rescue ::Rex::ConnectionError, ::Errno::ECONNREFUSED
+    rescue ::Rex::ConnectionError, ::Errno::ECONNREFUSED, ::Errno::ECONNRESET
       # This fires for host unreachable, net unreachable, and broadcast sends
       # We can safely ignore all of these for UDP sends
     end
@@ -175,9 +175,9 @@ module Auxiliary::UDPScanner
         for sock in readable
           begin
             res = sock.recvfrom(65535)
-          rescue ::Rex::ConnectionError, ::Errno::ECONNREFUSED
-            # A connected UDP socket surfaces ICMP port-unreachable as ECONNREFUSED
-            # on recvfrom; skip this socket and keep processing the others.
+          rescue ::Rex::ConnectionError, ::Errno::ECONNREFUSED, ::Errno::ECONNRESET
+            # A connected UDP socket surfaces ICMP port-unreachable differently
+            # by platform; skip this socket and keep processing the others.
             next
           end
 

--- a/lib/msf/core/handler/bind_udp.rb
+++ b/lib/msf/core/handler/bind_udp.rb
@@ -151,7 +151,7 @@ module BindUdp
             client.close()
             client = nil
           end
-        rescue Errno::ECONNREFUSED
+        rescue Errno::ECONNREFUSED, Errno::ECONNRESET
           client.close()
           client = nil
           wlog("Connection failed in udp bind handler continuing attempts: #{$!.class} #{$!}")

--- a/modules/auxiliary/admin/netbios/netbios_spoof.rb
+++ b/modules/auxiliary/admin/netbios/netbios_spoof.rb
@@ -71,7 +71,7 @@ class MetasploitModule < Msf::Auxiliary
         if pps > @targ_rate
           sleep(0.01)
         end
-      rescue Errno::ECONNREFUSED
+      rescue Errno::ECONNREFUSED, Errno::ECONNRESET
         print_error('Error: Target sent us an ICMP port unreachable, port is likely closed')
         live = false
         break

--- a/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_auth_bypass.rb
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status('DTLS handshake succeeded (self-signed cert accepted)') unless silent
 
     [ssl, ctx, udp_sock, rbio, wbio]
-  rescue ::Rex::ConnectionError, ::Errno::ECONNREFUSED => e
+  rescue ::Rex::ConnectionError, ::Errno::ECONNREFUSED, ::Errno::ECONNRESET => e
     print_error("Connection failed: #{e.message}") unless silent
     cleanup_dtls(ssl, ctx, udp_sock)
     [nil, nil, nil, nil, nil]

--- a/modules/auxiliary/admin/networking/cisco_sdwan_vhub_auth_bypass.rb
+++ b/modules/auxiliary/admin/networking/cisco_sdwan_vhub_auth_bypass.rb
@@ -184,7 +184,7 @@ class MetasploitModule < Msf::Auxiliary
     print_status('DTLS handshake succeeded (self-signed cert accepted)') unless silent
 
     [ssl, ctx, udp_sock, rbio, wbio]
-  rescue ::Rex::ConnectionError, ::Errno::ECONNREFUSED => e
+  rescue ::Rex::ConnectionError, ::Errno::ECONNREFUSED, ::Errno::ECONNRESET => e
     print_error("Connection failed: #{e.message}") unless silent
     cleanup_dtls(ssl, ctx, udp_sock)
     [nil, nil, nil, nil, nil]

--- a/modules/auxiliary/dos/rpc/rpcbomb.rb
+++ b/modules/auxiliary/dos/rpc/rpcbomb.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Auxiliary
     while count < datastore['COUNT']
       begin
         s.send(pkt, 0)
-      rescue ::Errno::ENOBUFS, ::Rex::ConnectionError, ::Errno::ECONNREFUSED
+      rescue ::Errno::ENOBUFS, ::Rex::ConnectionError, ::Errno::ECONNREFUSED, ::Errno::ECONNRESET
         vprint_error("Host #{ip} unreachable")
         break
       end

--- a/modules/auxiliary/scanner/snmp/snmp_enum_hp_laserjet.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum_hp_laserjet.rb
@@ -139,7 +139,7 @@ class MetasploitModule < Msf::Auxiliary
     disconnect_snmp
   rescue SNMP::RequestTimeout
     print_error("#{ip}, SNMP request timeout.")
-  rescue Errno::ECONNREFUSED
+  rescue Errno::ECONNREFUSED, Errno::ECONNRESET
     print_error("#{ip}, Connection refused.")
   rescue SNMP::InvalidIpAddress
     print_error("#{ip}, Invalid IP address. Check it with 'snmpwalk tool'.")

--- a/modules/auxiliary/server/netbios_spoof_nat.rb
+++ b/modules/auxiliary/server/netbios_spoof_nat.rb
@@ -137,7 +137,7 @@ class MetasploitModule < Msf::Auxiliary
           if pps > @targ_rate
             sleep(0.01)
           end
-        rescue Errno::ECONNREFUSED
+        rescue Errno::ECONNREFUSED, Errno::ECONNRESET
           print_error("Error: Target sent us an ICMP port unreachable, port is likely closed")
           live = false
           break

--- a/spec/lib/msf/core/auxiliary/udp_scanner_spec.rb
+++ b/spec/lib/msf/core/auxiliary/udp_scanner_spec.rb
@@ -8,18 +8,26 @@ RSpec.describe Msf::Auxiliary::UDPScanner do
     mod.extend described_class
     mod.instance_variable_set(:@udp_sockets, {})
     mod.instance_variable_set(:@udp_sockets_mutex, Mutex.new)
+    mod.instance_variable_set(:@udp_send_count, 0)
+    mod.instance_variable_set(:@interval_mutex, Mutex.new)
     mod.instance_variable_set(:@results, {})
-    mod.define_singleton_method(:datastore) { { 'ScannerRecvQueueLimit' => 100 } }
+    mod.define_singleton_method(:datastore) do
+      {
+        'ScannerMaxResends' => 10,
+        'ScannerRecvInterval' => 30,
+        'ScannerRecvQueueLimit' => 100
+      }
+    end
     mod.define_singleton_method(:inside_workspace_boundary?) { |_host| true }
     allow(mod).to receive(:cleanup_udp_sockets)
     mod
   end
 
-  # A socket whose recvfrom raises, mimicking a connected UDP socket that received an
-  # ICMP port-unreachable for a closed port.
-  let(:refused_socket) do
+  # A socket whose recvfrom raises, mimicking a connected UDP socket that received
+  # an ICMP port-unreachable for a closed port.
+  def error_socket(error_class)
     sock = double('refused_socket')
-    allow(sock).to receive(:recvfrom).and_raise(::Errno::ECONNREFUSED)
+    allow(sock).to receive(:recvfrom).and_raise(error_class)
     sock
   end
 
@@ -31,20 +39,36 @@ RSpec.describe Msf::Auxiliary::UDPScanner do
     sock
   end
 
-  describe '#scanner_recv' do
-    it 'swallows ECONNREFUSED raised by recvfrom instead of propagating it' do
-      allow(::IO).to receive(:select).and_return([[refused_socket], [], []], nil)
+  describe '#scanner_send' do
+    [::Errno::ECONNREFUSED, ::Errno::ECONNRESET].each do |error_class|
+      it "swallows #{error_class} raised while sending UDP probes" do
+        sock = double('send_socket')
+        allow(sock).to receive(:send).and_raise(error_class)
+        allow(subject).to receive(:udp_socket).and_return(sock)
 
-      expect { subject.scanner_recv(0.1) }.not_to raise_error
-      expect(subject.scanner_recv(0.1)).to eq(0)
-      expect(subject.results).to be_empty
+        expect { subject.scanner_send('probe', '192.0.2.5', 161) }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#scanner_recv' do
+    [::Errno::ECONNREFUSED, ::Errno::ECONNRESET].each do |error_class|
+      it "swallows #{error_class} raised by recvfrom instead of propagating it" do
+        allow(::IO).to receive(:select).and_return([[error_socket(error_class)], [], []], nil)
+
+        expect { subject.scanner_recv(0.1) }.not_to raise_error
+        expect(subject.scanner_recv(0.1)).to eq(0)
+        expect(subject.results).to be_empty
+      end
     end
 
-    it 'continues processing other readable sockets after one raises ECONNREFUSED' do
-      allow(::IO).to receive(:select).and_return([[refused_socket, responding_socket], [], []], nil)
+    [::Errno::ECONNREFUSED, ::Errno::ECONNRESET].each do |error_class|
+      it "continues processing other readable sockets after one raises #{error_class}" do
+        allow(::IO).to receive(:select).and_return([[error_socket(error_class), responding_socket], [], []], nil)
 
-      expect(subject.scanner_recv(0.1)).to eq(1)
-      expect(subject.results['192.0.2.5']).to eq(['response-data'])
+        expect(subject.scanner_recv(0.1)).to eq(1)
+        expect(subject.results['192.0.2.5']).to eq(['response-data'])
+      end
     end
   end
 end


### PR DESCRIPTION
Windows raises ECONNRESET not ECONNREFUSED as Linux does

## Description

**Related Issue:** rapid7/rex-socket#85

## Breaking Changes

<!-- Does this PR change existing behavior, remove options, rename datastore settings, or alter API/mixin interfaces? If yes, describe what breaks and how users should adapt. Write "None" if not applicable. -->

None, this fixes a regression I intro'ed in #21562 

## Reviewer Notes

<!-- (Optional) Guide the reviewer: where to start reading, what the key change is, what's intentionally left out or deferred. Delete this section if not needed. -->

## Verification Steps

1. - [ ] Apply the patch and run Metasploit on a Windows system
2. - [ ] Use the udp_sweep module and see it complete successfully with the expected results



## Test Evidence
This is a Windows Server 2019 instance where I manually installed the archive of master from the 6.5.141 tag.

### Old and Busted
```
msf auxiliary(scanner/discovery/udp_sweep) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf auxiliary(scanner/discovery/udp_sweep) > run
[*] Sending 13 probes to 127.0.0.1->127.0.0.1 (1 hosts)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/discovery/udp_sweep) >
```

### New and Fixed
```
msf auxiliary(scanner/discovery/udp_sweep) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf auxiliary(scanner/discovery/udp_sweep) > run
[*] Sending 13 probes to 127.0.0.1->127.0.0.1 (1 hosts)
[*] Discovered DNS on 127.0.0.1:53 (Microsoft DNS)
[*] Discovered NTP on 127.0.0.1:123 (1c0104e900000000000a236b4c4f434ceded163a5ad760a4c54f234b71b152f3eded44ed06df62d1eded44ed06dfa79a)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(scanner/discovery/udp_sweep) >
````

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Windows Server 2019 |
| **Target Software/Hardware** | Windows Server 2019 (scanned the loopback interfface) |
| **Docker Image / Vagrant Setup** | <!-- (Optional) Image name or setup instructions if applicable, otherwise remove this row --> |

## AI Usage Disclosure

<!-- Was AI used in the creation of this PR? If so, describe what tools were used and how (e.g., code generation, documentation drafting, test writing). Write "None" if no AI tools were used. -->


## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
