### PR TITLE
Fix icpr_cert module error handling with missing HRESULT

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,7 +682,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     win32api (0.1.0)
-    windows_error (0.1.5)
+    windows_error (0.1.6)
     winrm (2.3.9)
       builder (>= 2.1.2)
       erubi (~> 1.8)

--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -110,7 +110,7 @@ module Exploit::Remote::MsIcpr
     else
       print_error('There was an error while requesting the certificate.')
       print_error(response[:disposition_message].strip.to_s) unless response[:disposition_message].blank?
-      hresult = ::WindowsError::HResult.find_by_retval(response[:disposition]).first
+      hresult = ::WindowsError::HResult.find_by_retval(response[:disposition])&.first
 
       if hresult
         print_error('Error details:')
@@ -126,7 +126,15 @@ module Exploit::Remote::MsIcpr
       when ::WindowsError::HResult::CERTSRV_E_UNSUPPORTED_CERT_TYPE
         raise MsIcprNotFoundError.new(hresult.description)
       else
-        raise MsIcprUnknownError.new(hresult.description)
+        if hresult
+          message = "#{hresult.description} (0x#{response[:disposition].to_i.to_s(16).rjust(8, '0')})"
+        elsif response[:disposition]
+          message = "Unknown HRESULT 0x#{response[:disposition].to_s(16).rjust(8, '0')}"
+        else
+          message = "Unknown error, no disposition code"
+        end
+
+        raise MsIcprUnknownError.new(message)
       end
     end
 


### PR DESCRIPTION
## Description

A crash was privately reported to me where the icpr_cert module was failing due to the `hresult` being `nil` becuase the constant didn't exist. When the reporter shared it with me, it was a win32 error with the win32 facility. The changes in this PR handle future, hypothetical scenarios where the `hresult` lookup fails so you at least get the hex value and can Google (ChatGPT?) it.

There's also a gemfile bump that pulls in changes to the windows_error gem which adds lookups for the win32 error code when the facility is win32. These changes are in https://github.com/rapid7/windows_error/pull/9

**Related Issue:** N/A this was privately reported to me

## Breaking Changes

None

## Reviewer Notes

## Verification Steps

I wasn't able to reproduce the exact conditions where the `hresult` would be nil but there's not much to the logic here. It's pretty straight forward to see that `.find_by_retval` can return `nil` and then that accessing the message on it would cause a crash.

1. - [ ] 



## Test Evidence

```
msf auxiliary(admin/dcerpc/icpr_cert) > show options 

Module options (auxiliary/admin/dcerpc/icpr_cert):

   Name                 Current Setting  Required  Description
   ----                 ---------------  --------  -----------
   ADD_CERT_APP_POLICY                   no        Add certificate application policy OIDs
   ALT_DNS                               no        Alternative certificate DNS
   ALT_SID                               no        Alternative object SID
   ALT_UPN                               no        Alternative certificate UPN (format: USER@DOMAIN)
   CA                   msflab-DC-CA     yes       The target certificate authority
   CERT_TEMPLATE        User             yes       The certificate template
   ON_BEHALF_OF                          no        Username to request on behalf of (format: DOMAIN\USER)
   PFX                                   no        Certificate to request on behalf of


   Used when connecting via an existing SESSION:

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   no        The session to run this module on


   Used when making a new connection via RHOSTS:

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOSTS     192.168.159.10   no        The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit
                                         .html
   RPORT      445              no        The target port (TCP)
   SMBDomain  MSFLAB           no        The Windows domain to use for authentication
   SMBPass    Password1!       no        The password for the specified username
   SMBUser    smcintyre        no        The username to authenticate as


Auxiliary action:

   Name          Description
   ----          -----------
   REQUEST_CERT  Request a certificate



View the full module info with the info, or info -d command.

msf auxiliary(admin/dcerpc/icpr_cert) > run
[*] Running module against 192.168.159.10
[+] 192.168.159.10:445 - The requested certificate was issued.
[*] 192.168.159.10:445 - Certificate Policies:
[*] 192.168.159.10:445 -   * msEFS
[*] 192.168.159.10:445 -   * emailProtection
[*] 192.168.159.10:445 -   * clientAuth
[*] 192.168.159.10:445 - Certificate Email: smcintyre@msflab.local
[*] 192.168.159.10:445 - Certificate SID: S-1-5-21-3978004297-3499718965-4169012971-1000
[*] 192.168.159.10:445 - Certificate UPN: smcintyre@msflab.local
[*] 192.168.159.10:445 - Certificate stored at: /home/smcintyre/.msf4/loot/20260708151220_default_192.168.159.10_windows.ad.cs_674087.pfx
[*] Auxiliary module execution completed
msf auxiliary(admin/dcerpc/icpr_cert) > pry
[*] Starting Pry shell...
[*] You are in the "auxiliary/admin/dcerpc/icpr_cert" module object

[1] pry(#<Msf::Modules::Auxiliary__Admin__Dcerpc__Icpr_cert::MetasploitModule>)> ::WindowsError::HResult.find_by_retval(0x80070547)
=> [#<WindowsError::ErrorCode:0x00007f1b8e4627a0
  @description=
   "Configuration information could not be read from the domain controller, either because the machine is unavailable, or access has been denied.",
  @name="ERROR_CANT_ACCESS_DOMAIN_INFO",
  @value=1351>]
[2] pry(#<Msf::Modules::Auxiliary__Admin__Dcerpc__Icpr_cert::MetasploitModule>)> 
msf auxiliary(admin/dcerpc/icpr_cert) > set CERT_TEMPLATE Computer
CERT_TEMPLATE => Computer
msf auxiliary(admin/dcerpc/icpr_cert) > run
[*] Running module against 192.168.159.10
[-] 192.168.159.10:445 - There was an error while requesting the certificate.
[-] 192.168.159.10:445 - Denied by Policy Module  0x80094800, The request was for a certificate template that is not supported by the Active Directory Certificate Services policy: Computer.
[-] 192.168.159.10:445 - Error details:
[-] 192.168.159.10:445 -   Source:  (0x0009) FACILITY_SECURITY: The source of the error code is the Security API layer.
[-] 192.168.159.10:445 -   HRESULT: (0x80094800) CERTSRV_E_UNSUPPORTED_CERT_TYPE: The requested certificate template is not supported by this CA.
[-] 192.168.159.10:445 - Auxiliary aborted due to failure: not-found: The requested certificate template is not supported by this CA.
[*] Auxiliary module execution completed
msf auxiliary(admin/dcerpc/icpr_cert) >
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Windows Server 2019 |
| **Target Software/Hardware** | AD CS |
| **Docker Image / Vagrant Setup** | <!-- (Optional) Image name or setup instructions if applicable, otherwise remove this row --> |

## AI Usage Disclosure

I only used AI to check my work and only on the rapid7/windows_error PR.



## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [ ] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [ ] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [ ] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
