### PR TITLE
Fix msftidy lint failures introduced after revert

### DIFF
--- a/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
+++ b/modules/exploits/multi/http/vbulletin_getindexablecontent.rb
@@ -368,7 +368,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   # Saves a new page to the vBulletin install
-  def save_page(nodeid, userid, pt_id, payload_url, wi_id, session_info)
+  def save_vbulletin_page(nodeid, userid, pt_id, payload_url, wi_id, session_info)
     print_status("Sending request to '#{target_uri.path}/admin/savepage' to save new page at '#{payload_url}'.")
     res = send_request_cgi({
       'method' => 'POST',
@@ -577,7 +577,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Add page with widget embedded
     payload_url = rand_text_alphanumeric(rand(6..10))
     session_info = [login_token, cookie_jar]
-    page_id = save_page(node_id, admin_uid, pt_id, payload_url, wi_id, session_info)
+    page_id = save_vbulletin_page(node_id, admin_uid, pt_id, payload_url, wi_id, session_info)
     fail_with(Failure::UnexpectedReply, 'Could not save newly created page with malicious widget.') unless page_id
 
     # Execute php payload

--- a/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
+++ b/modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb
@@ -19,7 +19,6 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'CVE', '2023-32781']
         ],
         'DisclosureDate' => '2023-08-09',
-        'Platform' => 'win',
         'Targets' => [
           [
             'Windows_Fetch',


### PR DESCRIPTION
This PR resolves two `msftidy`/`rubocop` lint errors that surfaced after reverting unrelated Rubocop fixes in my recent PR:
https://github.com/rapid7/metasploit-framework/pull/21715

**Changes:**

1. `modules/exploits/multi/http/vbulletin_getindexablecontent.rb`:
   Renamed `save_page` to `save_vbulletin_page`. The original method name triggered a false-positive `Lint/Debugger` warning due to a name collision with Capybara's debug helper. It is a legitimate exploit method that sends a POST request to `/admin/savepage`, not a leftover development debug call.

2. `modules/exploits/windows/http/prtg_authenticated_rce_cve_2023_32781.rb`:
   Removed the redundant top-level `Platform` definition. Since #20786, the framework automatically merges target-level Platform/Arch entries into the module's top-level metadata, so this explicit definition is no longer needed and was correctly flagged by `Lint/ModuleRedundantArchPlatform`.
   *(Note: I previously attempted to include this cleanup in PR #21715, but reverted it there since it was out of scope. Submitting it properly here.)*

Both changes are lint/style fixes only — no functional or exploit logic was modified.