### PR TITLE
Wrap hash argument in curly braces

### DIFF
--- a/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
+++ b/modules/auxiliary/admin/dcerpc/esc_update_ldap_object.rb
@@ -135,11 +135,11 @@ class MetasploitModule < Msf::Auxiliary
     ldap_update_module.datastore['ACTION'] = action
 
     print_status("Running #{mod_refname}")
-    ldap_update_module.run_simple(
+    ldap_update_module.run_simple({
       'LocalInput' => user_input,
       'LocalOutput' => user_output,
       'RunAsJob' => false
-    )
+    })
   end
 
   def call_shadow_credentials_module(action, device_id = nil)
@@ -166,11 +166,11 @@ class MetasploitModule < Msf::Auxiliary
     ldap_update_module.datastore['ACTION'] = action
 
     print_status("Running #{mod_refname}")
-    ldap_update_module.run_simple(
+    ldap_update_module.run_simple({
       'LocalInput' => user_input,
       'LocalOutput' => user_output,
       'RunAsJob' => false
-    )
+    })
   end
 
   def automate_get_hash(cert_path, username, domain, rhosts)
@@ -192,11 +192,11 @@ class MetasploitModule < Msf::Auxiliary
     get_ticket_module.datastore['RPORT'] = 88
     get_ticket_module.datastore['ACTION'] = 'GET_HASH'
 
-    res = get_ticket_module.run_simple(
+    res = get_ticket_module.run_simple({
       'LocalInput' => user_input,
       'LocalOutput' => user_output,
       'RunAsJob' => false
-    )
+    })
     fail_with(Failure::Unknown, 'Failed to get hash for target user') unless res
     res
   end

--- a/modules/auxiliary/admin/ldap/bad_successor.rb
+++ b/modules/auxiliary/admin/ldap/bad_successor.rb
@@ -319,10 +319,10 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    result = mod.run_simple(
+    result = mod.run_simple({
       'LocalInput' => user_input,
       'LocalOutput' => user_output
-    )
+    })
 
     # Exceptions raised in the get_ticket won't propagate here, so fail if the credential is nil
     fail_with(Failure::Unknown, 'Failed to run get_ticket module.') unless result

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -388,13 +388,13 @@ class MetasploitModule < Msf::Auxiliary
     @exploits[name].datastore['SSLVersion'] = datastore['SSLVersion']
     @exploits[name].datastore['EXITFUNC'] = datastore['EXITFUNC'] || 'thread'
     @exploits[name].datastore['DisablePayloadHandler'] = true
-    @exploits[name].exploit_simple(
+    @exploits[name].exploit_simple({
       'LocalInput' => self.user_input,
       'LocalOutput' => self.user_output,
       'Target' => targ,
       'Payload' => payload,
       'RunAsJob' => true
-    )
+    })
 
     # It takes a little time for the resources to get set up, so sleep for
     # a bit to make sure the exploit is fully working.  Without this,
@@ -526,12 +526,12 @@ class MetasploitModule < Msf::Auxiliary
           multihandler.datastore['AutoSystemInfo'] = datastore['AutoSystemInfo']
           multihandler.datastore['InitialAutoRunScript'] = datastore['InitialAutoRunScript']
         end
-        multihandler.exploit_simple(
+        multihandler.exploit_simple({
           'LocalInput' => self.user_input,
           'LocalOutput' => self.user_output,
           'Payload' => @payloads[lport],
           'RunAsJob' => true
-        )
+        })
         @handler_job_ids.push(multihandler.job_id)
       end
     end

--- a/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
+++ b/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
@@ -151,12 +151,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # this is kind of nasty would be better to split psexec code out to a mixin (on the TODO List)
     begin
-      psexec.exploit_simple(
+      psexec.exploit_simple({
         'LocalInput' => self.user_input,
         'LocalOutput' => self.user_output,
         'Payload' => psexec.datastore['PAYLOAD'],
         'RunAsJob' => true
-      )
+      })
     rescue
       credential_data = {
         user: user,

--- a/modules/exploits/windows/http/manageengine_adselfservice_plus_cve_2022_28810.rb
+++ b/modules/exploits/windows/http/manageengine_adselfservice_plus_cve_2022_28810.rb
@@ -197,12 +197,12 @@ class MetasploitModule < Msf::Exploit::Remote
     # Validate module options
     mh.options.validate(mh.datastore)
     # Execute showing output
-    mh.exploit_simple(
+    mh.exploit_simple({
       'Payload' => mh.datastore['PAYLOAD'],
       'LocalInput' => user_input,
       'LocalOutput' => user_output,
       'RunAsJob' => true
-    )
+    })
 
     # Check to make sure that the handler is actually valid
     # If another process has the port open, then the handler will fail

--- a/modules/exploits/windows/local/ntlm_relay_2_self.rb
+++ b/modules/exploits/windows/local/ntlm_relay_2_self.rb
@@ -394,11 +394,11 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Running #{mod_refname} to #{action} key for #{target_name}...")
 
-    results = shadow_module.run_simple(
+    results = shadow_module.run_simple({
       'LocalInput' => user_input,
       'LocalOutput' => user_output,
       'RunAsJob' => false
-    )
+    })
 
     if action == 'ADD'
       if results && results.is_a?(Array) && results.length >= 2
@@ -436,11 +436,11 @@ class MetasploitModule < Msf::Exploit::Local
     rbcd_module.datastore['VERBOSE'] = datastore['VERBOSE']
 
     buffer_output = Rex::Ui::Text::Output::Buffer.new
-    rbcd_module.run_simple(
+    rbcd_module.run_simple({
       'LocalInput' => user_input,
       'LocalOutput' => buffer_output,
       'RunAsJob' => false
-    )
+    })
 
     read_result = buffer_output.dump_buffer
 
@@ -465,11 +465,11 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Running #{mod_refname} WRITE: DELEGATE_FROM=#{target_name} -> DELEGATE_TO=#{target_name}")
 
-    rbcd_module_write.run_simple(
+    rbcd_module_write.run_simple({
       'LocalInput' => user_input,
       'LocalOutput' => user_output,
       'RunAsJob' => false
-    )
+    })
 
     print_good("Successfully configured RBCD for #{target_name}.")
     :written
@@ -496,11 +496,11 @@ class MetasploitModule < Msf::Exploit::Local
     rbcd_module.datastore['DELEGATE_FROM'] = target_name
     rbcd_module.datastore['VERBOSE'] = datastore['VERBOSE']
 
-    rbcd_module.run_simple(
+    rbcd_module.run_simple({
       'LocalInput' => user_input,
       'LocalOutput' => user_output,
       'RunAsJob' => false
-    )
+    })
 
     print_good("RBCD delegation removed for #{target_name}.")
   rescue StandardError => e
@@ -540,7 +540,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status("SPN: #{get_ticket_mod.datastore['SPN']}")
 
     begin
-      get_ticket_mod.run_simple('LocalInput' => user_input, 'LocalOutput' => user_output)
+      get_ticket_mod.run_simple({ 'LocalInput' => user_input, 'LocalOutput' => user_output })
     rescue StandardError => e
       print_error("Getting the #{is_tgs ? 'TGS' : 'TGT'} has failed: #{e.message}.")
       return nil
@@ -579,11 +579,11 @@ class MetasploitModule < Msf::Exploit::Local
 
     print_status("Launching PsExec against #{fqdn} as Administrator (Kerberos) via COMM session #{session.sid}...")
 
-    psexec_mod.exploit_simple(
+    psexec_mod.exploit_simple({
       'LocalInput' => user_input,
       'LocalOutput' => user_output,
       'RunAsJob' => true
-    )
+    })
 
     print_good('PsExec module launched. Check sessions for new elevated session.')
   end

--- a/modules/post/multi/manage/multi_post.rb
+++ b/modules/post/multi/manage/multi_post.rb
@@ -92,10 +92,10 @@ class MetasploitModule < Msf::Post
         end
       end
       m.options.validate(m.datastore)
-      m.run_simple(
+      m.run_simple({
         'LocalInput' => user_input,
         'LocalOutput' => user_output
-      )
+      })
     end
   end
 end

--- a/modules/post/multi/manage/shell_to_meterpreter.rb
+++ b/modules/post/multi/manage/shell_to_meterpreter.rb
@@ -425,12 +425,12 @@ class MetasploitModule < Msf::Post
     # Validate module options
     mh.options.validate(mh.datastore)
     # Execute showing output
-    mh.exploit_simple(
+    mh.exploit_simple({
       'Payload' => mh.datastore['PAYLOAD'],
       'LocalInput' => user_input,
       'LocalOutput' => user_output,
       'RunAsJob' => true
-    )
+    })
 
     # Check to make sure that the handler is actually valid
     # If another process has the port open, then the handler will fail

--- a/modules/post/multi/manage/system_session.rb
+++ b/modules/post/multi/manage/system_session.rb
@@ -136,12 +136,12 @@ class MetasploitModule < Msf::Post
       # Validate module options
       mul.options.validate(mul.datastore)
       # Execute showing output
-      mul.exploit_simple(
+      mul.exploit_simple({
         'Payload' => mul.datastore['PAYLOAD'],
         'LocalInput' => user_input,
         'LocalOutput' => user_output,
         'RunAsJob' => true
-      )
+      })
     else
       print_error('Could not start handler!')
       print_error('A job is listening on the same Port')

--- a/modules/post/windows/manage/multi_meterpreter_inject.rb
+++ b/modules/post/windows/manage/multi_meterpreter_inject.rb
@@ -129,10 +129,10 @@ class MetasploitModule < Msf::Post
     mul.datastore['EXITFUNC'] = 'process'
     mul.datastore['ExitOnSession'] = false
 
-    mul.exploit_simple(
+    mul.exploit_simple({
       'Payload' => mul.datastore['PAYLOAD'],
       'RunAsJob' => true
-    )
+    })
     print_good('exploit/multi/handler started!')
   end
 

--- a/plugins/aggregator.rb
+++ b/plugins/aggregator.rb
@@ -435,12 +435,12 @@ module Msf
         multi_handler.datastore['ExitOnSession'] = false
         multi_handler.datastore['EXITFUNC'] = 'thread'
 
-        multi_handler.exploit_simple(
+        multi_handler.exploit_simple({
           'LocalInput' => nil,
           'LocalOutput' => nil,
           'Payload' => multi_handler.datastore['PAYLOAD'],
           'RunAsJob' => true
-        )
+        })
         @payload_job_ids << multi_handler.job_id
         # requester = Metasploit::Aggregator::Http::SslRequester.new(multi_handler.datastore['LHOST'], multi_handler.datastore['LPORT'])
         requester = Metasploit::Aggregator::Http::Requester.new(multi_handler.datastore['LHOST'], multi_handler.datastore['LPORT'])

--- a/plugins/ffautoregen.rb
+++ b/plugins/ffautoregen.rb
@@ -61,7 +61,7 @@ module Msf
           target = nmod.datastore['TARGET']
           nop = nmod.datastore['NOP']
 
-          nmod.exploit_simple(
+          nmod.exploit_simple({
             'Encoder' => encoder,
             'Payload' => payload,
             'Target' => target,
@@ -70,7 +70,7 @@ module Msf
             'LocalInput' => driver.input,
             'LocalOutput' => driver.output,
             'RunAsJob' => jobify
-          )
+          })
         end
       end
     end

--- a/scripts/meterpreter/duplicate.rb
+++ b/scripts/meterpreter/duplicate.rb
@@ -79,10 +79,10 @@ mul.datastore['PAYLOAD'] = payload
 mul.datastore['EXITFUNC'] = 'process'
 mul.datastore['ExitOnSession'] = true
 print_status("Running payload handler")
-mul.exploit_simple(
+mul.exploit_simple({
   'Payload'  => mul.datastore['PAYLOAD'],
   'RunAsJob' => true
-)
+})
 
 if client.platform == 'windows'
   server = client.sys.process.open

--- a/scripts/meterpreter/metsvc.rb
+++ b/scripts/meterpreter/metsvc.rb
@@ -127,10 +127,10 @@ if client.platform == 'windows'
     mul.datastore['LPORT']   = rport
     mul.datastore['RHOST']   = client.session_host
     mul.datastore['ExitOnSession'] = false
-    mul.exploit_simple(
+    mul.exploit_simple({
       'Payload'        => mul.datastore['PAYLOAD'],
       'RunAsJob'       => true
-    )
+    })
   end
 
 else

--- a/scripts/meterpreter/multi_meter_inject.rb
+++ b/scripts/meterpreter/multi_meter_inject.rb
@@ -77,10 +77,10 @@ def create_multi_handler(payload_to_inject)
   mul.datastore['EXITFUNC'] = 'process'
   mul.datastore['ExitOnSession'] = true
   print_status("Running payload handler")
-  mul.exploit_simple(
+  mul.exploit_simple({
     'Payload'  => mul.datastore['PAYLOAD'],
     'RunAsJob' => true
-  )
+  })
 
 end
 

--- a/scripts/meterpreter/service_permissions_escalate.rb
+++ b/scripts/meterpreter/service_permissions_escalate.rb
@@ -84,10 +84,10 @@ handler.datastore['LPORT']   = rport
 handler.datastore['InitialAutoRunScript'] = "migrate -f"
 handler.datastore['ExitOnSession'] = false
 #start a handler to be ready
-handler.exploit_simple(
+handler.exploit_simple({
   'Payload'  => handler.datastore['PAYLOAD'],
   'RunAsJob' => true
-)
+})
 
 #attempt to make new service
 client.railgun.kernel32.LoadLibraryA("advapi32.dll")

--- a/scripts/meterpreter/vnc.rb
+++ b/scripts/meterpreter/vnc.rb
@@ -132,10 +132,10 @@ if autoconn
   mul.datastore['AUTOVNC'] = autovnc
 
   print_status("Running payload handler")
-  mul.exploit_simple(
+  mul.exploit_simple({
     'Payload'  => mul.datastore['PAYLOAD'],
     'RunAsJob' => true
-  )
+  })
 end
 
 raw = pay.generate

--- a/test/functional/framework/msfconsole_spec.rb
+++ b/test/functional/framework/msfconsole_spec.rb
@@ -165,12 +165,12 @@ module MsfTest
       payload_name = 'windows/meterpreter/bind_tcp'
 
       ## Fire it off against a known-vulnerable host
-      session = @framework.exploits.create(exploit_name).exploit_simple(
+      session = @framework.exploits.create(exploit_name).exploit_simple({
         'Options' => { 'RHOST' => "vulnerable", "SMBUser" => "administrator", "SMBPass" => "" },
         'Payload' => payload_name,
         'LocalInput' => input,
         'LocalOutput' => output
-      )
+      })
 
       ## If a session came back, try to interact with it.
       if session

--- a/test/functional/meterpreter/meterpreter_java_spec.rb
+++ b/test/functional/meterpreter/meterpreter_java_spec.rb
@@ -66,12 +66,12 @@ module MsfTest
       exploit = @framework.exploits.create(@exploit_name)
 
       ## Fire it off against a known-vulnerable host
-      @session = exploit.exploit_simple(
+      @session = exploit.exploit_simple({
         'Options' => {},
         'Payload' => @payload_name,
         'LocalInput' => @input,
         'LocalOutput' => @output
-      )
+      })
 
       puts @session.inspect
 

--- a/test/functional/meterpreter/meterpreter_php_spec.rb
+++ b/test/functional/meterpreter/meterpreter_php_spec.rb
@@ -57,12 +57,12 @@ module MsfTest
       exploit = @framework.exploits.create(@exploit_name)
 
       ## Fire it off against a known-vulnerable host
-      @session = exploit.exploit_simple(
+      @session = exploit.exploit_simple({
         'Options' => { 'RHOST' => "metasploitable" },
         'Payload' => @payload_name,
         'LocalInput' => @input,
         'LocalOutput' => @output
-      )
+      })
 
       puts @session.inspect
 

--- a/test/functional/meterpreter/meterpreter_win32_spec.rb
+++ b/test/functional/meterpreter/meterpreter_win32_spec.rb
@@ -76,12 +76,12 @@ module MsfTest
       exploit = @framework.exploits.create(@exploit_name)
 
       ## Fire it off against a known-vulnerable host
-      @session = exploit.exploit_simple(
+      @session = exploit.exploit_simple({
         'Options' => { 'RHOST' => "vulnerable", "SMBUser" => "administrator", "SMBPass" => "" },
         'Payload' => @payload_name,
         'LocalInput' => @input,
         'LocalOutput' => @output
-      )
+      })
 
       ## If a session came back, try to interact with it.
       if @session

--- a/test/modules/post/test/all.rb
+++ b/test/modules/post/test/all.rb
@@ -63,11 +63,11 @@ class MetasploitModule < Msf::Post
       print_status("-" * 80)
 
       module_replicant = nil
-      available_module[:module].run_simple(
+      available_module[:module].run_simple({
         'LocalInput' => user_input,
         'LocalOutput' => user_output,
         'Options' => datastore.copy
-      ) { |yielded_module_replicant| module_replicant = yielded_module_replicant }
+      }) { |yielded_module_replicant| module_replicant = yielded_module_replicant }
 
       results << {
         **available_module,


### PR DESCRIPTION
## Description
This fixes https://github.com/rapid7/metasploit-framework/issues/21690

This fixes an issue with keyword arguments for `run_simple`, `exploit_simple` and `check_simple` (see the original issue for details)

## Breaking Changes
None

## Verification Steps

Open a plain shell session and run `sessions -u <id>`. Confirm the Meterpreter upgrade completes without any `ArgumentError` error.

## Test Evidence

### Before
```
msf payload(cmd/windows/powershell/shell_reverse_tcp) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session: [1]
[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[-] Post failed: ArgumentError wrong number of arguments (given 0, expected 1)
[-] Call stack:
[-]   /home/msfuser//metasploit-framework/lib/msf/base/simple/exploit.rb:174:in `exploit_simple'
[-]   /home/msfuser//metasploit-framework/modules/post/multi/manage/shell_to_meterpreter.rb:428:in `create_multihandler'
[-]   /home/msfuser//metasploit-framework/modules/post/multi/manage/shell_to_meterpreter.rb:193:in `run'
```

### After
```
msf payload(cmd/windows/powershell/shell_reverse_tcp) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session: [1]
[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.5.12:4433
[*] Sending stage (248902 bytes) to 192.168.5.89
[*] Meterpreter session 2 opened (192.168.5.12:4433 -> 192.168.5.89:50138) at 2026-07-24 18:13:54 +0200
[*] Stopping exploit/multi/handler
```


## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS |
| **Target Software/Hardware** | Windows 10 |
| **Docker Image / Vagrant Setup** | n/a |

## AI Usage Disclosure
Copilot was used to mass refactor.

## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
