### PR TITLE
Fix dns question name stripping on frozen strings

### DIFF
--- a/lib/net/dns/question.rb
+++ b/lib/net/dns/question.rb
@@ -166,14 +166,14 @@ module Net # :nodoc:
       end
       
       def check_name(name)
-        name.strip!
-        if name =~ /[^\w\.\-_]/
-          raise QuestionNameError, "Question name #{name.inspect} not valid"          
+        stripped_name = name.strip
+        if stripped_name =~ /[^\w\.\-_]/
+          raise QuestionNameError, "Question name #{stripped_name.inspect} not valid"
         else
-          name
+          stripped_name
         end
-      rescue
-        raise QuestionNameError, "Question name #{name.inspect} not valid"                  
+      rescue StandardError => e
+        raise QuestionNameError, "Question name #{name.inspect} not valid\n#{e.backtrace.join("\n")}"
       end
       
       def new_from_binary(data)
@@ -182,7 +182,7 @@ module Net # :nodoc:
         @qType = Net::DNS::RR::Types.new type
         @qClass = Net::DNS::RR::Classes.new cls
       rescue StandardError => e
-        raise QuestionArgumentError, "Invalid data: #{data.inspect}\n{e.backtrace}"
+        raise QuestionArgumentError, "Invalid data: #{data.inspect}\n#{e.backtrace.join("\n")}"
       end
 
     end # class Question


### PR DESCRIPTION
## Description
This PR fixes trying to modify a frozen string in-place, which caused the mcp plugin to fail during loading.

For example:
```
    168: def check_name(name)
    169:   require 'pry-byebug'; binding.pry;
 => 170:   name.strip!
...
[1] pry(#<Net::DNS::Question>)> name.frozen?
=> true
...
    176: rescue StandardError => e
    177:   require 'pry-byebug'; binding.pry;
 => 178:   raise QuestionNameError, "Question name #{name.inspect} not valid"                  
    179: end

[1] pry(#<Net::DNS::Question>)> e
=> #<FrozenError: can't modify frozen String: "localhost">
```

*This issue did not affect users that had the DNS feature turned off.*

**Related Issue:** 

https://github.com/rapid7/metasploit-framework/issues/21684

## Breaking Changes

None

## Reviewer Notes

## Verification Steps

1. - [ ] bundle exec msfconsole -q
2. - [ ] features set dns true
3. - [ ] save
4. - [ ] exit
5. - [ ] bundle exec msfconsole -q
6. - [ ] dns reset-config
7. - [ ] load mcp
8. - [ ] mcp start

## Test Evidence
```
msf payload(windows/x64/meterpreter_reverse_tcp) > mcp start
[*] Waiting for msgrpc server to initialize on 127.0.0.1:55552...
[*] Waiting for msgrpc server to become available on 127.0.0.1:55552...
[*] Auto-started msgrpc - User: msf, Pass: rzOx847CO78t
[*] Starting MCP server on HTTP transport...
[*] Waiting for MCP server to become available on localhost:3000...
[*] MCP server listening on http://localhost:3000/
[*] Authentication: Bearer token (auto-generated)
[*]   Configure your MCP client with: Authorization: Bearer 1c1003f01613bb26c129b8d73859bca48103a1f11c3b285acb62c72790895d1b
```

## Before
Broken:
```
msf payload(windows/x64/meterpreter_reverse_tcp) > mcp start
[*] Waiting for msgrpc server to initialize on 127.0.0.1:55552...
[*] Waiting for msgrpc server to become available on 127.0.0.1:55552...
[*] Auto-started msgrpc - User: msf, Pass: KYddW7UAKwTQ
[*] Starting MCP server on HTTP transport...
[*] Waiting for MCP server to become available on localhost:3000...
[-] Failed to start MCP server: getaddrinfo: Name or service not known
```
