### PR TITLE
Fix 'successfully' typos in module console outputs

### DIFF
--- a/modules/exploits/linux/http/centreon_auth_rce_cve_2025_5946.rb
+++ b/modules/exploits/linux/http/centreon_auth_rce_cve_2025_5946.rb
@@ -283,7 +283,7 @@ class MetasploitModule < Msf::Exploit::Remote
     password = datastore['PASSWORD']
     print_status("Trying to log in with admin credentials #{username}:#{password} at the Centreon Web application.")
     fail_with(Failure::NoAccess, 'Failed to authenticate at the Centreon Web application.') unless centreon_login(username, password)
-    print_status('Succesfully authenticated at the Centreon Web application.')
+    print_status('Successfully authenticated at the Centreon Web application.')
 
     # storing credentials at the msf database
     print_status('Saving admin credentials at the msf database.')

--- a/modules/exploits/linux/http/centreon_auth_rce_cve_2025_5946.rb
+++ b/modules/exploits/linux/http/centreon_auth_rce_cve_2025_5946.rb
@@ -283,7 +283,7 @@ class MetasploitModule < Msf::Exploit::Remote
     password = datastore['PASSWORD']
     print_status("Trying to log in with admin credentials #{username}:#{password} at the Centreon Web application.")
     fail_with(Failure::NoAccess, 'Failed to authenticate at the Centreon Web application.') unless centreon_login(username, password)
-    print_status('Authenticated at the Centreon Web application.')
+    print_status('Successfully authenticated at the Centreon Web application.')
 
     # storing credentials at the msf database
     print_status('Saving admin credentials at the msf database.')

--- a/modules/exploits/linux/http/centreon_auth_rce_cve_2025_5946.rb
+++ b/modules/exploits/linux/http/centreon_auth_rce_cve_2025_5946.rb
@@ -225,7 +225,7 @@ class MetasploitModule < Msf::Exploit::Remote
     if @clean_payload
       vprint_status('Cleaning up the mess...')
       if drop_rce_payload(nil)
-        print_good('Payload has been successfully removed from the poller setting "broker_reload_command".')
+        print_good('Payload has been removed from the poller setting "broker_reload_command".')
       else
         print_warning('Payload not removed. Try to remove it manually from the poller setting "broker_reload_command".')
       end
@@ -283,7 +283,7 @@ class MetasploitModule < Msf::Exploit::Remote
     password = datastore['PASSWORD']
     print_status("Trying to log in with admin credentials #{username}:#{password} at the Centreon Web application.")
     fail_with(Failure::NoAccess, 'Failed to authenticate at the Centreon Web application.') unless centreon_login(username, password)
-    print_status('Successfully authenticated at the Centreon Web application.')
+    print_status('Authenticated at the Centreon Web application.')
 
     # storing credentials at the msf database
     print_status('Saving admin credentials at the msf database.')

--- a/modules/exploits/linux/http/pandora_fms_auth_rce_cve_2024_11320.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_rce_cve_2024_11320.rb
@@ -346,7 +346,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Trying to log in with new admin credentials #{@username}:#{@password} at the Pandora FMS Web application.")
       fail_with(Failure::NoAccess, 'Failed to authenticate at the Pandora FMS application.') unless pandora_login(@username, @password)
     end
-    print_status('Succesfully authenticated at the Pandora FMS Web application.')
+    print_status('Successfully authenticated at the Pandora FMS Web application.')
 
     # storing credentials at the msf database
     print_status('Saving admin credentials at the msf database.')

--- a/modules/exploits/linux/http/pandora_fms_auth_rce_cve_2024_11320.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_rce_cve_2024_11320.rb
@@ -346,7 +346,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Trying to log in with new admin credentials #{@username}:#{@password} at the Pandora FMS Web application.")
       fail_with(Failure::NoAccess, 'Failed to authenticate at the Pandora FMS application.') unless pandora_login(@username, @password)
     end
-    print_status('Successfully authenticated at the Pandora FMS Web application.')
+    print_status('Authenticated at the Pandora FMS Web application.')
 
     # storing credentials at the msf database
     print_status('Saving admin credentials at the msf database.')

--- a/modules/exploits/linux/http/pandora_fms_auth_rce_cve_2024_12971.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_rce_cve_2024_12971.rb
@@ -351,7 +351,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Trying to log in with new admin credentials #{username}:#{password} at the Pandora FMS Web application.")
       fail_with(Failure::NoAccess, 'Failed to authenticate at the Pandora FMS application.') unless pandora_login(username, password)
     end
-    print_status('Succesfully authenticated at the Pandora FMS Web application.')
+    print_status('Successfully authenticated at the Pandora FMS Web application.')
 
     # storing credentials at the msf database
     print_status('Saving admin credentials at the msf database.')

--- a/modules/exploits/linux/http/pandora_fms_auth_rce_cve_2024_12971.rb
+++ b/modules/exploits/linux/http/pandora_fms_auth_rce_cve_2024_12971.rb
@@ -351,7 +351,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status("Trying to log in with new admin credentials #{username}:#{password} at the Pandora FMS Web application.")
       fail_with(Failure::NoAccess, 'Failed to authenticate at the Pandora FMS application.') unless pandora_login(username, password)
     end
-    print_status('Successfully authenticated at the Pandora FMS Web application.')
+    print_status('Authenticated at the Pandora FMS Web application.')
 
     # storing credentials at the msf database
     print_status('Saving admin credentials at the msf database.')

--- a/modules/exploits/multi/http/microfocus_ucmdb_unauth_deser.rb
+++ b/modules/exploits/multi/http/microfocus_ucmdb_unauth_deser.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, "#{peer} - Failed to authenticate with the diagnostics user!")
     end
     cookies = res.get_cookies
-    print_good("#{peer} - Succesfully authenticated and obtained our cookie!")
+    print_good("#{peer} - Successfully authenticated and obtained our cookie!")
 
     # Now let's pick a random service since we have so many to choose from :D
     vuln_service = [

--- a/modules/exploits/multi/http/microfocus_ucmdb_unauth_deser.rb
+++ b/modules/exploits/multi/http/microfocus_ucmdb_unauth_deser.rb
@@ -120,7 +120,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, "#{peer} - Failed to authenticate with the diagnostics user!")
     end
     cookies = res.get_cookies
-    print_good("#{peer} - Successfully authenticated and obtained our cookie!")
+    print_good("#{peer} - Authenticated and obtained our cookie!")
 
     # Now let's pick a random service since we have so many to choose from :D
     vuln_service = [

--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
           This module exploits a SQL injection vulnerability found in vBulletin 5.6.1 and earlier
           This module uses the getIndexableContent vulnerability to reset the administrators password,
           it then uses the administrators login information to achieve RCE on the target. This module
-          has been tested successfully on VBulletin Version 5.6.1 on Ubuntu Linux distribution.
+          has been tested on VBulletin Version 5.6.1 on Ubuntu Linux distribution.
         },
         'License' => MSF_LICENSE,
         'Author' => [

--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     tbl_prefix = table_name.split('language')[0]
-    print_good("Sucessfully retrieved table to get prefix from #{table_name}.")
+    print_good("Successfully retrieved table to get prefix from #{table_name}.")
 
     tbl_prefix
   end
@@ -344,7 +344,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return nil
     end
 
-    print_good('Request made succesfully, payload should be executing now.')
+    print_good('Request made successfully, payload should be executing now.')
 
     true
   end
@@ -396,7 +396,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil unless res && res.code == 200 && (parsed_resp = res.get_json_document) && parsed_resp['success']
 
-    print_good("Page succesfully created and should be accessible at '#{normalize_uri(target_uri.path, payload_url.to_s)}'.")
+    print_good("Page successfully created and should be accessible at '#{normalize_uri(target_uri.path, payload_url.to_s)}'.")
 
     parsed_resp['pageid']
   end
@@ -454,7 +454,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil unless res && res.code == 200 && (parsed_resp = res.get_json_document) && !parsed_resp['errors']
 
-    print_good("Sucessfully found node at id #{id}")
+    print_good("Successfully found node at id #{id}")
     true
   end
 

--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -577,7 +577,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Add page with widget embedded
     payload_url = rand_text_alphanumeric(rand(6..10))
     session_info = [login_token, cookie_jar]
-    page_id = save_page(node_id, admin_uid, pt_id, payload_url, wi_id, session_info)
+    page_id = save_page(node_id, admin_uid, pt_id, payload_url, wi_id, session_info) # rubocop:disable Lint/Debugger
     fail_with(Failure::UnexpectedReply, 'Could not save newly created page with malicious widget.') unless page_id
 
     # Execute php payload

--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -577,7 +577,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Add page with widget embedded
     payload_url = rand_text_alphanumeric(rand(6..10))
     session_info = [login_token, cookie_jar]
-    page_id = save_page(node_id, admin_uid, pt_id, payload_url, wi_id, session_info) # rubocop:disable Lint/Debugger
+    page_id = save_page(node_id, admin_uid, pt_id, payload_url, wi_id, session_info)
     fail_with(Failure::UnexpectedReply, 'Could not save newly created page with malicious widget.') unless page_id
 
     # Execute php payload

--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -128,7 +128,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     tbl_prefix = table_name.split('language')[0]
-    print_good("Successfully retrieved table to get prefix from #{table_name}.")
+    print_good("Retrieved table to get prefix from #{table_name}.")
 
     tbl_prefix
   end
@@ -183,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return [nil, nil] unless res && res.code == 200 && (parsed_resp = res.get_json_document) && parsed_resp['success']
 
-    print_good("Successfully logged in as #{user} #{type}.")
+    print_good("Logged in as #{user} #{type}.")
 
     [res.get_cookies, parsed_resp['newtoken']]
   end
@@ -226,7 +226,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil unless res && res.code == 200 && (parsed_resp = res.get_json_document) && !parsed_resp['errors']
 
-    print_good('Successfully enabled site-builder functionality.')
+    print_good('Enabled site-builder functionality.')
     true
   end
 
@@ -277,7 +277,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil unless res && res.code == 200 && (parsed_resp = res.get_json_document) && !parsed_resp['errors']
 
-    print_good('Successfully added payload to widget.')
+    print_good('Added payload to widget.')
 
     true
   end
@@ -304,7 +304,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return nil
     end
 
-    print_good("User with userid '#{admin_uid}' successfully reset password to '#{new_pass}'.")
+    print_good("User with userid '#{admin_uid}' reset password to '#{new_pass}'.")
 
     true
   end
@@ -327,7 +327,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil unless res && res.code == 200 && (parsed_resp = res.get_json_document) && !parsed_resp['errors']
 
-    print_good("Successfully deleted page with pageid: #{pageid}")
+    print_good("Deleted page with pageid: #{pageid}")
 
     true
   end
@@ -344,7 +344,7 @@ class MetasploitModule < Msf::Exploit::Remote
       return nil
     end
 
-    print_good('Request made successfully, payload should be executing now.')
+    print_good('Request made, payload should be executing now.')
 
     true
   end
@@ -396,7 +396,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil unless res && res.code == 200 && (parsed_resp = res.get_json_document) && parsed_resp['success']
 
-    print_good("Page successfully created and should be accessible at '#{normalize_uri(target_uri.path, payload_url.to_s)}'.")
+    print_good("Page created and should be accessible at '#{normalize_uri(target_uri.path, payload_url.to_s)}'.")
 
     parsed_resp['pageid']
   end
@@ -454,7 +454,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return nil unless res && res.code == 200 && (parsed_resp = res.get_json_document) && !parsed_resp['errors']
 
-    print_good("Successfully found node at id #{id}")
+    print_good("Found node at id #{id}")
     true
   end
 

--- a/modules/exploits/osx/local/rsh_libmalloc.rb
+++ b/modules/exploits/osx/local/rsh_libmalloc.rb
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NotVulnerable, "Could not successfully write to crontab file.")
     end
 
-    print_good("Succesfully wrote to crontab file!")
+    print_good("Successfully wrote to crontab file!")
 
     # Wait for sudoers to change
     new_size = get_stat_size(sudoer_path)
@@ -217,7 +217,7 @@ class MetasploitModule < Msf::Exploit::Local
       Rex.sleep(1)
       kill_ret = cmd_exec("killall cron 2>/dev/null; echo $?")
       if kill_ret.chomp.to_i == 0
-        vprint_good("Succesfully killed cron!")
+        vprint_good("Successfully killed cron!")
       else
         print_warning("Could not kill cron process.")
       end

--- a/modules/exploits/osx/local/rsh_libmalloc.rb
+++ b/modules/exploits/osx/local/rsh_libmalloc.rb
@@ -147,7 +147,7 @@ class MetasploitModule < Msf::Exploit::Local
       fail_with(Failure::NotVulnerable, "Could not successfully write to crontab file.")
     end
 
-    print_good("Successfully wrote to crontab file!")
+    print_good("Wrote to crontab file!")
 
     # Wait for sudoers to change
     new_size = get_stat_size(sudoer_path)
@@ -210,14 +210,14 @@ class MetasploitModule < Msf::Exploit::Local
       vprint_status("Killing cron process and removing crontab file since it did not exist prior to exploit.")
       rm_ret = cmd_exec("rm /etc/crontab 2>/dev/null; echo $?")
       if rm_ret.chomp.to_i == 0
-        vprint_good("Successfully removed crontab file!")
+        vprint_good("Removed crontab file!")
       else
         print_warning("Could not remove crontab file.")
       end
       Rex.sleep(1)
       kill_ret = cmd_exec("killall cron 2>/dev/null; echo $?")
       if kill_ret.chomp.to_i == 0
-        vprint_good("Successfully killed cron!")
+        vprint_good("Killed cron!")
       else
         print_warning("Could not kill cron process.")
       end

--- a/modules/exploits/osx/local/rsh_libmalloc.rb
+++ b/modules/exploits/osx/local/rsh_libmalloc.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Exploit::Local
     vprint_status("Reading crontab yielded the following response: #{crontab}")
     unless crontab.include? "ALL ALL=(ALL) NOPASSWD: ALL"
       vprint_error("Bad news... it did not write to the file.")
-      fail_with(Failure::NotVulnerable, "Could not successfully write to crontab file.")
+      fail_with(Failure::NotVulnerable, "Could not write to crontab file.")
     end
 
     print_good("Wrote to crontab file!")

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -213,7 +213,7 @@ class MetasploitModule < Msf::Exploit::Local
     if output =~ /incorrect password attempts\s*$/i
       fail_with(Failure::NotFound, 'User has never run sudo, and is therefore not vulnerable. Bailing.')
     elsif output =~ /#{test}/
-      print_good('Test executed successfully. Running payload.')
+      print_good('Test executed. Running payload.')
     else
       print_error('Unknown fail while testing, trying to execute the payload anyway...')
     end

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -213,7 +213,7 @@ class MetasploitModule < Msf::Exploit::Local
     if output =~ /incorrect password attempts\s*$/i
       fail_with(Failure::NotFound, 'User has never run sudo, and is therefore not vulnerable. Bailing.')
     elsif output =~ /#{test}/
-      print_good('Test executed succesfully. Running payload.')
+      print_good('Test executed successfully. Running payload.')
     else
       print_error('Unknown fail while testing, trying to execute the payload anyway...')
     end

--- a/modules/exploits/windows/fileformat/vlc_mkv.rb
+++ b/modules/exploits/windows/fileformat/vlc_mkv.rb
@@ -303,7 +303,7 @@ class MetasploitModule < Msf::Exploit
     File.open(full_path, 'ab') do |fd|
       count.times { fd.write(simple_block) }
     end
-    print_good("Succesfully appended blocks to #{f1}")
+    print_good("Successfully appended blocks to #{f1}")
   end
 
   def file_format_filename(name = '')

--- a/modules/exploits/windows/fileformat/vlc_mkv.rb
+++ b/modules/exploits/windows/fileformat/vlc_mkv.rb
@@ -303,7 +303,7 @@ class MetasploitModule < Msf::Exploit
     File.open(full_path, 'ab') do |fd|
       count.times { fd.write(simple_block) }
     end
-    print_good("Successfully appended blocks to #{f1}")
+    print_good("Appended blocks to #{f1}")
   end
 
   def file_format_filename(name = '')

--- a/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
@@ -280,7 +280,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res && res.code == 302
-      print_good('HL7 Sensor succesfully created')
+      print_good('HL7 Sensor successfully created')
     else
       fail_with(Failure::NoAccess, 'Failure to create HL7 sensor')
     end

--- a/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
@@ -19,6 +19,7 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2023-32781']
         ],
         'DisclosureDate' => '2023-08-09',
+        'Platform' => 'win',
         'Targets' => [
           [
             'Windows_Fetch',

--- a/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
@@ -19,7 +19,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2023-32781']
         ],
         'DisclosureDate' => '2023-08-09',
-        'Platform' => 'win',
         'Targets' => [
           [
             'Windows_Fetch',

--- a/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, 'Failure to connect to PRTG')
     end
     if res && res.code == 302 && res.get_cookies
-      print_good('Successfully authenticated against PRTG')
+      print_good('Authenticated against PRTG')
     else
       fail_with(Failure::NoAccess, 'Failure to authenticate against PRTG')
     end
@@ -280,7 +280,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     if res && res.code == 302
-      print_good('HL7 Sensor successfully created')
+      print_good('HL7 Sensor created')
     else
       fail_with(Failure::NoAccess, 'Failure to create HL7 sensor')
     end

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -22,7 +22,7 @@ class MetasploitModule < Msf::Exploit::Remote
           accounts are enabled so an account can be created.
 
           It can be exploited in Windows and Linux environments to get remote code
-          execution (usualy as SYSTEM). This module has been tested successfully
+          execution (usually as SYSTEM). This module has been tested
           on Ahsay Backup v8.1.1.50 with Windows 2003 SP2 Server. Because of this
           flaw all connected clients can be configured to execute a command before
           the backup starts. Allowing an attacker to takeover even more systems

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -17,9 +17,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Ahsay Backup v7.x-v8.1.1.50 (authenticated) file upload',
         'Description' => %q{
           This module exploits an authenticated insecure file upload and code
-          execution flaw in Ahsay Backup v7.x - v8.1.1.50. To execute
-          the upload credentials are needed, default on Ahsay Backup trial
-          accounts are enabled so an account can be created.
+          execution flaw in Ahsay Backup v7.x - v8.1.1.50. To successfully
+          execute the upload,
+          credentials are needed; default Ahsay Backup trial accounts are enabled
+          so an account can be created.
 
           It can be exploited in Windows and Linux environments to get remote code
           execution (usually as SYSTEM). This module has been tested

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Ahsay Backup v7.x-v8.1.1.50 (authenticated) file upload',
         'Description' => %q{
           This module exploits an authenticated insecure file upload and code
-          execution flaw in Ahsay Backup v7.x - v8.1.1.50. To successfully execute
+          execution flaw in Ahsay Backup v7.x - v8.1.1.50. To execute
           the upload credentials are needed, default on Ahsay Backup trial
           accounts are enabled so an account can be created.
 

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -284,7 +284,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'timeout' => 20
     })
     if res && res.code == 201
-      print_good("Succesfully uploaded file to #{fileLocation}")
+      print_good("Successfully uploaded file to #{fileLocation}")
     else
       fail_with(Failure::Unknown, "#{peer} - Server did not respond in an expected way")
     end

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -284,7 +284,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'timeout' => 20
     })
     if res && res.code == 201
-      print_good("Successfully uploaded file to #{fileLocation}")
+      print_good("Uploaded file to #{fileLocation}")
     else
       fail_with(Failure::Unknown, "#{peer} - Server did not respond in an expected way")
     end

--- a/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
+++ b/modules/exploits/windows/misc/ahsay_backup_fileupload.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Ahsay Backup v7.x-v8.1.1.50 (authenticated) file upload',
         'Description' => %q{
           This module exploits an authenticated insecure file upload and code
-          execution flaw in Ahsay Backup v7.x - v8.1.1.50. To succesfully execute
+          execution flaw in Ahsay Backup v7.x - v8.1.1.50. To successfully execute
           the upload credentials are needed, default on Ahsay Backup trial
           accounts are enabled so an account can be created.
 


### PR DESCRIPTION
Thank you for contributing to Metasploit Framework! Your time and effort help make this project better for the entire security community. If you have questions at any point, reach out on [GitHub Discussions](https://github.com/rapid7/metasploit-framework/discussions) or the [Metasploit Slack](https://metasploit.com/slack).

## Description

Fixed multiple spelling errors of the word "successfully" (`Succesfully` and `Sucessfully` -> `Successfully`) across various exploit modules. These typos were present in user-facing console output strings (`print_status` and `print_good`). 

Modules affected:
- `windows/misc/ahsay_backup_fileupload`
- `windows/http/prtg_authenticated_rce_cve_2023_32781`
- `windows/fileformat/vlc_mkv`
- `osx/local/rsh_libmalloc`
- `osx/local/sudo_password_bypass`
- `multi/http/microfocus_ucmdb_unauth_deser`
- `multi/http/vbulletin_getindexablecontent`
- `linux/http/centreon_auth_rce_cve_2025_5946`
- `linux/http/pandora_fms_auth_rce_cve_2024_12971`
- `linux/http/pandora_fms_auth_rce_cve_2024_11320`

## Breaking Changes

None

## Verification Steps

1. Review the modified `.rb` files.
2. Confirm that only string outputs within `print_good`, `vprint_good`, and `print_status` calls were modified.
3. Verify that these changes do not impact exploit execution logic.

## Test Evidence

(String changes only - logic is not affected)

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | N/A |
| **Target Software/Hardware** | N/A |

## AI Usage Disclosure

None

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
