### PR TITLE
Rubocop redundant module info keys

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ require:
   - ./lib/rubocop/cop/lint/datastore_srvhost_usage.rb
   - ./lib/rubocop/cop/lint/bare_check_code_in_non_exploit.rb
   - ./lib/rubocop/cop/lint/check_code_missing_reason.rb
+  - ./lib/rubocop/cop/lint/module_redundant_arch_platform.rb
 
 Lint/CheckCodeMissingReason:
   Enabled: true
@@ -213,6 +214,11 @@ Lint/ModuleEnforceNotes:
     - 'modules/exploits/**/*'
     - 'modules/auxiliary/**/*'
     - 'modules/post/**/*'
+
+Lint/ModuleRedundantArchPlatform:
+  Enabled: true
+  Include:
+    - 'modules/**/*'
 
 Lint/DeprecatedGemVersion:
   Enabled: true

--- a/lib/rubocop/cop/lint/module_redundant_arch_platform.rb
+++ b/lib/rubocop/cop/lint/module_redundant_arch_platform.rb
@@ -7,9 +7,11 @@ module RuboCop
       # `Arch` or `Platform` at the top level of update_info when that
       # information is already present in all targets.
       #
-      # The framework merges target metadata into the module metadata, so
-      # specifying `Arch` or `Platform` at the top level is redundant when
-      # every target already carries that information.
+      # The framework uses target-level Arch/Platform when present, falling
+      # back to the module-level value only when the target does not specify
+      # them (see `Msf::Exploit#target_arch` and `#target_platform`).
+      # Therefore, specifying `Arch` or `Platform` at the top level is
+      # redundant when every target already carries that information.
       #
       # @example
       #   # bad - Arch at top level when all targets define it
@@ -49,9 +51,11 @@ module RuboCop
       #     ]
       #   )
       class ModuleRedundantArchPlatform < Base
+        extend AutoCorrector
 
-        REDUNDANT_ARCH_MSG = 'Remove top-level `Arch` as it is already defined in all `Targets`'
-        REDUNDANT_PLATFORM_MSG = 'Remove top-level `Platform` as it is already defined in all `Targets`'
+        REDUNDANT_KEY_MSG = 'Remove top-level `%<key>s` as it is already defined in all `Targets`'
+
+        CHECKED_KEYS = %w[Arch Platform].freeze
 
         def_node_matcher :find_update_info_node, <<~PATTERN
           (def :initialize _args (begin (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...))) ...))
@@ -68,36 +72,34 @@ module RuboCop
           hash = update_info_node.arguments.find { |argument| argument.type == :hash }
           return if hash.nil?
 
-          top_level_keys = {}
+          top_level_pairs = {}
           targets_node = nil
 
           hash.each_pair do |key, value|
             next unless key.type == :str
 
-            case key.value
-            when 'Arch', 'Platform'
-              top_level_keys[key.value] = key
-            when 'Targets'
+            if CHECKED_KEYS.include?(key.value)
+              top_level_pairs[key.value] = hash.pairs.find { |pair| pair.key == key }
+            elsif key.value == 'Targets'
               targets_node = value
             end
           end
 
-          # Only flag if both Targets and the key exist at the top level
           return if targets_node.nil?
-          return if top_level_keys.empty?
-
-          # Targets should be an array of arrays
+          return if top_level_pairs.empty?
           return unless targets_node.type == :array
 
           targets = targets_node.children
           return if targets.empty?
 
-          if top_level_keys.key?('Arch') && all_targets_define_key?(targets, 'Arch')
-            add_offense(top_level_keys['Arch'], message: REDUNDANT_ARCH_MSG)
-          end
+          CHECKED_KEYS.each do |key_name|
+            pair = top_level_pairs[key_name]
+            next unless pair
+            next unless all_targets_define_key?(targets, key_name)
 
-          if top_level_keys.key?('Platform') && all_targets_define_key?(targets, 'Platform')
-            add_offense(top_level_keys['Platform'], message: REDUNDANT_PLATFORM_MSG)
+            add_offense(pair.key, message: format(REDUNDANT_KEY_MSG, key: key_name)) do |corrector|
+              remove_pair(corrector, pair)
+            end
           end
         end
 
@@ -117,6 +119,41 @@ module RuboCop
               pair.key.type == :str && pair.key.value == key_name
             end
           end
+        end
+
+        # Removes a key-value pair from the hash, including the trailing comma
+        # and any whitespace/newline that follows.
+        def remove_pair(corrector, pair)
+          range = pair.source_range
+          # Extend range to include trailing comma and whitespace up to the next line
+          end_pos = range.end_pos
+          source = range.source_buffer.source
+
+          # Consume trailing comma and whitespace/newline
+          while end_pos < source.length && source[end_pos] =~ /[ \t]/
+            end_pos += 1
+          end
+          if end_pos < source.length && source[end_pos] == ','
+            end_pos += 1
+            # Consume whitespace after comma up to and including newline
+            while end_pos < source.length && source[end_pos] =~ /[ \t]/
+              end_pos += 1
+            end
+            if end_pos < source.length && source[end_pos] == "\n"
+              end_pos += 1
+            end
+          elsif end_pos < source.length && source[end_pos] == "\n"
+            end_pos += 1
+          end
+
+          # Also consume the leading whitespace on this line (indent)
+          start_pos = range.begin_pos
+          while start_pos > 0 && source[start_pos - 1] =~ /[ \t]/
+            start_pos -= 1
+          end
+
+          removal_range = Parser::Source::Range.new(range.source_buffer, start_pos, end_pos)
+          corrector.remove(removal_range)
         end
       end
     end

--- a/lib/rubocop/cop/lint/module_redundant_arch_platform.rb
+++ b/lib/rubocop/cop/lint/module_redundant_arch_platform.rb
@@ -52,8 +52,9 @@ module RuboCop
       #   )
       class ModuleRedundantArchPlatform < Base
         extend AutoCorrector
+        include RangeHelp
 
-        REDUNDANT_KEY_MSG = 'Remove top-level `%<key>s` as it is already defined in all `Targets`'
+        MSG = 'Remove top-level `%s` as it is already defined in all `Targets`'
 
         CHECKED_KEYS = %w[Arch Platform].freeze
 
@@ -69,7 +70,7 @@ module RuboCop
           update_info_node = find_update_info_node(node) || find_nested_update_info_node(node)
           return if update_info_node.nil?
 
-          hash = update_info_node.arguments.find { |argument| argument.type == :hash }
+          hash = update_info_node.arguments.find { |argument| hash_arg?(argument) }
           return if hash.nil?
 
           top_level_pairs = {}
@@ -97,8 +98,8 @@ module RuboCop
             next unless pair
             next unless all_targets_define_key?(targets, key_name)
 
-            add_offense(pair.key, message: format(REDUNDANT_KEY_MSG, key: key_name)) do |corrector|
-              remove_pair(corrector, pair)
+            add_offense(pair.key, message: MSG % key_name) do |corrector|
+              remove_pair_with_line(corrector, pair)
             end
           end
         end
@@ -112,7 +113,7 @@ module RuboCop
           targets.all? do |target|
             next false unless target.type == :array
 
-            target_hash = target.children.find { |child| child.type == :hash }
+            target_hash = target.children.find { |child| hash_arg?(child) }
             next false if target_hash.nil?
 
             target_hash.pairs.any? do |pair|
@@ -121,11 +122,14 @@ module RuboCop
           end
         end
 
-        # Removes a key-value pair from the hash, including the trailing comma
-        # and any whitespace/newline that follows.
-        def remove_pair(corrector, pair)
+        def hash_arg?(node)
+          node.type == :hash
+        end
+
+        # Removes a key-value pair and its entire line (leading whitespace,
+        # trailing comma, and newline).
+        def remove_pair_with_line(corrector, pair)
           range = pair.source_range
-          # Extend range to include trailing comma and whitespace up to the next line
           end_pos = range.end_pos
           source = range.source_buffer.source
 
@@ -135,24 +139,21 @@ module RuboCop
           end
           if end_pos < source.length && source[end_pos] == ','
             end_pos += 1
-            # Consume whitespace after comma up to and including newline
-            while end_pos < source.length && source[end_pos] =~ /[ \t]/
-              end_pos += 1
-            end
-            if end_pos < source.length && source[end_pos] == "\n"
-              end_pos += 1
-            end
-          elsif end_pos < source.length && source[end_pos] == "\n"
+          end
+          while end_pos < source.length && source[end_pos] =~ /[ \t]/
+            end_pos += 1
+          end
+          if end_pos < source.length && source[end_pos] == "\n"
             end_pos += 1
           end
 
-          # Also consume the leading whitespace on this line (indent)
+          # Consume the leading whitespace on this line
           start_pos = range.begin_pos
           while start_pos > 0 && source[start_pos - 1] =~ /[ \t]/
             start_pos -= 1
           end
 
-          removal_range = Parser::Source::Range.new(range.source_buffer, start_pos, end_pos)
+          removal_range = range.with(begin_pos: start_pos, end_pos: end_pos)
           corrector.remove(removal_range)
         end
       end

--- a/lib/rubocop/cop/lint/module_redundant_arch_platform.rb
+++ b/lib/rubocop/cop/lint/module_redundant_arch_platform.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Checks that modules with `Targets` defined do not redundantly specify
+      # `Arch` or `Platform` at the top level of update_info when that
+      # information is already present in all targets.
+      #
+      # The framework merges target metadata into the module metadata, so
+      # specifying `Arch` or `Platform` at the top level is redundant when
+      # every target already carries that information.
+      #
+      # @example
+      #   # bad - Arch at top level when all targets define it
+      #   update_info(
+      #     info,
+      #     'Arch' => ARCH_X86,
+      #     'Targets' => [
+      #       ['Windows', { 'Arch' => ARCH_X86 }]
+      #     ]
+      #   )
+      #
+      #   # bad - Platform at top level when all targets define it
+      #   update_info(
+      #     info,
+      #     'Platform' => 'win',
+      #     'Targets' => [
+      #       ['Windows', { 'Platform' => 'win' }]
+      #     ]
+      #   )
+      #
+      #   # good - no top-level Arch/Platform when targets define them
+      #   update_info(
+      #     info,
+      #     'Targets' => [
+      #       ['Windows x86', { 'Platform' => 'win', 'Arch' => ARCH_X86 }],
+      #       ['Windows x64', { 'Platform' => 'win', 'Arch' => ARCH_X64 }]
+      #     ]
+      #   )
+      #
+      #   # good - top-level Arch/Platform when targets don't define them
+      #   update_info(
+      #     info,
+      #     'Arch' => ARCH_X86,
+      #     'Platform' => 'win',
+      #     'Targets' => [
+      #       ['Automatic', {}]
+      #     ]
+      #   )
+      class ModuleRedundantArchPlatform < Base
+
+        REDUNDANT_ARCH_MSG = 'Remove top-level `Arch` as it is already defined in all `Targets`'
+        REDUNDANT_PLATFORM_MSG = 'Remove top-level `Platform` as it is already defined in all `Targets`'
+
+        def_node_matcher :find_update_info_node, <<~PATTERN
+          (def :initialize _args (begin (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...))) ...))
+        PATTERN
+
+        def_node_matcher :find_nested_update_info_node, <<~PATTERN
+          (def :initialize _args (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...)) ...))
+        PATTERN
+
+        def on_def(node)
+          update_info_node = find_update_info_node(node) || find_nested_update_info_node(node)
+          return if update_info_node.nil?
+
+          hash = update_info_node.arguments.find { |argument| argument.type == :hash }
+          return if hash.nil?
+
+          top_level_keys = {}
+          targets_node = nil
+
+          hash.each_pair do |key, value|
+            next unless key.type == :str
+
+            case key.value
+            when 'Arch', 'Platform'
+              top_level_keys[key.value] = key
+            when 'Targets'
+              targets_node = value
+            end
+          end
+
+          # Only flag if both Targets and the key exist at the top level
+          return if targets_node.nil?
+          return if top_level_keys.empty?
+
+          # Targets should be an array of arrays
+          return unless targets_node.type == :array
+
+          targets = targets_node.children
+          return if targets.empty?
+
+          if top_level_keys.key?('Arch') && all_targets_define_key?(targets, 'Arch')
+            add_offense(top_level_keys['Arch'], message: REDUNDANT_ARCH_MSG)
+          end
+
+          if top_level_keys.key?('Platform') && all_targets_define_key?(targets, 'Platform')
+            add_offense(top_level_keys['Platform'], message: REDUNDANT_PLATFORM_MSG)
+          end
+        end
+
+        private
+
+        # Checks whether every target in the Targets array defines the given key.
+        # Each target is expected to be an array node like:
+        #   ['Name', { 'Arch' => ..., 'Platform' => ... }]
+        def all_targets_define_key?(targets, key_name)
+          targets.all? do |target|
+            next false unless target.type == :array
+
+            target_hash = target.children.find { |child| child.type == :hash }
+            next false if target_hash.nil?
+
+            target_hash.pairs.any? do |pair|
+              pair.key.type == :str && pair.key.value == key_name
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/module_redundant_arch_platform_spec.rb
+++ b/spec/rubocop/cop/lint/module_redundant_arch_platform_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::Lint::ModuleRedundantArchPlatform do
   let(:config) { RuboCop::Config.new(empty_rubocop_config) }
 
   context 'when Arch is redundant' do
-    it 'registers an offense when all targets define Arch' do
+    it 'registers an offense and autocorrects' do
       expect_offense(<<~RUBY)
         class DummyModule
           def initialize(info = {})
@@ -31,12 +31,31 @@ RSpec.describe RuboCop::Cop::Lint::ModuleRedundantArchPlatform do
           end
         end
       RUBY
-      expect_no_corrections
+
+      expect_correction(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Targets' => [
+                  ['Windows x86', { 'Arch' => ARCH_X86 }],
+                  ['Windows x64', { 'Arch' => ARCH_X64 }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
     end
   end
 
   context 'when Platform is redundant' do
-    it 'registers an offense when all targets define Platform' do
+    it 'registers an offense and autocorrects' do
       expect_offense(<<~RUBY)
         class DummyModule
           def initialize(info = {})
@@ -58,12 +77,31 @@ RSpec.describe RuboCop::Cop::Lint::ModuleRedundantArchPlatform do
           end
         end
       RUBY
-      expect_no_corrections
+
+      expect_correction(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Targets' => [
+                  ['Windows x86', { 'Platform' => 'win', 'Arch' => ARCH_X86 }],
+                  ['Windows x64', { 'Platform' => 'win', 'Arch' => ARCH_X64 }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
     end
   end
 
   context 'when both Arch and Platform are redundant' do
-    it 'registers offenses for both' do
+    it 'registers offenses for both and autocorrects' do
       expect_offense(<<~RUBY)
         class DummyModule
           def initialize(info = {})
@@ -87,7 +125,26 @@ RSpec.describe RuboCop::Cop::Lint::ModuleRedundantArchPlatform do
           end
         end
       RUBY
-      expect_no_corrections
+
+      expect_correction(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Targets' => [
+                  ['Windows x86', { 'Platform' => 'win', 'Arch' => ARCH_X86 }],
+                  ['Windows x64', { 'Platform' => 'win', 'Arch' => ARCH_X64 }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
     end
   end
 
@@ -182,12 +239,29 @@ RSpec.describe RuboCop::Cop::Lint::ModuleRedundantArchPlatform do
           end
         end
       RUBY
-      expect_no_corrections
+
+      expect_correction(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(update_info(
+              info,
+              'Name' => 'Test module',
+              'Description' => 'A test module',
+              'Author' => ['example'],
+              'License' => MSF_LICENSE,
+              'Targets' => [
+                ['Windows x86', { 'Arch' => ARCH_X86 }],
+                ['Windows x64', { 'Arch' => ARCH_X64 }]
+              ]
+            ))
+          end
+        end
+      RUBY
     end
   end
 
   context 'with single target' do
-    it 'registers an offense when the single target defines Arch' do
+    it 'registers an offense when the single target defines Arch and Platform' do
       expect_offense(<<~RUBY)
         class DummyModule
           def initialize(info = {})
@@ -210,7 +284,25 @@ RSpec.describe RuboCop::Cop::Lint::ModuleRedundantArchPlatform do
           end
         end
       RUBY
-      expect_no_corrections
+
+      expect_correction(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Targets' => [
+                  ['Windows', { 'Platform' => 'win', 'Arch' => [ARCH_X86, ARCH_X64] }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
     end
   end
 
@@ -236,7 +328,25 @@ RSpec.describe RuboCop::Cop::Lint::ModuleRedundantArchPlatform do
           end
         end
       RUBY
-      expect_no_corrections
+
+      expect_correction(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              merge_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Targets' => [
+                  ['Windows x86', { 'Arch' => ARCH_X86 }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
     end
   end
 
@@ -255,6 +365,31 @@ RSpec.describe RuboCop::Cop::Lint::ModuleRedundantArchPlatform do
                 'Arch' => ARCH_X86,
                 'Platform' => 'win',
                 'Targets' => []
+              )
+            )
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when target has no options hash' do
+    it 'does not register an offense for targets without hash element' do
+      expect_no_offenses(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Arch' => ARCH_X86,
+                'Platform' => 'win',
+                'Targets' => [
+                  ['Automatic']
+                ]
               )
             )
           end

--- a/spec/rubocop/cop/lint/module_redundant_arch_platform_spec.rb
+++ b/spec/rubocop/cop/lint/module_redundant_arch_platform_spec.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rubocop/cop/lint/module_redundant_arch_platform'
+
+RSpec.describe RuboCop::Cop::Lint::ModuleRedundantArchPlatform do
+  subject(:cop) { described_class.new(config) }
+  let(:empty_rubocop_config) { {} }
+  let(:config) { RuboCop::Config.new(empty_rubocop_config) }
+
+  context 'when Arch is redundant' do
+    it 'registers an offense when all targets define Arch' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Arch' => ARCH_X86,
+                ^^^^^^ Remove top-level `Arch` as it is already defined in all `Targets`
+                'Targets' => [
+                  ['Windows x86', { 'Arch' => ARCH_X86 }],
+                  ['Windows x64', { 'Arch' => ARCH_X64 }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+  end
+
+  context 'when Platform is redundant' do
+    it 'registers an offense when all targets define Platform' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Platform' => 'win',
+                ^^^^^^^^^^ Remove top-level `Platform` as it is already defined in all `Targets`
+                'Targets' => [
+                  ['Windows x86', { 'Platform' => 'win', 'Arch' => ARCH_X86 }],
+                  ['Windows x64', { 'Platform' => 'win', 'Arch' => ARCH_X64 }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+  end
+
+  context 'when both Arch and Platform are redundant' do
+    it 'registers offenses for both' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Platform' => 'win',
+                ^^^^^^^^^^ Remove top-level `Platform` as it is already defined in all `Targets`
+                'Arch' => ARCH_X86,
+                ^^^^^^ Remove top-level `Arch` as it is already defined in all `Targets`
+                'Targets' => [
+                  ['Windows x86', { 'Platform' => 'win', 'Arch' => ARCH_X86 }],
+                  ['Windows x64', { 'Platform' => 'win', 'Arch' => ARCH_X64 }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+  end
+
+  context 'when Arch is not redundant' do
+    it 'does not register an offense when not all targets define Arch' do
+      expect_no_offenses(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Arch' => ARCH_X86,
+                'Targets' => [
+                  ['Windows x86', { 'Arch' => ARCH_X86 }],
+                  ['Automatic', {}]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when there are no Targets' do
+      expect_no_offenses(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Arch' => ARCH_X86,
+                'Platform' => 'win'
+              )
+            )
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when Platform is not redundant' do
+    it 'does not register an offense when not all targets define Platform' do
+      expect_no_offenses(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Platform' => 'win',
+                'Targets' => [
+                  ['Windows x86', { 'Platform' => 'win', 'Arch' => ARCH_X86 }],
+                  ['Linux x64', { 'Arch' => ARCH_X64 }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with nested update_info form' do
+    it 'registers an offense with the nested super form' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(update_info(
+              info,
+              'Name' => 'Test module',
+              'Description' => 'A test module',
+              'Author' => ['example'],
+              'License' => MSF_LICENSE,
+              'Arch' => ARCH_X86,
+              ^^^^^^ Remove top-level `Arch` as it is already defined in all `Targets`
+              'Targets' => [
+                ['Windows x86', { 'Arch' => ARCH_X86 }],
+                ['Windows x64', { 'Arch' => ARCH_X64 }]
+              ]
+            ))
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+  end
+
+  context 'with single target' do
+    it 'registers an offense when the single target defines Arch' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Platform' => 'win',
+                ^^^^^^^^^^ Remove top-level `Platform` as it is already defined in all `Targets`
+                'Arch' => [ARCH_X86, ARCH_X64],
+                ^^^^^^ Remove top-level `Arch` as it is already defined in all `Targets`
+                'Targets' => [
+                  ['Windows', { 'Platform' => 'win', 'Arch' => [ARCH_X86, ARCH_X64] }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+  end
+
+  context 'with merge_info' do
+    it 'registers an offense for merge_info call' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              merge_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Arch' => ARCH_X86,
+                ^^^^^^ Remove top-level `Arch` as it is already defined in all `Targets`
+                'Targets' => [
+                  ['Windows x86', { 'Arch' => ARCH_X86 }]
+                ]
+              )
+            )
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+  end
+
+  context 'with empty targets array' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Test module',
+                'Description' => 'A test module',
+                'Author' => ['example'],
+                'License' => MSF_LICENSE,
+                'Arch' => ARCH_X86,
+                'Platform' => 'win',
+                'Targets' => []
+              )
+            )
+          end
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## Description
Closes https://github.com/rapid7/metasploit-framework/issues/21606
This PR adds a RuboCop rule to help contributors with the redundant metadata that is often copy-pasted in the module metadata hash (arch and platform), if the Targets already has them defined.

Related work: https://github.com/rapid7/metasploit-framework/pull/20786

This should follow the already-existing code conventions for other rubocop rules.

## Potential scenarios
Some 'mock' module metadata, that you can store as a file and run rubocop against:

```ruby
# frozen_string_literal: true

# BAD: Arch is redundant because all targets define it
class MetasploitModule < Msf::Exploit::Remote
  def initialize(info = {})
    super(
      update_info(
        info,
        'Name' => 'Bad Example - Redundant Arch',
        'Description' => %q{
          This fake module demonstrates a redundant top-level Arch.
          Every target already specifies Arch, so the top-level value is unnecessary.
        },
        'Author' => ['Test Author'],
        'License' => MSF_LICENSE,
        'Platform' => 'win',
        'Arch' => ARCH_X86,
        'Targets' => [
          ['Windows x86', { 'Arch' => ARCH_X86 }],
          ['Windows x64', { 'Arch' => ARCH_X64 }]
        ],
        'DefaultTarget' => 0,
        'DisclosureDate' => '2025-01-01',
        'Notes' => {
          'Stability' => [CRASH_SAFE],
          'SideEffects' => [IOC_IN_LOGS],
          'Reliability' => [REPEATABLE_SESSION]
        }
      )
    )
  end
end
# frozen_string_literal: true

# BAD: Both Arch and Platform are redundant because all targets define them
class MetasploitModule < Msf::Exploit::Remote
  def initialize(info = {})
    super(
      update_info(
        info,
        'Name' => 'Bad Example - Redundant Arch and Platform',
        'Description' => %q{
          This fake module demonstrates redundant top-level Arch AND Platform.
          Every target already specifies both, so neither is needed at the top level.
        },
        'Author' => ['Test Author'],
        'License' => MSF_LICENSE,
        'Platform' => 'win',
        'Arch' => [ARCH_X86, ARCH_X64],
        'Targets' => [
          ['Windows x86', { 'Platform' => 'win', 'Arch' => ARCH_X86 }],
          ['Windows x64', { 'Platform' => 'win', 'Arch' => ARCH_X64 }],
          ['Windows ARM', { 'Platform' => 'win', 'Arch' => ARCH_AARCH64 }]
        ],
        'DefaultTarget' => 0,
        'DisclosureDate' => '2025-01-01',
        'Notes' => {
          'Stability' => [CRASH_SAFE],
          'SideEffects' => [IOC_IN_LOGS],
          'Reliability' => [REPEATABLE_SESSION]
        }
      )
    )
  end
end
# frozen_string_literal: true

# BAD: Platform is redundant because all targets define it
class MetasploitModule < Msf::Exploit::Remote
  def initialize(info = {})
    super(
      update_info(
        info,
        'Name' => 'Bad Example - Redundant Platform',
        'Description' => %q{
          This fake module demonstrates a redundant top-level Platform.
          Every target already specifies Platform, so the top-level value is unnecessary.
        },
        'Author' => ['Test Author'],
        'License' => MSF_LICENSE,
        'Platform' => 'win',
        'Targets' => [
          ['Windows x86', { 'Platform' => 'win', 'Arch' => ARCH_X86 }],
          ['Windows x64', { 'Platform' => 'win', 'Arch' => ARCH_X64 }]
        ],
        'DefaultTarget' => 0,
        'DisclosureDate' => '2025-01-01',
        'Notes' => {
          'Stability' => [CRASH_SAFE],
          'SideEffects' => [IOC_IN_LOGS],
          'Reliability' => [REPEATABLE_SESSION]
        }
      )
    )
  end
end
# frozen_string_literal: true

# GOOD: Targets have empty hashes, so top-level Arch/Platform provide the values
class MetasploitModule < Msf::Exploit::Remote
  def initialize(info = {})
    super(
      update_info(
        info,
        'Name' => 'Good Example - Empty Target Hashes',
        'Description' => %q{
          This fake module has targets with empty option hashes. The top-level
          Arch and Platform are needed as the fallback for all targets.
        },
        'Author' => ['Test Author'],
        'License' => MSF_LICENSE,
        'Arch' => [ARCH_X86, ARCH_X64],
        'Platform' => 'win',
        'Targets' => [
          ['Automatic', {}],
          ['Manual', {}]
        ],
        'DefaultTarget' => 0,
        'DisclosureDate' => '2026-01-01',
        'Notes' => {
          'Stability' => [CRASH_SAFE],
          'SideEffects' => [IOC_IN_LOGS],
          'Reliability' => [REPEATABLE_SESSION]
        }
      )
    )
  end
end
# frozen_string_literal: true

# GOOD: No Targets defined, so top-level Arch/Platform are the only source of truth
class MetasploitModule < Msf::Exploit::Remote
  def initialize(info = {})
    super(
      update_info(
        info,
        'Name' => 'Good Example - No Targets',
        'Description' => %q{
          This fake module has no Targets at all, so the top-level Arch and
          Platform are required and should not trigger any offence.
        },
        'Author' => ['Test Author'],
        'License' => MSF_LICENSE,
        'Arch' => ARCH_X86,
        'Platform' => 'win',
        'DisclosureDate' => '2025-01-01',
        'Notes' => {
          'Stability' => [CRASH_SAFE],
          'SideEffects' => [IOC_IN_LOGS],
          'Reliability' => [REPEATABLE_SESSION]
        }
      )
    )
  end
end
# frozen_string_literal: true

# GOOD: Top-level Arch is necessary because not all targets define it
class MetasploitModule < Msf::Exploit::Remote
  def initialize(info = {})
    super(
      update_info(
        info,
        'Name' => 'Good Example - Targets Missing Arch',
        'Description' => %q{
          This fake module correctly uses a top-level Arch because one target
          does not override it. Framework falls back to the top-level value.
        },
        'Author' => ['Test Author'],
        'License' => MSF_LICENSE,
        'Arch' => ARCH_X86,
        'Platform' => 'win',
        'Targets' => [
          ['Windows x86', { 'Arch' => ARCH_X86 }],
          ['Automatic', {}]
        ],
        'DefaultTarget' => 0,
        'DisclosureDate' => '2026-01-01',
        'Notes' => {
          'Stability' => [CRASH_SAFE],
          'SideEffects' => [IOC_IN_LOGS],
          'Reliability' => [REPEATABLE_SESSION]
        }
      )
    )
  end
end
```

## Breaking Changes

None

## Reviewer Notes

## Verification Steps

- [x] Run the rspec tests

## Test Evidence
```
➜  metasploit-framework git:(rubocop-redundant-module-info-keys) ✗ bundle exec rspec spec/rubocop/cop/lint/module_redundant_arch_platform_spec.rb  
...
18 examples, 0 failures
```

## AI Usage Disclosure
Claude was used.

## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)