### PR TITLE
Update gogs_rebase_rce module with CVE-2026-52806 and fix version

### DIFF
--- a/documentation/modules/exploit/multi/http/gogs_rebase_rce.md
+++ b/documentation/modules/exploit/multi/http/gogs_rebase_rce.md
@@ -1,7 +1,8 @@
 ## Vulnerable Application
 
-This module exploits an argument injection vulnerability in the pull request merge flow
-of [Gogs](https://github.com/gogs/gogs) (<= 0.14.2 and <= 0.15.0+dev).
+This module exploits an argument injection vulnerability (CVE-2026-52806) in the pull
+request merge flow of [Gogs](https://github.com/gogs/gogs) (< 0.14.3). Fixed in
+[Gogs 0.14.3](https://github.com/gogs/gogs/releases/tag/v0.14.3).
 
 The `Merge()` function in `internal/database/pull.go` passes the PR base branch name to
 `git rebase` without a `--` separator. A branch named `--exec=<CMD>` is parsed by Git as

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -74,8 +74,6 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2026-03-17',
         'License' => MSF_LICENSE,
-        'Platform' => ['unix', 'linux', 'win'],
-        'Arch' => ARCH_CMD,
         'Privileged' => false,
         'Targets' => [
           [

--- a/modules/exploits/multi/http/gogs_rebase_rce.rb
+++ b/modules/exploits/multi/http/gogs_rebase_rce.rb
@@ -18,8 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Gogs Git Rebase Argument Injection RCE',
         'Description' => %q{
-          This module exploits an argument injection vulnerability in the
-          pull request merge flow of Gogs (<= 0.14.2 and <= 0.15.0+dev).
+          This module exploits an argument injection vulnerability (CVE-2026-52806)
+          in the pull request merge flow of Gogs (< 0.14.3).
 
           The Merge() function in internal/database/pull.go passes the PR
           base branch name to `git rebase` without a `--` separator. A
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Crypto-Cat', # Vulnerability discovery and Metasploit module
         ],
         'References' => [
-          # ['CVE', ''],
+          ['CVE', '2026-52806'],
           ['GHSA', 'qf6p-p7ww-cwr9', 'gogs/gogs'],
           ['URL', 'https://www.rapid7.com/blog/post/ve-authenticated-rce-via-argument-injection-gogs-unfixed'],
           ['URL', 'https://github.com/gogs/gogs'],
@@ -137,6 +137,7 @@ class MetasploitModule < Msf::Exploit::Remote
   # Maps CSS/JS commit hashes to Gogs release versions for fingerprinting.
   # The hash appears in the ?v= parameter of static asset URLs on unauthenticated pages.
   COMMIT_TO_VERSION = {
+    '3ba8aca90e17e5410b7e8b227c9f29256ac3e875' => '0.14.3',
     '5dcb6c64bdf61e38dbdbb941c1d69789c560d0fb' => '0.14.2',
     'f5c8030c1fd936f3e0e9f774e3c7c39fd102f56f' => '0.14.1',
     '36c26c4ccc3ca0339db53eb1fa41e4e86b55163d' => '0.14.0',
@@ -181,13 +182,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if version
       ver = Rex::Version.new(version)
-      # NOTE: No fix exists yet. We assume a future version > 0.14.2 will
-      # include a patch. If the next release (e.g. 0.14.3) is still
-      # vulnerable, update this threshold accordingly.
-      if ver <= Rex::Version.new('0.14.2')
-        return CheckCode::Appears("Gogs #{version} detected.")
+      if ver < Rex::Version.new('0.14.3')
+        return CheckCode::Appears("Gogs #{version} detected, fixed in 0.14.3.")
       else
-        return CheckCode::Safe("Gogs #{version} detected.")
+        return CheckCode::Safe("Gogs #{version} detected, fixed in 0.14.3.")
       end
     end
 


### PR DESCRIPTION
Updates the Gogs rebase argument injection RCE module following the assignment of CVE-2026-52806 and the release of Gogs 0.14.3 (June 7, 2026) which fixes the vulnerability.

Changes:
- Added CVE-2026-52806 reference
- Updated module description to reference the CVE and fixed version (< 0.14.3)
- Added 0.14.3 commit hash to the version fingerprint map for accurate detection
- Updated check method to mark 0.14.3+ as safe (removed placeholder comment about future fix)
- Updated module documentation with CVE and fix version info

References:
- CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-52806
- GHSA: https://github.com/gogs/gogs/security/advisories/GHSA-qf6p-p7ww-cwr9
- Fix: https://github.com/gogs/gogs/releases/tag/v0.14.3
- Patch PR: https://github.com/gogs/gogs/pull/8301
- Blog: https://www.rapid7.com/blog/post/ve-authenticated-rce-via-argument-injection-gogs-unfixed