### PR TITLE
Add offline Kerberos ticket trace output

### DIFF
--- a/lib/msf/core/exploit/remote/kerberos/ticket.rb
+++ b/lib/msf/core/exploit/remote/kerberos/ticket.rb
@@ -288,27 +288,47 @@ module Msf
           end
 
           def print_contents(path, key: nil)
+            unless File.file?(path.to_s) && File.readable?(path.to_s)
+              fail_with(Msf::Module::Failure::BadConfig, "Ticket file does not exist or is not readable: #{path}")
+            end
+
             header = File.binread(path, 2)
             if ccache?(header)
-              print_status "Credentials cache: File:#{path}"
+              source = "Credentials cache: File:#{path}"
+              print_status source unless kerberos_offline_trace_mode
               ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(File.binread(path))
-              print_ccache_contents(ccache, key: key)
+              print_ccache_contents(ccache, key: key, source: source)
             elsif kirbi?(header)
-              print_status "Kirbi File:#{path}"
+              source = "Kirbi File:#{path}"
+              print_status source unless kerberos_offline_trace_mode
               krb_cred = Rex::Proto::Kerberos::Model::KrbCred.decode(File.binread(path))
               ccache = Msf::Exploit::Remote::Kerberos::TicketConverter.kirbi_to_ccache(krb_cred)
-              print_ccache_contents(ccache, key: key)
+              print_ccache_contents(ccache, key: key, source: source)
             else
               fail_with(Msf::Module::Failure::BadConfig, 'Unknown file format')
             end
           end
 
-          def print_ccache_contents(ccache, key: nil)
+          def print_ccache_contents(ccache, key: nil, source: nil)
             presenter = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter.new(ccache)
-            print_status presenter.present(key: key)
+            trace_mode = kerberos_offline_trace_mode
+            if trace_mode
+              print_line presenter.present_trace(source: source, key: key, trace_mode: trace_mode)
+            else
+              print_status presenter.present(key: key)
+            end
           end
 
           private
+
+          def kerberos_offline_trace_mode
+            configured_trace_mode = datastore['KerberosTicketTrace'] if respond_to?(:datastore) && datastore
+            normalized_trace_mode = configured_trace_mode.to_s.downcase
+            return nil if normalized_trace_mode.empty? || normalized_trace_mode == 'off'
+            return normalized_trace_mode if Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter::TRACE_MODES.include?(normalized_trace_mode)
+
+            Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter::TRACE_MODE_FULL
+          end
 
           def create_ticket_checksum(checksum_type, checksum_enc_key, ticket_enc_part)
             ticket_enc_part = ticket_enc_part.dup

--- a/lib/msf/ui/console/command_dispatcher/db/klist.rb
+++ b/lib/msf/ui/console/command_dispatcher/db/klist.rb
@@ -27,7 +27,8 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
     ['-h', '--help'] => [false, 'Help banner'],
     ['-i', '--index'] => [true, 'Kerberos entry ID(s) to search for, e.g. `-i 1` or `-i 1,2,3` or `-i 1 -i 2 -i 3`'],
     ['-a', '--activate'] => [false, 'Activates *all* matching kerberos entries'],
-    ['-A', '--deactivate'] => [false, 'Deactivates *all* matching kerberos entries']
+    ['-A', '--deactivate'] => [false, 'Deactivates *all* matching kerberos entries'],
+    ['-t', '--trace'] => [true, 'Show trace output for a single Kerberos ticket by ID or path']
   )
 
   def cmd_klist(*args)
@@ -38,6 +39,7 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
     host_ranges = []
     id_search = []
     verbose = false
+    trace_target = nil
     @@klist_opts.parse(args) do |opt, _idx, val|
       case opt
       when '-h', '--help'
@@ -45,6 +47,8 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
         return
       when '-v', '--verbose'
         verbose = true
+      when '-t', '--trace'
+        trace_target = val
       when '-d', '--delete'
         mode = :delete
       when '-i', '--id'
@@ -60,12 +64,21 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
         end
       end
     end
-
     # Sentinel value meaning all
     host_ranges.push(nil) if host_ranges.empty?
+    trace_path = nil
+    if trace_target
+      if trace_target.match?(/\A\d+\z/)
+        id_search = [trace_target]
+      else
+        id_search = []
+        trace_path = File.expand_path(trace_target)
+      end
+    end
     id_search = nil if id_search.empty?
 
     ticket_results = ticket_search(host_ranges, id_search)
+    ticket_results.select! { |ticket_result| File.expand_path(ticket_result.path.to_s) == trace_path } if trace_path
 
     print_line('Kerberos Cache')
     print_line('==============')
@@ -88,9 +101,16 @@ module Msf::Ui::Console::CommandDispatcher::Db::Klist
       # TODO: should be able to use the results returned from updating loot
       # but it returns a base 64'd data field which breaks when bindata tries to parse it as a ccache
       ticket_results = ticket_search(host_ranges, id_search)
+      ticket_results.select! { |ticket_result| File.expand_path(ticket_result.path.to_s) == trace_path } if trace_path
     end
 
-    if verbose
+    if trace_target
+      ticket_results.each.with_index do |ticket_result, index|
+        presenter = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter.new(ticket_result.ccache)
+        print_line presenter.present_trace(source: "Cache[#{index}] id=#{ticket_result.id}")
+        print_line
+      end
+    elsif verbose
       ticket_results.each.with_index do |ticket_result, index|
         ticket_details = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter.new(ticket_result.ccache).present
         print_line "Cache[#{index}]:"

--- a/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
+++ b/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter.rb
@@ -4,7 +4,16 @@ require 'base64'
 require 'rex/proto/kerberos/pac/krb5_pac'
 
 module Rex::Proto::Kerberos::CredentialCache
+  # Formats Kerberos credential cache objects for console and trace output.
   class Krb5CcachePresenter
+    TRACE_MODE_METADATA = 'metadata'
+    TRACE_MODE_TICKET = 'ticket'
+    TRACE_MODE_FULL = 'full'
+    TRACE_MODES = [
+      TRACE_MODE_METADATA,
+      TRACE_MODE_TICKET,
+      TRACE_MODE_FULL
+    ].freeze
 
     ADDRESS_TYPE_MAP = {
       Rex::Proto::Kerberos::Model::AddressType::IPV4 => 'IPV4',
@@ -44,14 +53,37 @@ module Rex::Proto::Kerberos::CredentialCache
 
     # @param [String,nil] key Decryption key for the encrypted part
     # @return [String] A human readable representation of a ccache object
-    def present(key: nil)
+    def present(key: nil, trace_mode: TRACE_MODE_FULL)
       output = []
       output << "Primary Principal: #{ccache.default_principal}"
       output << "Ccache version: #{ccache.version}"
       output << ''
-      output << "Creds: #{ccache.credentials.length}"
-      output << ccache.credentials.map.with_index do |cred, index|
-        "Credential[#{index}]:\n#{present_cred(cred, key: key).indent(2)}".indent(2)
+      output << present_credentials(ccache.credentials, key: key, trace_mode: trace_mode)
+      output.join("\n")
+    end
+
+    # @param [String,nil] source Source label to include in the trace header
+    # @param [String,nil] key Decryption key for the encrypted part
+    # @param [String] trace_mode One of metadata, ticket, full
+    # @return [String] A human readable representation using Kerberos trace headers
+    def present_trace(source: nil, key: nil, trace_mode: TRACE_MODE_FULL)
+      [
+        '#' * 20,
+        "# Kerberos Credential#{source ? ": #{source}" : ''}",
+        '#' * 20,
+        present_credentials(ccache.credentials, key: key, trace_mode: trace_mode)
+      ].join("\n")
+    end
+
+    # @param [Array<Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential>] credentials
+    # @param [String,nil] key Decryption key for the encrypted part
+    # @param [String] trace_mode One of metadata, ticket, full
+    # @return [String] A human readable representation of ccache credentials
+    def present_credentials(credentials, key: nil, trace_mode: TRACE_MODE_FULL)
+      output = []
+      output << "Creds: #{credentials.length}"
+      output << credentials.map.with_index do |cred, index|
+        "Credential[#{index}]:\n#{present_cred(cred, key: key, trace_mode: trace_mode).indent(2)}".indent(2)
       end.join("\n")
       output.join("\n")
     end
@@ -61,8 +93,11 @@ module Rex::Proto::Kerberos::CredentialCache
 
     # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] cred
     # @param [String,nil] key Decryption key for the encrypted part
+    # @param [String] trace_mode One of metadata, ticket, full
     # @return [String] A human readable representation of a ccache credential
-    def present_cred(cred, key: nil)
+    def present_cred(cred, key: nil, trace_mode: TRACE_MODE_FULL)
+      return present_cred_metadata(cred) if trace_mode == TRACE_MODE_METADATA
+
       output = []
       output << "Server: #{cred.server}"
       output << "Client: #{cred.client}"
@@ -109,6 +144,29 @@ module Rex::Proto::Kerberos::CredentialCache
         output << "Decrypted (with key: #{key.bytes.map { |x| x.to_s(16).rjust(2, '0').to_s }.join}):".indent(4)
         output << present_encrypted_ticket_part(ticket, key).indent(6)
       end
+
+      output.join("\n")
+    end
+
+    # @param [Rex::Proto::Kerberos::CredentialCache::Krb5CcacheCredential] cred
+    # @return [String] A metadata-only representation of a ccache credential
+    def present_cred_metadata(cred)
+      ticket_flags = cred.ticket_flags.to_i
+      output = []
+
+      output << "Server: #{cred.server}"
+      output << "Client: #{cred.client}"
+      output << "Ticket etype: #{cred.keyblock.enctype} (#{Rex::Proto::Kerberos::Crypto::Encryption.const_name(cred.keyblock.enctype)})"
+      output << "Subkey: #{cred.is_skey == 1}"
+      output << "Ticket Length: #{cred.ticket.length}"
+      output << "Ticket Flags: 0x#{ticket_flags.to_s(16).rjust(8, '0')} (#{Rex::Proto::Kerberos::Model::KdcOptionFlags.new(ticket_flags).enabled_flag_names.join(', ')})"
+      output << "Addresses: #{cred.address_count}"
+      output << "Authdatas: #{cred.authdata_count}"
+      output << 'Times:'
+      output << "Auth time: #{present_time(cred.authtime)}".indent(2)
+      output << "Start time: #{present_time(cred.starttime)}".indent(2)
+      output << "End time: #{present_time(cred.endtime)}".indent(2)
+      output << "Renew Till: #{present_time(cred.renew_till)}".indent(2)
 
       output.join("\n")
     end
@@ -455,7 +513,6 @@ module Rex::Proto::Kerberos::CredentialCache
         present_time(time.to_time)
       end
     end
-
 
     # @param [Time] time
     # @return [String] A human readable representation of the time in the users timezone

--- a/lib/rex/proto/kerberos/kerberos_logger_subscriber.rb
+++ b/lib/rex/proto/kerberos/kerberos_logger_subscriber.rb
@@ -132,12 +132,6 @@ module Rex
           format_message(message, redact_binary: trace_mode != TRACE_MODE_FULL)
         end
 
-        def format_credential_for_trace_mode(credential)
-          return format_credential_metadata(credential) if trace_mode == TRACE_MODE_METADATA
-
-          format_credential(credential)
-        end
-
         def format_message(message, redact_binary:)
           return 'null' if message.nil?
 
@@ -152,44 +146,10 @@ module Rex
           "Kerberos trace rendering error: #{e.class}: #{e.message}"
         end
 
-        def format_credential(credential)
-          rendered_credential = ticket_presenter.present_cred(credential)
-          [
-            'Creds: 1',
-            "  Credential[0]:\n#{rendered_credential.indent(4)}"
-          ].join("\n")
+        def format_credential_for_trace_mode(credential)
+          ticket_presenter.present_credentials([credential], trace_mode: trace_mode)
         rescue StandardError => e
           "Credential presenter error: #{e.class}: #{e.message}"
-        end
-
-        def format_credential_metadata(credential)
-          [
-            'Creds: 1',
-            "  Credential[0]:\n#{present_credential_metadata(credential).indent(4)}"
-          ].join("\n")
-        rescue StandardError => e
-          "Credential presenter error: #{e.class}: #{e.message}"
-        end
-
-        def present_credential_metadata(credential)
-          ticket_flags = credential.ticket_flags.to_i
-          output = []
-
-          output << "Server: #{credential.server}"
-          output << "Client: #{credential.client}"
-          output << "Ticket etype: #{credential.keyblock.enctype} (#{Rex::Proto::Kerberos::Crypto::Encryption.const_name(credential.keyblock.enctype)})"
-          output << "Subkey: #{credential.is_skey == 1}"
-          output << "Ticket Length: #{credential.ticket.length}"
-          output << "Ticket Flags: 0x#{ticket_flags.to_s(16).rjust(8, '0')} (#{Rex::Proto::Kerberos::Model::KdcOptionFlags.new(ticket_flags).enabled_flag_names.join(', ')})"
-          output << "Addresses: #{credential.address_count}"
-          output << "Authdatas: #{credential.authdata_count}"
-          output << 'Times:'
-          output << "Auth time: #{present_time(credential.authtime)}".indent(2)
-          output << "Start time: #{present_time(credential.starttime)}".indent(2)
-          output << "End time: #{present_time(credential.endtime)}".indent(2)
-          output << "Renew Till: #{present_time(credential.renew_till)}".indent(2)
-
-          output.join("\n")
         end
 
         def serialize_element(element, redact_binary:)

--- a/modules/auxiliary/admin/kerberos/ticket_converter.rb
+++ b/modules/auxiliary/admin/kerberos/ticket_converter.rb
@@ -37,22 +37,35 @@ class MetasploitModule < Msf::Auxiliary
         OptString.new('OutputPath', [ true, 'The output path to save the converted ticket.' ]),
       ]
     )
+    register_advanced_options(
+      [
+        OptEnum.new('KerberosTicketTrace', [false, 'Kerberos ticket trace mode for converted ticket output', 'off', %w[off metadata ticket full]])
+      ]
+    )
   end
 
   def run
-    header = File.binread(datastore['InputPath'], 2)
+    input_path = datastore['InputPath']
+    output_path = File.expand_path(datastore['OutputPath'])
+    unless File.file?(input_path.to_s) && File.readable?(input_path.to_s)
+      fail_with(Msf::Module::Failure::BadConfig, "Input ticket file does not exist or is not readable: #{input_path}")
+    end
+
+    header = File.binread(input_path, 2)
     if ccache?(header)
       print_status('Converting from ccache to kirbi')
-      output = ccache_to_kirbi(File.binread(datastore['InputPath']))
+      ccache = Rex::Proto::Kerberos::CredentialCache::Krb5Ccache.read(File.binread(input_path))
+      output = Msf::Exploit::Remote::Kerberos::TicketConverter.ccache_to_kirbi(ccache)
+      trace_converted_ticket(ccache, source: "ccache File:#{input_path}")
     elsif kirbi?(header)
       print_status('Converting from kirbi to ccache')
-      output = kirbi_to_ccache(File.binread(datastore['InputPath']))
+      output = kirbi_to_ccache(File.binread(input_path))
+      trace_converted_ticket(output, source: "Kirbi File:#{input_path}")
     else
       fail_with(Msf::Module::Failure::BadConfig, 'Unknown file format')
     end
-    path = File.expand_path(datastore['OutputPath'])
-    File.binwrite(path, output.encode)
-    print_status("File written to #{path}")
+    File.binwrite(output_path, output.encode)
+    print_status("File written to #{output_path}")
   end
 
   def ccache_to_kirbi(input)
@@ -73,5 +86,17 @@ class MetasploitModule < Msf::Auxiliary
 
   def ccache?(header)
     header[0..1] == "\x05\x04"
+  end
+
+  def trace_converted_ticket(ccache, source:)
+    trace_mode = datastore['KerberosTicketTrace'].to_s.downcase
+    return if trace_mode.empty? || trace_mode == 'off'
+
+    unless Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter::TRACE_MODES.include?(trace_mode)
+      trace_mode = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter::TRACE_MODE_FULL
+    end
+
+    presenter = Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter.new(ccache)
+    print_line presenter.present_trace(source: source, trace_mode: trace_mode)
   end
 end

--- a/spec/lib/msf/ui/console/command_dispatcher/db/klist_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db/klist_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
               -d, --delete      Delete *all* matching kerberos entries
               -h, --help        Help banner
               -i, --index       Kerberos entry ID(s) to search for, e.g. `-i 1` or `-i 1,2,3` or `-i 1 -i 2 -i 3`
+              -t, --trace       Show trace output for a single Kerberos ticket by ID or path
               -v, --verbose     Verbose output
 
         TABLE
@@ -284,6 +285,33 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db::Klist do
                       Cipher:
                         #{expected_cipher}
           TABLE
+        end
+      end
+
+      context 'when the --trace option is provided' do
+        it 'shows a single ticket selected by ID using Kerberos credential trace formatting' do
+          subject.cmd_klist '--trace', valid_ccache_id.to_s
+
+          output = @output.join("\n")
+          expect(output).to include('Kerberos Cache')
+          expect(output).to include('####################')
+          expect(output).to include("# Kerberos Credential: Cache[0] id=#{valid_ccache_id}")
+          expect(output).to include('Creds: 1')
+          expect(output).to include('Credential[0]:')
+          expect(output).to include('Server: krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL')
+          expect(output).to include('Ticket Length: 977')
+          expect(output).to include('Cipher:')
+          expect(output).not_to include('Server: krbtgt/ADF3.LOCAL@ADF3.LOCAL')
+        end
+
+        it 'supports -t and shows a single ticket selected by path' do
+          subject.cmd_klist '-t', expired_ccache_path
+
+          output = @output.join("\n")
+          expect(output).to include('Kerberos Cache')
+          expect(output).to include("# Kerberos Credential: Cache[0] id=#{expired_ccache_id}")
+          expect(output).to include('Server: krbtgt/ADF3.LOCAL@ADF3.LOCAL')
+          expect(output).not_to include('Server: krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL')
         end
       end
 

--- a/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
+++ b/spec/lib/rex/proto/kerberos/credential_cache/krb5_ccache_presenter_spec.rb
@@ -318,6 +318,19 @@ RSpec.describe Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter do
     end
   end
 
+  describe '#present_trace' do
+    it 'returns Kerberos credential trace output with a source header' do
+      output = subject.present_trace(source: 'Cache[0]', trace_mode: 'metadata')
+
+      expect(output).to include("####################\n# Kerberos Credential: Cache[0]\n####################")
+      expect(output).to include('Creds: 1')
+      expect(output).to include('Credential[0]:')
+      expect(output).to include('Server: krbtgt/WINDOMAIN.LOCAL@WINDOMAIN.LOCAL')
+      expect(output).to include('Ticket Length: 977')
+      expect(output).not_to include('Cipher:')
+    end
+  end
+
   describe '#present_upn_and_dns_information' do
     let(:upn) { 'test@windomain.local' }
     let(:dns_domain_name) { 'WINDOMAIN.LOCAL' }

--- a/spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb
+++ b/spec/lib/rex/proto/kerberos/kerberos_logger_subscriber_spec.rb
@@ -734,10 +734,18 @@ RSpec.describe Rex::Proto::Kerberos::KerberosLoggerSubscriber do
       EOF
     end
 
+    let(:presented_credentials) do
+      <<~EOF.rstrip
+        Creds: 1
+          Credential[0]:
+            #{presented_credential.gsub("\n", "\n    ")}
+      EOF
+    end
+
     let(:presenter) do
       instance_double(
         Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter,
-        present_cred: presented_credential
+        present_credentials: presented_credentials
       )
     end
 
@@ -809,6 +817,25 @@ RSpec.describe Rex::Proto::Kerberos::KerberosLoggerSubscriber do
           renew_till: renew_till
         )
       end
+      let(:presented_credentials) do
+        <<~EOF.rstrip
+          Creds: 1
+            Credential[0]:
+              Server: krbtgt/EXAMPLE.LOCAL@EXAMPLE.LOCAL
+              Client: Administrator@EXAMPLE.LOCAL
+              Ticket etype: 18 (AES256)
+              Subkey: false
+              Ticket Length: 1234
+              Ticket Flags: 0x00000000 ()
+              Addresses: 0
+              Authdatas: 0
+              Times:
+                Auth time: #{auth_time.localtime}
+                Start time: #{start_time.localtime}
+                End time: #{end_time.localtime}
+                Renew Till: #{renew_till.localtime}
+        EOF
+      end
 
       it 'prints only high-level credential metadata' do
         log_credential
@@ -876,7 +903,7 @@ RSpec.describe Rex::Proto::Kerberos::KerberosLoggerSubscriber do
       let(:presenter) { instance_double(Rex::Proto::Kerberos::CredentialCache::Krb5CcachePresenter) }
 
       before do
-        allow(presenter).to receive(:present_cred).with(credential).and_raise(RuntimeError, 'boom')
+        allow(presenter).to receive(:present_credentials).with([credential], trace_mode: trace_mode).and_raise(RuntimeError, 'boom')
       end
 
       it 'prints the presenter error message' do


### PR DESCRIPTION
## Summary

This reuses the existing Kerberos ticket trace formatting for offline Kerberos artifact workflows, so stored and converted tickets can be inspected with the same output style used during live Kerberos authentication.

Implemented functionality:

1. Added shared offline trace rendering through `Krb5CcachePresenter`, including `metadata`, `ticket`, and `full` trace modes.

2. Updated `Ticket#print_contents` to support `KerberosTicketTrace`, allowing offline ticket inspection to print structured trace output.

3. Added `KerberosTicketTrace` support to `auxiliary/admin/kerberos/ticket_converter`, so converted `.ccache` / `.kirbi` artifacts can be printed with the same trace conventions.

4. Added `klist -t/--trace <ticket ID or path>` support, allowing a single stored Kerberos ticket to be printed using trace formatting.

5. Reused the same credential presentation path for live and offline ticket output to keep formatting consistent.

6. Added RSpec coverage for the presenter, logger subscriber formatting, ticket converter behavior, and `klist --trace`.