### PR TITLE
Suppress Pry history loading only if Pry is already defined

### DIFF
--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -122,12 +122,9 @@ module Shell
   # Run the command processing loop.
   #
   def run(&block)
-    begin
-      require 'pry'
-      # pry history will not be loaded by default when pry is used as a breakpoint like `binding.pry`
+    # Only suppress Pry history if Pry is already loaded
+    if defined?(Pry)
       Pry.config.history_load = false
-    rescue LoadError
-      # Pry is a development dependency, if not available suppressing history_load can be safely ignored.
     end
 
     with_history_manager_context do


### PR DESCRIPTION
Here's your PR description:

---

## Description

Defer Pry loading in `Rex::Ui::Text::Shell#run` to avoid paying the `require 'pry'` cost on every msfconsole boot. Saves about 0.2s on my machine.

The `run` method previously did an unconditional `require 'pry'` solely to set `Pry.config.history_load = false` — a config that prevents Pry from loading its own history when `binding.pry` is used. This loaded the entire Pry gem at boot even though most sessions never use Pry.

The change replaces `require 'pry'` with `if defined?(Pry)`, which only sets the config when Pry has already been loaded elsewhere.

## Verification Steps

1. - [ ] Start `msfconsole` normally — verify it boots without errors
2. - [ ] Run the `pry` command inside msfconsole — verify Pry session starts and Pry history isn't polluted with framework commands

## Test Evidence

```
# Before (with require 'pry' at boot):
hyperfine  --warmup 3 "bundle exec ruby ./msfconsole -q -x 'exit'"                                                                                                                                                        
Benchmark 1: bundle exec ruby ./msfconsole -q -x 'exit'
  Time (mean ± σ):      4.337 s ±  0.080 s    [User: 3.055 s, System: 1.351 s]
  Range (min … max):    4.237 s …  4.485 s    10 runs

# After
hyperfine  --warmup 3 "bundle exec ruby ./msfconsole -q -x 'exit'"                                                                                                                                                        
Benchmark 1: bundle exec ruby ./msfconsole -q -x 'exit'
  Time (mean ± σ):      4.155 s ±  0.058 s    [User: 2.986 s, System: 1.272 s]
  Range (min … max):    4.048 s …  4.232 s    10 runs
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS (26.5.2) |
| **Ruby version** | 3.3.8 |

## AI Usage Disclosure

Kiro

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)