### PR TITLE
Add feature flag to skip checksum validation for faster development boot

### DIFF
--- a/lib/msf/core/feature_manager.rb
+++ b/lib/msf/core/feature_manager.rb
@@ -19,6 +19,7 @@ module Msf
     MANAGER_COMMANDS = 'manager_commands'
     METASPLOIT_PAYLOAD_WARNINGS = 'metasploit_payload_warnings'
     DEFER_MODULE_LOADS = 'defer_module_loads'
+    SKIP_CHECKSUM_VALIDATION = 'skip_checksum_validation'
     DNS = 'dns'
     HIERARCHICAL_SEARCH_TABLE = 'hierarchical_search_table'
     SMB_SESSION_TYPE = 'smb_session_type'
@@ -61,6 +62,13 @@ module Msf
         requires_restart: true,
         default_value: true,
         developer_notes: 'Enabled in Metasploit 6.4.x'
+      }.freeze,
+      {
+        name: SKIP_CHECKSUM_VALIDATION,
+        description: 'When enabled skips module file checksum validation at boot, improving startup time. Use reload_all to refresh modules after changes.',
+        requires_restart: true,
+        default_value: false,
+        developer_notes: 'Useful for developers who want faster boot and can reload_all manually when modules change'
       }.freeze,
       {
         name: SMB_SESSION_TYPE,

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -72,14 +72,18 @@ class Driver < Msf::Ui::Driver
       elog(e)
     end
 
-    # Check if files have been modified and force immediate loading if so
-    has_modified_metasploit_files = !Msf::Modules::Metadata::Store.valid_checksum?
+    # Check if files have been modified and force immediate loading if so.
+    # Can be skipped via feature flag for faster dev boots (use reload_all to refresh).
+    has_modified_metasploit_files = false
+    unless Msf::FeatureManager.instance.enabled?(Msf::FeatureManager::SKIP_CHECKSUM_VALIDATION)
+      has_modified_metasploit_files = !Msf::Modules::Metadata::Store.valid_checksum?
 
-    if has_modified_metasploit_files
-      current_checksum = Msf::Modules::Metadata::Store.get_current_checksum
-      Msf::Modules::Metadata::Store.update_cache_checksum(current_checksum)
-      # Force immediate module loading when files have changed
-      opts['DeferModuleLoads'] = false
+      if has_modified_metasploit_files
+        current_checksum = Msf::Modules::Metadata::Store.get_current_checksum
+        Msf::Modules::Metadata::Store.update_cache_checksum(current_checksum)
+        # Force immediate module loading when files have changed
+        opts['DeferModuleLoads'] = false
+      end
     end
 
     if opts['DeferModuleLoads'].nil?

--- a/spec/lib/msf/ui/console/driver_skip_checksum_spec.rb
+++ b/spec/lib/msf/ui/console/driver_skip_checksum_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Skip checksum validation feature flag' do
+  it 'is registered in the FeatureManager' do
+    expect(Msf::FeatureManager.instance.exists?('skip_checksum_validation')).to be true
+  end
+
+  it 'is disabled by default' do
+    expect(Msf::FeatureManager.instance.enabled?('skip_checksum_validation')).to be false
+  end
+
+  it 'can be enabled' do
+    Msf::FeatureManager.instance.set('skip_checksum_validation', true)
+    expect(Msf::FeatureManager.instance.enabled?('skip_checksum_validation')).to be true
+  ensure
+    Msf::FeatureManager.instance.set('skip_checksum_validation', false)
+  end
+end


### PR DESCRIPTION
## Description

Add a `skip_checksum_validation` feature flag that skips module file checksum validation during boot.

On every startup, msfconsole stat's all files under `modules/` and computes CRC32 checksums to detect whether any module files have changed since the last boot. If files changed, it forces a full (non-deferred) module reload. This costs ~250ms per boot even when no files have changed, purely from the filesystem traversal and checksum comparison.

For developers who iterate frequently on the framework itself (not module files), this check is unnecessary overhead — they can run `reload_all` when they've actually modified modules. This flag lets them skip it.

Related to: #21639

## Verification Steps

1. - [ ] Start `msfconsole` normally — boot behavior is unchanged (flag is off by default)
2. - [ ] Run `features` in msfconsole — confirm `skip_checksum_validation` appears in the list, disabled
3. - [ ] Run `features set skip_checksum_validation true` save, then restart msfconsole — confirm it boots faster
4. - [ ] With the flag enabled, modify a module file (e.g. `touch modules/exploits/multi/handler.rb`), restart — confirm the change is NOT auto-detected (deferred load still used)
5. - [ ] Run `reload_all` — confirm modules reload correctly
6. - [ ] Run `bundle exec rspec spec/lib/msf/ui/console/driver_skip_checksum_spec.rb` — 3 examples pass
7. - [ ] Run `bundle exec rspec spec/lib/msf/core/feature_manager_spec.rb` — all existing tests pass

## Test Evidence

Before:
```
Benchmark 1: bundle exec ruby ./msfconsole -q -x 'exit'
  Time (mean ± σ):      4.207 s ±  0.055 s    [User: 2.975 s, System: 1.307 s]
  Range (min … max):    4.151 s …  4.330 s    10 runs
```

After:
```
Benchmark 1: bundle exec ruby ./msfconsole -q -x 'exit'
  Time (mean ± σ):      3.904 s ±  0.060 s    [User: 2.811 s, System: 1.123 s]
  Range (min … max):    3.816 s …  3.997 s    10 runs
```
## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS (26.5.2) |
| **Target Software/Hardware** | Metasploit Framework (Ruby 3.3.8) |

## AI Usage Disclosure

Kiro

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)