### PR TITLE
Fix office_word_macro payload compatibility

### DIFF
--- a/modules/exploits/multi/fileformat/office_word_macro.rb
+++ b/modules/exploits/multi/fileformat/office_word_macro.rb
@@ -39,6 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
             'Microsoft Office Word on Windows',
             {
               'Platform' => 'win',
+              'Arch' => [ ARCH_X86, ARCH_X64 ]
             }
           ],
           [


### PR DESCRIPTION
## Fix office_word_macro Windows payload compatibility

### Description

The `exploit/multi/fileformat/office_word_macro` module no longer exposed Windows payloads with newer Metasploit Framework versions.

The Windows target only defined:

```ruby
'Platform' => 'win'
```

Without an explicit architecture declaration, the payload compatibility resolver filtered out Windows payloads such as Meterpreter payloads.

This change adds:
```ruby
'Arch' => [ ARCH_X86, ARCH_X64 ]
```
to the Windows target definition.

### Problem

Before this change:
```ruby
msf> exploit(multi/fileformat/office_word_macro) > show payloads

Compatible Payloads
===================

generic/shell_reverse_tcp
generic/shell_bind_tcp
...
```
Attempting to use a Windows payload resulted in:
```ruby
[-] Exploit failed: windows/meterpreter/reverse_tcp is not a compatible payload.
```
After adding the architecture information, Windows payloads are correctly available.

### Verification

Tested with:
```ruby
msfconsole
use exploit/multi/fileformat/office_word_macro
set TARGET 0
show payloads
```
Expected result:

Windows payloads are listed as compatible.

Tested payload selection:
```ruby
set payload windows/meterpreter/reverse_tcp
```
Result:

The module successfully generates the Office document.

Testing
 - Tested locally with Metasploit Framework 6.4.142
 - Verified payload compatibility list before and after the change
 - Verified Windows payload selection after the patch
 - Office word macro document generated and successfully executed on windows target