### PR TITLE
RPC: Add job tracking for all module types

### DIFF
--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -129,7 +129,7 @@ module Scriptable
         opts[k.downcase] = v
       end
       if mod.type == "post"
-        mod.run_simple(
+        mod.run_simple({
           # Run with whatever the default stance is for now.  At some
           # point in the future, we'll probably want a way to force a
           # module to run in the background
@@ -137,7 +137,7 @@ module Scriptable
           'LocalInput'  => self.user_input,
           'LocalOutput' => self.user_output,
           'Options'     => opts
-        )
+        })
       elsif mod.type == "exploit"
         # well it must be a local, we're not currently supporting anything else
         if mod.exploit_type == "local"
@@ -160,13 +160,13 @@ module Scriptable
           # session
           local_exploit_opts = local_exploit_opts.merge(opts)
 
-          mod.exploit_simple(
+          mod.exploit_simple({
             'Payload'       => local_exploit_opts.delete('payload'),
             'Target'        => local_exploit_opts.delete('target'),
             'LocalInput'    => self.user_input,
             'LocalOutput'   => self.user_output,
             'Options'       => local_exploit_opts
-            )
+            })
 
         end # end if local
       end # end if exploit

--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -70,6 +70,8 @@ module Auxiliary
     end
 
     run_uuid = Rex::Text.rand_text_alphanumeric(24)
+    mod.run_uuid = run_uuid
+    omod.run_uuid = run_uuid
     job_listener.waiting run_uuid
     ctx = [mod, run_uuid, job_listener]
     run_as_job = opts['RunAsJob'].nil? ? mod.passive? : opts['RunAsJob']
@@ -94,8 +96,8 @@ module Auxiliary
   #
   # Calls the class method.
   #
-  def run_simple(opts = {}, &block)
-    Msf::Simple::Auxiliary.run_simple(self, opts, &block)
+  def run_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
+    Msf::Simple::Auxiliary.run_simple(self, opts, job_listener: job_listener, &block)
   end
 
   #
@@ -128,6 +130,7 @@ module Auxiliary
     mod.validate
 
     run_uuid = Rex::Text.rand_text_alphanumeric(24)
+    mod.run_uuid = run_uuid
     job_listener.waiting run_uuid
     ctx = [mod, run_uuid, job_listener]
 
@@ -158,8 +161,8 @@ module Auxiliary
   #
   # Calls the class method.
   #
-  def check_simple(opts = {})
-    Msf::Simple::Auxiliary.check_simple(self, opts)
+  def check_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance)
+    Msf::Simple::Auxiliary.check_simple(self, opts, job_listener: job_listener)
   end
 
 

--- a/lib/msf/base/simple/evasion.rb
+++ b/lib/msf/base/simple/evasion.rb
@@ -7,7 +7,7 @@ module Evasion
 
   include Module
 
-  def self.run_simple(oevasion, opts, &block)
+  def self.run_simple(oevasion, opts, job_listener: Msf::Simple::NoopJobListener.instance, &block)
     evasion = oevasion.replicant
     # Trap and print errors here (makes them UI-independent)
     begin
@@ -28,7 +28,7 @@ module Evasion
       evasion.options.validate(evasion.datastore)
 
       # Start it up
-      driver = EvasionDriver.new(evasion.framework)
+      driver = EvasionDriver.new(evasion.framework, job_listener: job_listener)
 
       # Initialize the driver instance
       driver.evasion = evasion
@@ -85,9 +85,11 @@ module Evasion
 
       # Save the job identifier this evasion is running as
       evasion.job_id  = driver.job_id
+      evasion.run_uuid = driver.run_uuid
 
       # Propagate this back to the caller for console mgmt
       oevasion.job_id = evasion.job_id
+      oevasion.run_uuid = evasion.run_uuid
     rescue ::Interrupt
       evasion.error = $!
       raise $!
@@ -103,8 +105,8 @@ module Evasion
     nil
   end
 
-  def run_simple(opts = {}, &block)
-    Msf::Simple::Evasion.run_simple(self, opts, &block)
+  def run_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
+    Msf::Simple::Evasion.run_simple(self, opts, job_listener: job_listener, &block)
   end
 
 end

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -54,7 +54,7 @@ module Exploit
   # 	Whether or not the exploit should be run in the context of a background
   # 	job.
   #
-  def self.exploit_simple(oexploit, opts, &block)
+  def self.exploit_simple(oexploit, opts, job_listener: Msf::Simple::NoopJobListener.instance, &block)
     exploit = oexploit.replicant
     # Trap and print errors here (makes them UI-independent)
     begin
@@ -83,7 +83,7 @@ module Exploit
       exploit.validate
 
       # Start it up
-      driver = Msf::ExploitDriver.new(exploit.framework)
+      driver = Msf::ExploitDriver.new(exploit.framework, job_listener: job_listener)
 
       # Keep the handler of driver running if exploiting multiple targets.
       driver.keep_handler = true if opts['multi']
@@ -146,9 +146,11 @@ module Exploit
 
       # Save the job identifier this exploit is running as
       exploit.job_id  = driver.job_id
+      exploit.run_uuid = driver.run_uuid
 
       # Propagate this back to the caller for console mgmt
       oexploit.job_id = exploit.job_id
+      oexploit.run_uuid = exploit.run_uuid
     rescue ::Interrupt
       exploit.error = $!
       raise $!
@@ -169,8 +171,8 @@ module Exploit
   #
   # Calls the class method.
   #
-  def exploit_simple(opts, &block)
-    Msf::Simple::Exploit.exploit_simple(self, opts, &block)
+  def exploit_simple(opts, job_listener: Msf::Simple::NoopJobListener.instance, &block)
+    Msf::Simple::Exploit.exploit_simple(self, opts, job_listener: job_listener, &block)
   end
 
   alias run_simple exploit_simple
@@ -223,8 +225,8 @@ module Exploit
   #
   # Calls the class method.
   #
-  def check_simple(opts = {})
-    Msf::Simple::Exploit.check_simple(self, opts)
+  def check_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance)
+    Msf::Simple::Exploit.check_simple(self, opts, job_listener: job_listener)
   end
 
   protected

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -37,7 +37,7 @@ module Post
   # 	Whether or not the module should be run in the context of a background
   # 	job.
   #
-  def self.run_simple(omod, opts = {}, &block)
+  def self.run_simple(omod, opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
 
     # Clone the module to prevent changes to the original instance
     mod = omod.replicant
@@ -64,11 +64,16 @@ module Post
       mod.init_ui(nil, nil)
     end
 
+    run_uuid = Rex::Text.rand_text_alphanumeric(24)
+    mod.run_uuid = run_uuid
+    omod.run_uuid = run_uuid
+    job_listener.waiting run_uuid
+    ctx = [mod, run_uuid, job_listener]
+
     #
     # Disable this until we can test background stuff a little better
     #
     if(mod.passive? or opts['RunAsJob'])
-      ctx = [ mod.replicant ]
       mod.job_id = mod.framework.jobs.start_bg_job(
         "Post: #{mod.refname}",
         ctx,
@@ -78,7 +83,6 @@ module Post
       # Propagate this back to the caller for console mgmt
       omod.job_id = mod.job_id
     else
-      ctx = [ mod ]
       self.job_run_proc(ctx)
       self.job_cleanup_proc(ctx)
     end
@@ -87,8 +91,8 @@ module Post
   #
   # Calls the class method.
   #
-  def run_simple(opts = {}, &block)
-    Msf::Simple::Post.run_simple(self, opts, &block)
+  def run_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
+    Msf::Simple::Post.run_simple(self, opts, job_listener: job_listener, &block)
   end
 
 protected
@@ -99,8 +103,9 @@ protected
   # XXX: Mostly Copy/pasted from simple/auxiliary.rb
   #
   def self.job_run_proc(ctx)
-    mod = ctx[0]
+    mod, run_uuid, job_listener = ctx
     begin
+      job_listener.start run_uuid
       mod.setup
       mod.framework.events.on_module_run(mod)
       # Grab the session object since we need to fire an event for not
@@ -109,33 +114,41 @@ protected
       s = mod.framework.sessions.get(mod.datastore["SESSION"])
       if s
         mod.framework.events.on_session_module_run(s, mod)
-        mod.run
+        result = mod.run
+        job_listener.completed(run_uuid, result, mod)
+        return result
       else
         mod.print_error("Session not found")
+        job_listener.failed(run_uuid, 'Session not found', mod)
         mod.cleanup
         return
       end
     rescue Msf::Post::Complete
+      job_listener.completed(run_uuid, nil, mod)
       mod.cleanup
       return
     rescue Msf::Post::Failed => e
       mod.error = e
       mod.print_error("Post aborted due to failure: #{e.message}")
+      job_listener.failed(run_uuid, e, mod)
       mod.cleanup
       return
     rescue ::Timeout::Error => e
       mod.error = e
       mod.print_error("Post triggered a timeout exception")
+      job_listener.failed(run_uuid, e, mod)
       mod.cleanup
       return
     rescue ::Interrupt => e
       mod.error = e
       mod.print_error("Post interrupted by the console user")
+      job_listener.failed(run_uuid, e, mod)
       mod.cleanup
       return
     rescue ::Msf::OptionValidateError => e
       mod.error = e
       ::Msf::Ui::Formatter::OptionValidateError.print_error(mod, e)
+      job_listener.failed(run_uuid, e, mod)
     rescue ::Exception => e
       mod.error = e
       mod.print_error("Post failed: #{e.class} #{e}")
@@ -148,6 +161,7 @@ protected
       end
 
       elog('Post failed', error: e)
+      job_listener.failed(run_uuid, e, mod)
       mod.cleanup
 
       return

--- a/lib/msf/core/evasion_driver.rb
+++ b/lib/msf/core/evasion_driver.rb
@@ -7,13 +7,14 @@ class EvasionDriver
   #
   # Initializes the evasion driver using the supplied framework instance.
   #
-  def initialize(framework)
+  def initialize(framework, job_listener: Msf::Simple::NoopJobListener.instance)
     self.payload                = nil
     self.evasion                = nil
     self.use_job                = false
     self.job_id                 = nil
     self.force_wait_for_session = false
     self.semaphore              = Mutex.new
+    self.job_listener           = job_listener
   end
 
   def target_idx=(target_idx)
@@ -80,15 +81,20 @@ class EvasionDriver
     # evasion module instance
     evasion.generate_payload(payload)
 
+    self.run_uuid = Rex::Text.rand_text_alphanumeric(24)
+    evasion.run_uuid = self.run_uuid
+    self.job_listener.waiting self.run_uuid
+
     # No need to copy since we aren't creating a job.  We wait until
     # they're finished running to do anything else with them, so
     # nothing should be able to modify their datastore or other
     # settings until after they're done.
-    ctx = [ evasion, payload ]
+    ctx = [ evasion, payload, self.run_uuid, self.job_listener ]
 
     job_run_proc(ctx)
     job_cleanup_proc(ctx)
 
+    nil
   end
 
   attr_accessor :evasion # :nodoc:
@@ -99,11 +105,19 @@ class EvasionDriver
   # job.
   #
   attr_accessor :job_id
+  #
+  # The run UUID generated for the most recent #run invocation. Used by the
+  # job listener and reported back to RPC clients via the module attribute of
+  # the same name.
+  #
+  attr_accessor :run_uuid
   attr_accessor :force_wait_for_session # :nodoc:
   attr_accessor :session # :nodoc:
 
   # To synchronize threads cleaning up the evasion
   attr_accessor :semaphore
+
+  attr_accessor :job_listener
 
 protected
 
@@ -111,12 +125,20 @@ protected
   # Job run proc, sets up the eevasion and kicks it off.
   #
   def job_run_proc(ctx)
-    evasion, payload = ctx
-    evasion.setup
-    evasion.framework.events.on_module_run(evasion)
+    evasion, payload, run_uuid, job_listener = ctx
+    job_listener ||= self.job_listener
+    begin
+      job_listener.start run_uuid
+      evasion.setup
+      evasion.framework.events.on_module_run(evasion)
 
-    # Launch the evasion module
-    evasion.run
+      # Launch the evasion module
+      result = evasion.run
+      job_listener.completed(run_uuid, result, evasion)
+    rescue ::Exception => e
+      job_listener.failed(run_uuid, e, evasion)
+      raise
+    end
   end
 
   #

--- a/lib/msf/core/exploit/local.rb
+++ b/lib/msf/core/exploit/local.rb
@@ -19,7 +19,7 @@ class Msf::Exploit::Local < Msf::Exploit
     Msf::Exploit::Type::Local
   end
 
-  def run_simple(opts = {}, &block)
-    Msf::Simple::Exploit.exploit_simple(self, opts, &block)
+  def run_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
+    Msf::Simple::Exploit.exploit_simple(self, opts, job_listener: job_listener, &block)
   end
 end

--- a/lib/msf/core/exploit/remote/browser_autopwn2.rb
+++ b/lib/msf/core/exploit/remote/browser_autopwn2.rb
@@ -339,12 +339,12 @@ module Msf
         multi_handler.register_parent(self)
 
         # Now we're ready to start the handler
-        multi_handler.exploit_simple(
+        multi_handler.exploit_simple({
           'LocalInput' => nil,
           'LocalOutput' => nil,
           'Payload' => payload_name,
           'RunAsJob' => true
-        )
+        })
         @payload_job_ids << multi_handler.job_id
       end
     end
@@ -445,14 +445,14 @@ module Msf
     def start_exploits
       bap_exploits.each do |m|
         set_exploit_options(m)
-        m.exploit_simple(
+        m.exploit_simple({
           'LocalInput'  => nil,
           'LocalOutput' => nil,
           'Quiet'       => true,
           'Target'      => 0,
           'Payload'     => m.datastore['PAYLOAD'],
           'RunAsJob'    => true
-        )
+        })
         @exploit_job_ids << m.job_id
       end
     end

--- a/lib/msf/core/exploit/remote/check_module.rb
+++ b/lib/msf/core/exploit/remote/check_module.rb
@@ -46,12 +46,12 @@ module Exploit::Remote::CheckModule
     print_status("Using #{check_module} as check")
 
     # Retrieve the module's return value
-    res = mod.run_simple(
+    res = mod.run_simple({
       'LocalInput'  => user_input,
       'LocalOutput' => user_output,
       'Options'     => datastore.merge(check_options),
       'RunAsJob'    => false
-    )
+    })
 
     # Ensure return value is a CheckCode
     case res

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -15,7 +15,7 @@ class ExploitDriver
   #
   # Initializes the exploit driver using the supplied framework instance.
   #
-  def initialize(framework)
+  def initialize(framework, job_listener: Msf::Simple::NoopJobListener.instance)
     self.payload                = nil
     self.exploit                = nil
     self.use_job                = false
@@ -23,6 +23,7 @@ class ExploitDriver
     self.force_wait_for_session = false
     self.keep_handler           = false
     self.semaphore              = Mutex.new
+    self.job_listener           = job_listener
   end
 
   #
@@ -138,6 +139,9 @@ class ExploitDriver
     # run
     exploit.job_id = nil
 
+    self.run_uuid = Rex::Text.rand_text_alphanumeric(24)
+    self.job_listener.waiting self.run_uuid
+
     # If we are being instructed to run as a job then let's create that job
     # like a good person.
     if (use_job or exploit.passive?)
@@ -153,7 +157,8 @@ class ExploitDriver
       # Generate the encoded version of the supplied payload for the
       # newly copied exploit module instance
       e.generate_payload(p)
-      ctx = [ e, p ]
+      e.run_uuid = self.run_uuid
+      ctx = [ e, p, self.run_uuid, self.job_listener ]
 
       e.job_id = e.framework.jobs.start_bg_job(
         "Exploit: #{e.refname}",
@@ -171,7 +176,8 @@ class ExploitDriver
       # they're finished running to do anything else with them, so
       # nothing should be able to modify their datastore or other
       # settings until after they're done.
-      ctx = [ exploit, payload ]
+      exploit.run_uuid = self.run_uuid
+      ctx = [ exploit, payload, self.run_uuid, self.job_listener ]
 
       begin
         job_run_proc(ctx)
@@ -185,7 +191,7 @@ class ExploitDriver
       end
     end
 
-    return session
+    self.session
   end
 
   attr_accessor :exploit # :nodoc:
@@ -196,12 +202,20 @@ class ExploitDriver
   # job.
   #
   attr_accessor :job_id
+  #
+  # The run UUID generated for the most recent #run invocation. Used by the
+  # job listener and reported back to RPC clients via the module attribute of
+  # the same name.
+  #
+  attr_accessor :run_uuid
   attr_accessor :force_wait_for_session # :nodoc:
   attr_accessor :session # :nodoc:
   attr_accessor :keep_handler # :nodoc:
 
   # To synchronize threads cleaning up the exploit and the handler
   attr_accessor :semaphore
+
+  attr_accessor :job_listener
 
 protected
 
@@ -210,11 +224,12 @@ protected
   #
   def job_run_proc(ctx)
     begin
-      exploit, payload = ctx
+      exploit, payload, run_uuid, job_listener = ctx
       # Default session wait time..
       delay = payload.wfs_delay + exploit.wfs_delay
       delay = nil if exploit.passive?
 
+      job_listener.start run_uuid
       # Set the exploit up the bomb
       exploit.setup
 
@@ -229,7 +244,15 @@ protected
         delay = 0.01
       end
 
+      iout = StringIO.new
+      rex_out = Rex::Ui::Text::Output::Stdio.new(io: iout)
+      rex_out.disable_color
+      old_user_output = exploit.user_output
+      exploit.user_output = rex_out
       fail_reason = exploit.handle_exception(e)
+      iout.close_write
+      exploit.user_output = old_user_output
+      job_listener.failed(run_uuid, iout.string.strip, exploit)
     end
 
     # Start bind handlers after exploit completion
@@ -243,6 +266,10 @@ protected
       (exploit.passive? == false and exploit.handler_enabled?)
       begin
         self.session = payload.wait_for_session(delay)
+        # Update the result to reflect the session creation
+        if self.session
+          job_listener.completed(run_uuid, "#{session.desc} session #{session.name} opened (#{session.tunnel_to_s}) at #{Time.now}", exploit)
+        end
       rescue ::Interrupt, Timeout::ExitException
         # Don't let interrupt pass upward
         # We also want report a failure when the Timeout expires
@@ -255,6 +282,7 @@ protected
       exploit.fail_reason = Msf::Exploit::Failure::PayloadFailed
       exploit.fail_detail = "No session created"
       exploit.report_failure
+      job_listener.failed(run_uuid, exploit.fail_detail, exploit)
     end
 
     if fail_reason && fail_reason == Msf::Exploit::Failure::UserInterrupt

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -424,6 +424,14 @@ module Msf
     attr_accessor :job_id
 
     #
+    # The run UUID produced by the most recent invocation of this module via
+    # one of the Simple wrappers (exploit_simple / run_simple). Mirrors the
+    # value reported to the job listener and tracked by
+    # Msf::RPC::RpcJobStatusTracker.
+    #
+    attr_accessor :run_uuid
+
+    #
     # The last exception to occur using this module
     #
     attr_accessor :error

--- a/lib/msf/core/post/session_upgrade.rb
+++ b/lib/msf/core/post/session_upgrade.rb
@@ -143,12 +143,12 @@ module Msf::Post::SessionUpgrade
     handler_mod.datastore['LPORT'] = lport
     handler_mod.datastore['ExitOnSession'] = true
 
-    handler_mod.exploit_simple(
+    handler_mod.exploit_simple({
       'Payload' => payload_name,
       'LocalInput' => user_input,
       'LocalOutput' => user_output,
       'RunAsJob' => true
-    )
+    })
 
     # Allow handler time to bind; if it fails, the job disappears
     Rex::ThreadSafe.sleep(2)

--- a/lib/msf/core/rpc/v10/rpc_job_status_tracker.rb
+++ b/lib/msf/core/rpc/v10/rpc_job_status_tracker.rb
@@ -101,7 +101,8 @@ module Msf
       private
 
       def add_result(id, result, mod)
-        string = result.to_json
+        sanitized = result.transform_values { |v| json_safe(v) }
+        string = sanitized.to_json
         results.write(id, string)
       rescue ::Exception => e
         wlog("Job with id: #{id} finished but the result could not be stored")
@@ -109,6 +110,22 @@ module Msf
         add_fallback_result(id, mod)
       ensure
         running.delete(id)
+      end
+
+      # Framework objects (Session, LoginScanner::Result) hold cyclic refs that blow to_json's stack.
+      def json_safe(value)
+        case value
+        when nil, true, false, Numeric, String, Symbol
+          value
+        when Msf::Exploit::CheckCode
+          value
+        when Hash
+          value.each_with_object({}) { |(k, v), h| h[json_safe(k)] = json_safe(v) }
+        when Array
+          value.map { |v| json_safe(v) }
+        else
+          value.to_s
+        end
       end
 
       def add_fallback_result(id, mod)

--- a/lib/msf/core/rpc/v10/rpc_job_status_tracker.rb
+++ b/lib/msf/core/rpc/v10/rpc_job_status_tracker.rb
@@ -124,8 +124,21 @@ module Msf
         when Array
           value.map { |v| json_safe(v) }
         else
-          value.to_s
+          stringify_unknown(value)
         end
+      end
+
+      # Convert an unrecognised value to a JSON-safe string. Guards against
+      # `to_s` implementations that raise, produce invalid UTF-8, or dump
+      # unbounded state. On failure the value's class name is returned instead
+      # so operators still get a diagnosable placeholder.
+      def stringify_unknown(value)
+        str = value.to_s
+        str = str.byteslice(0, 4096) if str.bytesize > 4096
+        str.valid_encoding? ? str : str.scrub
+      rescue ::Exception => e
+        class_name = (value.class.name || value.class.to_s) rescue 'UnknownClass'
+        "#<#{class_name}: unserialisable (#{e.class})>"
       end
 
       def add_fallback_result(id, mod)

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -496,6 +496,7 @@ class RPC_Module < RPC_Base
   #  opts = {'LHOST' => '0.0.0.0', 'LPORT'=>6669, 'PAYLOAD'=>'windows/meterpreter/reverse_tcp'}
   #  rpc.call('module.execute', 'exploit', 'multi/handler', opts)
   def rpc_execute(mtype, mname, opts)
+    _validate_options!(opts)
     mod = _find_module(mtype,mname)
 
     case mtype
@@ -523,6 +524,7 @@ class RPC_Module < RPC_Base
   # @raise [Msf::RPC::Exception] Module not found (either wrong type or name).
   # @return
   def rpc_check(mtype, mname, opts)
+    _validate_options!(opts)
     mod = _find_module(mtype,mname)
     case mtype
     when 'exploit'
@@ -556,7 +558,7 @@ class RPC_Module < RPC_Base
     elsif self.job_status_tracker.waiting? uuid
       {"status" => "ready"}
     else
-      error(404, "Results not found for module instance #{uuid}")
+      error(500, "Results not found for module instance #{uuid}")
     end
   end
 
@@ -728,6 +730,40 @@ class RPC_Module < RPC_Base
 
 private
 
+  # Structural validation for the datastore options hash forwarded to
+  # module.execute / module.check. Rejects obviously abusive input
+  # (non-hash, nested structures, oversized values, malformed keys) at the
+  # RPC boundary so callers other than the MCP transport -- which performs
+  # additional policy-level validation of its own -- still have basic
+  # defence-in-depth against DoS-style payloads.
+  RPC_MODULE_OPTIONS_MAX_KEYS = 100
+  RPC_MODULE_OPTIONS_KEY_MAX_LENGTH = 128
+  RPC_MODULE_OPTIONS_VALUE_MAX_BYTES = 8 * 1024
+  RPC_MODULE_OPTION_SCALAR_TYPES = [String, Integer, Float, TrueClass, FalseClass, NilClass].freeze
+
+  def _validate_options!(opts)
+    error(400, 'Module options must be a Hash') unless opts.is_a?(Hash)
+
+    if opts.size > RPC_MODULE_OPTIONS_MAX_KEYS
+      error(400, "Module options has too many keys (max #{RPC_MODULE_OPTIONS_MAX_KEYS})")
+    end
+
+    opts.each do |key, value|
+      unless key.is_a?(String) || key.is_a?(Symbol)
+        error(400, "Invalid module option key type: #{key.class}")
+      end
+      if key.to_s.length > RPC_MODULE_OPTIONS_KEY_MAX_LENGTH
+        error(400, "Module option key too long (max #{RPC_MODULE_OPTIONS_KEY_MAX_LENGTH} chars)")
+      end
+      unless RPC_MODULE_OPTION_SCALAR_TYPES.any? { |klass| value.is_a?(klass) }
+        error(400, "Invalid module option value for #{key}: must be a scalar")
+      end
+      if value.is_a?(String) && value.bytesize > RPC_MODULE_OPTIONS_VALUE_MAX_BYTES
+        error(400, "Module option #{key} string value exceeds #{RPC_MODULE_OPTIONS_VALUE_MAX_BYTES} bytes")
+      end
+    end
+  end
+
   # @param [String] mtype The module type
   # @param [String] mname The module name
   # @return [Msf::Module] The module if found
@@ -751,27 +787,27 @@ private
       opts['PAYLOAD'] = Msf::Payload.choose_payload(mod)
     end
 
-    s = Msf::Simple::Exploit.exploit_simple(mod, {
+    Msf::Simple::Exploit.exploit_simple(mod, {
       'Payload'  => opts['PAYLOAD'],
       'Target'   => opts['TARGET'],
       'RunAsJob' => true,
       'Options'  => opts
-    })
+    }, job_listener: self.job_status_tracker)
     {
       "job_id" => mod.job_id,
-      "uuid" => mod.uuid
+      "uuid" => mod.run_uuid
     }
   end
 
   def _run_auxiliary(mod, opts)
-    uuid, job = Msf::Simple::Auxiliary.run_simple(mod,{
+    Msf::Simple::Auxiliary.run_simple(mod,{
       'Action'   => opts['ACTION'],
       'RunAsJob' => true,
       'Options'  => opts
     }, job_listener: self.job_status_tracker)
     {
-      "job_id" => job,
-      "uuid" => uuid
+      "job_id" => mod.job_id,
+      "uuid" => mod.run_uuid
     }
   end
 
@@ -802,10 +838,10 @@ private
     Msf::Simple::Post.run_simple(mod, {
       'RunAsJob' => true,
       'Options'  => opts
-    })
+    }, job_listener: self.job_status_tracker)
     {
       "job_id" => mod.job_id,
-      "uuid" => mod.uuid
+      "uuid" => mod.run_uuid
     }
   end
 
@@ -815,11 +851,11 @@ private
       'Target'   => opts['TARGET'],
       'RunAsJob' => true,
       'Options'  => opts
-    })
+    }, job_listener: self.job_status_tracker)
 
     {
       'job_id' => mod.job_id,
-      'uuid'   => mod.uuid
+      'uuid'   => mod.run_uuid
     }
   end
 

--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -181,7 +181,7 @@ class RPC_Session < RPC_Base
     rpc_interactive_read(sid)
   end
 
-  # Reads the output from an interactive session (meterpreter, DB sessions, SMB)
+  # Reads the output from an interactive session (meterpreter, DB sessions, SMB, shell, powershell)
   #
   # @note Multiple concurrent callers writing and reading the same Meterperter session can lead to
   #  a conflict, where one caller gets the others output and vice versa. Concurrent access to a
@@ -190,12 +190,21 @@ class RPC_Session < RPC_Base
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Unknown Session ID.
   #                              * 500 Session doesn't support interactive operations.
+  #                              * 500 Session is disconnected.
   # @return [Hash] It contains the following key:
   #  * 'data' [String] Data read.
   # @example Here's how you would use this from the client:
   #  rpc.call('session.interactive_read', 2)
   def rpc_interactive_read(sid)
     session = _valid_interactive_session(sid)
+
+    if SHELL_SESSION_TYPES.include?(session.type)
+      begin
+        return { 'data' => session.shell_read.to_s }
+      rescue ::Exception => e
+        error(500, "Session Disconnected: #{e.class} #{e}")
+      end
+    end
 
     unless session.user_output.respond_to?(:dump_buffer)
       session.init_ui(Rex::Ui::Text::Input::Buffer.new, Rex::Ui::Text::Output::Buffer.new)
@@ -302,7 +311,7 @@ class RPC_Session < RPC_Base
     rpc_interactive_write(sid, data)
   end
 
-  # Sends an input to an interactive prompt (meterpreter, DB sessions, SMB)
+  # Sends an input to an interactive prompt (meterpreter, DB sessions, SMB, shell, powershell)
   # You may want to use #rpc_interactive_read to retrieve the output.
   # @note Multiple concurrent callers writing and reading the same Meterperter session can lead to
   #       a conflict, where one caller gets the others output and vice versa. Concurrent access to
@@ -312,12 +321,23 @@ class RPC_Session < RPC_Base
   # @raise [Msf::RPC::Exception] An error that could be one of these:
   #                              * 500 Unknown Session ID.
   #                              * 500 Session doesn't support interactive operations.
+  #                              * 500 Session is disconnected.
   # @return [Hash] A hash indicating the action was successful or not. It contains the following key:
   #  * 'result' [String] Either 'success' or 'failure'.
   # @example Here's how you would use this from the client:
   # rpc.call('session.interactive_write', 2, "sysinfo")
   def rpc_interactive_write(sid, data)
     session = _valid_interactive_session(sid)
+
+    if SHELL_SESSION_TYPES.include?(session.type)
+      begin
+        payload = data.end_with?("\n") ? data : "#{data}\n"
+        session.shell_write(payload)
+        return { 'result' => 'success' }
+      rescue ::Exception => e
+        error(500, "Session Disconnected: #{e.class} #{e}")
+      end
+    end
 
     unless session.user_output.respond_to? :dump_buffer
       session.init_ui(Rex::Ui::Text::Input::Buffer.new, Rex::Ui::Text::Output::Buffer.new)
@@ -532,7 +552,11 @@ class RPC_Session < RPC_Base
     mysql
     smb
     ldap
+    shell
+    powershell
   ].freeze
+
+  SHELL_SESSION_TYPES = %w[shell powershell].freeze
 
   def _find_module(_mtype, mname)
     mod = framework.modules.create(mname)

--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -135,6 +135,7 @@ class RPC_Session < RPC_Base
   # @example Here's how you would use this from the client:
   #  rpc.call('session.shell_write', 2, "DATA")
   def rpc_shell_write( sid, data)
+    error(400, 'Data must be a String') unless data.is_a?(String)
     s = _valid_session(sid,"shell")
     begin
       res = s.shell_write(data)
@@ -251,6 +252,7 @@ class RPC_Session < RPC_Base
   # @example Here's how you would use this from the client:
   #  rpc.call('session.ring_put', 2, "DATA")
   def rpc_ring_put(sid, data)
+    error(400, 'Data must be a String') unless data.is_a?(String)
     s = _valid_session(sid,"ring")
     begin
       res = s.shell_write(data)
@@ -327,6 +329,7 @@ class RPC_Session < RPC_Base
   # @example Here's how you would use this from the client:
   # rpc.call('session.interactive_write', 2, "sysinfo")
   def rpc_interactive_write(sid, data)
+    error(400, 'Data must be a String') unless data.is_a?(String)
     session = _valid_interactive_session(sid)
 
     if SHELL_SESSION_TYPES.include?(session.type)

--- a/lib/msf/core/rpc/v10/service.rb
+++ b/lib/msf/core/rpc/v10/service.rb
@@ -84,8 +84,8 @@ class Service
       res.body = process_exception(e).to_msgpack
       res.code = e.code
       res.message = e.http_msg
-    rescue ::StandardError => e
-      elog('Unknown Exception', error: e)
+    rescue ::StandardError, ::ScriptError => e
+      elog('Unhandled Exception', error: e)
       res.body = process_exception(e).to_msgpack
       res.code = 500
       res.message = 'Internal Server Error'

--- a/lib/msf/ui/console/command_dispatcher/auxiliary.rb
+++ b/lib/msf/ui/console/command_dispatcher/auxiliary.rb
@@ -65,13 +65,13 @@ class Auxiliary
       if rhosts.blank? ||
          mod.class.included_modules.include?(Msf::Auxiliary::MultipleTargetHosts) ||
          !mod.datastore.options.key?('RHOSTS')
-        mod_with_opts.run_simple(
+        mod_with_opts.run_simple({
           'Action'         => args[:action],
           'LocalInput'     => driver.input,
           'LocalOutput'    => driver.output,
           'RunAsJob'       => jobify,
           'Quiet'          => args[:quiet]
-        )
+        })
       # For multi target attempts with non-scanner modules.
       else
         # When RHOSTS is split, the validation changes slightly, so perform it reports the host the validation failed for
@@ -80,13 +80,13 @@ class Auxiliary
           mod_with_opts = mod.replicant
           mod_with_opts.datastore.merge!(datastore)
           print_status("Running module against #{datastore['RHOSTS']}")
-          mod_with_opts.run_simple(
+          mod_with_opts.run_simple({
             'Action'         => args[:action],
             'LocalInput'     => driver.input,
             'LocalOutput'    => driver.output,
             'RunAsJob'       => false,
             'Quiet'          => args[:quiet]
-          )
+          })
         end
       end
     rescue ::Timeout::Error

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1834,11 +1834,11 @@ class Core
               opts[key] = session.exploit_datastore[key] if session.exploit_datastore[key]
             end
           end
-          mod.run_simple(
+          mod.run_simple({
             'LocalInput' => driver.input,
             'LocalOutput' => driver.output,
             'Options' => opts
-          )
+          })
         else
           print_status("Executing 'post/multi/manage/shell_to_meterpreter' on " \
                         "session: [#{sess_id}]")

--- a/lib/msf/ui/console/command_dispatcher/post.rb
+++ b/lib/msf/ui/console/command_dispatcher/post.rb
@@ -85,14 +85,14 @@ class Post
     end
 
     begin
-      mod.run_simple(
+      mod.run_simple({
         'Action'         => args[:action],
         'Options'      => args[:datastore_options],
         'LocalInput'     => driver.input,
         'LocalOutput'    => driver.output,
         'RunAsJob'       => jobify,
         'Quiet'          => args[:quiet]
-      )
+      })
     rescue ::Timeout::Error
       print_error("Post triggered a timeout exception")
     rescue ::Interrupt

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -226,10 +226,10 @@ module ModuleCommandDispatcher
 
     begin
       if instance.respond_to?(:check_simple)
-        code = instance.check_simple(
+        code = instance.check_simple({
           'LocalInput'  => driver.input,
           'LocalOutput' => driver.output
-        )
+        })
       else
         msg = "Check failed: #{instance.type.capitalize} modules do not support check."
         raise NotImplementedError, msg

--- a/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/hwbridge/ui/console/command_dispatcher/core.rb
@@ -391,12 +391,12 @@ class Console::CommandDispatcher::Core
         end
 
         opts = (args + [ "SESSION=#{client.sid}" ]).join(',')
-        reloaded_mod.run_simple(
+        reloaded_mod.run_simple({
           #'RunAsJob' => true,
           'LocalInput'  => shell.input,
           'LocalOutput' => shell.output,
           'OptionStr'   => opts
-        )
+        })
       else
         # the rest of the arguments get passed in through the binding
         client.execute_script(script_name, args)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1372,12 +1372,12 @@ class Console::CommandDispatcher::Core
         end
 
         opts  << (args + [ "SESSION=#{client.sid}" ]).join(',')
-        result = reloaded_mod.run_simple(
+        result = reloaded_mod.run_simple({
           #'RunAsJob' => true,
           'LocalInput'  => shell.input,
           'LocalOutput' => shell.output,
           'OptionStr'   => opts
-        )
+        })
 
         print_status("Session #{result.sid} created in the background.") if result.is_a?(Msf::Session)
       else

--- a/spec/lib/msf/base/simple/auxiliary_job_tracking_spec.rb
+++ b/spec/lib/msf/base/simple/auxiliary_job_tracking_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'msf/base/simple/auxiliary'
+require 'msf/base/simple/noop_job_listener'
+
+RSpec.describe Msf::Simple::Auxiliary, '#job_run_proc job tracking' do
+  let(:run_uuid) { 'aux-run-uuid' }
+  let(:job_listener) { double('JobListener', waiting: nil, start: nil, completed: nil, failed: nil) }
+  let(:events) { double('EventDispatcher', on_module_run: nil, on_module_complete: nil, on_session_module_run: nil) }
+  let(:framework) { double('Framework', events: events) }
+  let(:mod) do
+    double(
+      'AuxiliaryModule',
+      framework: framework,
+      respond_to?: true,
+      :check_code= => nil,
+      :last_vuln_attempt= => nil,
+      setup: nil,
+      cleanup: nil,
+      report_failure: nil,
+      :error= => nil,
+      :fail_reason= => nil,
+      :fail_detail= => nil,
+      print_error: nil,
+      print_status: nil,
+      fail_reason: Msf::Module::Failure::None,
+      fail_detail: nil
+    )
+  end
+  let(:ctx) { [mod, run_uuid, job_listener] }
+
+  context 'when the block completes successfully' do
+    it 'reports start then completed with the block result' do
+      result = 'aux-result'
+      described_class.job_run_proc(ctx) { |_m| result }
+      expect(job_listener).to have_received(:start).with(run_uuid)
+      expect(job_listener).to have_received(:completed).with(run_uuid, result, mod)
+      expect(job_listener).not_to have_received(:failed)
+    end
+  end
+
+  context 'when the block raises a generic exception' do
+    it 'reports failed with the exception and propagates' do
+      err = RuntimeError.new('boom')
+      described_class.job_run_proc(ctx) { |_m| raise err }
+      expect(job_listener).to have_received(:start).with(run_uuid)
+      expect(job_listener).to have_received(:failed).with(run_uuid, err, mod)
+      expect(job_listener).not_to have_received(:completed)
+    end
+  end
+
+  context 'when the block raises Msf::Auxiliary::Complete' do
+    it 'is reported via failed (mirrors existing aux behavior) then is swallowed' do
+      described_class.job_run_proc(ctx) { |_m| raise Msf::Auxiliary::Complete }
+      expect(job_listener).to have_received(:failed).with(run_uuid, kind_of(Msf::Auxiliary::Complete), mod)
+    end
+  end
+end
+
+RSpec.describe Msf::Simple::Auxiliary, 'job_listener keyword signature' do
+  it '.run_simple accepts a job_listener kwarg' do
+    expect(described_class.method(:run_simple).parameters).to include(%i[key job_listener])
+  end
+
+  it '.check_simple accepts a job_listener kwarg' do
+    expect(described_class.method(:check_simple).parameters).to include(%i[key job_listener])
+  end
+
+  it 'the instance-level run_simple accepts a job_listener kwarg' do
+    expect(described_class.instance_method(:run_simple).parameters).to include(%i[key job_listener])
+  end
+
+  it 'the instance-level run_simple forwards job_listener: to the class method' do
+    mod = Class.new { include Msf::Simple::Auxiliary }.new
+    listener = double('JobListener')
+    expect(described_class).to receive(:run_simple).with(mod, { opts: 1 }, job_listener: listener)
+    mod.run_simple({ opts: 1 }, job_listener: listener)
+  end
+end

--- a/spec/lib/msf/base/simple/evasion_job_tracking_spec.rb
+++ b/spec/lib/msf/base/simple/evasion_job_tracking_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'msf/base/simple/evasion'
+require 'msf/base/simple/noop_job_listener'
+require 'msf/core/evasion_driver'
+
+RSpec.describe Msf::EvasionDriver, '#job_run_proc job tracking' do
+  let(:run_uuid) { 'evasion-run-uuid' }
+  let(:job_listener) { double('JobListener', waiting: nil, start: nil, completed: nil, failed: nil) }
+  let(:events) { double('EventDispatcher', on_module_run: nil, on_module_complete: nil) }
+  let(:framework) { double('Framework', events: events) }
+  let(:evasion_mod) { double('EvasionModule', setup: nil, framework: framework, run: 'evasion-output', cleanup: nil) }
+  let(:payload) { double('Payload') }
+  let(:driver) { described_class.new(framework) }
+
+  before do
+    driver.job_listener = job_listener if driver.respond_to?(:job_listener=)
+    driver.evasion = evasion_mod
+    driver.payload = payload
+  end
+
+  context 'when the module runs successfully' do
+    it 'reports start then completed' do
+      driver.send(:job_run_proc, [evasion_mod, payload, run_uuid, job_listener])
+      expect(job_listener).to have_received(:start).with(run_uuid)
+      expect(job_listener).to have_received(:completed).with(run_uuid, 'evasion-output', evasion_mod)
+      expect(job_listener).not_to have_received(:failed)
+    end
+  end
+
+  context 'when the module raises' do
+    it 'reports failed with the exception' do
+      err = RuntimeError.new('evasion-boom')
+      allow(evasion_mod).to receive(:run).and_raise(err)
+      expect do
+        driver.send(:job_run_proc, [evasion_mod, payload, run_uuid, job_listener])
+      end.to raise_error(RuntimeError, 'evasion-boom')
+      expect(job_listener).to have_received(:failed).with(run_uuid, err, evasion_mod)
+    end
+  end
+end
+
+RSpec.describe Msf::EvasionDriver, '#initialize' do
+  let(:framework) { double('Framework') }
+
+  it 'accepts a job_listener keyword argument' do
+    listener = double('JobListener')
+    driver = described_class.new(framework, job_listener: listener)
+    expect(driver.job_listener).to eq(listener)
+  end
+
+  it 'defaults to the noop job listener' do
+    driver = described_class.new(framework)
+    expect(driver.job_listener).to eq(Msf::Simple::NoopJobListener.instance)
+  end
+end
+
+RSpec.describe Msf::Simple::Evasion, '.run_simple' do
+  let(:job_listener) { double('JobListener', waiting: nil, start: nil, completed: nil, failed: nil) }
+
+  it 'is a singleton method that accepts a job_listener keyword' do
+    expect(described_class.method(:run_simple).parameters).to include(%i[key job_listener])
+  end
+end

--- a/spec/lib/msf/base/simple/exploit_job_tracking_spec.rb
+++ b/spec/lib/msf/base/simple/exploit_job_tracking_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'msf/base/simple/exploit'
+require 'msf/base/simple/noop_job_listener'
+require 'msf/core/exploit_driver'
+
+RSpec.describe Msf::ExploitDriver, 'job listener integration' do
+  let(:framework) { double('Framework') }
+  let(:custom_listener) { double('JobListener', waiting: nil, start: nil, completed: nil, failed: nil) }
+
+  describe '#initialize' do
+    it 'accepts an explicit job_listener kwarg' do
+      driver = described_class.new(framework, job_listener: custom_listener)
+      expect(driver.job_listener).to eq(custom_listener)
+    end
+
+    it 'defaults to the noop job listener' do
+      driver = described_class.new(framework)
+      expect(driver.job_listener).to eq(Msf::Simple::NoopJobListener.instance)
+    end
+  end
+
+  describe '#job_run_proc lifecycle' do
+    let(:run_uuid) { 'exploit-run-uuid' }
+    let(:events) { double('EventDispatcher', on_module_run: nil, on_module_complete: nil) }
+    let(:framework_for_exploit) { double('Framework', events: events) }
+    let(:exploit_mod) do
+      double(
+        'ExploitModule',
+        setup: nil,
+        framework: framework_for_exploit,
+        exploit: nil,
+        passive?: false,
+        wfs_delay: 0,
+        handler_enabled?: false,
+        handler_bind?: false,
+        fail_reason: Msf::Exploit::Failure::None,
+        fail_detail: 'No session created',
+        :fail_reason= => nil,
+        :fail_detail= => nil,
+        report_failure: nil,
+        cleanup: nil
+      )
+    end
+    let(:payload_mod) { double('Payload', wfs_delay: 0, start_handler: nil, wait_for_session: nil) }
+    let(:driver) { described_class.new(framework_for_exploit, job_listener: custom_listener) }
+
+    it 'always fires start(uuid) before running the exploit' do
+      driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+      expect(custom_listener).to have_received(:start).with(run_uuid)
+    end
+
+    context 'when the exploit runs without raising and no session opens' do
+      it 'fires failed(uuid) with the "No session created" detail' do
+        driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+        expect(custom_listener).to have_received(:failed).with(run_uuid, 'No session created', exploit_mod)
+      end
+
+      it 'reports the failure to the database via exploit.report_failure' do
+        driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+        expect(exploit_mod).to have_received(:report_failure)
+      end
+
+      it 'does not fire completed on this path' do
+        driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+        expect(custom_listener).not_to have_received(:completed)
+      end
+    end
+
+    context 'when a session opens' do
+      let(:session) do
+        double('Session', desc: 'meterpreter', name: '1', tunnel_to_s: '192.0.2.1:4444')
+      end
+
+      before do
+        allow(exploit_mod).to receive(:handler_enabled?).and_return(true)
+        allow(payload_mod).to receive(:wait_for_session).and_return(session)
+      end
+
+      it 'fires completed(uuid) with the session-opened message' do
+        driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+        expect(custom_listener).to have_received(:completed)
+          .with(run_uuid, a_string_matching(/session 1 opened/), exploit_mod)
+      end
+
+      it 'does not fire failed on the success path' do
+        driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+        expect(custom_listener).not_to have_received(:failed)
+      end
+
+      it 'does not call report_failure on the success path' do
+        driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+        expect(exploit_mod).not_to have_received(:report_failure)
+      end
+    end
+
+    it 'reports failed when the exploit raises' do
+      err = RuntimeError.new('exploit-boom')
+      allow(exploit_mod).to receive(:exploit).and_raise(err)
+      allow(exploit_mod).to receive(:handle_exception).and_return(Msf::Exploit::Failure::Unknown)
+      # handle_exception sets fail_reason on the exploit instance in real code
+      allow(exploit_mod).to receive(:fail_reason).and_return(Msf::Exploit::Failure::Unknown)
+      allow(exploit_mod).to receive(:user_output).and_return(nil)
+      allow(exploit_mod).to receive(:user_output=)
+      driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+      expect(custom_listener).to have_received(:failed).with(run_uuid, kind_of(String), exploit_mod)
+    end
+
+    it 'does not double-fire failed on the exception path (rescue path skips the no-session tail)' do
+      err = RuntimeError.new('exploit-boom')
+      allow(exploit_mod).to receive(:exploit).and_raise(err)
+      allow(exploit_mod).to receive(:handle_exception).and_return(Msf::Exploit::Failure::Unknown)
+      # After handle_exception, the exploit's fail_reason is non-None, so the tail if-block is skipped.
+      allow(exploit_mod).to receive(:fail_reason).and_return(Msf::Exploit::Failure::Unknown)
+      allow(exploit_mod).to receive(:user_output).and_return(nil)
+      allow(exploit_mod).to receive(:user_output=)
+      driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+      expect(custom_listener).to have_received(:failed).once
+      expect(exploit_mod).not_to have_received(:report_failure)
+    end
+  end
+end
+
+RSpec.describe Msf::Simple::Exploit, 'job_listener keyword signature' do
+  it '.exploit_simple accepts a job_listener kwarg defaulting to the noop listener' do
+    expect(described_class.method(:exploit_simple).parameters).to include(%i[key job_listener])
+  end
+
+  it '.check_simple accepts a job_listener kwarg defaulting to the noop listener' do
+    expect(described_class.method(:check_simple).parameters).to include(%i[key job_listener])
+  end
+
+  it 'the instance-level exploit_simple accepts a job_listener kwarg' do
+    expect(described_class.instance_method(:exploit_simple).parameters).to include(%i[key job_listener])
+  end
+
+  it 'the instance-level check_simple accepts a job_listener kwarg' do
+    expect(described_class.instance_method(:check_simple).parameters).to include(%i[key job_listener])
+  end
+
+  describe 'forwarding' do
+    let(:framework)   { double('Framework') }
+    let(:job_listener) { double('JobListener') }
+
+    it 'the instance-level exploit_simple forwards job_listener: to the class method' do
+      mod = Class.new { include Msf::Simple::Exploit }.new
+      expect(described_class).to receive(:exploit_simple).with(mod, { opts: 1 }, job_listener: job_listener)
+      mod.exploit_simple({ opts: 1 }, job_listener: job_listener)
+    end
+
+    it 'the instance-level check_simple forwards job_listener: to the class method' do
+      mod = Class.new { include Msf::Simple::Exploit }.new
+      expect(described_class).to receive(:check_simple).with(mod, { opts: 1 }, job_listener: job_listener)
+      mod.check_simple({ opts: 1 }, job_listener: job_listener)
+    end
+  end
+end

--- a/spec/lib/msf/base/simple/post_job_tracking_spec.rb
+++ b/spec/lib/msf/base/simple/post_job_tracking_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'msf/base/simple/post'
+require 'msf/base/simple/noop_job_listener'
+
+RSpec.describe Msf::Simple::Post, '#job_run_proc job tracking' do
+  let(:run_uuid) { 'post-run-uuid' }
+  let(:job_listener) { double('JobListener', waiting: nil, start: nil, completed: nil, failed: nil) }
+  let(:events) { double('EventDispatcher', on_module_run: nil, on_module_complete: nil, on_session_module_run: nil) }
+  let(:sessions) { double('SessionManager', get: session) }
+  let(:session) { double('Session') }
+  let(:framework) { double('Framework', events: events, sessions: sessions) }
+  let(:datastore) { { 'SESSION' => 1 } }
+  let(:mod) do
+    double(
+      'PostModule',
+      framework: framework,
+      datastore: datastore,
+      setup: nil,
+      cleanup: nil,
+      print_error: nil,
+      :error= => nil
+    )
+  end
+  let(:ctx) { [mod, run_uuid, job_listener] }
+
+  context 'when the module run succeeds' do
+    it 'reports start then completed with the run result' do
+      result = 'post-result'
+      allow(mod).to receive(:run).and_return(result)
+      described_class.job_run_proc(ctx)
+      expect(job_listener).to have_received(:start).with(run_uuid)
+      expect(job_listener).to have_received(:completed).with(run_uuid, result, mod)
+      expect(job_listener).not_to have_received(:failed)
+    end
+  end
+
+  context 'when the session is missing' do
+    let(:session) { nil }
+    it 'reports failed and does not invoke mod.run' do
+      expect(mod).not_to receive(:run)
+      described_class.job_run_proc(ctx)
+      expect(job_listener).to have_received(:start).with(run_uuid)
+      expect(job_listener).to have_received(:failed).with(run_uuid, kind_of(String), mod)
+      expect(job_listener).not_to have_received(:completed)
+    end
+  end
+
+  context 'when the module run raises' do
+    it 'reports failed with the exception' do
+      err = RuntimeError.new('post-boom')
+      allow(mod).to receive(:run).and_raise(err)
+      described_class.job_run_proc(ctx)
+      expect(job_listener).to have_received(:start).with(run_uuid)
+      expect(job_listener).to have_received(:failed).with(run_uuid, err, mod)
+      expect(job_listener).not_to have_received(:completed)
+    end
+  end
+
+  context 'when the module raises Msf::Post::Complete' do
+    it 'reports completed via the listener' do
+      allow(mod).to receive(:run).and_raise(Msf::Post::Complete)
+      described_class.job_run_proc(ctx)
+      expect(job_listener).to have_received(:completed).with(run_uuid, nil, mod)
+    end
+  end
+end
+
+RSpec.describe Msf::Simple::Post, '.run_simple' do
+  let(:job_listener) { double('JobListener', waiting: nil, start: nil, completed: nil, failed: nil) }
+  let(:datastore) { double('Datastore', :[]= => nil, :[] => nil) }
+  let(:framework) { double('Framework', jobs: jobs) }
+  let(:jobs) { double('JobManager') }
+  let(:mod) do
+    mod = double(
+      'PostModule',
+      replicant: nil,
+      refname: 'multi/general/execute',
+      framework: framework,
+      datastore: datastore,
+      actions: [],
+      action: nil,
+      passive?: true,
+      validate: nil,
+      init_ui: nil,
+      user_input: nil,
+      user_output: nil,
+      _import_extra_options: nil,
+      :job_id= => nil,
+      job_id: 42,
+      :run_uuid= => nil,
+      run_uuid: nil
+    )
+    allow(mod).to receive(:replicant).and_return(mod)
+    allow(mod).to receive(:extend)
+    mod
+  end
+
+  before do
+    allow(Msf::Simple::Framework).to receive(:simplify_module)
+    allow(jobs).to receive(:start_bg_job).and_return(42)
+    require 'rex/text'
+  end
+
+  it 'generates a run uuid, notifies the listener, and assigns mod.run_uuid / mod.job_id' do
+    captured_uuid = nil
+    expect(job_listener).to receive(:waiting) { |uuid| captured_uuid = uuid }
+    expect(mod).to receive(:run_uuid=).with(kind_of(String)).at_least(:once)
+    expect(mod).to receive(:job_id=).with(42).at_least(:once)
+
+    described_class.run_simple(mod, { 'RunAsJob' => true }, job_listener: job_listener)
+
+    expect(captured_uuid).to be_a(String)
+    expect(captured_uuid.length).to be >= 8
+  end
+end

--- a/spec/lib/msf/core/rpc/v10/rpc_job_status_tracker_spec.rb
+++ b/spec/lib/msf/core/rpc/v10/rpc_job_status_tracker_spec.rb
@@ -261,6 +261,109 @@ RSpec.describe Msf::RPC::RpcJobStatusTracker do
             expect(stored['tag']).to eq('scanner')
           end
         end
+
+        context 'The job result contains an object whose #to_s raises' do
+          let(:raising_object) do
+            Class.new do
+              def to_s
+                raise 'boom'
+              end
+            end.new
+          end
+          let(:mock_result) { { host: '192.0.2.10', detail: raising_object } }
+
+          before(:each) do
+            job_status_tracker.completed(job_id, mock_result, mod)
+          end
+
+          it 'does not crash the tracker' do
+            expect(job_status_tracker).to be_finished(job_id)
+          end
+
+          it 'does not fall through to the "could not be stored" fallback' do
+            expect(job_status_tracker.result(job_id)).not_to have_key('error')
+          end
+
+          it 'substitutes a class-tagged placeholder for the raising leaf' do
+            stored = job_status_tracker.result(job_id)['result']
+            expect(stored['detail']).to include('unserialisable', 'RuntimeError')
+          end
+
+          it 'preserves sibling primitive leaves' do
+            stored = job_status_tracker.result(job_id)['result']
+            expect(stored['host']).to eq('192.0.2.10')
+          end
+        end
+
+        context 'The job result contains an object whose #to_s returns a huge string' do
+          let(:huge_object) do
+            Class.new do
+              def to_s
+                'x' * 1_000_000
+              end
+            end.new
+          end
+          let(:mock_result) { { blob: huge_object } }
+
+          before(:each) do
+            job_status_tracker.completed(job_id, mock_result, mod)
+          end
+
+          it 'truncates the stringified leaf to the 4096-byte cap' do
+            stored = job_status_tracker.result(job_id)['result']
+            expect(stored['blob'].bytesize).to eq(4096)
+          end
+        end
+
+        context 'The job result contains an object whose #to_s returns a non-String' do
+          let(:non_string_object) do
+            Class.new do
+              def to_s
+                42
+              end
+            end.new
+          end
+          let(:mock_result) { { detail: non_string_object } }
+
+          before(:each) do
+            job_status_tracker.completed(job_id, mock_result, mod)
+          end
+
+          it 'falls back to a class-tagged placeholder rather than crashing the tracker' do
+            stored = job_status_tracker.result(job_id)['result']
+            expect(stored['detail']).to be_a(String)
+            expect(stored['detail']).to include('unserialisable')
+          end
+
+          it 'does not fall through to the "could not be stored" fallback' do
+            expect(job_status_tracker.result(job_id)).not_to have_key('error')
+          end
+        end
+
+        context 'The job result contains an object whose #to_s returns invalid UTF-8' do
+          let(:binary_object) do
+            Class.new do
+              def to_s
+                (+"header-\xC3\x28-tail").force_encoding(Encoding::UTF_8)
+              end
+            end.new
+          end
+          let(:mock_result) { { blob: binary_object } }
+
+          before(:each) do
+            job_status_tracker.completed(job_id, mock_result, mod)
+          end
+
+          it 'scrubs the invalid bytes so the JSON encode succeeds' do
+            stored = job_status_tracker.result(job_id)['result']
+            expect(stored['blob']).to be_a(String)
+            expect(stored['blob'].valid_encoding?).to be true
+          end
+
+          it 'does not fall through to the "could not be stored" fallback' do
+            expect(job_status_tracker.result(job_id)).not_to have_key('error')
+          end
+        end
       end
     end
   end

--- a/spec/lib/msf/core/rpc/v10/rpc_job_status_tracker_spec.rb
+++ b/spec/lib/msf/core/rpc/v10/rpc_job_status_tracker_spec.rb
@@ -170,6 +170,97 @@ RSpec.describe Msf::RPC::RpcJobStatusTracker do
             )
           end
         end
+
+        context 'The job result contains framework objects that cannot be JSON-serialized' do
+          let(:framework_object) do
+            klass = Class.new do
+              def initialize
+                @self_ref = self
+              end
+
+              def to_s
+                'framework-object-summary'
+              end
+            end
+            klass.new
+          end
+          let(:host_result) do
+            {
+              '192.0.2.10' => {
+                successful_logins: [framework_object],
+                successful_sessions: [framework_object],
+                banner: 'SMB 3.0'
+              }
+            }
+          end
+
+          before(:each) do
+            job_status_tracker.completed(job_id, host_result, mod)
+          end
+
+          it 'preserves the outer hash structure' do
+            stored = job_status_tracker.result(job_id)
+            expect(stored['result']['192.0.2.10']).to be_a(Hash)
+            expect(stored['result']['192.0.2.10'].keys)
+              .to include('successful_logins', 'successful_sessions', 'banner')
+          end
+
+          it 'stringifies non-primitive leaves via to_s' do
+            stored = job_status_tracker.result(job_id)
+            expect(stored['result']['192.0.2.10']['successful_logins'])
+              .to eq(['framework-object-summary'])
+            expect(stored['result']['192.0.2.10']['successful_sessions'])
+              .to eq(['framework-object-summary'])
+          end
+
+          it 'preserves JSON-primitive leaves as-is' do
+            stored = job_status_tracker.result(job_id)
+            expect(stored['result']['192.0.2.10']['banner']).to eq('SMB 3.0')
+          end
+
+          it 'does not fall through to the "could not be stored" fallback' do
+            expect(job_status_tracker.result(job_id)).not_to have_key('error')
+          end
+        end
+
+        context 'The job result contains a Msf::Exploit::CheckCode' do
+          let(:check_result) { Msf::Exploit::CheckCode::Vulnerable }
+          let(:mock_result) { { host: '192.0.2.10', check: check_result } }
+
+          before(:each) do
+            job_status_tracker.completed(job_id, mock_result, mod)
+          end
+
+          it 'preserves the CheckCode round-trip through JSON' do
+            stored = job_status_tracker.result(job_id)
+            expect(stored['result']['check']).to eq(check_result.to_json.then { |s| ::JSON.parse(s) })
+          end
+        end
+
+        context 'The job result preserves JSON primitive types' do
+          let(:mock_result) do
+            {
+              count: 3,
+              rate: 1.5,
+              found: true,
+              missing: nil,
+              tag: :scanner
+            }
+          end
+
+          before(:each) do
+            job_status_tracker.completed(job_id, mock_result, mod)
+          end
+
+          it 'preserves numbers, booleans, nil, and stringifies symbols per JSON conventions' do
+            stored = job_status_tracker.result(job_id)['result']
+            expect(stored['count']).to eq(3)
+            expect(stored['rate']).to eq(1.5)
+            expect(stored['found']).to be true
+            expect(stored['missing']).to be_nil
+            expect(stored['tag']).to eq('scanner')
+          end
+        end
       end
     end
   end

--- a/spec/lib/msf/core/rpc/v10/rpc_module_check_spec.rb
+++ b/spec/lib/msf/core/rpc/v10/rpc_module_check_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'msf/core/rpc/v10/rpc_module'
+require 'msf/core/rpc/v10/rpc_job_status_tracker'
+
+RSpec.describe Msf::RPC::RPC_Module, '#rpc_check propagates NotImplementedError from check_simple' do
+  let(:service) { double('Service') }
+  let(:job_status_tracker) { Msf::RPC::RpcJobStatusTracker.new }
+  let(:framework) { double('Framework', modules: modules) }
+  let(:modules) { double('ModuleManager') }
+  let(:rpc) do
+    instance = described_class.allocate
+    allow(instance).to receive(:framework).and_return(framework)
+    allow(instance).to receive(:job_status_tracker).and_return(job_status_tracker)
+    instance
+  end
+
+  context 'for an exploit module without a check method' do
+    it 'lets ::NotImplementedError propagate so the transport layer can surface a 500 with backtrace' do
+      mod = double('ExploitModule')
+      allow(modules).to receive(:create).with('exploit/multi/handler').and_return(mod)
+      allow(mod).to receive(:type).and_return('exploit')
+
+      unsupported_msg = Msf::Exploit::CheckCode::Unsupported.message
+      allow(Msf::Simple::Exploit).to receive(:check_simple).and_raise(::NotImplementedError.new(unsupported_msg))
+
+      expect { rpc.rpc_check('exploit', 'multi/handler', {}) }
+        .to raise_error(::NotImplementedError, unsupported_msg)
+    end
+  end
+
+  context 'for an auxiliary module without a check method' do
+    it 'lets ::NotImplementedError propagate so the transport layer can surface a 500 with backtrace' do
+      mod = double('AuxiliaryModule')
+      allow(modules).to receive(:create).with('auxiliary/scanner/portscan/tcp').and_return(mod)
+      allow(mod).to receive(:type).and_return('auxiliary')
+
+      unsupported_msg = Msf::Exploit::CheckCode::Unsupported.message
+      allow(Msf::Simple::Auxiliary).to receive(:check_simple).and_raise(::NotImplementedError.new(unsupported_msg))
+
+      expect { rpc.rpc_check('auxiliary', 'scanner/portscan/tcp', {}) }
+        .to raise_error(::NotImplementedError, unsupported_msg)
+    end
+  end
+
+  context 'job_listener wiring' do
+    it 'passes the RPC job_status_tracker via the job_listener: kwarg for exploit checks' do
+      mod = double('ExploitModule')
+      allow(modules).to receive(:create).with('exploit/multi/handler').and_return(mod)
+      allow(mod).to receive(:type).and_return('exploit')
+      allow(Msf::Simple::Exploit).to receive(:check_simple).and_return(['uuid', 1])
+
+      rpc.rpc_check('exploit', 'multi/handler', {})
+
+      expect(Msf::Simple::Exploit).to have_received(:check_simple).with(
+        mod,
+        hash_excluding('JobListener'),
+        job_listener: job_status_tracker
+      )
+    end
+
+    it 'passes the RPC job_status_tracker via the job_listener: kwarg for auxiliary checks' do
+      mod = double('AuxiliaryModule')
+      allow(modules).to receive(:create).with('auxiliary/scanner/portscan/tcp').and_return(mod)
+      allow(mod).to receive(:type).and_return('auxiliary')
+      allow(Msf::Simple::Auxiliary).to receive(:check_simple).and_return(['uuid', 1])
+
+      rpc.rpc_check('auxiliary', 'scanner/portscan/tcp', {})
+
+      expect(Msf::Simple::Auxiliary).to have_received(:check_simple).with(
+        mod,
+        hash_excluding('JobListener'),
+        job_listener: job_status_tracker
+      )
+    end
+  end
+end

--- a/spec/lib/msf/core/rpc/v10/rpc_module_execute_spec.rb
+++ b/spec/lib/msf/core/rpc/v10/rpc_module_execute_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'msf/core/rpc/v10/rpc_module'
+require 'msf/core/rpc/v10/rpc_job_status_tracker'
+
+RSpec.describe Msf::RPC::RPC_Module, '#rpc_execute returns uuid/job_id for all module types' do
+  let(:service) { double('Service') }
+  let(:job_status_tracker) { Msf::RPC::RpcJobStatusTracker.new }
+  let(:framework) { double('Framework', modules: modules) }
+  let(:modules) { double('ModuleManager') }
+  let(:rpc) do
+    instance = described_class.allocate
+    allow(instance).to receive(:framework).and_return(framework)
+    allow(instance).to receive(:job_status_tracker).and_return(job_status_tracker)
+    instance
+  end
+
+  shared_examples 'returns a hash with job_id and uuid' do |mtype, mname, simple_klass, simple_method|
+    it "returns { job_id, uuid } for #{mtype} modules" do
+      mod = double('Module', uuid: 'mod-uuid', job_id: 99, run_uuid: 'run-uuid')
+      allow(modules).to receive(:create).with("#{mtype}/#{mname}").and_return(mod)
+      allow(mod).to receive(:type).and_return(mtype)
+
+      allow(simple_klass).to receive(simple_method)
+
+      opts = mtype == 'exploit' ? { 'PAYLOAD' => 'generic/shell_reverse_tcp' } : {}
+      response = rpc.rpc_execute(mtype, mname, opts)
+      expect(response).to include('job_id', 'uuid')
+      expect(response['job_id']).to eq(99)
+      expect(response['uuid']).to eq('run-uuid')
+    end
+
+    it "passes the RPC job_status_tracker via the job_listener: kwarg for #{mtype} modules" do
+      mod = double('Module', uuid: 'mod-uuid', job_id: 99, run_uuid: 'run-uuid')
+      allow(modules).to receive(:create).with("#{mtype}/#{mname}").and_return(mod)
+      allow(mod).to receive(:type).and_return(mtype)
+      allow(simple_klass).to receive(simple_method)
+
+      opts = mtype == 'exploit' ? { 'PAYLOAD' => 'generic/shell_reverse_tcp' } : {}
+      rpc.rpc_execute(mtype, mname, opts)
+
+      expect(simple_klass).to have_received(simple_method).with(
+        mod,
+        hash_excluding('JobListener'),
+        job_listener: job_status_tracker
+      )
+    end
+  end
+
+  include_examples 'returns a hash with job_id and uuid',
+                   'exploit', 'multi/handler', Msf::Simple::Exploit, :exploit_simple
+  include_examples 'returns a hash with job_id and uuid',
+                   'auxiliary', 'scanner/portscan/tcp', Msf::Simple::Auxiliary, :run_simple
+
+  context 'for post modules' do
+    it 'returns the run uuid recorded on the module (not just mod.uuid)' do
+      mod = double('PostModule', uuid: 'mod-uuid', job_id: 11, run_uuid: 'run-uuid-post')
+      allow(modules).to receive(:create).with('post/multi/general/execute').and_return(mod)
+      allow(mod).to receive(:type).and_return('post')
+      allow(Msf::Simple::Post).to receive(:run_simple)
+
+      response = rpc.rpc_execute('post', 'multi/general/execute', {})
+      expect(response['uuid']).to eq('run-uuid-post')
+      expect(response['job_id']).to eq(11)
+    end
+
+    it 'passes the RPC job_status_tracker via the job_listener: kwarg' do
+      mod = double('PostModule', uuid: 'mod-uuid', job_id: 11, run_uuid: 'run-uuid-post')
+      allow(modules).to receive(:create).with('post/multi/general/execute').and_return(mod)
+      allow(mod).to receive(:type).and_return('post')
+      allow(Msf::Simple::Post).to receive(:run_simple)
+
+      rpc.rpc_execute('post', 'multi/general/execute', {})
+
+      expect(Msf::Simple::Post).to have_received(:run_simple).with(
+        mod,
+        hash_excluding('JobListener'),
+        job_listener: job_status_tracker
+      )
+    end
+  end
+
+  context 'for evasion modules' do
+    it 'returns the run uuid recorded on the module (not just mod.uuid)' do
+      mod = double('EvasionModule', uuid: 'mod-uuid', job_id: 22, run_uuid: 'run-uuid-evasion')
+      allow(modules).to receive(:create).with('evasion/windows/applocker_evasion_msbuild').and_return(mod)
+      allow(mod).to receive(:type).and_return('evasion')
+      allow(Msf::Simple::Evasion).to receive(:run_simple)
+
+      response = rpc.rpc_execute('evasion', 'windows/applocker_evasion_msbuild', {})
+      expect(response['uuid']).to eq('run-uuid-evasion')
+      expect(response['job_id']).to eq(22)
+    end
+
+    it 'passes the RPC job_status_tracker via the job_listener: kwarg' do
+      mod = double('EvasionModule', uuid: 'mod-uuid', job_id: 22, run_uuid: 'run-uuid-evasion')
+      allow(modules).to receive(:create).with('evasion/windows/applocker_evasion_msbuild').and_return(mod)
+      allow(mod).to receive(:type).and_return('evasion')
+      allow(Msf::Simple::Evasion).to receive(:run_simple)
+
+      rpc.rpc_execute('evasion', 'windows/applocker_evasion_msbuild', {})
+
+      expect(Msf::Simple::Evasion).to have_received(:run_simple).with(
+        mod,
+        hash_excluding('JobListener'),
+        job_listener: job_status_tracker
+      )
+    end
+  end
+
+  context 'when run_uuid is not set on the module' do
+    it 'returns nil for the uuid field' do
+      mod = double('PostModule', uuid: 'mod-uuid', job_id: 11, run_uuid: nil)
+      allow(modules).to receive(:create).with('post/multi/general/execute').and_return(mod)
+      allow(mod).to receive(:type).and_return('post')
+      allow(Msf::Simple::Post).to receive(:run_simple)
+
+      response = rpc.rpc_execute('post', 'multi/general/execute', {})
+      expect(response['uuid']).to be_nil
+    end
+  end
+
+  context 'structural options validation (defence-in-depth for non-MCP callers)' do
+    it 'accepts a well-formed options hash with scalar values' do
+      mod = double('Module', uuid: 'u', job_id: 1, run_uuid: 'r', type: 'auxiliary')
+      allow(modules).to receive(:create).with('auxiliary/scanner/portscan/tcp').and_return(mod)
+      allow(Msf::Simple::Auxiliary).to receive(:run_simple)
+
+      opts = { 'RHOSTS' => '192.0.2.1', 'RPORT' => 445, 'VERBOSE' => true, 'TIMEOUT' => 3.5, 'NOTES' => nil }
+      expect { rpc.rpc_execute('auxiliary', 'scanner/portscan/tcp', opts) }.not_to raise_error
+    end
+
+    it 'rejects non-Hash options with a 400 error' do
+      expect { rpc.rpc_execute('exploit', 'multi/handler', 'not-a-hash') }
+        .to raise_error(Msf::RPC::Exception, /Module options must be a Hash/)
+    end
+
+    it 'rejects a nested Hash value' do
+      opts = { 'RHOSTS' => { 'nested' => 'value' } }
+      expect { rpc.rpc_execute('auxiliary', 'scanner/portscan/tcp', opts) }
+        .to raise_error(Msf::RPC::Exception, /must be a scalar/)
+    end
+
+    it 'rejects an Array value' do
+      opts = { 'RHOSTS' => ['a', 'b'] }
+      expect { rpc.rpc_execute('auxiliary', 'scanner/portscan/tcp', opts) }
+        .to raise_error(Msf::RPC::Exception, /must be a scalar/)
+    end
+
+    it 'rejects a non-String/Symbol key' do
+      opts = { 42 => 'x' }
+      expect { rpc.rpc_execute('auxiliary', 'scanner/portscan/tcp', opts) }
+        .to raise_error(Msf::RPC::Exception, /Invalid module option key type/)
+    end
+
+    it 'rejects an oversized key' do
+      opts = { ('K' * 200) => 'x' }
+      expect { rpc.rpc_execute('auxiliary', 'scanner/portscan/tcp', opts) }
+        .to raise_error(Msf::RPC::Exception, /key too long/)
+    end
+
+    it 'rejects an oversized String value' do
+      opts = { 'BIG' => 'x' * (Msf::RPC::RPC_Module::RPC_MODULE_OPTIONS_VALUE_MAX_BYTES + 1) }
+      expect { rpc.rpc_execute('auxiliary', 'scanner/portscan/tcp', opts) }
+        .to raise_error(Msf::RPC::Exception, /exceeds .* bytes/)
+    end
+
+    it 'rejects an options hash with too many keys' do
+      opts = Array.new(Msf::RPC::RPC_Module::RPC_MODULE_OPTIONS_MAX_KEYS + 1) { |i| ["K#{i}", 'v'] }.to_h
+      expect { rpc.rpc_execute('auxiliary', 'scanner/portscan/tcp', opts) }
+        .to raise_error(Msf::RPC::Exception, /too many keys/)
+    end
+
+    it 'rejects nil options with a 400 error' do
+      expect { rpc.rpc_execute('auxiliary', 'scanner/portscan/tcp', nil) }
+        .to raise_error(Msf::RPC::Exception, /Module options must be a Hash/)
+    end
+  end
+end

--- a/spec/lib/msf/core/rpc/v10/rpc_session_spec.rb
+++ b/spec/lib/msf/core/rpc/v10/rpc_session_spec.rb
@@ -158,6 +158,36 @@ RSpec.describe Msf::RPC::RPC_Session do
     end
   end
 
+  shared_examples 'interactive shell read' do
+    let(:expected_data) { 'test response' }
+
+    before do
+      allow(rstream).to receive(:get_once).and_return(expected_data)
+    end
+
+    it 'returns expected data' do
+      expect(response).to eq({ 'data' => expected_data })
+    end
+  end
+
+  shared_examples 'interactive shell write' do
+    let(:test_command) { 'help' }
+
+    it 'writes the command with a trailing newline and returns success' do
+      expect(rstream).to receive(:write).with("#{test_command}\n").and_return(test_command.length + 1)
+      expect(response).to eq({ 'result' => 'success' })
+    end
+
+    context 'when the input already ends with a newline' do
+      let(:test_command) { "help\n" }
+
+      it 'does not append an extra newline' do
+        expect(rstream).to receive(:write).with(test_command).and_return(test_command.length)
+        expect(response).to eq({ 'result' => 'success' })
+      end
+    end
+  end
+
   describe '#rpc_compatible_modules' do
     context 'when the session does not exist' do
       let(:session) { meterpreter_session }
@@ -195,11 +225,13 @@ RSpec.describe Msf::RPC::RPC_Session do
     end
 
     context 'with shell session' do
-      let(:session) { shell_session }
-
-      it 'raises an error' do
-        expect { response }.to raise_error(Msf::RPC::Exception)
+      let(:session) do
+        session = Msf::Sessions::CommandShell.new(rstream)
+        session.framework = framework
+        session
       end
+
+      it_behaves_like 'interactive shell read'
     end
   end
 
@@ -221,11 +253,13 @@ RSpec.describe Msf::RPC::RPC_Session do
     end
 
     context 'with shell session' do
-      let(:session) { shell_session }
-
-      it 'raises an error' do
-        expect { response }.to raise_error(Msf::RPC::Exception)
+      let(:session) do
+        session = Msf::Sessions::CommandShell.new(rstream)
+        session.framework = framework
+        session
       end
+
+      it_behaves_like 'interactive shell read'
     end
   end
 
@@ -303,11 +337,13 @@ RSpec.describe Msf::RPC::RPC_Session do
     subject(:response) { rpc.rpc_interactive_write(target_sid, test_command) }
 
     context 'with shell session' do
-      let(:session) { shell_session }
-
-      it 'raises error' do
-        expect { response }.to raise_error(Msf::RPC::Exception)
+      let(:session) do
+        session = Msf::Sessions::CommandShell.new(rstream)
+        session.framework = framework
+        session
       end
+
+      it_behaves_like 'interactive shell write'
     end
 
     context 'with meterpreter session' do
@@ -329,11 +365,13 @@ RSpec.describe Msf::RPC::RPC_Session do
     subject(:response) { rpc.rpc_meterpreter_write(target_sid, test_command) }
 
     context 'with shell session' do
-      let(:session) { shell_session }
-
-      it 'raises error' do
-        expect { response }.to raise_error(Msf::RPC::Exception)
+      let(:session) do
+        session = Msf::Sessions::CommandShell.new(rstream)
+        session.framework = framework
+        session
       end
+
+      it_behaves_like 'interactive shell write'
     end
 
     context 'with meterpreter session' do

--- a/spec/lib/msf/core/rpc/v10/rpc_session_spec.rb
+++ b/spec/lib/msf/core/rpc/v10/rpc_session_spec.rb
@@ -188,6 +188,21 @@ RSpec.describe Msf::RPC::RPC_Session do
     end
   end
 
+  shared_examples 'rejects non-String data with 400' do
+    [nil, 42, ['array'], { key: 'value' }].each do |bad_input|
+      context "when data is #{bad_input.inspect}" do
+        let(:test_command) { bad_input }
+
+        it 'raises Msf::RPC::Exception with code 400' do
+          expect { response }.to raise_error(Msf::RPC::Exception) do |e|
+            expect(e.code).to eq(400)
+            expect(e.message).to eq('Data must be a String')
+          end
+        end
+      end
+    end
+  end
+
   describe '#rpc_compatible_modules' do
     context 'when the session does not exist' do
       let(:session) { meterpreter_session }
@@ -317,17 +332,21 @@ RSpec.describe Msf::RPC::RPC_Session do
         session
       end
 
-      before do
-        allow(rstream).to receive(:write).with(test_command).and_return(test_command.length)
+      context 'with valid String input' do
+        before do
+          allow(rstream).to receive(:write).with(test_command).and_return(test_command.length)
+        end
+
+        it "doesn't raise an error" do
+          expect { response }.not_to raise_error
+        end
+
+        it 'returns write_count data' do
+          expect(response).to eq({ 'write_count' => test_command.length.to_s })
+        end
       end
 
-      it "doesn't raise an error" do
-        expect { response }.not_to raise_error
-      end
-
-      it 'returns write_count data' do
-        expect(response).to eq({ 'write_count' => test_command.length.to_s })
-      end
+      it_behaves_like 'rejects non-String data with 400'
     end
   end
 
@@ -344,18 +363,21 @@ RSpec.describe Msf::RPC::RPC_Session do
       end
 
       it_behaves_like 'interactive shell write'
+      it_behaves_like 'rejects non-String data with 400'
     end
 
     context 'with meterpreter session' do
       let(:session) { meterpreter_session }
 
       it_behaves_like 'interactive write'
+      it_behaves_like 'rejects non-String data with 400'
     end
 
     context 'with postgresql session' do
       let(:session) { postgresql_session }
 
       it_behaves_like 'interactive write'
+      it_behaves_like 'rejects non-String data with 400'
     end
   end
 
@@ -372,18 +394,37 @@ RSpec.describe Msf::RPC::RPC_Session do
       end
 
       it_behaves_like 'interactive shell write'
+      it_behaves_like 'rejects non-String data with 400'
     end
 
     context 'with meterpreter session' do
       let(:session) { meterpreter_session }
 
       it_behaves_like 'interactive write'
+      it_behaves_like 'rejects non-String data with 400'
     end
 
     context 'with postgresql session' do
       let(:session) { postgresql_session }
 
       it_behaves_like 'interactive write'
+      it_behaves_like 'rejects non-String data with 400'
+    end
+  end
+
+  describe '#rpc_ring_put' do
+    let(:test_command) { 'help' }
+
+    subject(:response) { rpc.rpc_ring_put(target_sid, test_command) }
+
+    context 'with shell session' do
+      let(:session) do
+        session = Msf::Sessions::CommandShell.new(rstream)
+        session.framework = framework
+        session
+      end
+
+      it_behaves_like 'rejects non-String data with 400'
     end
   end
 end

--- a/spec/lib/msf/exploit/local_spec.rb
+++ b/spec/lib/msf/exploit/local_spec.rb
@@ -53,4 +53,26 @@ RSpec.describe Msf::Exploit::Local do
       end
     end
   end
+
+  describe '#run_simple' do
+    it 'accepts a job_listener keyword argument defaulting to the noop listener' do
+      expect(described_class.instance_method(:run_simple).parameters).to include(%i[key job_listener])
+    end
+
+    it 'forwards opts and job_listener: to Msf::Simple::Exploit.exploit_simple' do
+      listener = double('JobListener')
+      opts = { 'SESSION' => 1 }
+      expect(Msf::Simple::Exploit).to receive(:exploit_simple).with(subject, opts, job_listener: listener)
+      subject.run_simple(opts, job_listener: listener)
+    end
+
+    it 'defaults job_listener to Msf::Simple::NoopJobListener.instance when omitted' do
+      expect(Msf::Simple::Exploit).to receive(:exploit_simple).with(
+        subject,
+        {},
+        job_listener: Msf::Simple::NoopJobListener.instance
+      )
+      subject.run_simple
+    end
+  end
 end


### PR DESCRIPTION
## Description

This PR adds support to job tracking for all module types when run through the RPC endpoints. This is required for the new MCP tools that were added and submitted in a separate PR. Particularly:
- adds a `job_listener:` kwarg to `run_simple` / `check_simple` for exploit, auxiliary, post and evasion modules
- exposes `Msf::Module#run_uuid`
- threads the resulting UUID through `Msf::ExploitDriver` and `Msf::EvasionDriver` so RunAsJob paths return `[uuid, job_id]` uniformly.

This also fixes two issues:
- fix RPC `module.check` `NotImplementedError` handling and JSON-RPC regression
- fix RPC `session.interactive_read/write` for non-meterpreter sessions


**Related Issue:** 
Orignial PR: https://github.com/rapid7/metasploit-framework/pull/21632

## Breaking Changes
- `module.execute` / `module.check` RPC endpoints: `uuid` field now returns `run_uuid`, not `mod.uuid`
- `module.execute` / `module.check` RPC endpoints: new input validation on opts
- `module.results`: status code for unknown UUID changed from 404 to 500
- `module.results` result payload is now JSON-sanitised
- `service.rb`: `ScriptError` (incl. `NotImplementedError`) is now caught at the RPC entry point

## Reviewer Notes

This comes from this [PR](https://github.com/rapid7/metasploit-framework/pull/21632). I have extracted the RPC/Framework changes here, as requested. The MCP-related code is in a separate [PR](https://github.com/rapid7/metasploit-framework/pull/21654).

## Verification Steps

Setup a simple target with docker:
- **Dockerfile**
```dockerfile
FROM php:7.2-apache

LABEL MAINTAINER="phithon <root@leavesongs.com>"

RUN set -ex \
        && echo 'deb http://archive.debian.org/debian/ buster main contrib non-free' > /etc/apt/sources.list \
        && echo 'deb http://archive.debian.org/debian-security buster/updates main contrib non-free' >> /etc/apt/sources.list \
        && echo 'deb http://archive.debian.org/debian/ buster-updates main contrib non-free' >> /etc/apt/sources.list \
        && apt-get update \
        && apt-get install -y --no-install-recommends unzip \
        && rm -rf /var/lib/apt/lists/*

ENV APACHE_DOCUMENT_ROOT=/var/www/public

RUN set -ex \
    && cd /var/www \
    && rm -rf * \
    && curl -#SL https://github.com/top-think/think/archive/v5.0.23.tar.gz | tar zx --strip-components=1 \
    && sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
    && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf

COPY composer.json /var/www/

RUN set -ex \
    && cd /var/www \
    && curl -#sSL https://getcomposer.org/download/2.3.10/composer.phar -o composer.phar \
    && php composer.phar install \
    && php composer.phar require "topthink/think-captcha:^1.0" \
    && chown www-data:www-data -R .

WORKDIR /var/www/public
```

- **docker-compose.yml**
```yaml
services:
 web:
   build: .
   image: thinkphp:5.0.23
   ports:
    - "8080:80"
```

- Start it with `docker compose up`


1. - [x] Start the RPC server: `./msfrpcd -f -U msfuser -P 123456 -p 55553 -a 127.0.0.1`
2. - [x] Start the RPC client: `./msfrpc -a 127.0.0.1 -U msfuser -P 123456`
3. - [x] Run an exploit module from the client: `rpc.call('module.execute', 'exploit', 'unix/webapp/thinkphp_rce', {'LHOST' => '192.168.4.4', 'RPORT'=>8080, 'RHOSTS'=>'127.0.0.1', 'SRVPORT'=>8888})`
4. - [x] Verify the 24-character UUID is returned.
5. - [x] Check the status with `module.running_stats`: `rpc.call('module.running_stats')`
6. - [x] Verify the 24-character UUID is part of `waiting`, `running` or `results` arrays
7. - [x] Check the results: `rpc.call('module.results', <UUID>)`
8. - [x] List sessions: `rpc.call('session.list')`
9. - [x] Send command to the interactive session: `rpc.call('session.interactive_write', <sessionID>, "sysinfo")`
10. - [x] Read the result: `rpc.call('session.interactive_read', 1)`
11. - [x] Redo these tests with other module types (auxiliary, post, evasion, local)
12. - [x] Test other session types (SMB, LDAP, shell, etc.)
13. - [x] From a Meterpreter session, open a shell interactive channel: rpc.call('session.interactive_write', <sessionID>, "shell")` and run shell commands.
14. - [x] Test the check methods: `rpc.call('module.check', 'exploit', 'unix/webapp/thinkphp_rce', {'LHOST' => '192.168.4.4', 'RPORT'=>8080, 'RHOSTS'=>'127.0.0.1', 'SRVPORT'=>8888})`


## Test Evidence

```
✗ ./msfrpc -a 127.0.0.1 -U msfuser -P 123456
[*] The 'rpc' object holds the RPC client interface
[*] Use rpc.call('group.command') to make RPC calls

>> rpc.call('module.execute', 'exploit', 'unix/webapp/thinkphp_rce', {'LHOST' => '192.168.4.4', 'RPORT'=>8080, 'RHOSTS'=>'127.0.0.1', 'SRVPORT'=>8888})
=> {"job_id"=>0, "uuid"=>"WWQ8hMcMz34PITDJaitmodB2"}
>> rpc.call('module.running_stats')
=> {"waiting"=>[], "running"=>[], "results"=>["WWQ8hMcMz34PITDJaitmodB2"]}
>> rpc.call('module.results', 'WWQ8hMcMz34PITDJaitmodB2')
=>
{"status"=>"completed",
 "result"=>"Meterpreter session 1 opened (192.168.4.4:4444 -> 192.168.4.4:62031) at 2026-07-07 14:56:54 +0200"}
>> rpc.call('session.list')
=>
{1=>
  {"type"=>"meterpreter",
   "tunnel_local"=>"192.168.4.4:4444",
   "tunnel_peer"=>"192.168.4.4:62031",
   "via_exploit"=>"exploit/unix/webapp/thinkphp_rce",
   "via_payload"=>"payload/linux/x64/meterpreter/reverse_tcp",
   "desc"=>"Meterpreter",
   "info"=>"www-data @ 346322c4470a",
   "workspace"=>"default",
   "session_host"=>"127.0.0.1",
   "session_port"=>8080,
   "target_host"=>"127.0.0.1",
   "username"=>"cdelafuente",
   "uuid"=>"sv3slrjf",
   "exploit_uuid"=>"vk6x5j81",
   "routes"=>"",
   "arch"=>"x64",
   "platform"=>"linux"}}
>> rpc.call('session.interactive_write', 1, "sysinfo")
=> {"result"=>"success"}
>> rpc.call('session.interactive_read', 1)
=>
{"data"=>
  "Computer     : 346322c4470a\nOS           : Debian 10.7 (Linux 6.12.76-linuxkit)\nArchitecture : x64\nBuildTuple   : x86_64-linux-musl\nMeterpreter  : x64/linux\n"}
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | OSX |
| **Target Software/Hardware** | Vulnerable ThinkPHP docker instance |
| **Docker Image / Vagrant Setup** | See  the Verification Steps |

## AI Usage Disclosure

Copilot has been used to assist.


## Pre-Submission Checklist

- [] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [X] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [X] Tested on the target environment specified in the Environment section above
- [X] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [X] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)


<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
