### PR TITLE
fix: resource leaks in file and socket handling

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -350,9 +350,9 @@ class Driver < Msf::Ui::Driver
     path ||= File.join(Msf::Config.config_directory, 'msfconsole.rc')
 
     begin
-      rcfd = File.open(path, 'w')
-      rcfd.write(data)
-      rcfd.close
+      File.open(path, 'w') do |rcfd|
+        rcfd.write(data)
+      end
     rescue ::Exception
     end
   end

--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1252,18 +1252,22 @@ module Net # :nodoc:
 
         ans = nil
         response = ""
-        nameservers.each do |ns, _unused|
-          begin
-            @config[:udp_timeout].timeout do
-              @logger.info "Contacting nameserver #{ns} port #{@config[:port]}"
-              socket.send(packet_data,0,ns.to_s,@config[:port])
-              ans = socket.recvfrom(@config[:packet_size])
+        begin
+          nameservers.each do |ns, _unused|
+            begin
+              @config[:udp_timeout].timeout do
+                @logger.info "Contacting nameserver #{ns} port #{@config[:port]}"
+                socket.send(packet_data,0,ns.to_s,@config[:port])
+                ans = socket.recvfrom(@config[:packet_size])
+              end
+              break if ans
+            rescue Timeout::Error
+              @logger.warn "Nameserver #{ns} not responding within UDP timeout, trying next one"
+              next
             end
-            break if ans
-          rescue Timeout::Error
-            @logger.warn "Nameserver #{ns} not responding within UDP timeout, trying next one"
-            next
           end
+        ensure
+          socket.close
         end
         ans
       end


### PR DESCRIPTION
## Problem

This PR fixes resource leaks in Metasploit Framework:

1. **lib/msf/ui/console/driver.rb**: File handle leak in save_resource method - file opened without block form, not closed on exception
2. **lib/net/dns/resolver.rb**: UDP socket leak in send_udp method - socket not closed on exception

## Solution

1. Use block form of File.open for automatic cleanup
2. Add ensure block to close UDP socket

## Impact

- Prevents resource leaks when exceptions occur
- Improves stability during long-running sessions
- No breaking changes