### PR TITLE
Fix typos in module documentation

### DIFF
--- a/documentation/modules/auxiliary/gather/owncloud_phpinfo_reader.md
+++ b/documentation/modules/auxiliary/gather/owncloud_phpinfo_reader.md
@@ -110,7 +110,7 @@ Root path of the URI, which is different than `TARGETURI` as its ownCloud specif
 
 ### ENDFILE
 
-The file path to add to the end of hte URL, which is used to bypass filtering. Defaults to `all` which will try `/.css`, `/.js`, `/.svg`,
+The file path to add to the end of the URL, which is used to bypass filtering. Defaults to `all` which will try `/.css`, `/.js`, `/.svg`,
 `/.gif`, `/.png`, `/.html`, `/.ttf`, `/.woff`, `/.ico`, `/.jpg`, `/.jpeg`, `/.json`, `/.properties`, `/.min.map`, `/.js.map`, `/.auto.map`
 
 ## Scenarios

--- a/documentation/modules/post/linux/capture/grandstream_gxp1600_sip.md
+++ b/documentation/modules/post/linux/capture/grandstream_gxp1600_sip.md
@@ -1,5 +1,5 @@
 ## Vulnerable Application
-This capture module works against Grandstream GXP1600 series VoIP devices and can reconfigure hte device to use an
+This capture module works against Grandstream GXP1600 series VoIP devices and can reconfigure the device to use an
 arbitrary SIP proxy. You can first leverage the `exploit/linux/http/grandstream_gxp1600_unauth_rce` exploit
 module to get a root session on a target GXP1600 series device before running this post module.
 
@@ -27,7 +27,7 @@ List the configured SIP account and choose which one to proxy:
 7. `list`
 8. `set SIP_ACCOUNT_INDEX 0`
 
-Sart and stop proxying SIP traffic:
+Start and stop proxying SIP traffic:
 9. `start`
 10. `stop`
 


### PR DESCRIPTION
Thank you for contributing to Metasploit Framework! Your time and effort help make this project better for the entire security community. If you have questions at any point, reach out on [GitHub Discussions](https://github.com/rapid7/metasploit-framework/discussions) or the [Metasploit Slack](https://metasploit.com/slack).

## Description

Fixed minor typos in two module documentation files:

### `documentation/modules/post/linux/capture/grandstream_gxp1600_sip.md`
- Line 2: `hte` → `the`
- Line 30: `Sart` → `Start`

### `documentation/modules/auxiliary/gather/owncloud_phpinfo_reader.md`
- Line 113: `hte` → `the`

## Breaking Changes

None

## Verification Steps

1. Verify that the typos (`hte` -> `the`, `Sart` -> `Start`) have been corrected in the respective files.
2. Confirm there is no impact on module execution or behavior as this is a documentation-only change.

## Test Evidence

(Documentation only - No code changes)

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | N/A (Documentation change) |
| **Target Software/Hardware** | N/A (Documentation change) |

## AI Usage Disclosure

None

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
