### PR TITLE
Allow wildcard bind addresses for handlers that bind to all interfaces

### DIFF
--- a/lib/msf/core/opt_address_or_hostname.rb
+++ b/lib/msf/core/opt_address_or_hostname.rb
@@ -38,6 +38,8 @@ class OptAddressOrHostname < OptAddressRoutable
     return false unless value.kind_of?(String) || value.kind_of?(NilClass)
 
     if value && !value.empty?
+      return true if Rex::Socket.is_ip_addr?(value) && Rex::Socket.addr_atoi(value) == 0
+
       return super if Rex::Socket.is_ip_addr?(value)
 
       if Rex::Socket.is_name?(value)

--- a/spec/lib/msf/core/opt_address_or_hostname_spec.rb
+++ b/spec/lib/msf/core/opt_address_or_hostname_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe Msf::OptAddressOrHostname do
     { value: '127.0.0.1',    normalized: '127.0.0.1' },
     { value: '2001:db8::',   normalized: '2001:db8::' },
     { value: '::1',          normalized: '::1' },
+    { value: '0.0.0.0',      normalized: '0.0.0.0' },
+    { value: '0::0',         normalized: '::' },
     # Tunnel / proxy hostnames that may not be locally resolvable
     { value: 'tunnel.example.com', normalized: 'tunnel.example.com' },
     { value: 'abc123.ngrok.io', normalized: 'abc123.ngrok.io' },
@@ -30,9 +32,6 @@ RSpec.describe Msf::OptAddressOrHostname do
   ] + (iface ? [{ value: iface[:name], normalized: iface[:addr] }] : [])
 
   invalid_values = [
-    # Wildcard bind addresses are not valid callback addresses for LHOST
-    { value: '0.0.0.0' },
-    { value: '0::0' },
     # Malformed IPv6
     { value: '0:::0' },
     { value: '0:0:0' },


### PR DESCRIPTION
## Description

After #21552 introduced `OptAddressOrHostname` for LHOST in reverse handlers, setting `LHOST 0.0.0.0` on `multi/handler` (or any reverse handler) fails validation:

```
msf exploit(multi/handler) > set lhost 0.0.0.0
[-] The following options failed to validate: Value '0.0.0.0' is not valid for option 'LHOST'.
lhost => 127.0.0.1
```

Prior to that PR, LHOST used `OptAddressLocal` (via `Opt::LHOST`) which explicitly allowed `0.0.0.0`/`::` as valid wildcard bind addresses. The new `OptAddressOrHostname` delegates IP validation to `OptAddressRoutable#valid?`, which unconditionally rejects zero addresses which is correct for non-routable callback targets, but wrong for handlers that legitimately bind to all interfaces

This PR adds an early return in `OptAddressOrHostname#valid?` to allow zero addresses before they reach `OptAddressRoutable`'s rejection, restoring the pre-#21552 behaviour while preserving the original PRs intent

**Related Issue:** Regression from #21552

## Breaking Changes

None

## Verification Steps

1. - [ ] `msfconsole`
2. - [ ] `use exploit/multi/handler`
3. - [ ] `set payload windows/meterpreter/reverse_tcp`
4. - [ ] `set LHOST 0.0.0.0` — should succeed without validation error
5. - [ ] `show options` — LHOST should show `0.0.0.0`
6. - [ ] `run` — handler should start with "Started reverse TCP handler on 0.0.0.0:4444"
7. - [ ] Verify non-routable addresses are still rejected: `set LHOST 224.0.0.1` — should fail validation (multicast)
8. - [ ] CI passes

## Test Evidence

```
msf exploit(multi/handler) > set lhost 0.0.0.0
lhost => 0.0.0.0
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS |
| **Target Software/Hardware** | Metasploit Framework (multi/handler) |

## AI Usage Disclosure

Kiro 

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)