### PR TITLE
Update Linux development dependencies

### DIFF
--- a/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
+++ b/docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md
@@ -25,7 +25,7 @@ This guide has details for setting up both **Linux** and **Windows**.
 * Open a terminal on your Linux host and set up Git, build tools, and Ruby dependencies:
 
 ```bash
-sudo apt update && sudo apt install -y git autoconf build-essential libpcap-dev libpq-dev zlib1g-dev libsqlite3-dev
+sudo apt update && sudo apt install -y git autoconf build-essential libpcap-dev libpq-dev zlib1g-dev libsqlite3-dev libffi-dev libyaml-dev
 ```
 
 ### Windows


### PR DESCRIPTION
## Description

Add `libffi-dev` and `libyaml-dev` to the Linux development dependency command. These packages are needed when building the Ruby dependencies used by a fresh Metasploit development environment.

**Related Issue:** Fixes #21669

## Breaking Changes

None

## Verification Steps

1. Open `docs/metasploit-framework.wiki/dev/Setting-Up-a-Metasploit-Development-Environment.md`.
2. Find the Linux command under **Install dependencies**.
3. Confirm that the command installs both `libffi-dev` and `libyaml-dev` before the later `bundle install` step.

## Test Evidence

- `git diff --check` passes.
- The updated command was checked directly for both package names.
- `tools/dev/msftidy_docs.rb` was also run, but it is scoped to module documentation and rejects this pre-existing wiki guide as "Doc missing module"; its module-section warnings are not applicable to this file.

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS (documentation-only change) |
| **Target Software/Hardware** | Apt-based Linux development environments |

## AI Usage Disclosure

OpenAI Codex (GPT-5) was used to inspect the issue and repository guidance, make the one-line documentation edit, and run the checks listed above.

## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [ ] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [ ] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
