### PR TITLE
Use Puma::Server instead of Puma::Launcher to fix Ctrl+C handling

### DIFF
--- a/lib/msf/core/mcp/application.rb
+++ b/lib/msf/core/mcp/application.rb
@@ -46,6 +46,7 @@ module Msf::MCP
       authenticate_metasploit
       initialize_mcp_server
       start_mcp_server
+    rescue Interrupt
     rescue Msf::MCP::Config::ValidationError, Msf::MCP::Config::ConfigurationError => e
       handle_configuration_error(e)
     rescue Msf::MCP::Metasploit::ConnectionError => e

--- a/lib/msf/core/mcp/server.rb
+++ b/lib/msf/core/mcp/server.rb
@@ -132,6 +132,7 @@ module Msf::MCP
     def start_http(host, port, auth_token, min_threads: PUMA_MIN_THREADS, max_threads: PUMA_MAX_THREADS, workers: PUMA_WORKERS)
       require 'rack'
       require 'puma'
+      require 'puma/configuration'
       require 'puma/server'
       require 'puma/log_writer'
 

--- a/lib/msf/core/mcp/server.rb
+++ b/lib/msf/core/mcp/server.rb
@@ -87,12 +87,12 @@ module Msf::MCP
     # Shutdown the MCP server and cleanup resources
     #
     def shutdown
-      @puma_launcher&.stop
+      @puma_server&.stop(true)
     rescue StandardError => e
       elog({ message: 'Error stopping Puma', exception: e }, LOG_SOURCE, LOG_ERROR)
     ensure
       @puma_log_io&.close
-      @puma_launcher = nil
+      @puma_server = nil
       @puma_log_io = nil
       @msf_client&.shutdown
       @mcp_server = nil
@@ -130,8 +130,7 @@ module Msf::MCP
     def start_http(host, port, auth_token, min_threads: PUMA_MIN_THREADS, max_threads: PUMA_MAX_THREADS, workers: PUMA_WORKERS)
       require 'rack'
       require 'puma'
-      require 'puma/configuration'
-      require 'puma/launcher'
+      require 'puma/server'
       require 'puma/log_writer'
 
       transport = ::MCP::Server::Transports::StreamableHTTPTransport.new(@mcp_server)
@@ -147,26 +146,25 @@ module Msf::MCP
       # Use Puma's server API directly so we can stop it gracefully on shutdown.
       bind_host = host.include?(':') ? "[#{host}]" : host
       @puma_log_io = File.open(File::NULL, 'w')
-      begin
-        puma_config = Puma::Configuration.new do |config|
-          config.bind "tcp://#{bind_host}:#{port}"
-          config.threads min_threads, max_threads
-          config.workers workers
-          config.log_requests false
-          config.app rack_app
-        end
 
+      begin
         # Suppress Puma's startup banner by providing a silent log writer
         log_writer = Puma::LogWriter.new(@puma_log_io, @puma_log_io)
-        @puma_launcher = Puma::Launcher.new(puma_config, log_writer: log_writer)
-        @puma_launcher.run
+
+        @puma_server = Puma::Server.new(rack_app, nil, {
+          log_writer: log_writer,
+          min_threads: min_threads,
+          max_threads: max_threads
+        })
+        @puma_server.add_tcp_listener(bind_host, port)
+        @puma_server.run.join
       rescue StandardError
         begin
-          @puma_launcher&.stop
+          @puma_server&.stop(true)
         rescue StandardError
           nil
         end
-        @puma_launcher = nil
+        @puma_server = nil
         @puma_log_io&.close
         @puma_log_io = nil
         raise

--- a/lib/msf/core/mcp/server.rb
+++ b/lib/msf/core/mcp/server.rb
@@ -88,11 +88,13 @@ module Msf::MCP
     #
     def shutdown
       @puma_server&.stop(true)
+      @puma_launcher&.stop
     rescue StandardError => e
       elog({ message: 'Error stopping Puma', exception: e }, LOG_SOURCE, LOG_ERROR)
     ensure
       @puma_log_io&.close
       @puma_server = nil
+      @puma_launcher = nil
       @puma_log_io = nil
       @msf_client&.shutdown
       @mcp_server = nil
@@ -146,25 +148,41 @@ module Msf::MCP
       # Use Puma's server API directly so we can stop it gracefully on shutdown.
       bind_host = host.include?(':') ? "[#{host}]" : host
       @puma_log_io = File.open(File::NULL, 'w')
-
       begin
-        # Suppress Puma's startup banner by providing a silent log writer
         log_writer = Puma::LogWriter.new(@puma_log_io, @puma_log_io)
 
-        @puma_server = Puma::Server.new(rack_app, nil, {
-          log_writer: log_writer,
-          min_threads: min_threads,
-          max_threads: max_threads
-        })
-        @puma_server.add_tcp_listener(bind_host, port)
-        @puma_server.run.join
+        if workers.to_i > 0
+          require 'puma/configuration'
+          require 'puma/launcher'
+
+          puma_config = Puma::Configuration.new do |config|
+            config.bind "tcp://#{bind_host}:#{port}"
+            config.threads min_threads, max_threads
+            config.workers workers
+            config.log_requests false
+            config.app rack_app
+          end
+
+          @puma_launcher = Puma::Launcher.new(puma_config, log_writer: log_writer)
+          @puma_launcher.run
+        else
+          @puma_server = Puma::Server.new(rack_app, nil, {
+            log_writer: log_writer,
+            min_threads: min_threads,
+            max_threads: max_threads
+          })
+          @puma_server.add_tcp_listener(bind_host, port)
+          @puma_server.run.join
+        end
       rescue StandardError
         begin
           @puma_server&.stop(true)
+          @puma_launcher&.stop
         rescue StandardError
           nil
         end
         @puma_server = nil
+        @puma_launcher = nil
         @puma_log_io&.close
         @puma_log_io = nil
         raise

--- a/spec/lib/msf/core/mcp/server_spec.rb
+++ b/spec/lib/msf/core/mcp/server_spec.rb
@@ -186,12 +186,10 @@ RSpec.describe Msf::MCP::Server do
       before do
         require 'rack'
         require 'puma'
-        require 'puma/configuration'
-        require 'puma/launcher'
+        require 'puma/server'
         require 'puma/log_writer'
 
-        stub_const('Puma::Configuration', puma_config_class)
-        stub_const('Puma::Launcher', puma_launcher_class)
+        stub_const('Puma::Server', puma_server_class)
         stub_const('Puma::LogWriter', puma_log_writer_class)
 
         allow(::MCP::Server::Transports::StreamableHTTPTransport).to receive(:new).and_return(mock_http_transport)
@@ -206,30 +204,24 @@ RSpec.describe Msf::MCP::Server do
         server.shutdown
       end
 
-      let(:puma_config_class) do
+      let(:puma_server_class) do
         Class.new do
-          attr_reader :bound_url
+          attr_reader :bound_host, :bound_port
 
-          def initialize(&block)
-            block.call(self) if block
+          def initialize(_app, _events = nil, _options = {}); end
+
+          def add_tcp_listener(host, port, *_rest)
+            @bound_host = host
+            @bound_port = port
           end
 
-          def bind(url)
-            @bound_url = url
+          def run
+            self
           end
 
-          def threads(_min, _max); end
-          def workers(_n); end
-          def log_requests(_v); end
-          def app(_a = nil); end
-        end
-      end
+          def join; end
 
-      let(:puma_launcher_class) do
-        Class.new do
-          def initialize(_config, **_opts); end
-          def run; end
-          def stop; end
+          def stop(*_args); end
         end
       end
 
@@ -245,36 +237,38 @@ RSpec.describe Msf::MCP::Server do
         server.start(transport: :http, port: 3000)
       end
 
-      it 'starts Puma via Launcher' do
-        expect(puma_launcher_class).to receive(:new).and_call_original
+      it 'starts Puma via Server' do
+        expect(puma_server_class).to receive(:new).and_call_original
 
         server.start(transport: :http, port: 3000)
       end
 
       it 'binds to the configured host and port' do
-        config_instance = nil
-        allow(puma_config_class).to receive(:new) do |&block|
-          config_instance = puma_config_class.allocate
-          config_instance.send(:initialize, &block)
-          config_instance
+        server_instance = nil
+        allow(puma_server_class).to receive(:new) do |*args|
+          server_instance = puma_server_class.allocate
+          server_instance.send(:initialize, *args)
+          server_instance
         end
 
         server.start(transport: :http, port: 8080, host: '0.0.0.0')
 
-        expect(config_instance.bound_url).to eq('tcp://0.0.0.0:8080')
+        expect(server_instance.bound_host).to eq('0.0.0.0')
+        expect(server_instance.bound_port).to eq(8080)
       end
 
       it 'wraps IPv6 hosts in brackets for the bind URL' do
-        config_instance = nil
-        allow(puma_config_class).to receive(:new) do |&block|
-          config_instance = puma_config_class.allocate
-          config_instance.send(:initialize, &block)
-          config_instance
+        server_instance = nil
+        allow(puma_server_class).to receive(:new) do |*args|
+          server_instance = puma_server_class.allocate
+          server_instance.send(:initialize, *args)
+          server_instance
         end
 
         server.start(transport: :http, port: 3000, host: '::1')
 
-        expect(config_instance.bound_url).to eq('tcp://[::1]:3000')
+        expect(server_instance.bound_host).to eq('[::1]')
+        expect(server_instance.bound_port).to eq(3000)
       end
 
       it 'creates a Rack application' do
@@ -615,10 +609,16 @@ RSpec.describe Msf::MCP::Server do
       require 'puma/configuration'
       require 'puma/dsl'
       require 'puma/launcher'
+      require 'puma/server'
       require 'puma/log_writer'
 
       allow(::MCP::Server::Transports::StreamableHTTPTransport).to receive(:new).and_return(mock_http_transport)
       allow(Puma::Launcher).to receive(:new).and_return(instance_double(Puma::Launcher, run: nil, stop: nil))
+      mock_puma_thread = instance_double(Thread, join: nil)
+      allow(Puma::Server).to receive(:new) do |app, *_rest|
+        @rack_app = app
+        instance_double(Puma::Server, add_tcp_listener: nil, run: mock_puma_thread, stop: nil)
+      end
       allow_any_instance_of(Puma::DSL).to receive(:app).and_wrap_original do |method, rack_app = nil|
         @rack_app = rack_app if rack_app
         method.call(rack_app)


### PR DESCRIPTION
Puma::Launcher installs process-wide SIGINT/SIGTERM signal traps as part of its startup, intended for when Puma owns the entire process (e.g. run standalone via the `puma` CLI). Since the MCP server runs on a background thread inside msfconsole (spawned via `framework.threads.spawn`), these traps are process-global and silently override msfconsole's own Ctrl+C handling, which relies on Ruby's default `Interrupt` behavior.

This swaps `Puma::Launcher` for `Puma::Server`, the lower-level, embeddable API. `Puma::Server` does not install any signal traps, making it safe to run inside a host process like msfconsole. Also updated `shutdown` to call `.stop(true)` directly on the server for graceful shutdown.

### Related Issue:

Fixes #21650

### Verification Steps:

1. - [x] Load the `mcp` plugin, run `mcp start`, then press Ctrl+C. Expected: console prints `Interrupt: use the 'exit' command to quit` (matching normal msfconsole behavior), rather than doing nothing.
2. - [x] With the server running, run `mcp stop`. Expected: prints `MCP server stopped` cleanly with no hang or error.
3. - [x] Run `mcp start` followed by `mcp restart`. Expected: server restarts cleanly without error.

### Test Evidence:

msf > load mcp
[*] MCP plugin loaded. Use mcp start to start the server.
[*] Successfully loaded plugin: mcp
msf > mcp start
[*] Auto-started msgrpc - User: msf, Pass: [redacted]
[*] MCP server started on localhost:3000 (transport: http)
msf > Interrupt: use the 'exit' command to quit
msf > mcp stop
[*] MCP server stopped
msf > mcp start
[*] MCP server started on localhost:3000 (transport: http)
msf > mcp restart
[*] MCP server started on localhost:3000 (transport: http)

### Environment:

| Operating System                | Ubuntu 24.04 |
| Target Software/Hardware | N/A |

### AI Usage Disclosure:

Used AI to help identify the root cause and draft the fix. All testing and verification was done manually by me.

### Pre-Submission Checklist: 

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Read the CONTRIBUTING.md and module acceptance guidelines

### Reviewer Notes

Wasn't able to get the full local RSpec suite passing due to an unrelated local Postgres/msfdb environment setup issue on my machine  verified manually instead (see Test Evidence). Happy to dig further if CI surfaces anything.
