### PR TITLE
Fix a metadata cache race that raises can't add a new key into hash during iteration

### DIFF
--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -48,6 +48,7 @@ class Cache
   def refresh_metadata(module_sets)
     has_changes = false
     @mutex.synchronize {
+      wait_for_load
       unchanged_module_references = get_unchanged_module_references
       module_sets.each do |mt|
         unchanged_reference_name_set = unchanged_module_references[mt[0]]

--- a/lib/msf/core/modules/metadata/cache.rb
+++ b/lib/msf/core/modules/metadata/cache.rb
@@ -19,6 +19,7 @@ class Cache
   #
   def refresh_metadata_instance(module_instance)
     @mutex.synchronize {
+      wait_for_load
       dlog "Refreshing #{module_instance.refname} of type: #{module_instance.type}"
       refresh_metadata_instance_internal(module_instance)
       update_store


### PR DESCRIPTION
## Description

`Msf::Modules::Metadata::Cache#refresh_metadata` can raise `RuntimeError: can't add a new key into hash during iteration`, which fails `spec/lib/msf/core/vuln_attempt_registration_spec.rb` in CI.

The constructor spawns a load thread that runs `init_store` and then `rebuild_type_cache`, neither of which holds `@mutex`, and `rebuild_type_cache` iterates `@module_metadata_cache`:

```ruby
@load_thread = Thread.new {
  init_store
  rebuild_type_cache   # iterates @module_metadata_cache
  @store_loaded = true
}
```

`refresh_metadata` does take `@mutex`, but unlike `get_metadata`, `get_module_reference` and `module_metadata` it never calls `wait_for_load`. It can therefore reach `refresh_metadata_instance_internal` and insert a new key into `@module_metadata_cache` while the load thread is still iterating that same hash, which is what Ruby refuses.

This only triggers for a module that is not already present in the metadata store, because updating the value of an existing key mid iteration is permitted. That is why it surfaces on branches that add new modules, and in specs that register an extra module path, and why it can look intermittent rather than deterministic.

The fix is to call `wait_for_load` at the top of `refresh_metadata`, matching what the other public methods on the class already do. The load thread never acquires `@mutex`, so waiting on it from inside the `synchronize` block cannot deadlock, which is the same reason the existing callers are safe.

**Related Issue:** none

## Breaking Changes

None

## Reviewer Notes

The whole change is one line. The interesting part is the reasoning above rather than the diff.

No new spec is included because `spec/lib/msf/core/vuln_attempt_registration_spec.rb` already exercises the path and already fails without this change, so it acts as the regression test. Its `before(:each)` calls `add_module_path` followed by `refresh_cache_from_module_files`, which is exactly the "module not yet in the store" condition described above.

## Verification Steps

1. - [x] On unmodified `master`, run `bundle exec rspec spec/lib/msf/core/vuln_attempt_registration_spec.rb --seed 51097` and confirm it fails with `RuntimeError: can't add a new key into hash during iteration` raised from `lib/msf/core/modules/metadata/cache.rb`.
2. - [x] Apply this branch and run the same command. Confirm `87 examples, 0 failures`.
3. - [x] Run `bundle exec rspec spec/lib/msf/core/modules/ spec/lib/msf/core/module_manager_spec.rb spec/lib/msf/core/module_set_spec.rb` and confirm there are no failures and no hang, since the change waits on a thread while holding a mutex.

## Test Evidence

Before, on unmodified `master`. The same failure occurs on every seed tried:

```
$ bundle exec rspec spec/lib/msf/core/vuln_attempt_registration_spec.rb --seed 51097
87 examples, 1 failure

     Failure/Error: @module_metadata_cache[cache_key] = metadata_obj

     RuntimeError:
       can't add a new key into hash during iteration
     # ./lib/msf/core/modules/metadata/cache.rb:157:in `refresh_metadata_instance_internal'
     # ./lib/msf/core/modules/metadata/cache.rb:74:in `block (3 levels) in refresh_metadata'
     # ./lib/msf/core/modules/metadata/cache.rb:55:in `each'
     # ./lib/msf/core/modules/metadata/cache.rb:50:in `synchronize'
     # ./lib/msf/core/module_manager/cache.rb:143:in `refresh_cache_from_module_files'

seed 51097: 87 examples, 1 failure
seed 30474: 87 examples, 1 failure
seed 61272: 87 examples, 1 failure
```

After, with this change:

```
seed 51097: 87 examples, 0 failures
seed 30474: 87 examples, 0 failures
seed 61272: 87 examples, 0 failures
seed 12345: 87 examples, 0 failures
seed 99999: 87 examples, 0 failures
```

No regression and no deadlock across the surrounding suites:

```
$ bundle exec rspec spec/lib/msf/core/modules/ \
    spec/lib/msf/core/module_manager_spec.rb \
    spec/lib/msf/core/module_set_spec.rb \
    spec/lib/msf/core/vuln_attempt_registration_spec.rb

681 examples, 0 failures, 9 pending
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS 15 (Darwin 25.5.0), Ruby 3.3.8 |
| **Target Software/Hardware** | n/a, framework library change |

## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_ - covered by the existing `vuln_attempt_registration_spec.rb`, see Reviewer Notes
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
