### PR TITLE
Fix ssh login info details

### DIFF
--- a/.github/workflows/ssh_acceptance.yml
+++ b/.github/workflows/ssh_acceptance.yml
@@ -1,0 +1,171 @@
+name: SSH Acceptance
+
+# Optional, enabling concurrency limits: https://docs.github.com/en/actions/using-jobs/using-concurrency
+#concurrency:
+#  group: ${{ github.ref }}-${{ github.workflow }}
+#  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+on:
+  push:
+    branches-ignore:
+      - gh-pages
+      - metakitty
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - 'metasploit-framework.gemspec'
+      - 'Gemfile.lock'
+      - '**/**ssh**'
+      - 'lib/metasploit/framework/tcp/**'
+      - 'lib/metasploit/framework/login_scanner/**'
+      - 'spec/acceptance/**'
+      - 'spec/support/acceptance/**'
+      - 'spec/acceptance_spec_helper.rb'
+      - '.github/**'
+#   Example of running as a cron, to weed out flaky tests
+#  schedule:
+#    - cron: '*/15 * * * *'
+
+jobs:
+  ssh:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby:
+          - '3.2'
+        os:
+          - ubuntu-latest
+
+    env:
+      RAILS_ENV: test
+      SSH_USERNAME: acceptance_tests_user
+      SSH_PASSWORD: acceptance_tests_password
+      BUNDLE_WITHOUT: "coverage development pcap"
+
+    name: SSH Acceptance - ${{ matrix.os }} - Ruby ${{ matrix.ruby }}
+    steps:
+      - name: Install system dependencies
+        run: sudo apt-get install -y --no-install-recommends libpcap-dev graphviz
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run docker container
+        working-directory: 'test/ssh'
+        run: |
+          docker compose build
+          docker compose up --wait -d
+
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
+      - name: Setup Ruby
+        env:
+          # Nokogiri doesn't release pre-compiled binaries for preview versions of Ruby; So force compilation with BUNDLE_FORCE_RUBY_PLATFORM
+          BUNDLE_FORCE_RUBY_PLATFORM: "${{ contains(matrix.ruby, 'preview') && 'true' || 'false' }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '${{ matrix.ruby }}'
+          bundler-cache: true
+
+      - name: acceptance
+        env:
+          SPEC_HELPER_LOAD_METASPLOIT: false
+          SPEC_OPTS: "--tag acceptance --require acceptance_spec_helper.rb --color --format documentation --format AllureRspec::RSpecFormatter"
+          RUNTIME_VERSION: 'latest'
+        # Unix run command:
+        #   SPEC_HELPER_LOAD_METASPLOIT=false bundle exec ./spec/acceptance
+        # Note: rspec retry is intentionally not used, as it can cause issues with allure's reporting
+        # Additionally - flakey tests should be fixed or marked as flakey instead of silently retried
+        run: |
+          bundle exec rspec spec/acceptance/ssh_spec.rb
+
+      - name: Archive results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ssh-acceptance-${{ matrix.os }}
+          path: tmp/allure-raw-data
+
+  # Generate a final report from the previous test results
+  report:
+    name: Generate report
+    needs:
+      - ssh
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        if: always()
+
+      - name: Install system dependencies (Linux)
+        if: always()
+        run: sudo apt-get -y --no-install-recommends install libpcap-dev graphviz
+
+      # https://github.com/orgs/community/discussions/26952
+      - name: Support longpaths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
+      - name: Setup Ruby
+        if: always()
+        env:
+          BUNDLE_FORCE_RUBY_PLATFORM: true
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          cache-version: 4
+
+      - uses: actions/download-artifact@v4
+        id: download
+        if: always()
+        with:
+          # Note: Not specifying a name will download all artifacts from the previous workflow jobs
+          path: raw-data
+
+      - name: allure generate
+        if: always()
+        run: |
+          export VERSION=2.22.1
+
+          curl -o allure-$VERSION.tgz -Ls https://github.com/allure-framework/allure2/releases/download/$VERSION/allure-$VERSION.tgz
+          tar -zxvf allure-$VERSION.tgz -C .
+
+          ls -la ${{steps.download.outputs.download-path}}
+          ./allure-$VERSION/bin/allure generate ${{steps.download.outputs.download-path}}/* -o ./allure-report
+
+          find ${{steps.download.outputs.download-path}}
+          bundle exec ruby tools/dev/report_generation/support_matrix/generate.rb --allure-data ${{steps.download.outputs.download-path}} > ./allure-report/support_matrix.html
+
+      - name: archive results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: final-report-${{ github.run_id }}
+          path: |
+            ./allure-report

--- a/lib/msf/base/sessions/ssh_command_shell_bind.rb
+++ b/lib/msf/base/sessions/ssh_command_shell_bind.rb
@@ -226,6 +226,7 @@ module Msf::Sessions
     def initialize(ssh_connection, opts = {})
       @ssh_connection = ssh_connection
       @sock = ssh_connection.transport.socket
+      @peer_info = ssh_connection.transport.socket.peerinfo
       @server_channels = {}
 
       initialize_channels
@@ -254,7 +255,7 @@ module Msf::Sessions
       @rstream = Net::SSH::CommandStream.new(ssh_connection, session: self, logger: self).lsock
       super
 
-      @info = "SSH #{username} @ #{@peer_info}"
+      @info = "SSH #{ssh_connection.options[:user]} @ #{@peer_info}"
     end
 
     def desc

--- a/spec/acceptance/ldap_spec.rb
+++ b/spec/acceptance/ldap_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'LDAP modules' do
         session_module: 'auxiliary/scanner/ldap/ldap_login',
         type: 'LDAP',
         platforms: %i[linux osx windows],
+        session_info_pattern: /LDAP #{Regexp.escape(ENV.fetch('LDAP_LDAPUsername', 'DEV-AD\Administrator'))} @ \d+\.\d+\.\d+\.\d+/,
         datastore: {
           global: {},
           module: {
@@ -319,6 +320,14 @@ RSpec.describe 'LDAP modules' do
 
               session_id = session_message[session_opened_matcher, 1]
               expect(session_id).to_not be_nil
+            end
+
+            console.recvuntil(Acceptance::Console.prompt)
+
+            if target.session_info_pattern
+              console.sendline('sessions')
+              sessions_output = console.recvuntil(Acceptance::Console.prompt)
+              expect(Acceptance::Session.uncolorize(sessions_output)).to match(target.session_info_pattern)
             end
 
             session_id

--- a/spec/acceptance/mssql_spec.rb
+++ b/spec/acceptance/mssql_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'MSSQL sessions and MSSQL modules' do
         session_module: "auxiliary/scanner/mssql/mssql_login",
         type: 'MSSQL',
         platforms: [:linux, :osx, :windows],
+        session_info_pattern: /MSSQL #{Regexp.escape(ENV.fetch('MSSQL_USER', 'sa'))} @ \d+\.\d+\.\d+\.\d+/,
         datastore: {
           global: {},
           module: {
@@ -334,6 +335,14 @@ RSpec.describe 'MSSQL sessions and MSSQL modules' do
 
               session_id = session_message[session_opened_matcher, 1]
               expect(session_id).to_not be_nil
+            end
+
+            console.recvuntil(Acceptance::Console.prompt)
+
+            if target.session_info_pattern
+              console.sendline('sessions')
+              sessions_output = console.recvuntil(Acceptance::Console.prompt)
+              expect(Acceptance::Session.uncolorize(sessions_output)).to match(target.session_info_pattern)
             end
 
             session_id

--- a/spec/acceptance/postgres_spec.rb
+++ b/spec/acceptance/postgres_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Postgres sessions and postgres modules' do
         session_module: "auxiliary/scanner/postgres/postgres_login",
         type: 'PostgreSQL',
         platforms: [:linux, :osx, :windows],
+        session_info_pattern: /PostgreSQL #{Regexp.escape(ENV.fetch('POSTGRES_USERNAME', 'postgres'))} @ \d+\.\d+\.\d+\.\d+/,
         datastore: {
           global: {},
           module: {
@@ -303,6 +304,14 @@ RSpec.describe 'Postgres sessions and postgres modules' do
 
               session_id = session_message[session_opened_matcher, 1]
               expect(session_id).to_not be_nil
+            end
+
+            console.recvuntil(Acceptance::Console.prompt)
+
+            if target.session_info_pattern
+              console.sendline('sessions')
+              sessions_output = console.recvuntil(Acceptance::Console.prompt)
+              expect(Acceptance::Session.uncolorize(sessions_output)).to match(target.session_info_pattern)
             end
 
             session_id

--- a/spec/acceptance/smb_spec.rb
+++ b/spec/acceptance/smb_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'SMB sessions and SMB modules' do
         session_module: "auxiliary/scanner/smb/smb_login",
         type: 'SMB',
         platforms: [:linux, :osx, :windows],
+        session_info_pattern: /SMB #{Regexp.escape(ENV.fetch('SMB_USERNAME', 'acceptance_tests_user'))} @ \d+\.\d+\.\d+\.\d+/,
         datastore: {
           global: {},
           module: {
@@ -347,6 +348,14 @@ RSpec.describe 'SMB sessions and SMB modules' do
 
               session_id = session_message[session_opened_matcher, 1]
               expect(session_id).to_not be_nil
+            end
+
+            console.recvuntil(Acceptance::Console.prompt)
+
+            if target.session_info_pattern
+              console.sendline('sessions')
+              sessions_output = console.recvuntil(Acceptance::Console.prompt)
+              expect(Acceptance::Session.uncolorize(sessions_output)).to match(target.session_info_pattern)
             end
 
             session_id

--- a/spec/acceptance/ssh_spec.rb
+++ b/spec/acceptance/ssh_spec.rb
@@ -1,80 +1,43 @@
+# frozen_string_literal: true
+
 require 'acceptance_spec_helper'
 
-RSpec.describe 'MySQL sessions and MySQL modules' do
+RSpec.describe 'SSH sessions and SSH modules' do
   include_context 'wait_for_expect'
 
   tests = {
-    mysql: {
+    ssh: {
       target: {
-        session_module: "auxiliary/scanner/mysql/mysql_login",
-        type: 'MySQL',
-        platforms: [:linux, :osx, :windows],
-        session_info_pattern: /MySQL #{Regexp.escape(ENV.fetch('MYSQL_USERNAME', 'root'))} @ \d+\.\d+\.\d+\.\d+/,
+        session_module: 'auxiliary/scanner/ssh/ssh_login',
+        type: 'SSH',
+        platforms: %i[linux osx windows],
+        session_info_pattern: /SSH #{Regexp.escape(ENV.fetch('SSH_USERNAME', 'acceptance_tests_user'))} @ \d+\.\d+\.\d+\.\d+/,
         datastore: {
           global: {},
           module: {
-            username: ENV.fetch('MYSQL_USERNAME', 'root'),
-            password: ENV.fetch('MYSQL_PASSWORD', 'password'),
-            rhost: ENV.fetch('MYSQL_RHOST', '127.0.0.1'),
-            rport: ENV.fetch('MYSQL_RPORT', '3306'),
+            username: ENV.fetch('SSH_USERNAME', 'acceptance_tests_user'),
+            password: ENV.fetch('SSH_PASSWORD', 'acceptance_tests_password'),
+            rhost: ENV.fetch('SSH_RHOST', '127.0.0.1'),
+            rport: ENV.fetch('SSH_RPORT', '2222'),
           }
         }
       },
       module_tests: [
         {
-          name: "post/test/mysql",
-          platforms: [:linux, :osx, :windows],
+          name: 'post/test/unix',
+          platforms: %i[linux osx],
           targets: [:session],
           skipped: false,
         },
         {
-          name: "auxiliary/scanner/mysql/mysql_hashdump",
-          platforms: [:linux, :osx, :windows],
-          targets: [:session, :rhost],
+          name: 'auxiliary/scanner/ssh/ssh_version',
+          platforms: %i[linux osx windows],
+          targets: [:rhost],
           skipped: false,
           lines: {
             all: {
               required: [
-                /Saving HashString as Loot/
-              ]
-            },
-          }
-        },
-        {
-          name: "auxiliary/scanner/mysql/mysql_version",
-          platforms: [:linux, :osx, :windows],
-          targets: [:session, :rhost],
-          skipped: false,
-          lines: {
-            all: {
-              required: [
-                /\d+\.\d+\.\d+\.\d+:\d+ is running MySQL \d+.\d+.*/
-              ]
-            },
-          }
-        },
-        {
-          name: "auxiliary/admin/mysql/mysql_sql",
-          platforms: [:linux, :osx, :windows],
-          targets: [:session, :rhost],
-          skipped: false,
-          lines: {
-            all: {
-              required: [
-                /\| \d+.\d+.*/,
-              ]
-            },
-          }
-        },
-        {
-          name: "auxiliary/admin/mysql/mysql_enum",
-          platforms: [:linux, :osx, :windows],
-          targets: [:session, :rhost],
-          skipped: false,
-          lines: {
-            all: {
-              required: [
-                /MySQL Version: \d+.\d+.*/,
+                /SSH server version: SSH-\d+\.\d+-/,
               ]
             },
           }
@@ -85,7 +48,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
 
   allure_test_environment = AllureRspec.configuration.environment_properties
 
-  let_it_be(:current_platform) { Acceptance::Session::current_platform }
+  let_it_be(:current_platform) { Acceptance::Session.current_platform }
 
   # Driver instance, keeps track of all open processes/payloads/etc, so they can be closed cleanly
   let_it_be(:driver) do
@@ -106,19 +69,6 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
     console.recvuntil(/\d+ exploit modules[^\n]*\n/)
     console.recvuntil(/\d+ post modules[^\n]*\n/)
     console.recvuntil(Acceptance::Console.prompt)
-
-    # Read the remaining console
-    # console.sendline "quit -y"
-    # console.recv_available
-
-    features = %w[
-      mysql_session_type
-    ]
-
-    features.each do |feature|
-      console.sendline("features set #{feature} true")
-      console.recvuntil(Acceptance::Console.prompt)
-    end
 
     console
   end
@@ -151,7 +101,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
         # Skip any ignored lines from the validation input
         validated_lines = test_result.lines.reject do |line|
           is_acceptable = known_failures.any? do |acceptable_failure|
-            is_matching_line = is_matching_line.value.is_a?(Regexp) ? line.match?(acceptable_failure.value) : line.include?(acceptable_failure.value)
+            is_matching_line = acceptable_failure.value.is_a?(Regexp) ? line.match?(acceptable_failure.value) : line.include?(acceptable_failure.value)
             is_matching_line &&
               acceptable_failure.if?(test_environment)
           end || line.match?(/Passed: \d+; Failed: \d+/)
@@ -167,6 +117,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
         # Assert all expected lines are present
         required_lines.each do |required|
           next unless required.if?(test_environment)
+
           if required.value.is_a?(Regexp)
             expect(test_result).to match(required.value)
           else
@@ -174,8 +125,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
           end
         end
 
-        # Assert all ignored lines are present, if they are not present - they should be removed from
-        # the calling config
+        # Assert all ignored lines are present; if they are not present they should be removed from the calling config
         known_failures.each do |acceptable_failure|
           next if acceptable_failure.flaky?(test_environment)
           next unless acceptable_failure.if?(test_environment)
@@ -215,7 +165,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
       #{target_configuration_details}
 
       ## Replication commands
-      #{replication_commands.empty? ? 'no additional commands run' : replication_commands.join("\n")}
+      #{replication_commands.empty? ? '# no additional commands run' : replication_commands.join("\n")}
     EOF
 
     Allure.add_attachment(
@@ -253,15 +203,12 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
       test_config[:module_tests].each do |module_test|
         describe(
           module_test[:name],
-          if: (
-            Acceptance::Session.supported_platform?(module_test)
-          )
+          if: Acceptance::Session.supported_platform?(module_test)
         ) do
           let(:target) { Acceptance::Target.new(test_config[:target]) }
 
           let(:default_global_datastore) do
-            {
-            }
+            {}
           end
 
           let(:test_environment) { allure_test_environment }
@@ -300,6 +247,7 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
 
             console.recvuntil(Acceptance::Console.prompt)
 
+            # Verify the session info line shows the correct user and target host
             if target.session_info_pattern
               console.sendline('sessions')
               sessions_output = console.recvuntil(Acceptance::Console.prompt)
@@ -323,18 +271,18 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
             console.reset
           end
 
-          context "when targeting a session", if: module_test[:targets].include?(:session) do
+          context 'when targeting a session', if: module_test[:targets].include?(:session) do
             it(
               "#{Acceptance::Session.current_platform}/#{runtime_name} session opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 # Ensure we have a valid session id; We intentionally omit this from a `before(:each)` to ensure the allure attachments are generated if the session dies
                 expect(session_id).to_not(be_nil, proc do
-                  "There should be a session present"
+                  'There should be a session present'
                 end)
 
                 use_module = "use #{module_test[:name]}"
-                run_module = "run session=#{session_id} Verbose=true"
+                run_module = "run session=#{session_id} #{target.datastore_options(default_module_datastore: default_module_datastore.merge(module_test.fetch(:datastore, {})))} Verbose=true"
 
                 replication_commands << use_module
                 console.sendline(use_module)
@@ -348,13 +296,13 @@ RSpec.describe 'MySQL sessions and MySQL modules' do
             end
           end
 
-          context "when targeting an rhost", if: module_test[:targets].include?(:rhost) do
+          context 'when targeting an rhost', if: module_test[:targets].include?(:rhost) do
             it(
               "#{Acceptance::Session.current_platform}/#{runtime_name} rhost opens and passes the #{module_test[:name].inspect} tests"
             ) do
               with_test_harness(module_test) do |replication_commands|
                 use_module = "use #{module_test[:name]}"
-                run_module = "run #{target.datastore_options(default_module_datastore: default_module_datastore)} Verbose=true"
+                run_module = "run #{target.datastore_options(default_module_datastore: default_module_datastore.merge(module_test.fetch(:datastore, {})))} Verbose=true"
 
                 replication_commands << use_module
                 console.sendline(use_module)

--- a/spec/support/acceptance/target.rb
+++ b/spec/support/acceptance/target.rb
@@ -13,10 +13,13 @@ module Acceptance
       @type = options.fetch(:type)
       @session_module = options.fetch(:session_module)
       @datastore = options.fetch(:datastore)
+      @session_info_pattern = options[:session_info_pattern]
     end
 
-    def [](k)
-      options[k]
+    # Returns the session info pattern to verify after opening a session, or nil if not set.
+    # @return [Regexp, nil]
+    def session_info_pattern
+      @session_info_pattern
     end
 
     # @param [Hash] default_global_datastore

--- a/test/ldap/README.md
+++ b/test/ldap/README.md
@@ -1,15 +1,33 @@
-## Usage
+## Setup
 
-Building:
+This contains a custom Docker image used for LDAP acceptance testing.
 
-```
+## Credentials
+
+| Username                  | Password     | Domain   |
+|---------------------------|--------------|----------|
+| `DEV-AD\Administrator`    | `admin123!`  | `DEV-AD` |
+
+The server is available on `127.0.0.1:389` (LDAP) and `127.0.0.1:636` (LDAPS).
+
+## Running
+
+- Build:
+```shell
 docker compose build
-docker compose up
 ```
 
-The system should be available on `127.0.0.1:389` and `127.0.0.1:636` - with the creds `Administrator:admin123!` and `DEV-AD` as the domain.
+- Run:
+```shell
+docker compose up -d --wait
+```
 
-Example of running a wih a Metasploit module:
+- Shut down:
+```shell
+docker compose down
+```
+
+## Example
 
 ```msf
 msf auxiliary(scanner/ldap/ldap_login) > run rhost=127.0.0.1 username=DEV-AD\\Administrator password=admin123! CreateSession=true
@@ -17,5 +35,5 @@ msf auxiliary(scanner/ldap/ldap_login) > run rhost=127.0.0.1 username=DEV-AD\\Ad
 msf auxiliary(scanner/ldap/ldap_login) > sessions -i -1
 [*] Starting interaction with 1...
 
-LDAP (127.0.0.1) > 
+LDAP (127.0.0.1) >
 ```

--- a/test/smb/README.md
+++ b/test/smb/README.md
@@ -2,6 +2,12 @@
 
 This contains a custom Docker image used for SMB acceptance testing.
 
+## Credentials
+
+| Username                 | Password                       |
+|--------------------------|--------------------------------|
+| `acceptance_tests_user`  | `acceptance_tests_password`    |
+
 ## Running
 
 - Build:

--- a/test/ssh/Dockerfile
+++ b/test/ssh/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:22.04
+MAINTAINER metasploit-framework <https://github.com/rapid7/metasploit-framework>
+
+EXPOSE 22
+
+# Switch shells to support ANSI-C quoting:
+#   https://stackoverflow.com/questions/33439230/how-to-write-commands-with-multiple-lines-in-dockerfile-while-preserving-the-new
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssh-client \
+    openssh-server
+
+# Create the privilege separation directory required by sshd
+RUN mkdir -p /run/sshd
+
+# Create the test user and set a known password
+RUN useradd -m -s /bin/bash acceptance_tests_user
+RUN echo 'acceptance_tests_user:acceptance_tests_password' | chpasswd
+
+# Allow password authentication and permit root login for test purposes
+RUN sed -i \
+    -e 's/^#\?PasswordAuthentication.*/PasswordAuthentication yes/' \
+    -e 's/^#\?PermitRootLogin.*/PermitRootLogin yes/' \
+    /etc/ssh/sshd_config
+
+# Generate host keys
+RUN ssh-keygen -A
+
+ENTRYPOINT ["/usr/sbin/sshd", "-D", "-e"]

--- a/test/ssh/README.md
+++ b/test/ssh/README.md
@@ -1,0 +1,26 @@
+## Setup
+
+This contains a custom Docker image used for SSH acceptance testing.
+
+## Credentials
+
+| Username                 | Password                     |
+|--------------------------|------------------------------|
+| `acceptance_tests_user`  | `acceptance_tests_password`  |
+
+## Running
+
+- Build:
+```shell
+docker compose build
+```
+
+- Run:
+```shell
+docker compose up -d --wait
+```
+
+- Shut down:
+```shell
+docker compose down
+```

--- a/test/ssh/docker-compose.yml
+++ b/test/ssh/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  ssh:
+    tty: true
+    network_mode: bridge
+    ports:
+      - "2222:22"
+    healthcheck:
+      test: ssh-keyscan -T 5 127.0.0.1
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+    build:
+      context: .
+      dockerfile: Dockerfile


### PR DESCRIPTION
## Description

Fixes a bug with SSH session's debug information containing `localuser @ ` instead of `ssh_user @ ssh_ip`


Without this change:

```diff
  1) SSH sessions and SSH modules osx/ssh post/test/unix when targeting a session osx/ssh session opens and passes the "post/test/unix" tests
     Failure/Error: expect(Acceptance::Session.uncolorize(sessions_output)).to match(target.session_info_pattern)
     
       expected "\nActive sessions\n===============\n\n  Id  Name  Type         Information     Connection\n  --  ---...msf\u0001\u0002 auxiliary(\u0001\u0002\u0001\u0002scanner/ssh/ssh_login\u0001\u0002) \u0001\u0002> " to match /SSH acceptance_tests_user @ \d+\.\d+\.\d+\.\d+/
       Diff:
       @@ -1 +1,9 @@
       -/SSH acceptance_tests_user @ \d+\.\d+\.\d+\.\d+/
       +
       +Active sessions
       +===============
       +
       +  Id  Name  Type         Information     Connection
       +  --  ----  ----         -----------     ----------
       +  1         shell linux  SSH my_user @  127.0.0.1:63318 -> 127.0.0.1:2222 (127.0.0.1)
       +
       +msf auxiliary(scanner/ssh/ssh_login) > 

```

## Testing

- Run `ssh_login` and verify that `sessions` shows the correct login details