### PR TITLE
Add Bearer Authentication to the MCP server plugin

### DIFF
--- a/lib/msf/core/mcp/application.rb
+++ b/lib/msf/core/mcp/application.rb
@@ -282,7 +282,7 @@ module Msf::MCP
 
       if transport == :http
         @output.puts "Starting MCP server on HTTP transport..."
-        @output.puts "Server listening on http://#{Rex::Socket.to_authority(host, port)}/"
+        @output.puts "MCP server listening on http://#{Rex::Socket.to_authority(host, port)}/"
         auth_token = resolve_auth_token
         case auth_token
         when :disabled
@@ -292,7 +292,7 @@ module Msf::MCP
           @output.puts "Authentication: enabled"
           auth_token = @config.dig(:mcp, :auth_token)
         when :generated
-          auth_token = SecureRandom.hex(32)
+          auth_token = @mcp_server.class.generate_auth_token
           @output.puts "Authentication: Bearer token (auto-generated)"
           @output.puts "  Configure your MCP client with: Authorization: Bearer #{auth_token}"
         else

--- a/lib/msf/core/mcp/application.rb
+++ b/lib/msf/core/mcp/application.rb
@@ -304,15 +304,19 @@ module Msf::MCP
         max_threads = @config.dig(:mcp, :max_threads) || Msf::MCP::Server::PUMA_MAX_THREADS
         workers = @config.dig(:mcp, :workers) || Msf::MCP::Server::PUMA_WORKERS
 
-        @mcp_server.start(
-          transport: :http,
-          host: host,
-          port: port,
-          auth_token: auth_token,
-          min_threads: min_threads,
-          max_threads: max_threads,
-          workers: workers
-        )
+        begin
+          @mcp_server.start(
+            transport: :http,
+            host: host,
+            port: port,
+            auth_token: auth_token,
+            min_threads: min_threads,
+            max_threads: max_threads,
+            workers: workers
+          )
+        rescue Errno::EADDRINUSE => e
+          @output.puts "#{e.class}: #{e.message}"
+        end
       else
         @output.puts "Starting MCP server on stdio transport..."
         @output.puts "Server ready - waiting for MCP requests"

--- a/lib/msf/core/mcp/application.rb
+++ b/lib/msf/core/mcp/application.rb
@@ -316,6 +316,11 @@ module Msf::MCP
           )
         rescue Errno::EADDRINUSE => e
           @output.puts "#{e.class}: #{e.message}"
+          elog({
+            message: 'Cannot start the MCP server',
+            context: { host: host, port: port },
+            exception: e
+          }, LOG_SOURCE, LOG_ERROR)
         end
       else
         @output.puts "Starting MCP server on stdio transport..."

--- a/lib/msf/core/mcp/config/validator.rb
+++ b/lib/msf/core/mcp/config/validator.rb
@@ -75,6 +75,22 @@ module Msf::MCP
           end
         end
 
+        # Validate MCP authentication token
+        if config[:mcp].is_a?(Hash) && config[:mcp].key?(:auth_token)
+          auth_token = config[:mcp][:auth_token]
+          if auth_token.is_a?(String)
+            unless auth_token.match?(/\A[!-~]*\z/)
+              errors[:'mcp.auth_token'] = "must be a valid token"
+            end
+          elsif auth_token != nil
+            errors[:'mcp.auth_token'] = "must be a string"
+          end
+
+          unless config[:mcp][:transport] == 'http'
+            errors[:'mcp.auth_token'] = "authentication must only be used with the 'http' transport"
+          end
+        end
+
         # Validate MCP Puma thread/worker settings
         if config[:mcp].is_a?(Hash)
           if config[:mcp].key?(:min_threads)

--- a/lib/msf/core/mcp/server.rb
+++ b/lib/msf/core/mcp/server.rb
@@ -98,6 +98,12 @@ module Msf::MCP
       @mcp_server = nil
     end
 
+    # Generate a random authentication token
+    # @return [String]
+    def self.generate_auth_token
+      SecureRandom.hex(32)
+    end
+
     private
 
     ##

--- a/plugins/mcp.rb
+++ b/plugins/mcp.rb
@@ -23,6 +23,7 @@ module Msf
       # Valid option keys accepted by `mcp start` and `mcp restart`
       unless defined?(VALID_OPTIONS)
         VALID_OPTIONS = %w[
+          AuthToken
           ServerHost ServerPort
           RpcHost RpcPort RpcUser RpcPass RpcSSL
           RateLimit
@@ -67,6 +68,7 @@ module Msf
         print_line('  help    - Show this help message')
         print_line
         print_line('Options (for start/restart):')
+        print_line('  AuthToken=<token>           MCP server authentication token (default: random, blank: disabled)')
         print_line('  ServerHost=<host>           MCP server bind address (default: localhost)')
         print_line('  ServerPort=<port>           MCP server port (default: 3000)')
         print_line('  RpcHost=<host>              RPC server host (default: 127.0.0.1)')
@@ -130,7 +132,8 @@ module Msf
         opts = {}
         args.each do |arg|
           key, value = arg.split('=', 2)
-          unless key && value && !value.empty?
+          # AuthToken can be blank while the others have to be set (blank is explicitly disabled)
+          unless key && value && (key == 'AuthToken' || !value.empty?)
             print_error("Invalid option format: #{arg} (expected Key=Value)")
             return nil
           end
@@ -286,23 +289,33 @@ module Msf
 
       host = mcp_config[:host]
       port = mcp_config[:port]
+      if mcp_config.key?(:auth_token)
+        auth_token = mcp_config[:auth_token]
+        auth_token_generated = false
+      else
+        auth_token = @mcp_server.class.generate_auth_token
+        auth_token_generated = true
+      end
 
       @server_thread = framework.threads.spawn('MCPServer', false) do
-        @mcp_server.start(transport: :http, host: host, port: port)
+        print_status("Starting MCP server on HTTP transport...")
+        @mcp_server.start(transport: :http, host: host, port: port, auth_token: auth_token)
       end
 
       @started_at = Time.now
-      print_server_status(mcp_config)
+      print_status("MCP server listening on http://#{Rex::Socket.to_authority(mcp_config[:host], mcp_config[:port])}/")
+      if auth_token_generated
+        print_status("Authentication: Bearer token (auto-generated)")
+        print_status("  Configure your MCP client with: Authorization: Bearer #{auth_token}")
+      else
+        print_status("Authentication: #{auth_token ? 'enabled' : 'disabled'}")
+      end
     rescue Msf::MCP::Metasploit::AuthenticationError => e
       raise Msf::MCP::Metasploit::AuthenticationError, "RPC authentication failed: #{e.message}"
     rescue Msf::MCP::Metasploit::ConnectionError => e
       raise Msf::MCP::Metasploit::ConnectionError, "RPC connection failed: #{e.message}"
     rescue Errno::EADDRINUSE
       raise Msf::MCP::Error, "Address already in use: #{Rex::Socket.to_authority(mcp_config[:host], mcp_config[:port])}"
-    end
-
-    def print_server_status(mcp_config)
-      print_status("MCP server started on #{Rex::Socket.to_authority(mcp_config[:host], mcp_config[:port])} (transport: http)")
     end
 
     def format_uptime
@@ -441,6 +454,10 @@ module Msf
         host: opts['ServerHost'] || Msf::MCP::Config::Defaults::MCP_HOST,
         port: Integer(opts['ServerPort'] || Msf::MCP::Config::Defaults::MCP_PORT)
       }
+
+      if opts.key?('AuthToken')
+        mcp_config[:auth_token] = opts['AuthToken'].blank? ? nil : opts['AuthToken']
+      end
 
       rate_limit_value = Integer(opts['RateLimit'] || Msf::MCP::Config::Defaults::RATE_LIMIT_REQUESTS_PER_MINUTE)
 

--- a/plugins/mcp.rb
+++ b/plugins/mcp.rb
@@ -133,7 +133,7 @@ module Msf
         args.each do |arg|
           key, value = arg.split('=', 2)
           # AuthToken can be blank while the others have to be set (blank is explicitly disabled)
-          unless key && value && (key == 'AuthToken' || !value.empty?)
+          unless key && value && (key.casecmp('AuthToken').zero? || !value.empty?)
             print_error("Invalid option format: #{arg} (expected Key=Value)")
             return nil
           end
@@ -297,8 +297,8 @@ module Msf
         auth_token_generated = true
       end
 
+      print_status('Starting MCP server on HTTP transport...')
       @server_thread = framework.threads.spawn('MCPServer', false) do
-        print_status("Starting MCP server on HTTP transport...")
         @mcp_server.start(transport: :http, host: host, port: port, auth_token: auth_token)
       end
 

--- a/spec/lib/msf/core/mcp/application_spec.rb
+++ b/spec/lib/msf/core/mcp/application_spec.rb
@@ -376,6 +376,10 @@ RSpec.describe Msf::MCP::Application do
   describe '#start_mcp_server' do
     let(:mock_mcp_server) { instance_double(Msf::MCP::Server) }
 
+    before do
+      allow(mock_mcp_server).to receive(:class).and_return(Msf::MCP::Server)
+    end
+
     it 'starts server with stdio transport by default' do
       app = described_class.new([], output: output)
       app.instance_variable_set(:@config, valid_config)
@@ -413,7 +417,7 @@ RSpec.describe Msf::MCP::Application do
       app.send(:start_mcp_server)
 
       expect(output.string).to include('Starting MCP server on HTTP transport...')
-      expect(output.string).to include('Server listening on http://0.0.0.0:3000')
+      expect(output.string).to include('MCP server listening on http://0.0.0.0:3000')
     end
 
     it 'uses default host and port for HTTP transport' do

--- a/spec/lib/msf/core/mcp/config/validator_spec.rb
+++ b/spec/lib/msf/core/mcp/config/validator_spec.rb
@@ -173,6 +173,52 @@ RSpec.describe Msf::MCP::Config::Validator do
       end
     end
 
+    context 'with MCP auth token validation' do
+      let(:base_config) do
+        {
+          msf_api: {
+            type: 'messagepack',
+            host: 'localhost',
+            user: 'msf',
+            password: 'password'
+          },
+          mcp: {
+            transport: 'http'
+          }
+        }
+      end
+
+      it 'accepts nil, empty, and printable non-whitespace string tokens' do
+        [nil, '', 'password', 'abc_123-XYZ.~'].each do |auth_token|
+          config = base_config.merge(mcp: base_config[:mcp].merge(auth_token: auth_token))
+          expect(described_class.validate!(config)).to be true
+        end
+      end
+
+      it 'rejects non-string tokens' do
+        config = base_config.merge(mcp: base_config[:mcp].merge(auth_token: 123))
+
+        expect { described_class.validate!(config) }.to raise_error(Msf::MCP::Config::ValidationError, /mcp\.auth_token must be a string/)
+      end
+
+      it 'rejects whitespace and non-printable tokens' do
+        ['with space', "tab\t", "newline\n", "bad\x7f"].each do |auth_token|
+          config = base_config.merge(mcp: base_config[:mcp].merge(auth_token: auth_token))
+
+          expect { described_class.validate!(config) }.to raise_error(Msf::MCP::Config::ValidationError, /mcp\.auth_token must be a valid token/)
+        end
+      end
+
+      it 'rejects auth tokens for stdio transport' do
+        config = base_config.merge(mcp: { transport: 'stdio', auth_token: 'password' })
+
+        expect { described_class.validate!(config) }.to raise_error(
+          Msf::MCP::Config::ValidationError,
+          /mcp\.auth_token authentication must only be used with the 'http' transport/
+        )
+      end
+    end
+
     context 'with Puma thread/worker validation' do
       let(:valid_base) do
         {

--- a/spec/plugins/mcp/console_dispatcher_spec.rb
+++ b/spec/plugins/mcp/console_dispatcher_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe Msf::Plugin::MCP::McpCommandDispatcher do
 
   let(:mock_server_class) do
     Class.new do
+      def self.generate_auth_token
+        'a' * 64
+      end
+
       def initialize(**_args); end
 
       def start(**_args); end
@@ -249,7 +253,7 @@ RSpec.describe Msf::Plugin::MCP::McpCommandDispatcher do
     context 'when server is stopped' do
       it 'starts the server successfully' do
         mcp_plugin.start_server({})
-        expect(@output.join("\n")).to include('MCP server started')
+        expect(@output.join("\n")).to include('MCP server listening')
       end
 
       it 'sets the server instance' do

--- a/spec/plugins/mcp_spec.rb
+++ b/spec/plugins/mcp_spec.rb
@@ -48,6 +48,10 @@ RSpec.describe Msf::Plugin::MCP do
 
   let(:mock_server_class) do
     Class.new do
+      def self.generate_auth_token
+        'a' * 64
+      end
+
       def initialize(**_args); end
       def start(**_args); end
       def shutdown; end
@@ -123,7 +127,7 @@ RSpec.describe Msf::Plugin::MCP do
       end
 
       it 'prints a status message with the listening address' do
-        expect(@output.join("\n")).to include('MCP server started on localhost:3000 (transport: http)')
+        expect(@output.join("\n")).to include('MCP server listening on http://localhost:3000/')
       end
 
       it 'stores the server configuration' do
@@ -166,6 +170,10 @@ RSpec.describe Msf::Plugin::MCP do
     context 'when port is already in use' do
       let(:failing_server_class) do
         Class.new do
+          def self.generate_auth_token
+            'a' * 64
+          end
+
           def initialize(**_args); end
 
           def start(**_args)

--- a/spec/plugins/mcp_spec.rb
+++ b/spec/plugins/mcp_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Msf::Plugin::MCP do
       end
 
       def initialize(**_args); end
+
       def start(**_args); end
       def shutdown; end
     end
@@ -142,6 +143,47 @@ RSpec.describe Msf::Plugin::MCP do
       it 'applies the provided host and port' do
         expect(plugin.server_config[:mcp][:host]).to eq('0.0.0.0')
         expect(plugin.server_config[:mcp][:port]).to eq(8080)
+      end
+    end
+
+    context 'with AuthToken options' do
+      let(:mock_server) { instance_double(mock_server_class, shutdown: nil) }
+
+      before do
+        allow(mock_server_class).to receive(:new).and_return(mock_server)
+        allow(mock_server).to receive(:class).and_return(mock_server_class)
+        allow(threads_manager).to receive(:spawn) do |_name, _critical, &block|
+          block.call
+          mock_thread
+        end
+      end
+
+      it 'generates a bearer token when AuthToken is omitted' do
+        expect(mock_server).to receive(:start).with(hash_including(auth_token: 'a' * 64))
+
+        plugin.start_server({})
+
+        expect(@output.join("\n")).to include('Authentication: Bearer token (auto-generated)')
+        expect(@output.join("\n")).to include("Authorization: Bearer #{'a' * 64}")
+      end
+
+      it 'uses an explicit AuthToken without printing it' do
+        expect(mock_server_class).not_to receive(:generate_auth_token)
+        expect(mock_server).to receive(:start).with(hash_including(auth_token: 'custom-token'))
+
+        plugin.start_server('AuthToken' => 'custom-token')
+
+        expect(@output.join("\n")).to include('Authentication: enabled')
+        expect(@output.join("\n")).not_to include('custom-token')
+      end
+
+      it 'disables authentication when AuthToken is blank' do
+        expect(mock_server_class).not_to receive(:generate_auth_token)
+        expect(mock_server).to receive(:start).with(hash_including(auth_token: nil))
+
+        plugin.start_server('AuthToken' => '')
+
+        expect(@output.join("\n")).to include('Authentication: disabled')
       end
     end
 
@@ -605,6 +647,21 @@ RSpec.describe Msf::Plugin::MCP do
           expect(opts).to eq('RateLimit' => '120')
         end
         dispatcher.cmd_mcp('start', 'RateLimit=120')
+      end
+
+      it 'parses AuthToken values including blank and case-insensitive keys' do
+        parsed_options = []
+        allow(plugin_instance).to receive(:start_server) { |opts| parsed_options << opts }
+
+        dispatcher.cmd_mcp('start', 'AuthToken=')
+        dispatcher.cmd_mcp('start', 'AuthToken=custom-token')
+        dispatcher.cmd_mcp('start', 'authtoken=')
+
+        expect(parsed_options).to eq([
+          { 'AuthToken' => '' },
+          { 'AuthToken' => 'custom-token' },
+          { 'AuthToken' => '' }
+        ])
       end
 
       it 'starts with empty opts when no options given' do


### PR DESCRIPTION
## Description
This adds bearer authentication to the MCP server started by the plugin, bringing it inline with the same behavior added in https://github.com/rapid7/metasploit-framework/pull/21527. The value meanings are the same, by default a random token is generated, if the user explicitly sets a blank value, authentication is disabled otherwise the token is used as-is.

**Related Issue:** 

## Breaking Changes

None

## Reviewer Notes

<!-- (Optional) Guide the reviewer: where to start reading, what the key change is, what's intentionally left out or deferred. Delete this section if not needed. -->

## Verification Steps

Use the same steps from #21527

1. - [ ] Load the plugin
2. - [ ] Start the server by default, see a randomly generated API token displayed
3. - [ ] Stop the server and restart it, adding `AuthToken=` to the end, see that now authentication is disabled
4. - [ ] Stop the server and restart it, adding `AuthToken=whatever` to the end, see that now authentication is enabled, and the token is *not* echoed back to the user. They gave it to us, they know it, we don't need to be logging it anywhere.



## Test Evidence

```
msf exploit(windows/smb/psexec) > load mcp
[*] MCP plugin loaded. Use mcp start to start the server.
[*] Successfully loaded plugin: mcp
msf exploit(windows/smb/psexec) > mcp start
[*] Auto-started msgrpc - User: msf, Pass: 2MXwknnMf7zy
[*] MCP server listening on http://localhost:3000/
[*] Authentication: Bearer token (auto-generated)
[*]   Configure your MCP client with: Authorization: Bearer 43b93f53b68816f30dff19058fb4f676234e1943dc67ffa232b53b7a3e96733d
[*] Starting MCP server on HTTP transport...
msf exploit(windows/smb/psexec) > mcp stop
[*] MCP server stopped
msf exploit(windows/smb/psexec) > mcp start AuthToken=
key: "AuthToken" value: ""
[*] MCP server listening on http://localhost:3000/
[*] Authentication: disabled
[*] Starting MCP server on HTTP transport...
msf exploit(windows/smb/psexec) > mcp restart AuthToken=imhungryisitlunchtimeyet
[*] MCP server listening on http://localhost:3000/
[*] Authentication: enabled
[*] Starting MCP server on HTTP transport...
msf exploit(windows/smb/psexec) >
```
## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Fedora |
| **Target Software/Hardware** | N/A |
| **Docker Image / Vagrant Setup** | <!-- (Optional) Image name or setup instructions if applicable, otherwise remove this row --> |

## AI Usage Disclosure

Did everything by hand.

## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
