### PR TITLE
Refactor file collection logic to exclude lib/ directory

### DIFF
--- a/lib/msf/core/modules/metadata/store.rb
+++ b/lib/msf/core/modules/metadata/store.rb
@@ -182,15 +182,12 @@ module Msf::Modules::Metadata::Store
     Zlib.crc32(file_crc32s.join(','), 0)
   end
 
-  # Collect all files that need to be checked for checksums
+  # Collect all files that need to be checked for checksums.
   # @return [Array<String>] List of file paths
   def self.collect_files_to_check
-    # Define the directories to scan for files
     modules_dir = File.join(Msf::Config.install_root, 'modules', '**', '*')
     local_modules_dir = File.join(Msf::Config.user_module_directory, '**', '*')
-    lib_dir = File.join(Msf::Config.install_root, 'lib', '**', '*')
-    # Gather all files from the specified directories
-    Dir.glob([modules_dir, lib_dir, local_modules_dir]).select { |f| File.file?(f) }.sort
+    Dir.glob([modules_dir, local_modules_dir]).select { |f| File.file?(f) }.sort
   end
 
   # Calculate checksums for all files, using the cache when possible

--- a/spec/lib/msf/core/modules/metadata/store_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/store_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Modules::Metadata::Store do
+  describe '.collect_files_to_check' do
+    let(:temp_install_root) { Dir.mktmpdir('msf_install') }
+    let(:temp_user_modules) { Dir.mktmpdir('msf_user_modules') }
+
+    before do
+      allow(Msf::Config).to receive(:install_root).and_return(temp_install_root)
+      allow(Msf::Config).to receive(:user_module_directory).and_return(temp_user_modules)
+    end
+
+    after do
+      FileUtils.remove_entry(temp_install_root)
+      FileUtils.remove_entry(temp_user_modules)
+    end
+
+    context 'when files exist in modules/, lib/, and user module directories' do
+      before do
+        # Create files under modules/
+        FileUtils.mkdir_p(File.join(temp_install_root, 'modules', 'exploits', 'windows'))
+        File.write(File.join(temp_install_root, 'modules', 'exploits', 'windows', 'test_exploit.rb'), 'exploit')
+        File.write(File.join(temp_install_root, 'modules', 'exploits', 'auxiliary_helper.rb'), 'helper')
+
+        # Create files under lib/
+        FileUtils.mkdir_p(File.join(temp_install_root, 'lib', 'msf', 'core'))
+        File.write(File.join(temp_install_root, 'lib', 'msf', 'core', 'exploit.rb'), 'lib code')
+        File.write(File.join(temp_install_root, 'lib', 'msf', 'core', 'payload.rb'), 'lib code')
+
+        # Create files in user module directory
+        FileUtils.mkdir_p(File.join(temp_user_modules, 'exploits', 'custom'))
+        File.write(File.join(temp_user_modules, 'exploits', 'custom', 'my_exploit.rb'), 'custom exploit')
+      end
+
+      it 'returns files under modules/' do
+        result = described_class.collect_files_to_check
+        modules_files = result.select { |f| f.include?('/modules/') }
+        expect(modules_files.length).to eq(2)
+      end
+
+      it 'returns files under user module directories' do
+        result = described_class.collect_files_to_check
+        user_files = result.select { |f| f.start_with?(temp_user_modules) }
+        expect(user_files.length).to eq(1)
+        expect(user_files.first).to end_with('my_exploit.rb')
+      end
+
+      it 'does NOT include files under lib/' do
+        result = described_class.collect_files_to_check
+        lib_files = result.select { |f| f.include?('/lib/') }
+        expect(lib_files).to be_empty
+      end
+    end
+
+    context 'when only module files exist' do
+      before do
+        FileUtils.mkdir_p(File.join(temp_install_root, 'modules', 'post'))
+        File.write(File.join(temp_install_root, 'modules', 'post', 'gather.rb'), 'post module')
+      end
+
+      it 'detects changes to module files via checksum validation' do
+        # Get initial file list and compute checksum
+        files_before = described_class.collect_files_to_check
+        expect(files_before.length).to eq(1)
+
+        # Modify the file content
+        File.write(File.join(temp_install_root, 'modules', 'post', 'gather.rb'), 'modified post module')
+
+        # The file should still appear in the list (changed content detected at checksum level)
+        files_after = described_class.collect_files_to_check
+        expect(files_after.length).to eq(1)
+        expect(files_after.first).to eq(files_before.first)
+      end
+    end
+
+    it 'returns a sorted array' do
+      FileUtils.mkdir_p(File.join(temp_install_root, 'modules', 'b'))
+      FileUtils.mkdir_p(File.join(temp_install_root, 'modules', 'a'))
+      File.write(File.join(temp_install_root, 'modules', 'b', 'z.rb'), '')
+      File.write(File.join(temp_install_root, 'modules', 'a', 'a.rb'), '')
+
+      result = described_class.collect_files_to_check
+      expect(result).to eq(result.sort)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Remove `lib/` from the boot-time checksum validation scope in `Msf::Modules::Metadata::Store.collect_files_to_check`.

The checksum validation determines whether module files have changed since the metadata cache was last built. When files have changed, it forces immediate (non-deferred) module loading. Previously, this included all files under `lib/` (~3000+ files), meaning any library change would invalidate the module metadata cache and trigger a full module reload — even though library changes don't affect the cached metadata (module name, author, platform, references, etc.).

This reduces the number of files checksummed on every boot from ~7000+ to ~4000 (modules only), and eliminates false cache invalidations caused by unrelated library edits during development.

**Related Issue:**

## Breaking Changes

If a mixin change in `lib/` alters module metadata (e.g., changes default targets or platform support), the metadata cache will not automatically invalidate. Users can run `reload_all` to force a rebuild. 


## Verification Steps

1. - [ ] Start `msfconsole` normally, confirm it boots without error
2. - [ ] Modify a file in `lib/` (e.g., `touch lib/msf/core/exploit.rb`), restart `msfconsole` — it should still boot with deferred module loads (fast path) since lib changes no longer invalidate the checksum
3. - [ ] Modify a file in `modules/` (e.g., `touch modules/exploits/multi/handler.rb`), restart `msfconsole` — it should detect the change and force immediate module loading
4. - [ ] Run `bundle exec rspec spec/lib/msf/core/modules/metadata/store_spec.rb` — all 5 examples pass

## Test Evidence

### Before 
hyperfine  --warmup 3 "bundle exec ruby ./msfconsole -q -x 'exit'"                                                                                                     
Benchmark 1: bundle exec ruby ./msfconsole -q -x 'exit'
  Time (mean ± σ):      4.393 s ±  0.066 s    [User: 3.095 s, System: 1.362 s]
  Range (min … max):    4.284 s …  4.483 s    10 runs
  
 ### After
 
```
$ hyperfine --warmup 3 "bundle exec ruby ./msfconsole -q -x 'exit'"
Benchmark 1: bundle exec ruby ./msfconsole -q -x 'exit'
  Time (mean ± σ):      4.179 s ±  0.023 s    [User: 3.040 s, System: 1.176 s]
  Range (min … max):    4.154 s …  4.197 s    5 runs
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS (26.5.2) |
| **Target Software/Hardware** | Metasploit Framework (Ruby 3.3.8) |

## AI Usage Disclosure

Kiro

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)