### PR TITLE
Defer statistics update until first access to improve performance

### DIFF
--- a/lib/msf/base/simple/statistics.rb
+++ b/lib/msf/base/simple/statistics.rb
@@ -16,13 +16,13 @@ class Statistics
   #
   def initialize(framework)
     self.framework = framework
-    Msf::Modules::Metadata::Cache.instance.update_stats
   end
 
   #
   # Returns the number of encoders in the framework.
   #
   def num_encoders
+    ensure_stats_loaded
     Msf::Modules::Metadata::Cache.instance.module_counts[:encoder]
   end
 
@@ -30,6 +30,7 @@ class Statistics
   # Returns the number of exploits in the framework.
   #
   def num_exploits
+    ensure_stats_loaded
     Msf::Modules::Metadata::Cache.instance.module_counts[:exploit]
   end
 
@@ -37,6 +38,7 @@ class Statistics
   # Returns the number of NOP generators in the framework.
   #
   def num_nops
+    ensure_stats_loaded
     Msf::Modules::Metadata::Cache.instance.module_counts[:nop]
   end
 
@@ -44,6 +46,7 @@ class Statistics
   # Returns the number of payloads in the framework.
   #
   def num_payloads
+    ensure_stats_loaded
     Msf::Modules::Metadata::Cache.instance.module_counts[:payload]
   end
 
@@ -51,6 +54,7 @@ class Statistics
   # Returns the number of auxiliary modules in the framework.
   #
   def num_auxiliary
+    ensure_stats_loaded
     Msf::Modules::Metadata::Cache.instance.module_counts[:auxiliary]
   end
 
@@ -58,11 +62,22 @@ class Statistics
   # Returns the number of post modules in the framework.
   #
   def num_post
+    ensure_stats_loaded
     Msf::Modules::Metadata::Cache.instance.module_counts[:post]
   end
 
   def num_evasion
+    ensure_stats_loaded
     Msf::Modules::Metadata::Cache.instance.module_counts[:evasion]
+  end
+
+  private
+
+  # Defers update_stats until first access so boot doesn't pay the cost
+  # when stats aren't immediately needed (e.g. quiet mode with no banner).
+  def ensure_stats_loaded
+    cache = Msf::Modules::Metadata::Cache.instance
+    cache.update_stats unless cache.module_counts
   end
 end
 

--- a/spec/lib/msf/base/simple/statistics_spec.rb
+++ b/spec/lib/msf/base/simple/statistics_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Simple::Statistics do
+  let(:framework) { double('Framework') }
+  let(:cache_instance) { Msf::Modules::Metadata::Cache.instance }
+  let(:mock_counts) do
+    {
+      exploit: 2400,
+      auxiliary: 1300,
+      post: 400,
+      payload: 900,
+      encoder: 50,
+      nop: 15,
+      evasion: 10
+    }
+  end
+
+  before do
+    allow(cache_instance).to receive(:module_counts).and_return(nil)
+    allow(cache_instance).to receive(:update_stats) do
+      allow(cache_instance).to receive(:module_counts).and_return(mock_counts)
+    end
+  end
+
+  describe '#initialize' do
+    it 'does not call update_stats on the cache' do
+      expect(cache_instance).not_to receive(:update_stats)
+      described_class.new(framework)
+    end
+  end
+
+  describe '#num_exploits' do
+    it 'triggers update_stats on first access' do
+      stats = described_class.new(framework)
+      expect(cache_instance).to receive(:update_stats).once do
+        allow(cache_instance).to receive(:module_counts).and_return(mock_counts)
+      end
+      stats.num_exploits
+    end
+
+    it 'does not re-trigger update_stats on subsequent calls' do
+      stats = described_class.new(framework)
+      stats.num_exploits
+      expect(cache_instance).not_to receive(:update_stats)
+      stats.num_exploits
+    end
+
+    it 'returns the correct count' do
+      stats = described_class.new(framework)
+      expect(stats.num_exploits).to eq(2400)
+    end
+  end
+
+  describe 'all num_* methods return correct counts' do
+    subject(:stats) { described_class.new(framework) }
+
+    it { expect(stats.num_encoders).to eq(50) }
+    it { expect(stats.num_exploits).to eq(2400) }
+    it { expect(stats.num_nops).to eq(15) }
+    it { expect(stats.num_payloads).to eq(900) }
+    it { expect(stats.num_auxiliary).to eq(1300) }
+    it { expect(stats.num_post).to eq(400) }
+    it { expect(stats.num_evasion).to eq(10) }
+  end
+end


### PR DESCRIPTION

## Description

Defer stats calculation until we need it, this results in running msfconsole with the `-q` flag spinning up a 0.3-0.5s faster, I haven't removed the stats from the banner but I think we should consider it since it's really not that useful and it's adding time to the boot up process.


## Verification Steps

1. - [ ] Start `msfconsole` normally (without `-q`) — banner should display correct module counts as before
2. - [ ] Start `msfconsole -q -x 'exit'` — should boot and exit without error
3. - [ ] In msfconsole, run `banner` command — module counts should display correctly
4. - [ ] Run `bundle exec rspec spec/lib/msf/base/simple/statistics_spec.rb` — all 11 examples pass

## Test Evidence

with `-q`
```
hyperfine  --warmup 3 "bundle exec ruby ./msfconsole -q -x 'exit'"                                                                                                     
Benchmark 1: bundle exec ruby ./msfconsole -q -x 'exit'
  Time (mean ± σ):      3.732 s ±  0.034 s    [User: 2.561 s, System: 1.242 s]
  Range (min … max):    3.679 s …  3.777 s    10 runs
```

without `-q`
```
hyperfine  --warmup 3 "bundle exec ruby ./msfconsole -x 'exit'"                                                                                                        
Benchmark 1: bundle exec ruby ./msfconsole -x 'exit'
  Time (mean ± σ):      4.263 s ±  0.094 s    [User: 3.008 s, System: 1.319 s]
  Range (min … max):    4.178 s …  4.485 s    10 runs
  ```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS (26.5.2) |
| **Target Software/Hardware** | Metasploit Framework (Ruby 3.3.8) |

## AI Usage Disclosure
 Kiro

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)