### PR TITLE
Remove the `job_listener:` kwarg in `run_simple`, `exploit_simple` & `check_simple`

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -41,7 +41,8 @@ module Auxiliary
   # 	Whether or not the exploit should be run in the context of a background
   # 	job.
   #
-  def self.run_simple(omod, opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
+  def self.run_simple(omod, opts = {}, &block)
+    job_listener = opts.delete('JobListener') || Msf::Simple::NoopJobListener.instance
 
     # Clone the module to prevent changes to the original instance
     mod = omod.replicant
@@ -96,8 +97,8 @@ module Auxiliary
   #
   # Calls the class method.
   #
-  def run_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
-    Msf::Simple::Auxiliary.run_simple(self, opts, job_listener: job_listener, &block)
+  def run_simple(opts = {}, &block)
+    Msf::Simple::Auxiliary.run_simple(self, opts, &block)
   end
 
   #
@@ -112,7 +113,8 @@ module Auxiliary
   #
   # 	The local output through which data can be displayed.
   #
-  def self.check_simple(mod, opts, job_listener: Msf::Simple::NoopJobListener.instance)
+  def self.check_simple(mod, opts)
+    job_listener = opts.delete('JobListener') || Msf::Simple::NoopJobListener.instance
     Msf::Simple::Framework.simplify_module(mod)
 
     mod._import_extra_options(opts)
@@ -161,8 +163,8 @@ module Auxiliary
   #
   # Calls the class method.
   #
-  def check_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance)
-    Msf::Simple::Auxiliary.check_simple(self, opts, job_listener: job_listener)
+  def check_simple(opts = {})
+    Msf::Simple::Auxiliary.check_simple(self, opts)
   end
 
 

--- a/lib/msf/base/simple/evasion.rb
+++ b/lib/msf/base/simple/evasion.rb
@@ -7,7 +7,8 @@ module Evasion
 
   include Module
 
-  def self.run_simple(oevasion, opts, job_listener: Msf::Simple::NoopJobListener.instance, &block)
+  def self.run_simple(oevasion, opts, &block)
+    job_listener = opts.delete('JobListener') || Msf::Simple::NoopJobListener.instance
     evasion = oevasion.replicant
     # Trap and print errors here (makes them UI-independent)
     begin
@@ -105,8 +106,8 @@ module Evasion
     nil
   end
 
-  def run_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
-    Msf::Simple::Evasion.run_simple(self, opts, job_listener: job_listener, &block)
+  def run_simple(opts = {}, &block)
+    Msf::Simple::Evasion.run_simple(self, opts, &block)
   end
 
 end

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -54,7 +54,8 @@ module Exploit
   # 	Whether or not the exploit should be run in the context of a background
   # 	job.
   #
-  def self.exploit_simple(oexploit, opts, job_listener: Msf::Simple::NoopJobListener.instance, &block)
+  def self.exploit_simple(oexploit, opts, &block)
+    job_listener = opts.delete('JobListener') || Msf::Simple::NoopJobListener.instance
     exploit = oexploit.replicant
     # Trap and print errors here (makes them UI-independent)
     begin
@@ -171,8 +172,8 @@ module Exploit
   #
   # Calls the class method.
   #
-  def exploit_simple(opts, job_listener: Msf::Simple::NoopJobListener.instance, &block)
-    Msf::Simple::Exploit.exploit_simple(self, opts, job_listener: job_listener, &block)
+  def exploit_simple(opts, &block)
+    Msf::Simple::Exploit.exploit_simple(self, opts, &block)
   end
 
   alias run_simple exploit_simple
@@ -188,7 +189,8 @@ module Exploit
   #
   # 	The local output through which data can be displayed.
   #
-  def self.check_simple(mod, opts, job_listener: Msf::Simple::NoopJobListener.instance)
+  def self.check_simple(mod, opts)
+    job_listener = opts.delete('JobListener') || Msf::Simple::NoopJobListener.instance
     Msf::Simple::Framework.simplify_module(mod)
     mod._import_extra_options(opts)
 
@@ -225,8 +227,8 @@ module Exploit
   #
   # Calls the class method.
   #
-  def check_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance)
-    Msf::Simple::Exploit.check_simple(self, opts, job_listener: job_listener)
+  def check_simple(opts = {})
+    Msf::Simple::Exploit.check_simple(self, opts)
   end
 
   protected

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -37,7 +37,8 @@ module Post
   # 	Whether or not the module should be run in the context of a background
   # 	job.
   #
-  def self.run_simple(omod, opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
+  def self.run_simple(omod, opts = {}, &block)
+    job_listener = opts.delete('JobListener') || Msf::Simple::NoopJobListener.instance
 
     # Clone the module to prevent changes to the original instance
     mod = omod.replicant
@@ -91,8 +92,8 @@ module Post
   #
   # Calls the class method.
   #
-  def run_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
-    Msf::Simple::Post.run_simple(self, opts, job_listener: job_listener, &block)
+  def run_simple(opts = {}, &block)
+    Msf::Simple::Post.run_simple(self, opts, &block)
   end
 
 protected

--- a/lib/msf/core/exploit/local.rb
+++ b/lib/msf/core/exploit/local.rb
@@ -19,7 +19,7 @@ class Msf::Exploit::Local < Msf::Exploit
     Msf::Exploit::Type::Local
   end
 
-  def run_simple(opts = {}, job_listener: Msf::Simple::NoopJobListener.instance, &block)
-    Msf::Simple::Exploit.exploit_simple(self, opts, job_listener: job_listener, &block)
+  def run_simple(opts = {}, &block)
+    Msf::Simple::Exploit.exploit_simple(self, opts, &block)
   end
 end

--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -791,8 +791,9 @@ private
       'Payload'  => opts['PAYLOAD'],
       'Target'   => opts['TARGET'],
       'RunAsJob' => true,
-      'Options'  => opts
-    }, job_listener: self.job_status_tracker)
+      'Options'  => opts,
+      'JobListener' => self.job_status_tracker
+    })
     {
       "job_id" => mod.job_id,
       "uuid" => mod.run_uuid
@@ -803,8 +804,9 @@ private
     Msf::Simple::Auxiliary.run_simple(mod,{
       'Action'   => opts['ACTION'],
       'RunAsJob' => true,
-      'Options'  => opts
-    }, job_listener: self.job_status_tracker)
+      'Options'  => opts,
+      'JobListener' => self.job_status_tracker
+    })
     {
       "job_id" => mod.job_id,
       "uuid" => mod.run_uuid
@@ -814,8 +816,9 @@ private
   def _check_exploit(mod, opts)
     uuid, job = Msf::Simple::Exploit.check_simple(mod,{
         'RunAsJob' => true,
-        'Options'  => opts
-    }, job_listener: self.job_status_tracker)
+        'Options'  => opts,
+        'JobListener' => self.job_status_tracker
+    })
     {
       "job_id" => job,
       "uuid" => uuid
@@ -826,8 +829,9 @@ private
     uuid, job = Msf::Simple::Auxiliary.check_simple(mod,{
         'Action'   => opts['ACTION'],
         'RunAsJob' => true,
-        'Options'  => opts
-    }, job_listener: self.job_status_tracker)
+        'Options'  => opts,
+        'JobListener' => self.job_status_tracker
+    })
     {
       "job_id" => job,
       "uuid" => uuid
@@ -837,8 +841,9 @@ private
   def _run_post(mod, opts)
     Msf::Simple::Post.run_simple(mod, {
       'RunAsJob' => true,
-      'Options'  => opts
-    }, job_listener: self.job_status_tracker)
+      'Options'  => opts,
+      'JobListener' => self.job_status_tracker
+    })
     {
       "job_id" => mod.job_id,
       "uuid" => mod.run_uuid
@@ -850,8 +855,9 @@ private
       'Payload'  => opts['PAYLOAD'],
       'Target'   => opts['TARGET'],
       'RunAsJob' => true,
-      'Options'  => opts
-    }, job_listener: self.job_status_tracker)
+      'Options'  => opts,
+      'JobListener' => self.job_status_tracker
+    })
 
     {
       'job_id' => mod.job_id,

--- a/plugins/capture.rb
+++ b/plugins/capture.rb
@@ -325,7 +325,7 @@ module Msf
           event = Rex::Sync::Event.new(false, false)
           job_listener = CaptureJobListener.new(mod.name, event, self)
 
-          result = Msf::Simple::Auxiliary.run_simple(mod, opts, job_listener: job_listener)
+          result = Msf::Simple::Auxiliary.run_simple(mod, opts.merge('JobListener' => job_listener))
           job_id = result[1]
 
           # Wait for the event to trigger (socket server either waiting, or failed)

--- a/spec/lib/msf/base/simple/auxiliary_job_tracking_spec.rb
+++ b/spec/lib/msf/base/simple/auxiliary_job_tracking_spec.rb
@@ -58,23 +58,11 @@ RSpec.describe Msf::Simple::Auxiliary, '#job_run_proc job tracking' do
   end
 end
 
-RSpec.describe Msf::Simple::Auxiliary, 'job_listener keyword signature' do
-  it '.run_simple accepts a job_listener kwarg' do
-    expect(described_class.method(:run_simple).parameters).to include(%i[key job_listener])
-  end
-
-  it '.check_simple accepts a job_listener kwarg' do
-    expect(described_class.method(:check_simple).parameters).to include(%i[key job_listener])
-  end
-
-  it 'the instance-level run_simple accepts a job_listener kwarg' do
-    expect(described_class.instance_method(:run_simple).parameters).to include(%i[key job_listener])
-  end
-
-  it 'the instance-level run_simple forwards job_listener: to the class method' do
+RSpec.describe Msf::Simple::Auxiliary, "'JobListener' opts key signature" do
+  it "the instance-level run_simple forwards opts (including 'JobListener') to the class method" do
     mod = Class.new { include Msf::Simple::Auxiliary }.new
     listener = double('JobListener')
-    expect(described_class).to receive(:run_simple).with(mod, { opts: 1 }, job_listener: listener)
-    mod.run_simple({ opts: 1 }, job_listener: listener)
+    expect(described_class).to receive(:run_simple).with(mod, { opts: 1, 'JobListener' => listener })
+    mod.run_simple({ opts: 1, 'JobListener' => listener })
   end
 end

--- a/spec/lib/msf/base/simple/evasion_job_tracking_spec.rb
+++ b/spec/lib/msf/base/simple/evasion_job_tracking_spec.rb
@@ -55,11 +55,3 @@ RSpec.describe Msf::EvasionDriver, '#initialize' do
     expect(driver.job_listener).to eq(Msf::Simple::NoopJobListener.instance)
   end
 end
-
-RSpec.describe Msf::Simple::Evasion, '.run_simple' do
-  let(:job_listener) { double('JobListener', waiting: nil, start: nil, completed: nil, failed: nil) }
-
-  it 'is a singleton method that accepts a job_listener keyword' do
-    expect(described_class.method(:run_simple).parameters).to include(%i[key job_listener])
-  end
-end

--- a/spec/lib/msf/base/simple/exploit_job_tracking_spec.rb
+++ b/spec/lib/msf/base/simple/exploit_job_tracking_spec.rb
@@ -158,37 +158,21 @@ RSpec.describe Msf::ExploitDriver, 'job listener integration' do
   end
 end
 
-RSpec.describe Msf::Simple::Exploit, 'job_listener keyword signature' do
-  it '.exploit_simple accepts a job_listener kwarg defaulting to the noop listener' do
-    expect(described_class.method(:exploit_simple).parameters).to include(%i[key job_listener])
-  end
-
-  it '.check_simple accepts a job_listener kwarg defaulting to the noop listener' do
-    expect(described_class.method(:check_simple).parameters).to include(%i[key job_listener])
-  end
-
-  it 'the instance-level exploit_simple accepts a job_listener kwarg' do
-    expect(described_class.instance_method(:exploit_simple).parameters).to include(%i[key job_listener])
-  end
-
-  it 'the instance-level check_simple accepts a job_listener kwarg' do
-    expect(described_class.instance_method(:check_simple).parameters).to include(%i[key job_listener])
-  end
-
+RSpec.describe Msf::Simple::Exploit, "'JobListener' opts key signature" do
   describe 'forwarding' do
     let(:framework)   { double('Framework') }
     let(:job_listener) { double('JobListener') }
 
-    it 'the instance-level exploit_simple forwards job_listener: to the class method' do
+    it "the instance-level exploit_simple forwards opts (including 'JobListener') to the class method" do
       mod = Class.new { include Msf::Simple::Exploit }.new
-      expect(described_class).to receive(:exploit_simple).with(mod, { opts: 1 }, job_listener: job_listener)
-      mod.exploit_simple({ opts: 1 }, job_listener: job_listener)
+      expect(described_class).to receive(:exploit_simple).with(mod, { opts: 1, 'JobListener' => job_listener })
+      mod.exploit_simple({ opts: 1, 'JobListener' => job_listener })
     end
 
-    it 'the instance-level check_simple forwards job_listener: to the class method' do
+    it "the instance-level check_simple forwards opts (including 'JobListener') to the class method" do
       mod = Class.new { include Msf::Simple::Exploit }.new
-      expect(described_class).to receive(:check_simple).with(mod, { opts: 1 }, job_listener: job_listener)
-      mod.check_simple({ opts: 1 }, job_listener: job_listener)
+      expect(described_class).to receive(:check_simple).with(mod, { opts: 1, 'JobListener' => job_listener })
+      mod.check_simple({ opts: 1, 'JobListener' => job_listener })
     end
   end
 end

--- a/spec/lib/msf/base/simple/post_job_tracking_spec.rb
+++ b/spec/lib/msf/base/simple/post_job_tracking_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Msf::Simple::Post, '.run_simple' do
     expect(mod).to receive(:run_uuid=).with(kind_of(String)).at_least(:once)
     expect(mod).to receive(:job_id=).with(42).at_least(:once)
 
-    described_class.run_simple(mod, { 'RunAsJob' => true }, job_listener: job_listener)
+    described_class.run_simple(mod, { 'RunAsJob' => true, 'JobListener' => job_listener })
 
     expect(captured_uuid).to be_a(String)
     expect(captured_uuid.length).to be >= 8

--- a/spec/lib/msf/core/rpc/v10/rpc_module_check_spec.rb
+++ b/spec/lib/msf/core/rpc/v10/rpc_module_check_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Msf::RPC::RPC_Module, '#rpc_check propagates NotImplementedError 
   end
 
   context 'job_listener wiring' do
-    it 'passes the RPC job_status_tracker via the job_listener: kwarg for exploit checks' do
+    it "passes the RPC job_status_tracker via the 'JobListener' opts key for exploit checks" do
       mod = double('ExploitModule')
       allow(modules).to receive(:create).with('exploit/multi/handler').and_return(mod)
       allow(mod).to receive(:type).and_return('exploit')
@@ -55,12 +55,11 @@ RSpec.describe Msf::RPC::RPC_Module, '#rpc_check propagates NotImplementedError 
 
       expect(Msf::Simple::Exploit).to have_received(:check_simple).with(
         mod,
-        hash_excluding('JobListener'),
-        job_listener: job_status_tracker
+        hash_including('JobListener' => job_status_tracker)
       )
     end
 
-    it 'passes the RPC job_status_tracker via the job_listener: kwarg for auxiliary checks' do
+    it "passes the RPC job_status_tracker via the 'JobListener' opts key for auxiliary checks" do
       mod = double('AuxiliaryModule')
       allow(modules).to receive(:create).with('auxiliary/scanner/portscan/tcp').and_return(mod)
       allow(mod).to receive(:type).and_return('auxiliary')
@@ -70,8 +69,7 @@ RSpec.describe Msf::RPC::RPC_Module, '#rpc_check propagates NotImplementedError 
 
       expect(Msf::Simple::Auxiliary).to have_received(:check_simple).with(
         mod,
-        hash_excluding('JobListener'),
-        job_listener: job_status_tracker
+        hash_including('JobListener' => job_status_tracker)
       )
     end
   end

--- a/spec/lib/msf/core/rpc/v10/rpc_module_execute_spec.rb
+++ b/spec/lib/msf/core/rpc/v10/rpc_module_execute_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Msf::RPC::RPC_Module, '#rpc_execute returns uuid/job_id for all m
       expect(response['uuid']).to eq('run-uuid')
     end
 
-    it "passes the RPC job_status_tracker via the job_listener: kwarg for #{mtype} modules" do
+    it "passes the RPC job_status_tracker via the 'JobListener' opts key for #{mtype} modules" do
       mod = double('Module', uuid: 'mod-uuid', job_id: 99, run_uuid: 'run-uuid')
       allow(modules).to receive(:create).with("#{mtype}/#{mname}").and_return(mod)
       allow(mod).to receive(:type).and_return(mtype)
@@ -42,8 +42,7 @@ RSpec.describe Msf::RPC::RPC_Module, '#rpc_execute returns uuid/job_id for all m
 
       expect(simple_klass).to have_received(simple_method).with(
         mod,
-        hash_excluding('JobListener'),
-        job_listener: job_status_tracker
+        hash_including('JobListener' => job_status_tracker)
       )
     end
   end
@@ -65,7 +64,7 @@ RSpec.describe Msf::RPC::RPC_Module, '#rpc_execute returns uuid/job_id for all m
       expect(response['job_id']).to eq(11)
     end
 
-    it 'passes the RPC job_status_tracker via the job_listener: kwarg' do
+    it "passes the RPC job_status_tracker via the 'JobListener' opts key" do
       mod = double('PostModule', uuid: 'mod-uuid', job_id: 11, run_uuid: 'run-uuid-post')
       allow(modules).to receive(:create).with('post/multi/general/execute').and_return(mod)
       allow(mod).to receive(:type).and_return('post')
@@ -75,8 +74,7 @@ RSpec.describe Msf::RPC::RPC_Module, '#rpc_execute returns uuid/job_id for all m
 
       expect(Msf::Simple::Post).to have_received(:run_simple).with(
         mod,
-        hash_excluding('JobListener'),
-        job_listener: job_status_tracker
+        hash_including('JobListener' => job_status_tracker)
       )
     end
   end
@@ -93,7 +91,7 @@ RSpec.describe Msf::RPC::RPC_Module, '#rpc_execute returns uuid/job_id for all m
       expect(response['job_id']).to eq(22)
     end
 
-    it 'passes the RPC job_status_tracker via the job_listener: kwarg' do
+    it "passes the RPC job_status_tracker via the 'JobListener' opts key" do
       mod = double('EvasionModule', uuid: 'mod-uuid', job_id: 22, run_uuid: 'run-uuid-evasion')
       allow(modules).to receive(:create).with('evasion/windows/applocker_evasion_msbuild').and_return(mod)
       allow(mod).to receive(:type).and_return('evasion')
@@ -103,8 +101,7 @@ RSpec.describe Msf::RPC::RPC_Module, '#rpc_execute returns uuid/job_id for all m
 
       expect(Msf::Simple::Evasion).to have_received(:run_simple).with(
         mod,
-        hash_excluding('JobListener'),
-        job_listener: job_status_tracker
+        hash_including('JobListener' => job_status_tracker)
       )
     end
   end

--- a/spec/lib/msf/exploit/local_spec.rb
+++ b/spec/lib/msf/exploit/local_spec.rb
@@ -55,23 +55,15 @@ RSpec.describe Msf::Exploit::Local do
   end
 
   describe '#run_simple' do
-    it 'accepts a job_listener keyword argument defaulting to the noop listener' do
-      expect(described_class.instance_method(:run_simple).parameters).to include(%i[key job_listener])
-    end
-
-    it 'forwards opts and job_listener: to Msf::Simple::Exploit.exploit_simple' do
+    it "forwards opts (including 'JobListener') to Msf::Simple::Exploit.exploit_simple" do
       listener = double('JobListener')
-      opts = { 'SESSION' => 1 }
-      expect(Msf::Simple::Exploit).to receive(:exploit_simple).with(subject, opts, job_listener: listener)
-      subject.run_simple(opts, job_listener: listener)
+      opts = { 'SESSION' => 1, 'JobListener' => listener }
+      expect(Msf::Simple::Exploit).to receive(:exploit_simple).with(subject, opts)
+      subject.run_simple(opts)
     end
 
-    it 'defaults job_listener to Msf::Simple::NoopJobListener.instance when omitted' do
-      expect(Msf::Simple::Exploit).to receive(:exploit_simple).with(
-        subject,
-        {},
-        job_listener: Msf::Simple::NoopJobListener.instance
-      )
+    it "does not require a 'JobListener' opts key" do
+      expect(Msf::Simple::Exploit).to receive(:exploit_simple).with(subject, {})
       subject.run_simple
     end
   end


### PR DESCRIPTION
## Description
This fixes https://github.com/rapid7/metasploit-framework/issues/21690

This fixes an issue with keyword arguments for `run_simple`, `exploit_simple` and `check_simple` (see the original issue for details)

## Breaking Changes
None

## Verification Steps

Open a plain shell session and run `sessions -u <id>`. Confirm the Meterpreter upgrade completes without any `ArgumentError` error.

## Test Evidence

### Before
```
msf payload(cmd/windows/powershell/shell_reverse_tcp) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session: [1]
[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[-] Post failed: ArgumentError wrong number of arguments (given 0, expected 1)
[-] Call stack:
[-]   /home/msfuser//metasploit-framework/lib/msf/base/simple/exploit.rb:174:in `exploit_simple'
[-]   /home/msfuser//metasploit-framework/modules/post/multi/manage/shell_to_meterpreter.rb:428:in `create_multihandler'
[-]   /home/msfuser//metasploit-framework/modules/post/multi/manage/shell_to_meterpreter.rb:193:in `run'
```

### After
```
msf payload(cmd/windows/powershell/shell_reverse_tcp) > sessions -u 1
[*] Executing 'post/multi/manage/shell_to_meterpreter' on session: [1]
[*] Upgrading session ID: 1
[*] Starting exploit/multi/handler
[*] Started reverse TCP handler on 192.168.5.12:4433
[*] Sending stage (248902 bytes) to 192.168.5.89
[*] Meterpreter session 2 opened (192.168.5.12:4433 -> 192.168.5.89:50138) at 2026-07-24 18:13:54 +0200
[*] Stopping exploit/multi/handler
```


## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS |
| **Target Software/Hardware** | Windows 10 |
| **Docker Image / Vagrant Setup** | n/a |

## AI Usage Disclosure
Copilot was used to mass refactor.

## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)