### PR TITLE
Update the metasploit-payloads and metasploit-payloads_mettle gems for 6.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ PATH
       metasploit-model
       metasploit-payloads (= 2.0.247)
       metasploit_data_models (>= 6.0.15)
-      metasploit_payloads-mettle (= 1.0.48.pre.3)
+      metasploit_payloads-mettle (= 1.0.48)
       mqtt
       msgpack (~> 1.6.0)
       mutex_m
@@ -383,7 +383,7 @@ GEM
       railties (>= 7.0, < 8.1)
       recog
       webrick
-    metasploit_payloads-mettle (1.0.48.pre.3)
+    metasploit_payloads-mettle (1.0.48)
     method_source (1.1.0)
     mime-types (3.7.0)
       logger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ PATH
       metasploit-concern
       metasploit-credential (>= 6.0.21)
       metasploit-model
-      metasploit-payloads (= 2.0.246.pre.11)
+      metasploit-payloads (= 2.0.247)
       metasploit_data_models (>= 6.0.15)
       metasploit_payloads-mettle (= 1.0.48.pre.3)
       mqtt
@@ -369,7 +369,7 @@ GEM
       drb
       mutex_m
       railties (>= 7.0, < 8.1)
-    metasploit-payloads (2.0.246.pre.11)
+    metasploit-payloads (2.0.247)
     metasploit_data_models (6.0.18)
       activerecord (>= 7.0, < 8.1)
       activesupport (>= 7.0, < 8.1)

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -103,7 +103,7 @@ metasploit-concern, 5.0.6, "New BSD"
 metasploit-credential, 6.0.25, "New BSD"
 metasploit-framework, 6.4.145, "New BSD"
 metasploit-model, 5.0.5, "New BSD"
-metasploit-payloads, 2.0.245, "3-clause (or ""modified"") BSD"
+metasploit-payloads, 2.0.247, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.18, "New BSD"
 metasploit_payloads-mettle, 1.0.46, "3-clause (or ""modified"") BSD"
 method_source, 1.1.0, MIT

--- a/LICENSE_GEMS
+++ b/LICENSE_GEMS
@@ -105,7 +105,7 @@ metasploit-framework, 6.4.145, "New BSD"
 metasploit-model, 5.0.5, "New BSD"
 metasploit-payloads, 2.0.247, "3-clause (or ""modified"") BSD"
 metasploit_data_models, 6.0.18, "New BSD"
-metasploit_payloads-mettle, 1.0.46, "3-clause (or ""modified"") BSD"
+metasploit_payloads-mettle, 1.0.48, "3-clause (or ""modified"") BSD"
 method_source, 1.1.0, MIT
 mime-types, 3.7.0, MIT
 mime-types-data, 3.2025.0924, MIT

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -76,7 +76,7 @@ Gem::Specification.new do |spec|
   # Needed for Meterpreter
   spec.add_runtime_dependency 'metasploit-payloads', '2.0.247'
   # Needed for the next-generation POSIX Meterpreter
-  spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.48.pre.3'
+  spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.48'
   # Needed by msfgui and other rpc components
   # Locked until build env can handle newer version. See: https://github.com/msgpack/msgpack-ruby/issues/334
   spec.add_runtime_dependency 'msgpack', '~> 1.6.0'

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model'
   # Needed for Meterpreter
-  spec.add_runtime_dependency 'metasploit-payloads', '2.0.246.pre.11'
+  spec.add_runtime_dependency 'metasploit-payloads', '2.0.247'
   # Needed for the next-generation POSIX Meterpreter
   spec.add_runtime_dependency 'metasploit_payloads-mettle', '1.0.48.pre.3'
   # Needed by msfgui and other rpc components


### PR DESCRIPTION
Includes changes from:
* rapid7/metasploit-payloads#806
* rapid7/metasploit-payloads#805
* rapid7/metasploit-payloads#803
* rapid7/metasploit-payloads#802
* rapid7/metasploit-payloads#801
* rapid7/metasploit-payloads#759
* rapid7/mettle#286
* rapid7/mettle#294
* rapid7/mettle#296