### PR TITLE
Enable ISeq caching to improve performance

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -85,7 +85,7 @@ begin
     ignore_directories: [],
     development_mode: development_mode,
     load_path_cache: true, # Optimize the LOAD_PATH with a cache
-    compile_cache_iseq: false, # Don't compile Ruby code into ISeq cache, breaks coverage reporting.
+    compile_cache_iseq: true, # If coverage reports are inaccurate, disable this (ISeq caching bypasses Coverage tracing).
     compile_cache_yaml: false, # Don't compile YAML into a cache
     readonly: false, # Update caches - https://github.com/Shopify/bootsnap/commit/b51397f96c33aa421fd5c29484fb9574df9eb451
   }


### PR DESCRIPTION
---

## Description

Enable bootsnap's ISeq compile cache (`compile_cache_iseq: true`) to improve `msfconsole` startup time.

Bootsnap already caches `$LOAD_PATH` lookups (added in #17809), but the ISeq compile cache was left disabled. The ISeq cache compiles Ruby source files to bytecode on first load and serves the pre-compiled bytecode on subsequent boots, avoiding repeated parsing and compilation of ~500+ Ruby files during startup.

This was originally disabled with the comment "breaks coverage reporting" — but we don't do this in CI anymore, if we want to do it in the future it makes more sense to figure out how we should deal with this issue then rather than guess at the best way now when we aren't doing coverage

## Verification Steps

1. - [ ] Delete the existing bootsnap cache: `rm -rf ~/.msf4/bootsnap_cache`
2. - [ ] Start `msfconsole` — first boot builds the cache (may be slightly slower)
3. - [ ] Exit and start `msfconsole` again — second boot should be noticeably faster
4. - [ ] Run `hyperfine --warmup 3 "bundle exec ruby ./msfconsole -q -x 'exit'"` should be improved from master

## Test Evidence

```
# Before (compile_cache_iseq: false)
Benchmark 1: bundle exec ruby ./msfconsole -q -x 'exit'
  Time (mean ± σ):      4.242 s ±  0.066 s    [User: 3.024 s, System: 1.281 s]
  Range (min … max):    4.135 s …  4.366 s    10 runs

# After (compile_cache_iseq: true)
Benchmark 1: bundle exec ruby ./msfconsole -q -x 'exit'
  Time (mean ± σ):      3.941 s ±  0.069 s    [User: 2.358 s, System: 1.404 s]
  Range (min … max):    3.849 s …  4.083 s    10 runs
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS (26.5.2) |
| **Target Software/Hardware** | Metasploit Framework (Ruby 3.3.8) |

## AI Usage Disclosure

Kiro

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)