### PR TITLE
Fix/invalid option warning

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2152,14 +2152,7 @@ class Core
     if (active_module and global == false)
       datastore = active_module.datastore
 
-      tab_complete_option_names(active_module, '', []).each do |opt_name|
-        valid_options << opt_name
-        option = active_module.options[opt_name]
-        next unless option
-
-        # aliases that are defined for backwards compatibility are not tab completed but are still valid option names
-        valid_options += active_module.options[opt_name].aliases
-      end
+      valid_options = tab_complete_option_names(active_module, '', [], include_aliases: true)
     else
       global = true
       datastore = self.framework.datastore
@@ -2182,13 +2175,11 @@ class Core
           datastore) + "\n")
       return true
     elsif args.length == 1 && !clear
-      if global || valid_options.any? { |vo| vo.casecmp?(args[0]) }
+      message = global ? nil : unknown_datastore_option_message(active_module, args[0], valid_options: valid_options)
+      if message.nil?
         print_line("#{args[0]} => #{datastore[args[0]]}")
         return true
       else
-        message = "Unknown datastore option: #{args[0]}."
-        suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(args[0]).first
-        message << " Did you mean #{suggestion}?" if suggestion
         print_error(message)
         cmd_set_help
         return false
@@ -2218,11 +2209,9 @@ class Core
       end
     end
 
-    unless global || valid_options.any? { |vo| vo.casecmp?(name) }
-      message = "Unknown datastore option: #{name}."
-      suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first
-      message << " Did you mean #{suggestion}?" if suggestion
-      print_warning(message)
+    unless global
+      message = unknown_datastore_option_message(active_module, name, valid_options: valid_options)
+      print_warning(message) if message
     end
 
     # If the driver indicates that the value is not valid, bust out.

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2152,7 +2152,7 @@ class Core
     if (active_module and global == false)
       datastore = active_module.datastore
 
-      valid_options = tab_complete_option_names(active_module, '', [], include_aliases: true)
+      valid_options = valid_datastore_option_names(active_module, include_aliases: true)
     else
       global = true
       datastore = self.framework.datastore

--- a/lib/msf/ui/console/module_argument_parsing.rb
+++ b/lib/msf/ui/console/module_argument_parsing.rb
@@ -152,6 +152,25 @@ module ModuleArgumentParsing
           if name.upcase == 'ACTION'
             result[:action] = val
           else
+            if mod
+              valid_options = mod.options.keys
+              if (mod.exploit? || mod.evasion?)
+                valid_options << 'PAYLOAD'
+                if mod.datastore['PAYLOAD']
+                  p = framework.payloads.create(mod.datastore['PAYLOAD'])
+                  if p
+                    valid_options += p.options.keys
+                  end
+                end
+              end
+
+              unless valid_options.any? { |vo| vo.casecmp?(name) }
+                message = "Unknown datastore option: #{name}."
+                suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first
+                message << " Did you mean #{suggestion}?" if suggestion
+                print_warning(message)
+              end
+            end
             append_datastore_option(datastore_options, name, val)
           end
         elsif resembles_rhost_value?(val)

--- a/lib/msf/ui/console/module_argument_parsing.rb
+++ b/lib/msf/ui/console/module_argument_parsing.rb
@@ -153,23 +153,8 @@ module ModuleArgumentParsing
             result[:action] = val
           else
             if mod
-              valid_options = mod.options.keys
-              if (mod.exploit? || mod.evasion?)
-                valid_options << 'PAYLOAD'
-                if mod.datastore['PAYLOAD']
-                  p = framework.payloads.create(mod.datastore['PAYLOAD'])
-                  if p
-                    valid_options += p.options.keys
-                  end
-                end
-              end
-
-              unless valid_options.any? { |vo| vo.casecmp?(name) }
-                message = "Unknown datastore option: #{name}."
-                suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first
-                message << " Did you mean #{suggestion}?" if suggestion
-                print_warning(message)
-              end
+              message = unknown_datastore_option_message(mod, name)
+              print_warning(message) if message
             end
             append_datastore_option(datastore_options, name, val)
           end

--- a/lib/msf/ui/console/module_argument_parsing.rb
+++ b/lib/msf/ui/console/module_argument_parsing.rb
@@ -2,6 +2,7 @@
 
 require 'addressable'
 require 'msf/ui/console/command_dispatcher'
+require 'msf/ui/console/module_option_validation'
 
 module Msf
 module Ui
@@ -14,6 +15,7 @@ module Console
 #
 ###
 module ModuleArgumentParsing
+  include Msf::Ui::Console::ModuleOptionValidation
 
   # Options which are standard and predictable across all modules
   @@module_opts = Rex::Parser::Arguments.new(
@@ -124,6 +126,7 @@ module ModuleArgumentParsing
         val << '=' unless val.include?('=')
         val.split(',').each do |opt|
           name, value = opt.split('=', 2)
+          warn_unknown_datastore_option(name) if mod
           append_datastore_option(datastore_options, name, value)
         end
       when '-p'
@@ -152,10 +155,7 @@ module ModuleArgumentParsing
           if name.upcase == 'ACTION'
             result[:action] = val
           else
-            if mod
-              message = unknown_datastore_option_message(mod, name)
-              print_warning(message) if message
-            end
+            warn_unknown_datastore_option(name) if mod
             append_datastore_option(datastore_options, name, val)
           end
         elsif resembles_rhost_value?(val)
@@ -199,6 +199,11 @@ module ModuleArgumentParsing
       datastore_options[name.upcase] = value
     end
     datastore_options
+  end
+
+  def warn_unknown_datastore_option(name)
+    message = unknown_datastore_option_message(mod, name)
+    print_warning(message) if message
   end
 
   # Wraps values which contain spaces in quotes to ensure it's handled correctly later

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -71,7 +71,7 @@ module Msf
         #
         # Provide tab completion for name values
         #
-        def tab_complete_option_names(mod, str, words)
+        def tab_complete_option_names(mod, str, words, include_aliases: false)
           res = tab_complete_module_datastore_names(mod, str, words) || [ ]
 
           if !mod
@@ -79,8 +79,10 @@ module Msf
           end
 
           mod.options.each do |e|
-            name, _opt = e
+            name, opt = e
             res << name
+            # aliases that are defined for backwards compatibility are not tab completed but are still valid option names
+            res += opt.aliases if include_aliases
           end
           # Exploits provide these three default options
           if mod.exploit?
@@ -121,6 +123,22 @@ module Msf
           end
 
           return res.sort
+        end
+
+        #
+        # Returns an "Unknown datastore option" message (including a "Did you
+        # mean" suggestion when applicable) if +name+ is not a valid option
+        # name for +mod+, or nil if it is valid. Pass +valid_options+ if the
+        # caller has already computed it, to avoid recomputing it here.
+        #
+        def unknown_datastore_option_message(mod, name, valid_options: nil)
+          valid_options ||= tab_complete_option_names(mod, '', [], include_aliases: true)
+          return nil if valid_options.any? { |vo| vo.casecmp?(name) }
+
+          message = "Unknown datastore option: #{name}."
+          suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first
+          message << " Did you mean #{suggestion}?" if suggestion
+          message
         end
 
         #

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -1,3 +1,5 @@
+require 'msf/ui/console/module_option_validation'
+
 module Msf
   module Ui
     module Console
@@ -7,6 +9,8 @@ module Msf
       #
       ###
       module ModuleOptionTabCompletion
+        include Msf::Ui::Console::ModuleOptionValidation
+
         #
         # Tab completion for datastore names
         #
@@ -16,13 +20,7 @@ module Msf
         #   line. `_words` is always at least 1 when tab completion has reached this
         #   stage since the command itself has been completed.
         def tab_complete_datastore_names(datastore, _str, _words)
-          keys = (
-            Msf::DataStore::GLOBAL_KEYS +
-              datastore.options.keys
-          )
-          keys.concat(datastore.options.values.flat_map(&:fallbacks)) if datastore.is_a?(Msf::DataStore)
-          keys.uniq! { |key| key.downcase }
-          keys
+          datastore_option_names(datastore)
         end
 
         #
@@ -72,43 +70,7 @@ module Msf
         # Provide tab completion for name values
         #
         def tab_complete_option_names(mod, str, words, include_aliases: false)
-          res = tab_complete_module_datastore_names(mod, str, words) || [ ]
-
-          if !mod
-            return res
-          end
-
-          mod.options.each do |e|
-            name, opt = e
-            res << name
-            # aliases that are defined for backwards compatibility are not tab completed but are still valid option names
-            res += opt.aliases if include_aliases
-          end
-          # Exploits provide these three default options
-          if mod.exploit?
-            res << 'PAYLOAD'
-            res << 'NOP'
-            res << 'TARGET'
-            res << 'ENCODER'
-          elsif mod.evasion?
-            res << 'PAYLOAD'
-            res << 'TARGET'
-            res << 'ENCODER'
-          elsif mod.payload?
-            res << 'ENCODER'
-          end
-          if mod.is_a?(Msf::Module::HasActions)
-            res << 'ACTION'
-          end
-          if ((mod.exploit? || mod.evasion?) && mod.datastore['PAYLOAD'])
-            p = framework.payloads.create(mod.datastore['PAYLOAD'])
-            if p
-              p.options.each do |e|
-                name, _opt = e
-                res << name
-              end
-            end
-          end
+          res = valid_datastore_option_names(mod, include_aliases: include_aliases)
           unless str.blank?
             res = res.select { |term| term.upcase.start_with?(str.upcase) }
             res = res.map do |term|
@@ -123,22 +85,6 @@ module Msf
           end
 
           return res.sort
-        end
-
-        #
-        # Returns an "Unknown datastore option" message (including a "Did you
-        # mean" suggestion when applicable) if +name+ is not a valid option
-        # name for +mod+, or nil if it is valid. Pass +valid_options+ if the
-        # caller has already computed it, to avoid recomputing it here.
-        #
-        def unknown_datastore_option_message(mod, name, valid_options: nil)
-          valid_options ||= tab_complete_option_names(mod, '', [], include_aliases: true)
-          return nil if valid_options.any? { |vo| vo.casecmp?(name) }
-
-          message = "Unknown datastore option: #{name}."
-          suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first
-          message << " Did you mean #{suggestion}?" if suggestion
-          message
         end
 
         #

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -18,7 +18,7 @@ module Msf
         def tab_complete_datastore_names(datastore, _str, _words)
           keys = (
             Msf::DataStore::GLOBAL_KEYS +
-              datastore.keys
+              datastore.options.keys
           )
           keys.concat(datastore.options.values.flat_map(&:fallbacks)) if datastore.is_a?(Msf::DataStore)
           keys.uniq! { |key| key.downcase }

--- a/lib/msf/ui/console/module_option_tab_completion.rb
+++ b/lib/msf/ui/console/module_option_tab_completion.rb
@@ -70,7 +70,7 @@ module Msf
         # Provide tab completion for name values
         #
         def tab_complete_option_names(mod, str, words, include_aliases: false)
-          res = valid_datastore_option_names(mod, include_aliases: include_aliases)
+          res = valid_datastore_option_names(mod, include_aliases: include_aliases, active_only: true)
           unless str.blank?
             res = res.select { |term| term.upcase.start_with?(str.upcase) }
             res = res.map do |term|

--- a/lib/msf/ui/console/module_option_validation.rb
+++ b/lib/msf/ui/console/module_option_validation.rb
@@ -1,0 +1,81 @@
+# -*- coding: binary -*-
+# frozen_string_literal: true
+
+module Msf
+  module Ui
+    module Console
+      ###
+      #
+      # Module-specific datastore option validation helpers.
+      #
+      ###
+      module ModuleOptionValidation
+        def datastore_option_names(datastore)
+          keys = (
+            Msf::DataStore::GLOBAL_KEYS +
+              datastore.options.keys
+          )
+          keys.concat(datastore.options.values.flat_map(&:fallbacks)) if datastore.is_a?(Msf::DataStore)
+          keys.uniq!(&:downcase)
+          keys
+        end
+
+        def valid_datastore_option_names(mod, include_aliases: false)
+          datastore = mod ? mod.datastore : framework.datastore
+          res = datastore_option_names(datastore) || []
+
+          return res unless mod
+
+          mod.options.each do |name, opt|
+            res << name
+            # aliases that are defined for backwards compatibility are not tab completed but are still valid option names
+            res += opt.aliases if include_aliases
+          end
+
+          # Exploits provide these three default options
+          if mod.exploit?
+            res << 'PAYLOAD'
+            res << 'NOP'
+            res << 'TARGET'
+            res << 'ENCODER'
+          elsif mod.evasion?
+            res << 'PAYLOAD'
+            res << 'TARGET'
+            res << 'ENCODER'
+          elsif mod.payload?
+            res << 'ENCODER'
+          end
+
+          res << 'ACTION' if mod.is_a?(Msf::Module::HasActions)
+
+          if ((mod.exploit? || mod.evasion?) && mod.datastore['PAYLOAD'])
+            payload = framework.payloads.create(mod.datastore['PAYLOAD'])
+            if payload
+              payload.options.each_key do |name|
+                res << name
+              end
+            end
+          end
+
+          res
+        end
+
+        #
+        # Returns an "Unknown datastore option" message (including a "Did you
+        # mean" suggestion when applicable) if +name+ is not a valid option
+        # name for +mod+, or nil if it is valid. Pass +valid_options+ if the
+        # caller has already computed it, to avoid recomputing it here.
+        #
+        def unknown_datastore_option_message(mod, name, valid_options: nil)
+          valid_options ||= valid_datastore_option_names(mod, include_aliases: true)
+          return nil if valid_options.any? { |vo| vo.casecmp?(name) }
+
+          message = "Unknown datastore option: #{name}."
+          suggestion = DidYouMean::SpellChecker.new(dictionary: valid_options).correct(name).first
+          message << " Did you mean #{suggestion}?" if suggestion
+          message
+        end
+      end
+    end
+  end
+end

--- a/lib/msf/ui/console/module_option_validation.rb
+++ b/lib/msf/ui/console/module_option_validation.rb
@@ -22,29 +22,26 @@ module Msf
           keys
         end
 
-        def valid_datastore_option_names(mod, include_aliases: false)
+        def valid_datastore_option_names(mod, include_aliases: false, active_only: false)
           datastore = mod ? mod.datastore : framework.datastore
           res = datastore_option_names(datastore) || []
 
           return res unless mod
 
-          visible_options = {}
-          hidden_option_names = []
+          if active_only
+            hidden_option_names = datastore.options.each_with_object([]) do |(name, opt), names|
+              next if Msf::OptCondition.show_option(mod, opt)
 
-          mod.options.each do |name, opt|
-            unless Msf::OptCondition.show_option(mod, opt)
-              hidden_option_names << name
-              hidden_option_names.concat(opt.fallbacks)
-              hidden_option_names.concat(opt.aliases) if include_aliases
-              next
+              names << name
+              names.concat(opt.fallbacks)
+              names.concat(opt.aliases) if include_aliases
             end
-
-            visible_options[name] = opt
+            res.delete_if { |name| hidden_option_names.any? { |hidden_name| hidden_name.casecmp?(name) } }
           end
 
-          res.delete_if { |name| hidden_option_names.any? { |hidden_name| hidden_name.casecmp?(name) } }
+          mod.options.each do |name, opt|
+            next if active_only && !Msf::OptCondition.show_option(mod, opt)
 
-          visible_options.each do |name, opt|
             res << name
             # aliases that are defined for backwards compatibility are not tab completed but are still valid option names
             res += opt.aliases if include_aliases
@@ -69,8 +66,11 @@ module Msf
           if ((mod.exploit? || mod.evasion?) && mod.datastore['PAYLOAD'])
             payload = framework.payloads.create(mod.datastore['PAYLOAD'])
             if payload
-              payload.options.each_key do |name|
+              payload.options.each do |name, opt|
+                next if active_only && !Msf::OptCondition.show_option(mod, opt)
+
                 res << name
+                res += opt.aliases if include_aliases
               end
             end
           end

--- a/lib/msf/ui/console/module_option_validation.rb
+++ b/lib/msf/ui/console/module_option_validation.rb
@@ -1,6 +1,8 @@
 # -*- coding: binary -*-
 # frozen_string_literal: true
 
+require 'msf/core/opt_condition'
+
 module Msf
   module Ui
     module Console
@@ -26,7 +28,23 @@ module Msf
 
           return res unless mod
 
+          visible_options = {}
+          hidden_option_names = []
+
           mod.options.each do |name, opt|
+            unless Msf::OptCondition.show_option(mod, opt)
+              hidden_option_names << name
+              hidden_option_names.concat(opt.fallbacks)
+              hidden_option_names.concat(opt.aliases) if include_aliases
+              next
+            end
+
+            visible_options[name] = opt
+          end
+
+          res.delete_if { |name| hidden_option_names.any? { |hidden_name| hidden_name.casecmp?(name) } }
+
+          visible_options.each do |name, opt|
             res << name
             # aliases that are defined for backwards compatibility are not tab completed but are still valid option names
             res += opt.aliases if include_aliases

--- a/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/core_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
         before(:each) do
           allow(core).to receive(:active_module).and_return(mod)
           allow(core).to receive(:tab_complete_option_names).and_return([ name ])
+          allow(core).to receive(:valid_datastore_option_names).and_return([ name ])
           allow(driver).to receive(:on_variable_set).and_return(true)
         end
 
@@ -190,6 +191,41 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Core do
         it 'should set the datastore value to nil' do
           expect(mod.datastore['foo']).to eq nil
         end
+      end
+    end
+
+    context 'with an inactive conditional option' do
+      let(:mod) do
+        mod_klass = Class.new(Msf::Auxiliary) do
+          def initialize
+            super
+
+            register_options(
+              [
+                Msf::OptString.new('MODE', [false, 'Mode', 'visible']),
+                Msf::OptString.new('CONDITIONAL', [false, 'Conditional option', nil], conditions: %w[MODE == visible])
+              ]
+            )
+          end
+        end
+        mod = mod_klass.new
+        allow(mod).to receive(:framework).and_return(framework)
+        mod
+      end
+
+      before(:each) do
+        mod.datastore['MODE'] = 'hidden'
+      end
+
+      it 'does not warn that the option is unknown when setting it' do
+        subject.cmd_set('CONDITIONAL', 'value')
+
+        expect(@combined_output || []).not_to include('Unknown datastore option: CONDITIONAL.')
+        expect(mod.datastore['CONDITIONAL']).to eq 'value'
+      end
+
+      it 'does not tab complete the option' do
+        expect(subject.cmd_set_tabs('COND', ['set'])).not_to include('CONDITIONAL')
       end
     end
   end

--- a/spec/lib/msf/ui/console/module_option_validation_spec.rb
+++ b/spec/lib/msf/ui/console/module_option_validation_spec.rb
@@ -59,14 +59,27 @@ RSpec.describe Msf::Ui::Console::ModuleOptionValidation do
         mod.datastore['MODE'] = 'hidden'
       end
 
-      it 'excludes the option and its aliases' do
+      it 'includes the option and its aliases by default' do
         option_names = validator.valid_datastore_option_names(mod, include_aliases: true)
+
+        expect(option_names).to include('CONDITIONAL')
+        expect(option_names).to include('OLD_CONDITIONAL')
+      end
+
+      it 'excludes the option and its aliases when only active options are requested' do
+        option_names = validator.valid_datastore_option_names(mod, include_aliases: true, active_only: true)
 
         expect(option_names).to include('MODE')
         expect(option_names).to include('ALWAYS_VISIBLE')
         expect(option_names).to include('OLD_ALWAYS_VISIBLE')
         expect(option_names).not_to include('CONDITIONAL')
         expect(option_names).not_to include('OLD_CONDITIONAL')
+      end
+
+      it 'does not report the option as unknown' do
+        message = validator.unknown_datastore_option_message(mod, 'CONDITIONAL')
+
+        expect(message).to be_nil
       end
     end
   end

--- a/spec/lib/msf/ui/console/module_option_validation_spec.rb
+++ b/spec/lib/msf/ui/console/module_option_validation_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Ui::Console::ModuleOptionValidation do
+  subject(:validator) do
+    validator = validator_class.new
+    validator.framework = framework
+    validator
+  end
+
+  let(:validator_class) do
+    Class.new do
+      include Msf::Ui::Console::ModuleOptionValidation
+
+      attr_accessor :framework
+    end
+  end
+
+  let(:framework) do
+    instance_double(Msf::Framework, datastore: Msf::DataStore.new)
+  end
+
+  let(:mod) do
+    mod_klass = Class.new(Msf::Auxiliary) do
+      def initialize
+        super
+
+        register_options(
+          [
+            Msf::OptString.new('MODE', [false, 'Mode', 'visible']),
+            Msf::OptString.new('ALWAYS_VISIBLE', [false, 'Always visible', nil], aliases: ['OLD_ALWAYS_VISIBLE']),
+            Msf::OptString.new(
+              'CONDITIONAL',
+              [false, 'Conditional option', nil],
+              aliases: ['OLD_CONDITIONAL'],
+              conditions: %w[MODE == visible]
+            )
+          ]
+        )
+      end
+    end
+
+    mod_klass.new
+  end
+
+  describe '#valid_datastore_option_names' do
+    context 'when a conditional option is visible' do
+      it 'includes the option and its aliases' do
+        option_names = validator.valid_datastore_option_names(mod, include_aliases: true)
+
+        expect(option_names).to include('CONDITIONAL')
+        expect(option_names).to include('OLD_CONDITIONAL')
+      end
+    end
+
+    context 'when a conditional option is hidden' do
+      before do
+        mod.datastore['MODE'] = 'hidden'
+      end
+
+      it 'excludes the option and its aliases' do
+        option_names = validator.valid_datastore_option_names(mod, include_aliases: true)
+
+        expect(option_names).to include('MODE')
+        expect(option_names).to include('ALWAYS_VISIBLE')
+        expect(option_names).to include('OLD_ALWAYS_VISIBLE')
+        expect(option_names).not_to include('CONDITIONAL')
+        expect(option_names).not_to include('OLD_CONDITIONAL')
+      end
+    end
+  end
+end

--- a/spec/msf/ui/console/module_argument_parsing_spec.rb
+++ b/spec/msf/ui/console/module_argument_parsing_spec.rb
@@ -250,6 +250,7 @@ RSpec.describe Msf::Ui::Console::ModuleArgumentParsing do
     described_class = self.described_class
     dummy_class = Class.new do
       include Msf::Ui::Console::ModuleCommandDispatcher
+      include Msf::Ui::Console::ModuleOptionTabCompletion
       include described_class
 
       # Method not provided by the mixin, needs to be implemented by class that mixes in described_class
@@ -273,7 +274,7 @@ RSpec.describe Msf::Ui::Console::ModuleArgumentParsing do
   end
 
   describe '#parse_check_opts' do
-    let(:current_mod) { instance_double Msf::Auxiliary, datastore: {} }
+    let(:current_mod) { ::Msf::Auxiliary.new }
 
     before do
       allow(subject).to receive(:mod).and_return(current_mod)
@@ -289,7 +290,7 @@ RSpec.describe Msf::Ui::Console::ModuleArgumentParsing do
   end
 
   describe '#parse_run_opts' do
-    let(:current_mod) { instance_double Msf::Auxiliary, datastore: {} }
+    let(:current_mod) { ::Msf::Auxiliary.new }
 
     before do
       allow(subject).to receive(:mod).and_return(current_mod)
@@ -339,7 +340,7 @@ RSpec.describe Msf::Ui::Console::ModuleArgumentParsing do
   end
 
   describe '#parse_exploit_opts' do
-    let(:current_mod) { instance_double Msf::Exploit, datastore: {} }
+    let(:current_mod) { ::Msf::Exploit.new }
 
     before do
       allow(subject).to receive(:mod).and_return(current_mod)

--- a/spec/msf/ui/console/module_argument_parsing_spec.rb
+++ b/spec/msf/ui/console/module_argument_parsing_spec.rb
@@ -37,6 +37,12 @@ RSpec.shared_examples_for 'a command which parses datastore values' do |opts|
       expect(subject.send(opts[:method_name], ['-o', 'RHOSTS=192.168.172.1'])).to include(expected_result)
     end
 
+    it 'warns when setting an unknown option' do
+      expect(subject).to receive(:print_warning).with('Unknown datastore option: INVALID.')
+
+      subject.send(opts[:method_name], ['-o', 'INVALID=OPT'])
+    end
+
     it 'allows setting namespaced datastore options' do
       expected_result = {
         datastore_options: {
@@ -69,7 +75,7 @@ RSpec.shared_examples_for 'a command which parses datastore values' do |opts|
       expected_result = {
         datastore_options: {
           'RHOSTS' => '192.168.172.1',
-          'RPORT' => '1337',
+          'RPORT' => '1337'
         }
       }
       expected_result[:action] = 'action-name' unless opts[:method_name] == 'parse_check_opts'
@@ -134,6 +140,12 @@ RSpec.shared_examples_for 'a command which parses datastore values' do |opts|
         }
       }
       expect(subject.send(opts[:method_name], ['RHOSTS=192.168.172.1'])).to include(expected_result)
+    end
+
+    it 'warns when setting an unknown option' do
+      expect(subject).to receive(:print_warning).with('Unknown datastore option: INVALID.')
+
+      subject.send(opts[:method_name], ['INVALID=OPT'])
     end
 
     it 'allows setting multiple options individually' do
@@ -250,7 +262,6 @@ RSpec.describe Msf::Ui::Console::ModuleArgumentParsing do
     described_class = self.described_class
     dummy_class = Class.new do
       include Msf::Ui::Console::ModuleCommandDispatcher
-      include Msf::Ui::Console::ModuleOptionTabCompletion
       include described_class
 
       # Method not provided by the mixin, needs to be implemented by class that mixes in described_class


### PR DESCRIPTION
## Description
This updates and centralizes the warning message that's displayed when a user sets a datastore option that is not valid in the current context. What it does not do is provide any filtering, invalid options will still be set as they have been, that behavior is staying unchanged and is an unrelated issue. This also adds the warning for datastore options set in the `run` command like `run INVALID=OPT`. This should help users quickly identify that datastore options they're setting are wrong or typoed.

This also fixes a bug where tab completion for datastore options is set based on what the module registered and not what's currently in the datastore. This is particularly important for exploits where an option for a payload can be set and then the payload is changed. Setting the option again, shouldn't be offered through tab completion if it isn't valid in the current context. See the first commit.

**Related Issue:** N/A

## Breaking Changes

None. Specficially invalid options are still set, just after a warning is printed. This remains unchanged.

## Reviewer Notes
This came up while testing staged payload with the `MALLEABLEC2` option which isn't registered because it's not support but surprised the user. This will hopefully make it clear when an option isn't valid.

## Verification Steps

1. - [x] Use a module, any module
2. - [x] Run `set INVALID OPT` and see it warn you that `INVALID` is an invalid option name
3. - [x] Run the module with `run INVALID=OPT` see the same warning, that `INVALID is an invalid option name



## Test Evidence

```
msf exploit(windows/smb/psexec) > run INVALID=test
[!] Unknown datastore option: INVALID.
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[!] 192.168.159.10:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 192.168.159.10:445 - Uploading payload... OQboomGx.exe
[*] 192.168.159.10:445 - Created \OQboomGx.exe...
[+] 192.168.159.10:445 - Service started successfully...
[*] 192.168.159.10:445 - Deleting \OQboomGx.exe...
[*] Started bind TCP handler against 192.168.159.10:8081
[*] Sending stage (248902 bytes) to 192.168.159.10
[*] Meterpreter session 1 opened (192.168.159.128:44743 -> 192.168.159.10:8081) at 2026-07-20 15:28:31 -0400

meterpreter > exit
[*] Shutting down session: 1

[*] 192.168.159.10 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(windows/smb/psexec) > set INVALID test
[!] Unknown datastore option: INVALID.
INVALID => test
msf exploit(windows/smb/psexec) > 
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Metasploit on Fedora |
| **Target Software/Hardware** | N/A|
| **Docker Image / Vagrant Setup** | N/A|

## AI Usage Disclosure

Once I got the code setup for the `run` command, I used Claude to figure out how to refactor it so it wasn't in multiple locations and then fix the tests.



## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [ ] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [ ] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [ ] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
