### PR TITLE
Update metasploit payloads gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ PATH
       metasploit-concern
       metasploit-credential (>= 6.0.21)
       metasploit-model
-      metasploit-payloads (= 2.0.246.pre.7)
+      metasploit-payloads (= 2.0.246.pre.9)
       metasploit_data_models (>= 6.0.15)
       metasploit_payloads-mettle (= 1.0.48.pre.3)
       mqtt
@@ -369,7 +369,7 @@ GEM
       drb
       mutex_m
       railties (>= 7.0, < 8.1)
-    metasploit-payloads (2.0.246.pre.7)
+    metasploit-payloads (2.0.246.pre.9)
     metasploit_data_models (6.0.18)
       activerecord (>= 7.0, < 8.1)
       activesupport (>= 7.0, < 8.1)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.246.pre.7'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.246.pre.9'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.48.pre.3'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
## Description

Fixes an issue with the 90% failure rate of the Windows tcp channel tests: https://github.com/rapid7/metasploit-payloads/pull/803

## Testing

- Ensure CI passes
- Additional details on the other payloads PR: https://github.com/rapid7/metasploit-payloads/pull/803