### PR TITLE
Fix `fail_with` console output by tracking error messages

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1386,11 +1386,16 @@ class Exploit < Msf::Module
 
       when Msf::OptionValidateError
         self.fail_reason = Msf::Exploit::Failure::BadConfig
+        # The multi-line per-option formatter is emitted to the console; a
+        # single-line summary is stashed on the module for non-console
+        # consumers (RPC/MCP job listeners, log aggregators, etc.).
+        self.fail_message = "Exploit aborted due to failure: #{self.fail_reason}: #{msg}"
         ::Msf::Ui::Formatter::OptionValidateError.print_error(self, e)
         elog("Exploit failed (#{self.refname}): #{msg}", error: e)
 
       when Msf::Exploit::Failed
-        self.print_error("Exploit aborted due to failure: #{self.fail_reason}: #{msg}")
+        self.fail_message = "Exploit aborted due to failure: #{self.fail_reason}: #{msg}"
+        self.print_error(self.fail_message)
 
         # The caller should have already set self.fail_reason
         if self.fail_reason == Msf::Exploit::Failure::None
@@ -1399,22 +1404,26 @@ class Exploit < Msf::Module
 
       when Rex::ConnectionError
         self.fail_reason = Msf::Exploit::Failure::Unreachable
-        self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
+        self.fail_message = "Exploit failed [#{self.fail_reason}]: #{msg}"
+        self.print_error(self.fail_message)
         elog("Exploit failed (#{self.refname}): #{msg}", error: e)
 
       when Rex::BindFailed
         self.fail_reason = Msf::Exploit::Failure::BadConfig
-        self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
+        self.fail_message = "Exploit failed [#{self.fail_reason}]: #{msg}"
+        self.print_error(self.fail_message)
         elog("Exploit failed (#{self.refname}): #{msg}", error: e)
 
       when Timeout::Error
         self.fail_reason = Msf::Exploit::Failure::TimeoutExpired
-        self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
+        self.fail_message = "Exploit failed [#{self.fail_reason}]: #{msg}"
+        self.print_error(self.fail_message)
         elog("Exploit failed (#{self.refname}): #{msg}", error: e)
 
       when ::Interrupt
         self.fail_reason = Msf::Exploit::Failure::UserInterrupt
-        self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
+        self.fail_message = "Exploit failed [#{self.fail_reason}]: #{msg}"
+        self.print_error(self.fail_message)
         elog("Exploit failed (#{self.refname}): #{msg}", error: e)
       else
 
@@ -1439,11 +1448,13 @@ class Exploit < Msf::Module
           self.fail_reason = Msf::Exploit::Failure::Unknown
         end
 
-        if self.fail_reason == Msf::Exploit::Failure::Unknown
-          self.print_error("Exploit failed: #{msg}")
-        else
-          self.print_error("Exploit failed [#{self.fail_reason}]: #{msg}")
-        end
+        self.fail_message =
+          if self.fail_reason == Msf::Exploit::Failure::Unknown
+            "Exploit failed: #{msg}"
+          else
+            "Exploit failed [#{self.fail_reason}]: #{msg}"
+          end
+        self.print_error(self.fail_message)
 
         elog("Exploit failed (#{self.refname}): #{msg}", error: e)
     end
@@ -1492,6 +1503,15 @@ class Exploit < Msf::Module
   # Detailed exception string indicating why the exploit was not successful
   #
   attr_accessor  :fail_detail
+
+  #
+  # A formatted, human-readable failure message describing why the exploit
+  # was not successful. Populated by {#handle_exception} with the same string
+  # that is printed to the operator's console, so that non-console consumers
+  # (RPC/MCP job listeners, logs) can surface an identical description
+  # without having to intercept `user_output`.
+  #
+  attr_accessor  :fail_message
 
   #
   # The VulnAttempt object created during this run, or nil/false if none

--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -244,15 +244,8 @@ protected
         delay = 0.01
       end
 
-      iout = StringIO.new
-      rex_out = Rex::Ui::Text::Output::Stdio.new(io: iout)
-      rex_out.disable_color
-      old_user_output = exploit.user_output
-      exploit.user_output = rex_out
       fail_reason = exploit.handle_exception(e)
-      iout.close_write
-      exploit.user_output = old_user_output
-      job_listener.failed(run_uuid, iout.string.strip, exploit)
+      job_listener.failed(run_uuid, exploit.fail_message || e.message, exploit)
     end
 
     # Start bind handlers after exploit completion

--- a/spec/lib/msf/base/simple/exploit_job_tracking_spec.rb
+++ b/spec/lib/msf/base/simple/exploit_job_tracking_spec.rb
@@ -37,8 +37,10 @@ RSpec.describe Msf::ExploitDriver, 'job listener integration' do
         handler_bind?: false,
         fail_reason: Msf::Exploit::Failure::None,
         fail_detail: 'No session created',
+        fail_message: nil,
         :fail_reason= => nil,
         :fail_detail= => nil,
+        :fail_message= => nil,
         report_failure: nil,
         cleanup: nil
       )
@@ -99,10 +101,9 @@ RSpec.describe Msf::ExploitDriver, 'job listener integration' do
       err = RuntimeError.new('exploit-boom')
       allow(exploit_mod).to receive(:exploit).and_raise(err)
       allow(exploit_mod).to receive(:handle_exception).and_return(Msf::Exploit::Failure::Unknown)
-      # handle_exception sets fail_reason on the exploit instance in real code
+      # handle_exception sets fail_reason/fail_message on the exploit instance in real code
       allow(exploit_mod).to receive(:fail_reason).and_return(Msf::Exploit::Failure::Unknown)
-      allow(exploit_mod).to receive(:user_output).and_return(nil)
-      allow(exploit_mod).to receive(:user_output=)
+      allow(exploit_mod).to receive(:fail_message).and_return('Exploit failed: exploit-boom')
       driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
       expect(custom_listener).to have_received(:failed).with(run_uuid, kind_of(String), exploit_mod)
     end
@@ -113,11 +114,46 @@ RSpec.describe Msf::ExploitDriver, 'job listener integration' do
       allow(exploit_mod).to receive(:handle_exception).and_return(Msf::Exploit::Failure::Unknown)
       # After handle_exception, the exploit's fail_reason is non-None, so the tail if-block is skipped.
       allow(exploit_mod).to receive(:fail_reason).and_return(Msf::Exploit::Failure::Unknown)
-      allow(exploit_mod).to receive(:user_output).and_return(nil)
-      allow(exploit_mod).to receive(:user_output=)
+      allow(exploit_mod).to receive(:fail_message).and_return('Exploit failed: exploit-boom')
       driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
       expect(custom_listener).to have_received(:failed).once
       expect(exploit_mod).not_to have_received(:report_failure)
+    end
+
+    context 'when the exploit raises via fail_with' do
+      let(:err) { Msf::Exploit::Failed.new('RHOST is required') }
+      let(:formatted_message) do
+        "Exploit aborted due to failure: #{Msf::Exploit::Failure::BadConfig}: RHOST is required"
+      end
+
+      before do
+        allow(exploit_mod).to receive(:exploit).and_raise(err)
+        # Simulate what fail_with + handle_exception leave on the module.
+        allow(exploit_mod).to receive(:handle_exception).and_return(Msf::Exploit::Failure::BadConfig)
+        allow(exploit_mod).to receive(:fail_reason).and_return(Msf::Exploit::Failure::BadConfig)
+        allow(exploit_mod).to receive(:fail_message).and_return(formatted_message)
+      end
+
+      it 'forwards exploit.fail_message verbatim to the job listener' do
+        driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+        expect(custom_listener).to have_received(:failed).with(run_uuid, formatted_message, exploit_mod)
+      end
+    end
+
+    context 'when the exploit raises but fail_message is not populated' do
+      let(:err) { RuntimeError.new('unexpected-boom') }
+
+      before do
+        allow(exploit_mod).to receive(:exploit).and_raise(err)
+        allow(exploit_mod).to receive(:handle_exception).and_return(Msf::Exploit::Failure::None)
+        allow(exploit_mod).to receive(:fail_reason).and_return(Msf::Exploit::Failure::None)
+        allow(exploit_mod).to receive(:fail_message).and_return(nil)
+      end
+
+      it 'falls back to the exception message for the listener payload' do
+        driver.send(:job_run_proc, [exploit_mod, payload_mod, run_uuid, custom_listener])
+        expect(custom_listener).to have_received(:failed).with(run_uuid, 'unexpected-boom', exploit_mod)
+      end
     end
   end
 end

--- a/spec/lib/msf/core/exploit_handle_exception_spec.rb
+++ b/spec/lib/msf/core/exploit_handle_exception_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Exploit, '#handle_exception fail_message' do
+  include_context 'Msf::DBManager'
+  include_context 'Metasploit::Framework::Spec::Constants cleaner'
+
+  let(:exploit) do
+    framework.modules.add_module_path(File.join(FILE_FIXTURES_PATH, 'modules'))
+    mod = framework.modules.create('exploit/single_target_exploit')
+    # Silence side effects so we can focus on the fail_message attribute.
+    allow(mod).to receive(:print_error)
+    allow(mod).to receive(:elog)
+    allow(mod).to receive(:report_failure)
+    allow(mod).to receive(:interrupt_handler)
+    # framework.events uses method_missing to dispatch to subscribers, so a
+    # verifying stub isn't possible; use a null-object double to accept the
+    # on_module_error call without side effects.
+    allow(mod.framework).to receive(:events).and_return(double('events').as_null_object)
+    allow(::Msf::Ui::Formatter::OptionValidateError).to receive(:print_error)
+    mod
+  end
+
+  it 'is nil before handle_exception runs' do
+    expect(exploit.fail_message).to be_nil
+  end
+
+  context 'when the exploit calls fail_with (Msf::Exploit::Failed)' do
+    it 'stores the same string that is printed to the console' do
+      exploit.fail_reason = Msf::Exploit::Failure::BadConfig
+      exploit.fail_detail = 'RHOST is required'
+      err = Msf::Exploit::Failed.new('RHOST is required')
+
+      exploit.handle_exception(err)
+
+      expected = "Exploit aborted due to failure: #{Msf::Exploit::Failure::BadConfig}: RHOST is required"
+      expect(exploit.fail_message).to eq(expected)
+      expect(exploit).to have_received(:print_error).with(expected)
+    end
+  end
+
+  context 'when the exception is Rex::ConnectionError' do
+    it 'stores the "Exploit failed [<reason>]" phrasing' do
+      err = Rex::ConnectionError.new('192.0.2.1:445')
+      exploit.handle_exception(err)
+
+      expected = "Exploit failed [#{Msf::Exploit::Failure::Unreachable}]: #{err.class} #{err}"
+      expect(exploit.fail_message).to eq(expected)
+      expect(exploit).to have_received(:print_error).with(expected)
+    end
+  end
+
+  context 'when the exception is Rex::BindFailed' do
+    it 'stores the "Exploit failed [<reason>]" phrasing' do
+      err = Rex::BindFailed.new('0.0.0.0:4444')
+      exploit.handle_exception(err)
+
+      expected = "Exploit failed [#{Msf::Exploit::Failure::BadConfig}]: #{err.class} #{err}"
+      expect(exploit.fail_message).to eq(expected)
+    end
+  end
+
+  context 'when the exception is Timeout::Error' do
+    it 'stores the "Exploit failed [<reason>]" phrasing' do
+      err = Timeout::Error.new('execution expired')
+      exploit.handle_exception(err)
+
+      expected = "Exploit failed [#{Msf::Exploit::Failure::TimeoutExpired}]: #{err.class} #{err}"
+      expect(exploit.fail_message).to eq(expected)
+    end
+  end
+
+  context 'when the exception is ::Interrupt' do
+    it 'stores the "Exploit failed [<reason>]" phrasing' do
+      err = ::Interrupt.new
+      exploit.handle_exception(err)
+
+      expected = "Exploit failed [#{Msf::Exploit::Failure::UserInterrupt}]: #{err.class} #{err}"
+      expect(exploit.fail_message).to eq(expected)
+    end
+  end
+
+  context 'when the exception is an unknown class' do
+    it 'stores the "Exploit failed: <msg>" phrasing for the Unknown reason branch' do
+      err = RuntimeError.new('something totally unexpected')
+      exploit.handle_exception(err)
+
+      expected = "Exploit failed: RuntimeError #{err}"
+      expect(exploit.fail_message).to eq(expected)
+      expect(exploit.fail_reason).to eq(Msf::Exploit::Failure::Unknown)
+    end
+
+    it 'stores the "Exploit failed [<reason>]" phrasing when the message maps to a known reason' do
+      err = RuntimeError.new('The connection was refused by the target')
+      exploit.handle_exception(err)
+
+      expected = "Exploit failed [#{Msf::Exploit::Failure::Unreachable}]: RuntimeError #{err}"
+      expect(exploit.fail_message).to eq(expected)
+    end
+  end
+
+  context 'when the exception is Msf::OptionValidateError' do
+    it 'delegates console output to the multi-line formatter but stores a single-line summary' do
+      err = Msf::OptionValidateError.new(['RHOST'])
+      exploit.handle_exception(err)
+
+      expected = "Exploit aborted due to failure: #{Msf::Exploit::Failure::BadConfig}: #{err.class} #{err}"
+      expect(exploit.fail_message).to eq(expected)
+      expect(::Msf::Ui::Formatter::OptionValidateError).to have_received(:print_error).with(exploit, err)
+    end
+  end
+
+  context 'when the exception is Msf::Exploit::Complete' do
+    it 'leaves fail_message untouched (no failure to describe)' do
+      exploit.fail_message = nil
+      err = Msf::Exploit::Complete.new
+      exploit.handle_exception(err)
+      expect(exploit.fail_message).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fixes an issue introduced in [PR](https://github.com/rapid7/metasploit-framework/pull/21653).

The `rescue` block in `job_run_proc` was swapping the exploit's `user_output` for a `StringIO`-backed `Rex::Ui::Text::Output::Stdio` before calling `exploit.handle_exception(e)`, then handing the captured buffer to `job_listener.failed(...)`.

While this allowed the job listener to capture the error message, it caused a side effect: any error messages passed to `self.print_error` inside `Exploit#handle_exception` ended up trapped in the temporary `StringIO` object and were never displayed on the console.

This PR fix this by:
- removing the temporary `user_output` swap in `job_run_proc`.
- adding a new `fail_message` attribute to `Exploit`, which is populated inside `Exploit#handle_exception` with the exact message printed via `self.print_error`.
- updating `job_listener.failed(...)` to use the new `fail_message` attribute.

## Breaking Changes

None

## Reviewer Notes

This does not affect the related [PR](https://github.com/rapid7/metasploit-framework/pull/21654) and can be landed independently.

## Verification Steps & Test Evidence

Each scenario test a specific error path using both `msfconsole` and the RPC endpoints.
- Start the RPC server: `./msfrpcd -f -U msfuser -P 123456 -p 55553 -a 127.0.0.1`
- Start the RPC client: `./msfrpc -a 127.0.0.1 -U msfuser -P 123456`

Unless specified otherwise, these test cases use the `windows/smb/psexec` module.

### Test the `Msf::OptionValidateError` error path
```
msf exploit(windows/smb/psexec) > run rhosts=127.0.0.1 SERVICE_STUB_ENCODER=foo
[*] Started reverse TCP handler on 192.168.4.87:4444
[-] 127.0.0.1:445 - Msf::OptionValidateError The following options failed to validate:
[-] 127.0.0.1:445 - Invalid option SERVICE_STUB_ENCODER: Failed to find encoder "foo"
```
```
>> rpc.call('module.execute', 'exploit', 'windows/smb/psexec', {'RHOSTS'=>'127.0.0.1', 'SERVICE_STUB_ENCODER' => 'bad'})
=> {"job_id"=>1, "uuid"=>"nBavCHx19vqQ7Qn35DQHTljD"}
>> rpc.call('module.results', 'nBavCHx19vqQ7Qn35DQHTljD')
=> {"status"=>"errored", "error"=>"Exploit aborted due to failure: bad-config: Msf::OptionValidateError The following options failed to validate: SERVICE_STUB_ENCODER."}
```

### Test the `Msf::Exploit::Failed` error path (`fail_with`)
- add `fail_with(Failure::BadConfig, 'TESTING')` to the beginning of `#exploit`

```
msf exploit(windows/smb/psexec) > run rhosts=127.0.0.1
[*] Started reverse TCP handler on 192.168.4.87:4444
[-] 127.0.0.1:445 - Exploit aborted due to failure: bad-config: TESTING
[*] Exploit completed, but no session was created.
```
```
>> rpc.call('module.execute', 'exploit', 'windows/smb/psexec', {'RHOSTS'=>'127.0.0.1'})
=> {"job_id"=>0, "uuid"=>"BwvBxkrOabhIzTyBAXgswPRS"}
>> rpc.call('module.results', 'BwvBxkrOabhIzTyBAXgswPRS')
=> {"status"=>"errored", "error"=>"Exploit aborted due to failure: bad-config: TESTING"}
```

### Test the `Rex::ConnectionError` error path
```
msf exploit(windows/smb/psexec) > run rhosts=127.0.0.1 SERVICE_STUB_ENCODER=foo
[*] Started reverse TCP handler on 192.168.4.87:4444
[*] 127.0.0.1:445 - Connecting to the server...
[-] 127.0.0.1:445 - Exploit failed [unreachable]: Rex::ConnectionRefused The connection was refused by the remote host (127.0.0.1:445).
[*] Exploit completed, but no session was created.
```
```
>> rpc.call('module.execute', 'exploit', 'windows/smb/psexec', {'RHOSTS'=>'127.0.0.1'})
=> {"job_id"=>0, "uuid"=>"WEyIJh9NHsyKQWwFC9DBuc1Y"}
>> rpc.call('module.results', 'WEyIJh9NHsyKQWwFC9DBuc1Y')
=> {"status"=>"errored", "error"=>"Exploit failed [unreachable]: Rex::ConnectionRefused The connection was refused by the remote host (127.0.0.1:445)."}
```

### Test the `Rex::BindFailed` error path
- use `multi/handler` module.
- run `netcat` to listen on port 4444 locally (`ncat -vnl 4444`)
```
msf > use exploit/multi/handler
[*] Using configured payload generic/shell_reverse_tcp
msf exploit(multi/handler) > run lhost=4444
[-] Handler failed to bind to 0.0.17.92:4444:-  -
[-] Handler failed to bind to 0.0.0.0:4444:-  -
[-] Exploit failed [bad-config]: Rex::BindFailed The address is already in use or unavailable: (0.0.0.0:4444).
[*] Exploit completed, but no session was created.
```
```
>> rpc.call('module.execute', 'exploit', 'multi/handler', {'LPORT'=>4444})
=> {"job_id"=>1, "uuid"=>"yfPEhSV9e3QXqHY0EHhXo2p1"}
>> rpc.call('module.results', 'yfPEhSV9e3QXqHY0EHhXo2p1')
=> {"status"=>"errored", "error"=>"Exploit failed [bad-config]: Rex::BindFailed The address is already in use or unavailable: (0.0.0.0:4444)."}
```

### Test the `Timeout::Error` error path
- add `Timeout.timeout(1) { sleep 2 }` to the beginning of `#exploit`
```
msf exploit(windows/smb/psexec) > run rhosts=127.0.0.1
[*] Started reverse TCP handler on 192.168.4.87:4444
[-] 127.0.0.1:445 - Exploit failed [timeout-expired]: Timeout::Error execution expired
[*] Exploit completed, but no session was created.
```
```
>> rpc.call('module.execute', 'exploit', 'windows/smb/psexec', {'RHOSTS'=>'127.0.0.1'})
=> {"job_id"=>0, "uuid"=>"PWtju9TzEcNWhaq28ZCpntUM"}
>> rpc.call('module.results', 'PWtju9TzEcNWhaq28ZCpntUM')
=> {"status"=>"errored", "error"=>"Exploit failed [timeout-expired]: Timeout::Error execution expired"}
```

### Test the `::Interrupt` error path
- run `netcat` to listen on port 445 locally (`ncat -vnl 445`)
- hit Ctrl-C to interrupt the exploit
```
msf exploit(windows/smb/psexec) > run rhosts=127.0.0.1
[*] Started reverse TCP handler on 192.168.4.87:4444
[*] 127.0.0.1:445 - Connecting to the server...
[*] 127.0.0.1:445 - Authenticating to 127.0.0.1:445 as user ''...
^C
[-] 127.0.0.1:445 - Exploit failed [user-interrupt]: Interrupt
[-] run: Interrupted
````
Interrupting the RPC server close it. I couldn't find a way to interrupt the exploit with RPC.

### Test the default error path
- add `raise 'connection reset'` to the beginning of `#exploit`
```
msf exploit(windows/smb/psexec) > run rhosts=127.0.0.1
[*] Started reverse TCP handler on 192.168.4.87:4444
[-] 127.0.0.1:445 - Exploit failed [disconnected]: RuntimeError connection reset
[*] Exploit completed, but no session was created.
```
```
>> rpc.call('module.execute', 'exploit', 'windows/smb/psexec', {'RHOSTS'=>'127.0.0.1'})
=> {"job_id"=>0, "uuid"=>"BGbVOqhgSZrOa2oCjdq6aQac"}
>> rpc.call('module.results', 'BGbVOqhgSZrOa2oCjdq6aQac')
=> {"status"=>"errored", "error"=>"Exploit failed [disconnected]: RuntimeError connection reset"}
```

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
