### PR TITLE
Fix search_cache job cache generation by skipping multi arch payloads

### DIFF
--- a/modules/payloads/singles/linux/multi/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/multi/meterpreter_reverse_tcp.rb
@@ -4,8 +4,6 @@
 ##
 
 module MetasploitModule
-  CachedSize = 1140752
-
   include Msf::Payload::Single
   include Msf::Sessions::MeterpreterOptions::Linux
   include Msf::Sessions::MettleConfig

--- a/tools/modules/update_payload_cached_sizes.rb
+++ b/tools/modules/update_payload_cached_sizes.rb
@@ -86,6 +86,10 @@ modules.each do |name, mod|
 
   next if mod_inst.is_a?(Msf::Payload::Adapter)
 
+  # Multi-arch payloads such as linux/multi/meterpreter_reverse_tcp don't have a single specific cache size due to their support
+  # for multiple architectures, so we should likely skip them
+  next if mod_inst.is_a?(Msf::Payload::Linux::MultiArch)
+
   mod_dependencies = mod_inst.dependencies
   missing_dependencies = mod_dependencies.reject(&:available?)
   if missing_dependencies.any?


### PR DESCRIPTION
## Description

This PR fixes the CI search_cache generation job.
Previous error:
```
Caught Error while updating linux/multi/meterpreter_reverse_tcp:
bad-config: Unsupported or unset architecture: nil
	/r7-source/lib/msf/core/module.rb:321:in `fail_with'
	/r7-source/modules/payloads/singles/linux/multi/meterpreter_reverse_tcp.rb:32:in `generate'
```

The payload above supports multiple architectures, so I think it doesn't make sense for it to have a single specific cache size. Also, from the shared specs:
```
context 'linux/multi/meterpreter_reverse_tcp' do
    it_should_behave_like **'payload is not cached'**,  <-- Look here
                          ancestor_reference_names: [
                            'singles/linux/multi/meterpreter_reverse_tcp'
                          ],
                          reference_name: 'linux/multi/meterpreter_reverse_tcp'
```

MultiArch payloads can potentially have wildly different cache sizes per-arch. We only have a singular CachedSize constant, so this seems like the right step.

## Breaking Changes

None

## Verification Steps

1. - [ ] Run the steps:
```
docker build -t metasploitframework/metasploit-framework:latest .
./tools/automation/cache/update_module_cache.sh
```
2. - [ ] Confirm it works without issues

## Test Evidence

The tool works again.
```
[*] Processing tools/automation/cache/wait_for_cache.rc for ERB directives.
[*] resource (tools/automation/cache/wait_for_cache.rc)> Ruby Code (341 bytes)
resource (tools/automation/cache/wait_for_cache.rc)> exit
+ cp /home/msf/.msf4/store/modules_metadata.json db/modules_metadata_base.json
+ cp /home/msf/.msf4/logs/framework.log .
+ set +e
+ git diff --exit-code db/modules_metadata_base.json
diff --git a/db/modules_metadata_base.json b/db/modules_metadata_base.json
index e1536bb6ccd..59228970e94 100644
--- a/db/modules_metadata_base.json
+++ b/db/modules_metadata_base.json
@@ -66374,7 +66374,7 @@
     "autofilter_ports": null,
     "autofilter_services": null,
     "targets": null,
-    "mod_time": "2025-04-14 00:10:31 +0000",
+    "mod_time": "2026-07-11 13:26:13 +0000",
     "path": "/modules/encoders/x64/xor_dynamic.rb",
     "is_install_path": true,
     "ref_name": "x64/xor_dynamic",
@@ -67077,7 +67077,7 @@
     "autofilter_ports": null,
     "autofilter_services": null,
     "targets": null,
-    "mod_time": "2025-04-14 00:10:31 +0000",
+    "mod_time": "2026-07-11 13:26:13 +0000",
     "path": "/modules/encoders/x86/xor_dynamic.rb",
     "is_install_path": true,
     "ref_name": "x86/xor_dynamic",
@@ -211202,7 +211202,7 @@
       "MOF upload",
       "Command"
     ],
-    "mod_time": "2026-02-03 20:58:31 +0000",
+    "mod_time": "2026-06-24 14:29:47 +0000",
     "path": "/modules/exploits/windows/smb/psexec.rb",
     "is_install_path": true,
     "ref_name": "windows/smb/psexec",
@@ -292107,7 +292107,7 @@
     "autofilter_ports": null,
     "autofilter_services": null,
     "targets": null,
-    "mod_time": "2026-06-08 14:52:44 +0000",
+    "mod_time": "2026-07-15 11:03:05 +0000",
     "path": "/modules/payloads/singles/linux/multi/meterpreter_reverse_tcp.rb",
     "is_install_path": true,
     "ref_name": "linux/multi/meterpreter_reverse_tcp",
+ '[' '!' 1 ']'
real	11m 52.89s
user	11m 41.47s
sys	12m 11.95s
```

## AI Usage Disclosure

I used AI to help debug the issue.