### PR TITLE
Fix the Rex HTTP Server

### DIFF
--- a/lib/msf/base/sessions/mettle_config.rb
+++ b/lib/msf/base/sessions/mettle_config.rb
@@ -135,7 +135,7 @@ module Msf
         # Mettle reserves a fixed 8 KB slot in the binary for the config
         # block. Catch the overflow here with a useful message instead of
         # letting the gem's `to_binary` raise a generic "config block too
-        # large" — baked-in EXTENSIONS= is the usual culprit.
+        # large" -- baked-in EXTENSIONS= is the usual culprit.
         if opts[:config_block].length > MetasploitPayloads::Mettle::CONFIG_BLOCK_MAX
           raise ArgumentError, "Mettle config block (#{opts[:config_block].length} bytes) exceeds the #{MetasploitPayloads::Mettle::CONFIG_BLOCK_MAX}-byte embedded slot. " \
             "Drop EXTENSIONS= and `load <ext>` once the session is up."

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -287,14 +287,14 @@ module ReverseHttp
   #
   #   * query parameter   (profile: `parameter "name";`)
   #   * request header    (profile: `header    "name";`)
-  #   * trailing path seg (default — no placement directive)
+  #   * trailing path seg (default -- no placement directive)
   #
   # For the path case, the URI looks like `<base>/<id>`, where `<base>`
   # is the profile's per-verb `set uri` if defined, otherwise `LURI`
   # (each is registered as a separate mount point in `all_uris`).
   # Taking the last `/`-separated segment skips the base regardless of
   # which one was used. Profile authors should not put `/` in
-  # prepend/append directives — that would split the id across segments
+  # prepend/append directives -- that would split the id across segments
   # and defeat this scheme.
   #
   # If the profile applied `prepend` / `append` / `base64` / `base64url`
@@ -325,7 +325,7 @@ module ReverseHttp
 
   # Reverse the prepend/append + base64 transforms the profile applied
   # to the id on the payload side. If a declared wrapper is missing from
-  # the candidate, leave the candidate alone — this is not a payload
+  # the candidate, leave the candidate alone -- this is not a payload
   # request, and `process_uri_resource` will return nil for it.
   def unwrap_profile_uuid(candidate, placement)
     prefix = placement.prepend.map{|d| d.args[0]}.join('')
@@ -357,8 +357,8 @@ module ReverseHttp
 
   # Return the live meterpreter session whose passive dispatcher is
   # registered for this bare conn_id, or nil if none matches. Used so
-  # MC2 traffic — which Rex routes to on_request because the profile
-  # URI prefix outranks the session's /<conn_id> mount — can still be
+  # MC2 traffic -- which Rex routes to on_request because the profile
+  # URI prefix outranks the session's /<conn_id> mount -- can still be
   # delivered to the right session instead of triggering a fresh
   # "orphaned attach" on every poll.
   def session_for_conn_id(bare_conn_id)

--- a/lib/msf/core/payload/java/meterpreter_loader.rb
+++ b/lib/msf/core/payload/java/meterpreter_loader.rb
@@ -18,7 +18,7 @@ module Payload::Java::MeterpreterLoader
   include Msf::Sessions::MeterpreterOptions::Java
 
   # Resource path the stageless StagelessMain bootstrap reads. Deliberately
-  # innocuous — no meterpreter/metasploit markers in the name.
+  # innocuous -- no meterpreter/metasploit markers in the name.
   STAGELESS_CONFIG_RESOURCE = 'META-INF/data'.freeze
   STAGELESS_MAIN_CLASS = 'com.metasploit.meterpreter.StagelessMain'.freeze
 
@@ -44,7 +44,7 @@ module Payload::Java::MeterpreterLoader
   #
   # When opts[:stageless] is set, returns a self-contained jar with the
   # TLV config embedded as a resource and Main-Class pinned to
-  # StagelessMain — ready to run under `java -jar`.
+  # StagelessMain -- ready to run under `java -jar`.
   #
   def stage_meterpreter(opts={})
     met = MetasploitPayloads.read('meterpreter', 'meterpreter.jar')

--- a/lib/msf/core/payload/malleable_c2.rb
+++ b/lib/msf/core/payload/malleable_c2.rb
@@ -115,7 +115,7 @@ module Msf::Payload::MalleableC2
           # blank line
           next
         elsif scanner.scan(/#[^\n]*/)
-          # comment — anchorless so it matches indented comments too
+          # comment -- anchorless so it matches indented comments too
           # (the prior `\s+` rule has already eaten any leading
           # whitespace by the time we get here)
           next
@@ -450,7 +450,7 @@ module Msf::Payload::MalleableC2
           profile.sets << parse_set
         elsif block_ahead?
           # Any `name { ... }` is a block. We keep the ones we understand
-          # (http-get/http-post/etc.) and harmlessly retain the rest —
+          # (http-get/http-post/etc.) and harmlessly retain the rest --
           # unsupported CS blocks like dns-beacon/process-inject/post-ex
           # are parsed for structure and simply ignored by to_tlv.
           profile.sections << parse_section

--- a/lib/rex/proto/http/request.rb
+++ b/lib/rex/proto/http/request.rb
@@ -1,6 +1,8 @@
 # -*- coding: binary -*-
 require 'uri'
 
+require 'rex/text'
+
 
 module Rex
 module Proto
@@ -224,7 +226,7 @@ class Request < Packet
   def body
     str = super || ''
     if str.length == 0 && PostRequests.include?(self.method)
-      str = param_tring
+      str = param_string
     end
     str
   end

--- a/lib/rex/proto/http/request.rb
+++ b/lib/rex/proto/http/request.rb
@@ -221,7 +221,7 @@ class Request < Packet
 
   #
   # Returns a hijacked version of the body that shoves the request's query string in as a
-  # replacement in cases where there is no body. YOLO! ¯\_(ツ)_/¯
+  # replacement in cases where there is no body. YOLO!
   #
   def body
     str = super || ''

--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -294,7 +294,7 @@ protected
       p = resources[request.resource]
       # This branch is reached when resource_id is nil (e.g. fetch-payload
       # adapters have no find_resource_id), so the matched resource is the
-      # request resource itself — not resource_id, which would nil-deref.
+      # request resource itself -- not resource_id, which would nil-deref.
       len = request.resource.length
       root = request.resource
     else

--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -184,7 +184,7 @@ class Server
   #
   def add_response_headers(req, resp)
     resp['Server'] = self.server_name if not resp['Server']
-    expl = self.context['MsfExploit']
+    expl = self.context['MsfExploit'] if self.context
     expl.add_response_headers(req, resp) if expl&.respond_to?(:add_response_headers)
   end
 
@@ -282,7 +282,7 @@ protected
 
     # first, try to match up the request with a handler based on a matching
     # function that's present in the context, if specified.
-    expl = self.context['MsfExploit']
+    expl = self.context['MsfExploit'] if self.context
     resource_id = expl.find_resource_id(cli, request) if expl && expl.respond_to?(:find_resource_id)
     request.conn_id = resource_id
 
@@ -352,4 +352,3 @@ end
 end
 end
 end
-

--- a/spec/lib/rex/proto/http/request_spec.rb
+++ b/spec/lib/rex/proto/http/request_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+require 'rex/proto/http/packet'
+require 'rex/proto/http/packet/header'
+require 'rex/proto/http/request'
+
+RSpec.describe Rex::Proto::Http::Request do
+  describe '#body' do
+    it 'uses the query string as the body for POST requests without explicit body bytes' do
+      request = described_class.new('POST', '/api?foo=bar&baz=qux')
+
+      expect(request.body).to eq('foo=bar&baz=qux')
+      expect(request.to_s).to end_with("\r\n\r\nfoo=bar&baz=qux")
+    end
+  end
+end

--- a/spec/lib/rex/proto/http/server_spec.rb
+++ b/spec/lib/rex/proto/http/server_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+require 'rex/proto/http/packet'
+require 'rex/proto/http/packet/header'
+require 'rex/proto/http/request'
+require 'rex/proto/http/response'
+require 'rex/proto/http/handler'
+require 'rex/proto/http/handler/proc'
+require 'rex/proto/http/server'
+
+RSpec.describe Rex::Proto::Http::Server do
+  describe '#add_response_headers' do
+    it 'adds default response headers when context is nil' do
+      server = described_class.new(0, '127.0.0.1', false, nil)
+      request = Rex::Proto::Http::Request.new
+      response = Rex::Proto::Http::Response.new
+
+      expect { server.add_response_headers(request, response) }.not_to raise_error
+      expect(response['Server']).to eq('Rex')
+    end
+  end
+
+  describe '#dispatch_request' do
+    it 'dispatches mounted resources when context is nil' do
+      server = described_class.new(0, '127.0.0.1', false, nil)
+      client = instance_double('Rex::Proto::Http::ServerClient', keepalive: false)
+      request = Rex::Proto::Http::Request.new('POST', '/api')
+      handled_request = nil
+
+      allow(client).to receive(:keepalive=)
+      allow(server).to receive(:close_client)
+
+      server.add_resource('/api', {
+        'Proc' => proc { |_cli, req| handled_request = req }
+      })
+
+      expect { server.send(:dispatch_request, client, request) }.not_to raise_error
+      expect(handled_request).to be(request)
+    end
+  end
+end


### PR DESCRIPTION
The Rex HTTP Server reads the context in the generic handler now. This breaks things in Pro because there's no context or exploit in the RPC server.

Includes basic tests to prevent regressions in the future.
