### PR TITLE
Restore HTTPS meterpreter payloads on Windows acceptance tests

### DIFF
--- a/spec/support/acceptance/session/java.rb
+++ b/spec/support/acceptance/session/java.rb
@@ -56,8 +56,7 @@ module Acceptance::Session::Java
         name: "java/meterpreter_reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".jar",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [:osx, :linux],
+        platforms: [:osx, :linux, :windows],
         execute_cmd: ["java", "-jar", "${payload_path}"],
         generate_options: {
           '-f': "jar"
@@ -73,8 +72,7 @@ module Acceptance::Session::Java
         name: "java/meterpreter_reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".jar",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [:osx, :linux],
+        platforms: [:osx, :linux, :windows],
         execute_cmd: ["java", "-jar", "${payload_path}"],
         generate_options: {
           '-f': "jar"

--- a/spec/support/acceptance/session/php.rb
+++ b/spec/support/acceptance/session/php.rb
@@ -58,8 +58,7 @@ module Acceptance::Session::Php
         name: "php/meterpreter_reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".php",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [:osx, :linux],
+        platforms: [:osx, :linux, :windows],
         execute_cmd: ["php", "${payload_path}"],
         generate_options: {
           '-f': "raw"
@@ -76,8 +75,7 @@ module Acceptance::Session::Php
         name: "php/meterpreter_reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".php",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [:osx, :linux],
+        platforms: [:osx, :linux, :windows],
         execute_cmd: ["php", "${payload_path}"],
         generate_options: {
           '-f': "raw"
@@ -128,8 +126,7 @@ module Acceptance::Session::Php
         name: "php/meterpreter/reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".php",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [:osx, :linux],
+        platforms: [:osx, :linux, :windows],
         execute_cmd: ["php", "${payload_path}"],
         generate_options: {
           '-f': "raw"
@@ -146,8 +143,7 @@ module Acceptance::Session::Php
         name: "php/meterpreter/reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".php",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [:osx, :linux],
+        platforms: [:osx, :linux, :windows],
         execute_cmd: ["php", "${payload_path}"],
         generate_options: {
           '-f': "raw"

--- a/spec/support/acceptance/session/python.rb
+++ b/spec/support/acceptance/session/python.rb
@@ -61,8 +61,7 @@ module Acceptance::Session::Python
         name: "python/meterpreter_reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".py",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [:osx, :linux],
+        platforms: [:osx, :linux, :windows],
         execute_cmd: ["python", "${payload_path}"],
         generate_options: {
           '-f': "raw"
@@ -80,8 +79,7 @@ module Acceptance::Session::Python
         name: "python/meterpreter_reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".py",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [:osx, :linux],
+        platforms: [:osx, :linux, :windows],
         execute_cmd: ["python", "${payload_path}"],
         generate_options: {
           '-f': "raw"
@@ -135,8 +133,7 @@ module Acceptance::Session::Python
         name: "python/meterpreter/reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".py",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [:osx, :linux],
+        platforms: [:osx, :linux, :windows],
         execute_cmd: ["python", "${payload_path}"],
         generate_options: {
           '-f': "raw"
@@ -154,8 +151,7 @@ module Acceptance::Session::Python
         name: "python/meterpreter/reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".py",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [:osx, :linux],
+        platforms: [:osx, :linux, :windows],
         execute_cmd: ["python", "${payload_path}"],
         generate_options: {
           '-f': "raw"

--- a/spec/support/acceptance/session/windows_meterpreter.rb
+++ b/spec/support/acceptance/session/windows_meterpreter.rb
@@ -117,8 +117,7 @@ module Acceptance::Session::WindowsMeterpreter
         name: "windows/meterpreter_reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".exe",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [],
+        platforms: [:windows],
         execute_cmd: ["${payload_path}"],
         executable: true,
         generate_options: {
@@ -136,8 +135,7 @@ module Acceptance::Session::WindowsMeterpreter
         name: "windows/meterpreter_reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".exe",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [],
+        platforms: [:windows],
         execute_cmd: ["${payload_path}"],
         executable: true,
         generate_options: {
@@ -155,8 +153,7 @@ module Acceptance::Session::WindowsMeterpreter
         name: "windows/x64/meterpreter_reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".exe",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [],
+        platforms: [:windows],
         execute_cmd: ["${payload_path}"],
         executable: true,
         generate_options: {
@@ -174,8 +171,7 @@ module Acceptance::Session::WindowsMeterpreter
         name: "windows/x64/meterpreter_reverse_https",
         skip_module_tests: ['post/test/socket_channels'],
         extension: ".exe",
-        # TODO: HTTPS payloads broken on Windows environments
-        platforms: [],
+        platforms: [:windows],
         execute_cmd: ["${payload_path}"],
         executable: true,
         generate_options: {


### PR DESCRIPTION
Re-enables Windows as a target platform for HTTPS meterpreter payload acceptance tests. These were previously disabled with a TODO comment noting they were broken - which is now resolved by: https://github.com/rapid7/rex-socket/pull/88