### PR TITLE
Fix ACE SID comparion in RBCD module

### DIFF
--- a/modules/auxiliary/admin/ldap/rbcd.rb
+++ b/modules/auxiliary/admin/ldap/rbcd.rb
@@ -198,8 +198,9 @@ class MetasploitModule < Msf::Auxiliary
       return
     end
 
+    delegate_from_sid = Rex::Proto::MsDtyp::MsDtypSid.read(delegate_from[:objectSid].first)
     aces = security_descriptor.dacl.aces.snapshot
-    aces.delete_if { |ace| ace.body.sid == delegate_from[:objectSid].first }
+    aces.delete_if { |ace| ace.body.sid == delegate_from_sid }
     delta = security_descriptor.dacl.aces.length - aces.length
     if delta == 0
       print_status('No DACL ACEs matched. No changes are necessary.')
@@ -268,8 +269,10 @@ class MetasploitModule < Msf::Auxiliary
       vprint_status("Old #{ATTRIBUTE}: #{sddl}")
     end
 
+    delegate_from_sid = Rex::Proto::MsDtyp::MsDtypSid.read(delegate_from[:objectSid].first)
+
     if security_descriptor.dacl
-      if security_descriptor.dacl.aces.any? { |ace| ace.body.sid == delegate_from[:objectSid].first }
+      if security_descriptor.dacl.aces.any? { |ace| ace.body.sid == delegate_from_sid }
         print_status("Delegation from #{delegate_from[:sAMAccountName].first} to #{obj[:sAMAccountName].first} is already configured.")
       end
       # clear these fields so they'll be calculated automatically after the update
@@ -281,7 +284,6 @@ class MetasploitModule < Msf::Auxiliary
       security_descriptor.dacl.acl_revision = Rex::Proto::MsDtyp::MsDtypAcl::ACL_REVISION_DS
     end
 
-    delegate_from_sid = Rex::Proto::MsDtyp::MsDtypSid.read(delegate_from[:objectSid].first)
     security_descriptor.dacl.aces << build_ace(delegate_from_sid)
 
     if (sddl = sd_to_sddl(security_descriptor))


### PR DESCRIPTION
## Description

This fixes a broken SID comparison. `action_remove` was failing to remove the target ACE because of a type mismatch in how it compared SIDs. Before the module was doing:
```
aces.delete_if { |ace| ace.body.sid == delegate_from[:objectSid].first }
```

The two sides of that comparison aren't the same datatype. `ace.body.sid` is a `Rex::Proto::MsDtyp::MsDtypSid`, and when you compare it with ==, it uses its human-readable string form - something like "S-1-5-21-2324486357-...". But `delegate_from[:objectSid].first` is the raw binary SID straight from LDAP ie:`Net::BER::BerIdentifiedString`

The module was comparing a formatted SID string against raw bytes, which never matches. The `delete_if` block always returned false, and the ACE was never removed.

The fix is to parse the raw binary into a `MsDtypSid` first, so both sides are comparing on the same type. This mirrors what `#_action_write_create` already does before handing the SID off to `build_ace`, so it brings `#action_remove` in line with the existing pattern.

This also fixes the same bug in `#_action_write_update` - its "already configured" check had the identical type mismatch, meaning it would never detect an existing duplicate entry.

**Related Issue:** 

This is was discovered when making these changes: https://github.com/rapid7/metasploit-framework/pull/21647 however I figured it made sense to separate these PRs as they're different issues.


## Breaking Changes

<!-- Does this PR change existing behavior, remove options, rename datastore settings, or alter API/mixin interfaces? If yes, describe what breaks and how users should adapt. Write "None" if not applicable. -->

None

## Reviewer Notes

<!-- (Optional) Guide the reviewer: where to start reading, what the key change is, what's intentionally left out or deferred. Delete this section if not needed. -->

## Verification Steps
- Run the `READ` action of the rbcd module and verify there are no entries present for a specific machine account
- Run the `WRITE` action and verify an entry gets written to the attribute 
- Run the `READ` action to be extra super duper certain the entry was written successfully
- Run the `REMOVE` action, it should say the entry was removed
- Run the `READ` action once more to verify the entry to was removed

## Test Evidence
### Before
```
msf auxiliary(admin/ldap/rbcd) > set DELEGATE_FROM MINION1$
DELEGATE_FROM => MINION1$
msf auxiliary(admin/ldap/rbcd) > remove
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] No DACL ACEs matched. No changes are necessary.
[*] Auxiliary module execution completed
msf auxiliary(admin/ldap/rbcd) > set DELEGATE_TO MINION1$
DELEGATE_TO => MINION1$
msf auxiliary(admin/ldap/rbcd) > remove
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] No DACL ACEs matched. No changes are necessary.
[*] Auxiliary module execution completed
msf auxiliary(admin/ldap/rbcd) > read
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] Allowed accounts:
[*]   S-1-5-21-2324486357-3075865580-3606784161-2604 (MINION1$)
[*] Auxiliary module execution completed
msf auxiliary(admin/ldap/rbcd) > set DELEGATE_TO MINION1
DELEGATE_TO => MINION1
msf auxiliary(admin/ldap/rbcd) > set DELEGATE_FROM MINION1
DELEGATE_FROM => MINION1
msf auxiliary(admin/ldap/rbcd) > remove
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] No DACL ACEs matched. No changes are necessary.
[*] Auxiliary module execution completed
msf auxiliary(admin/ldap/rbcd) >
```


### After
```
msf auxiliary(admin/ldap/rbcd) > remove
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] Removed 1 matching ACE.
[+] Successfully updated the msDS-AllowedToActOnBehalfOfOtherIdentity attribute.
[*] Auxiliary module execution completed
msf auxiliary(admin/ldap/rbcd) > read
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] Allowed accounts:
[*] Auxiliary module execution completed
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Windows 2019 domain controller |

## AI Usage Disclosure

kiro-cli

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
