### PR TITLE
Fix/xor dynamic register preservation

### DIFF
--- a/modules/encoders/x64/xor_dynamic.rb
+++ b/modules/encoders/x64/xor_dynamic.rb
@@ -15,12 +15,8 @@ class MetasploitModule < Msf::Encoder::XorDynamic
       )
   end
 
-  # Indicate that this module can preserve some registers
-  # ...which is currently not true. This is a temp fix
-  # until the full preserve_registers functionality is
-  # implemented.
   def can_preserve_registers?
-    true
+    false
   end
 
   def stub

--- a/modules/encoders/x86/xor_dynamic.rb
+++ b/modules/encoders/x86/xor_dynamic.rb
@@ -15,12 +15,8 @@ class MetasploitModule < Msf::Encoder::XorDynamic
       )
   end
 
-  # Indicate that this module can preserve some registers
-  # ...which is currently not true. This is a temp fix
-  # until the full preserve_registers functionality is
-  # implemented.
   def can_preserve_registers?
-    true
+    false
   end
 
   def stub

--- a/spec/lib/msf/core/encoded_payload/stage_encoding_spec.rb
+++ b/spec/lib/msf/core/encoded_payload/stage_encoding_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'msf/core/encoded_payload'
+
+RSpec.describe 'stage encoding' do
+  include_context 'Msf::Simple::Framework#modules loading'
+
+  before do
+    expect_to_load_module_ancestors(
+      ancestor_reference_names: encoder_reference_names,
+      module_type: 'encoder',
+      modules_path: modules_path
+    )
+
+    allow(framework.encoders).to receive(:rank_modules).and_wrap_original do |original, *args|
+      original.call(*args).select do |ref_name, _metadata|
+        encoder_reference_names.include?(ref_name)
+      end
+    end
+  end
+
+  let(:encoder_reference_names) do
+    %w[
+      x64/xor_dynamic
+      x64/xor
+    ]
+  end
+
+  let(:payload) do
+    load_and_create_module(
+      ancestor_reference_names: %w[singles/linux/x64/shell_bind_tcp],
+      module_type: 'payload',
+      reference_name: 'linux/x64/shell_bind_tcp'
+    )
+  end
+
+  let(:badchars) { "\x00\x0a\x0d".b }
+
+  let(:encoded_payload) do
+    Msf::EncodedPayload.new(
+      framework,
+      payload,
+      {
+        'BadChars' => badchars,
+        'EncoderOptions' => {
+          'SaveRegisters' => 'rdi'
+        },
+        'ForceEncode' => true,
+        'ForceSaveRegisters' => true
+      }
+    )
+  end
+
+  before do
+    encoded_payload.generate("RAW\x00".b)
+  end
+
+  it 'skips x64/xor_dynamic when rdi must be preserved' do
+    expect(encoded_payload.encoder.refname).not_to eq('x64/xor_dynamic')
+  end
+
+  it 'encodes the payload' do
+    expect(encoded_payload.encoded).not_to include(badchars)
+  end
+end


### PR DESCRIPTION
## Description

This PR marks the dynamic XOR encoders as unable to preserve registers and adds regression coverage for stage encoding when a preserved register is required.

The bug is that `x64/xor_dynamic` and `x86/xor_dynamic` advertised register preservation support even though their decoder stubs do not preserve the registers they use. On the upstream `master` base commit, `x64/xor_dynamic` returns `true` from `#can_preserve_registers?` at [modules/encoders/x64/xor_dynamic.rb#L22-L23](https://github.com/rapid7/metasploit-framework/blob/dd425255fa3918bdb2cc3c23ae14453e95ea0b5d/modules/encoders/x64/xor_dynamic.rb#L22-L23), but the decoder stub immediately loads the encoded payload pointer into `rdi` with `pop rdi`, searches through memory using `scas ... [rdi]`, decodes bytes through `[rdi]`, and increments `rdi` at [modules/encoders/x64/xor_dynamic.rb#L30-L41](https://github.com/rapid7/metasploit-framework/blob/dd425255fa3918bdb2cc3c23ae14453e95ea0b5d/modules/encoders/x64/xor_dynamic.rb#L30-L41). That means the encoder clobbers `rdi`.

The same issue exists in `x86/xor_dynamic`: it returns `true` from `#can_preserve_registers?` at [modules/encoders/x86/xor_dynamic.rb#L22-L23](https://github.com/rapid7/metasploit-framework/blob/dd425255fa3918bdb2cc3c23ae14453e95ea0b5d/modules/encoders/x86/xor_dynamic.rb#L22-L23), then moves `ebx` into `edi`, searches through `[edi]`, decodes through `[edi]`, and increments `edi` at [modules/encoders/x86/xor_dynamic.rb#L29-L38](https://github.com/rapid7/metasploit-framework/blob/dd425255fa3918bdb2cc3c23ae14453e95ea0b5d/modules/encoders/x86/xor_dynamic.rb#L29-L38).

Stage encoding can be asked to preserve registers needed by the payload stage. In the failing Windows x64 bind Meterpreter case, the stage expects the socket handle in `rdi`. Because `x64/xor_dynamic` claimed it could preserve registers, Framework could select it for `EnableStageEncoding=true`; the decoder then clobbered `rdi`, causing the staged bind session to fail after the stage was sent. Marking these encoders as non-preserving makes the encoder selection logic skip them when register preservation is required.

**Related Issue:** N/A

## Breaking Changes

None expected for normal encoder selection. If a user explicitly forces `x64/xor_dynamic` or `x86/xor_dynamic` while also requiring preserved registers and disabling fallback, Framework can now reject that incompatible selection instead of emitting a stage that violates the register preservation contract.

## Reviewer Notes

The implementation change is intentionally small: the dynamic XOR encoders now return `false` from `#can_preserve_registers?` because their current stubs do not implement `SaveRegisters`.

The regression spec avoids asserting that a specific fallback encoder must be selected. It constrains the available x64 encoders to `x64/xor_dynamic` and `x64/xor`, requires `rdi` preservation, and verifies that `x64/xor_dynamic` is not selected while the payload still encodes successfully.

## Verification Steps

1. [x] Run `bundle exec rspec spec/lib/msf/core/encoded_payload/stage_encoding_spec.rb`.
2. [x] Run `bundle exec rspec spec/lib/msf/core/encoded_payload_spec.rb`.
3. [x] Run `bundle exec rubocop modules/encoders/x64/xor_dynamic.rb modules/encoders/x86/xor_dynamic.rb spec/lib/msf/core/encoded_payload/stage_encoding_spec.rb`.
4. [x] Run `ruby tools/dev/msftidy.rb modules/encoders/x64/xor_dynamic.rb modules/encoders/x86/xor_dynamic.rb`.
5. [x] Reproduce the staged Windows x64 bind payload case with `EnableStageEncoding=true`; the stage encoder should not use `x64/xor_dynamic` when `rdi` must be preserved, and the bind session should remain valid after the stage is sent.

## Test Evidence

Old and broken on the left (1181d3ff9fdf1b0a8c1972da4ce3b781d8e38c9a), new and fixed on the right (1e762bb9c254bb132ae8aa534bb81502894b140a).

<img width="2458" height="1332" alt="image" src="https://github.com/user-attachments/assets/c5762e70-caf5-4c45-82a0-d4d8499ac2d8" />

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Windows Server 2019 |
| **Target Software/Hardware** | Windows Server 2019 |
| **Docker Image / Vagrant Setup** | N/A |

## AI Usage Disclosure

Codex was used to help investigate the stage encoding failure, draft the fix and regression spec, and draft this PR description.

## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [ ] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [ ] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [ ] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)