### PR TITLE
Update JSON RPC test to use Linux payload for meterpreter reverse HTTP

### DIFF
--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -576,7 +576,7 @@ RSpec.describe "Metasploit's json-rpc" do
               host: host_ip,
               analyze_options: {
                 payloads: [
-                  'windows/meterpreter_reverse_http'
+                  'linux/x86/meterpreter_reverse_http'
                 ]
               }
             }


### PR DESCRIPTION
## Description

Fix failing `json_rpc_spec` test for the `db.analyze_host` endpoint when payload requirements are specified.

The test used `windows/meterpreter_reverse_http` as a payload expected to be incompatible with the Windows SMB exploits (`ms17_010_eternalblue`, `ms17_010_psexec`, `smb_doublepulsar_rce`). This previously worked because the payload's `CachedSize` (200284 bytes) exceeded the exploit's `Space` (2000 bytes), causing `is_payload_compatible?` to reject it. Commit `919ffe0a8f2` changed `CachedSize` to `:dynamic`, which makes `cached_size` return nil and bypasses the size check — so the payload now correctly passes platform/arch compatibility and is considered compatible.

The fix swaps the test payload to `linux/x86/meterpreter_reverse_http`, which is genuinely incompatible with Windows exploits due to platform mismatch (not just a size constraint).

**Related Issue:** N/A

## Breaking Changes

None

## Reviewer Notes

Single line change in the spec. The root cause is `919ffe0a8f2` (tagged 6.5.0) setting `CachedSize = :dynamic` on stageless Windows Meterpreter payloads. The previous test was relying on a size-based incompatibility rather than a true platform mismatch — using a Linux payload makes the test robust against future size changes.

Original test failure: https://github.com/rapid7/metasploit-framework/actions/runs/30619929620/job/91121840364?pr=21738#step:8:823
```
Metasploit's json-rpc F  
  1) Metasploit's json-rpc analyze when there are modules available when payloads requirements are specified returns the list of known modules associated with a reported host  
     Failure/Error: expect(last_json_response).to include(expected_response)  
       expected {"id" => 1, "jsonrpc" => "2.0", "result" => {"host" => {"address" => "127.190.247.44", "modules" => [{"descriptio..._rce", "mtype" => "exploit", "options" => {"invalid" => [], "missing" => []}, "state" => "READY_FOR_TEST"}]}}} to include {:result => {:host => {:address => "127.190.247.44", :modules => [{:mname => "exploit/windows/smb/ms17_010_eternalblue", :mtype => "exploit", :options => {:invalid => [], :missing => ["payload_match"]}, :state => "MISSING_PAYLOAD", :description => "none of the requested payloads match"}, {:mname => "exploit/windows/smb/ms17_010_psexec", :mtype => "exploit", :options => {:invalid => [], :missing => ["credential", "payload_match"]}, :state => "REQUIRES_CRED", :description => "credentials are required, none of the requested payloads match"}, {:mname => "exploit/windows/smb/smb_doublepulsar_rce", :mtype => "exploit", :options => {:invalid => [], :missing => ["payload_match"]}, :state => "MISSING_PAYLOAD", :description => "none of the requested payloads match"}]}}}  
       Diff:  
       @@ -1,3 +1,3 @@  
       -:id => 1,  
       -:jsonrpc => "2.0",  
       -:result => {:host=>{:address=>"127.190.247.44", :modules=>[{:description=>"none of the requested payloads match", :mname=>"exploit/windows/smb/ms17_010_eternalblue", :mtype=>"exploit", :options=>{:invalid=>[], :missing=>["payload_match"]}, :state=>"MISSING_PAYLOAD"}, {:description=>"credentials are required, none of the requested payloads match", :mname=>"exploit/windows/smb/ms17_010_psexec", :mtype=>"exploit", :options=>{:invalid=>[], :missing=>["credential", "payload_match"]}, :state=>"REQUIRES_CRED"}, {:description=>"none of the requested payloads match", :mname=>"exploit/windows/smb/smb_doublepulsar_rce", :mtype=>"exploit", :options=>{:invalid=>[], :missing=>["payload_match"]}, :state=>"MISSING_PAYLOAD"}]}},  
       +"id" => 1,  
       +"jsonrpc" => "2.0",  
       +"result" => {"host"=>{"address"=>"127.190.247.44", "modules"=>[{"description"=>"ready for testing", "mname"=>"exploit/windows/smb/ms17_010_eternalblue", "mtype"=>"exploit", "options"=>{"invalid"=>[], "missing"=>[]}, "state"=>"READY_FOR_TEST"}, {"description"=>"credentials are required", "mname"=>"exploit/windows/smb/ms17_010_psexec", "mtype"=>"exploit", "options"=>{"invalid"=>[], "missing"=>["credential"]}, "state"=>"REQUIRES_CRED"}, {"description"=>"ready for testing", "mname"=>"exploit/windows/smb/smb_doublepulsar_rce", "mtype"=>"exploit", "options"=>{"invalid"=>[], "missing"=>[]}, "state"=>"READY_FOR_TEST"}]}},  
```

## Verification Steps

1. - [ ] `bundle exec rspec spec/api/json_rpc_spec.rb -e "when payloads requirements are specified"` — passes
2. - [ ] `bundle exec rspec spec/api/json_rpc_spec.rb -e "analyze"` — all 3 analyze tests pass

## Test Evidence

CI passes

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS (darwin) |
| **Target Software/Hardware** | Metasploit Framework (Ruby 3.3.8) |

## AI Usage Disclosure

Kiro

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)