### PR TITLE
Add A pyenv Container Using GHCR For Acceptance Testing

### DIFF
--- a/.github/workflows/pyenv_image_publish.yml
+++ b/.github/workflows/pyenv_image_publish.yml
@@ -1,0 +1,54 @@
+name: Publish pyenv Acceptance Test Image
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: write
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'test/pyenv/Containerfile'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout metasploit-framework code
+        uses: actions/checkout@v4
+
+      - name: Set lowercased image repository
+        run: echo "IMAGE_REPO=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build pyenv image
+        run: |
+          docker build \
+            -f test/pyenv/Containerfile \
+            -t ghcr.io/${IMAGE_REPO}/pyenv:latest \
+            -t ghcr.io/${IMAGE_REPO}/pyenv:${{ github.sha }} \
+            test/pyenv
+
+      - name: Push pyenv image
+        run: |
+          docker push ghcr.io/${IMAGE_REPO}/pyenv:latest
+          docker push ghcr.io/${IMAGE_REPO}/pyenv:${{ github.sha }}
+
+      - name: Print published digest
+        run: docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/${IMAGE_REPO}/pyenv:latest

--- a/test/pyenv/Containerfile
+++ b/test/pyenv/Containerfile
@@ -1,0 +1,122 @@
+# podman build -t pyenv .
+# podman run -it pyenv /bin/bash
+
+FROM docker.io/ubuntu:24.04
+USER root
+
+RUN apt-get update; apt -y install build-essential curl git libbz2-dev libffi-dev liblzma-dev libreadline-dev libsqlite3-dev libssl-dev screen vim wget zlib1g-dev
+RUN curl -fsSL https://pyenv.run | bash
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc && \
+    echo '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc && \
+    echo 'eval "$(pyenv init - bash)"' >> ~/.bashrc
+
+ENV PYENV_ROOT="/root/.pyenv"
+ENV PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
+
+# OpenSSL 1.0.2u Installation for Python 2.5 and 2.6
+RUN cd /tmp && \
+    wget https://github.com/openssl/openssl/releases/download/OpenSSL_1_0_2u/openssl-1.0.2u.tar.gz && \
+    tar xzf openssl-1.0.2u.tar.gz && \
+    cd openssl-1.0.2u && \
+    ./config --prefix=/usr/local/openssl-1.0.2 \
+             --openssldir=/usr/local/openssl-1.0.2 \
+             shared no-ssl2 no-ssl3 && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/openssl-1.0.2u*
+
+# Python 2.5.6 Installation
+RUN eval "$(pyenv init -)" && \
+    export OPENSSL_DIR=/usr/local/openssl-1.0.2 && \
+    CPPFLAGS="-I${OPENSSL_DIR}/include -I/usr/include" \
+    CFLAGS="-I${OPENSSL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${OPENSSL_DIR}/lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib -Wl,-rpath,${OPENSSL_DIR}/lib" \
+    LD_LIBRARY_PATH="${OPENSSL_DIR}/lib" \
+    CONFIGURE_OPTS="--with-openssl=${OPENSSL_DIR}" \
+    pyenv install -v 2.5.6
+
+# Python 2.6.9 Installation
+RUN cp "$PYENV_ROOT/plugins/python-build/share/python-build/2.6.9" \
+       "$PYENV_ROOT/plugins/python-build/share/python-build/2.6.9-no-pip" && \
+    sed -i 's/ ensurepip$//' /root/.pyenv/plugins/python-build/share/python-build/2.6.9-no-pip
+
+RUN eval "$(pyenv init -)" && \
+    export OPENSSL_DIR=/usr/local/openssl-1.0.2 && \
+    CPPFLAGS="-I${OPENSSL_DIR}/include -I/usr/include" \
+    CFLAGS="-I${OPENSSL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${OPENSSL_DIR}/lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib -Wl,-rpath,${OPENSSL_DIR}/lib" \
+    LD_LIBRARY_PATH="${OPENSSL_DIR}/lib" \
+    CONFIGURE_OPTS="--with-openssl=${OPENSSL_DIR}" \
+    pyenv install -v 2.6.9-no-pip
+
+# Python 2.7.18 Installation
+RUN eval "$(pyenv init -)" && pyenv install -v 2.7.18
+
+# Python 3.1.5 Installation
+RUN eval "$(pyenv init -)" && \
+    export OPENSSL_DIR=/usr/local/openssl-1.0.2 && \
+    CPPFLAGS="-I${OPENSSL_DIR}/include -I/usr/include" \
+    CFLAGS="-I${OPENSSL_DIR}/include -I/usr/include -fno-strict-aliasing" \
+    LDFLAGS="-L${OPENSSL_DIR}/lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib -Wl,-rpath,${OPENSSL_DIR}/lib" \
+    LD_LIBRARY_PATH="${OPENSSL_DIR}/lib" \
+    CONFIGURE_OPTS="--with-openssl=${OPENSSL_DIR}" \
+    pyenv install -v 3.1.5
+
+# Python 3.2.6 Installation
+RUN eval "$(pyenv init -)" && \
+    export OPENSSL_DIR=/usr/local/openssl-1.0.2 && \
+    CPPFLAGS="-I${OPENSSL_DIR}/include -I/usr/include" \
+    CFLAGS="-I${OPENSSL_DIR}/include -I/usr/include -fno-strict-aliasing" \
+    LDFLAGS="-L${OPENSSL_DIR}/lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib -Wl,-rpath,${OPENSSL_DIR}/lib" \
+    LD_LIBRARY_PATH="${OPENSSL_DIR}/lib" \
+    CONFIGURE_OPTS="--with-openssl=${OPENSSL_DIR}" \
+    pyenv install -v 3.2.6
+
+# Python 3.3.7 Installation
+RUN eval "$(pyenv init -)" && \
+    export OPENSSL_DIR=/usr/local/openssl-1.0.2 && \
+    CPPFLAGS="-I${OPENSSL_DIR}/include -I/usr/include" \
+    CFLAGS="-I${OPENSSL_DIR}/include -I/usr/include -fno-strict-aliasing" \
+    LDFLAGS="-L${OPENSSL_DIR}/lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib -Wl,-rpath,${OPENSSL_DIR}/lib" \
+    LD_LIBRARY_PATH="${OPENSSL_DIR}/lib" \
+    CONFIGURE_OPTS="--with-openssl=${OPENSSL_DIR}" \
+    pyenv install -v 3.3.7
+
+# Python 3.4.10 Installation
+RUN eval "$(pyenv init -)" && \
+    export OPENSSL_DIR=/usr/local/openssl-1.0.2 && \
+    CPPFLAGS="-I${OPENSSL_DIR}/include -I/usr/include" \
+    CFLAGS="-I${OPENSSL_DIR}/include -I/usr/include" \
+    LDFLAGS="-L${OPENSSL_DIR}/lib -L/usr/lib/x86_64-linux-gnu -L/usr/lib -Wl,-rpath,${OPENSSL_DIR}/lib" \
+    LD_LIBRARY_PATH="${OPENSSL_DIR}/lib" \
+    CONFIGURE_OPTS="--with-openssl=${OPENSSL_DIR}" \
+    pyenv install -v 3.4.10
+
+# Python 3.5.10 Installation
+RUN eval "$(pyenv init -)" &&  pyenv install -v 3.5.10
+
+# Python 3.6.15 Installation
+RUN eval "$(pyenv init -)" &&  pyenv install -v 3.6.15
+
+# Python 3.7.17 Installation
+RUN eval "$(pyenv init -)" &&  pyenv install -v 3.7.17
+
+# Python 3.8.20 Installation
+RUN eval "$(pyenv init -)" &&  pyenv install -v 3.8.20
+
+# Python 3.9.23 Installation
+RUN eval "$(pyenv init -)" &&  pyenv install -v 3.9.25
+
+# Python 3.10.18 Installation
+RUN eval "$(pyenv init -)" &&  pyenv install -v 3.10.20
+
+# Python 3.11.13 Installation
+RUN eval "$(pyenv init -)" &&  pyenv install -v 3.11.15
+
+# Python 3.12.11 Installation
+RUN eval "$(pyenv init -)" &&  pyenv install -v 3.12.13
+
+# Python 3.13.7 Installation
+RUN eval "$(pyenv init -)" &&  pyenv install -v 3.13.13
+
+RUN eval "$(pyenv init -)" &&  pyenv install -v 3.14.5

--- a/test/pyenv/README.md
+++ b/test/pyenv/README.md
@@ -1,0 +1,26 @@
+## Setup
+
+This contains a custom container image used for Python-based acceptance testing. It provides multiple
+CPython interpreter versions (installed via [pyenv](https://github.com/pyenv/pyenv), including a couple of
+very old releases that need a custom-built OpenSSL to compile) so that payloads exercising Python's SSL
+support can be tested against the interpreter/OpenSSL combinations they actually target.
+
+This image is published to `ghcr.io/rapid7/metasploit-framework/pyenv` by the
+`.github/workflows/pyenv_image_publish.yml` workflow, which any maintainer can trigger via
+`workflow_dispatch` to rebuild/republish it.
+
+## Running
+
+- Build:
+```shell
+docker build -f Containerfile -t pyenv:local .
+```
+
+- Run a specific interpreter version by setting `PYENV_VERSION`:
+```shell
+docker run --rm -e PYENV_VERSION=3.13.7 pyenv:local python --version
+```
+
+There's no `docker-compose.yml` for this fixture — unlike the long-running service fixtures (SMB, SSH,
+LDAP), the acceptance tests invoke this image per-payload-execution via `docker run`/`podman run`, so
+there's nothing to start/stop as a standing service.


### PR DESCRIPTION
## Description

Moves the pyenv container image used by the Python SSL command shell acceptance tests off my personal AWS ECR (`public.ecr.aws/n5b4u6h0/zerosteiner/pyenv`) and onto GHCR (`ghcr.io/rapid7/metasploit-framework/pyenv`), published by a new `pyenv_image_publish.yml` workflow that any maintainer with repo access can trigger. Also lands the Containerfile source (`test/pyenv/Containerfile`), which previously only existed in a private repo of mine.

The old setup meant I was the only person who could rebuild/republish the image, and its usage was billed to my personal AWS account. This removes that single point of failure/cost. It's purely infrastructure -- no test behavior changes here. A follow-up PR will point the existing `python_ssl_*` acceptance tests (and new non-SSL Python coverage) at the image this publishes.

**Related Issue:** N/A

## Breaking Changes

None

## Reviewer Notes

- This is intentionally scoped to just the image build/publish plumbing so it can be reviewed and merged on its own. Nothing in the existing test suite references this image yet -- that's the next PR.
- `pyenv_image_publish.yml` only rebuilds automatically on a `master` push that touches `test/pyenv/Containerfile` (path-filtered), plus manual `workflow_dispatch` -- it won't run on unrelated commits.
- Non-obvious GitHub Actions quirk if you want to `workflow_dispatch` this yourself before merging: `workflow_dispatch` only recognizes workflows that exist on the repo's **default** branch, even when targeting a different `--ref`. I worked around this on my own fork by temporarily flipping the fork's default branch to this topic branch, dispatching, then flipping it back -- no content on `master` was touched. See Test Evidence below for the real runs this produced; you shouldn't need to repeat this to review the code, but it's worth knowing before this merges, since it also means the real publish (once merged) needs a `workflow_dispatch` run against `master` to actually create the `rapid7`-owned image -- it won't publish itself just by merging.
- GHCR packages came back `public` by default when first created from this public repo -- no manual visibility flip was needed for anonymous `docker pull` to work (I'd expected to need one).

## Verification Steps

Can't fully exercise the publish step without merging (it needs `packages: write` against `rapid7/metasploit-framework`'s GHCR namespace, which only a real push to `master` provides). I validated the entire mechanism for real against my own fork instead -- both linked runs below are genuine GitHub Actions executions, not simulated:

1. - [ ] Review `test/pyenv/Containerfile` -- confirm it matches what's described (multi-version pyenv build, unchanged from my private source)
2. - [ ] Review `.github/workflows/pyenv_image_publish.yml` -- confirm `permissions:` is minimal (`contents: read`, `packages: write`, everything else `none`), no `pull_request` trigger, and the image path uses `${{ github.repository }}` (not hardcoded) so it resolves correctly wherever it runs

## Test Evidence

Stub smoke test (validates login/build/push/pull mechanics before spending ~30 min on the real build): https://github.com/zeroSteiner/metasploit-framework/actions/runs/30854960516

Real build, using the actual Containerfile (29m22s): https://github.com/zeroSteiner/metasploit-framework/actions/runs/30855109695

Published package: https://github.com/users/zeroSteiner/packages/container/package/metasploit-framework%2Fpyenv

Anonymous pull confirmed working with zero local credentials:
```
docker logout ghcr.io
docker pull ghcr.io/zerosteiner/metasploit-framework/pyenv@sha256:bc3398ad96f06ac4c9f2a371488b7b75c60eaaa37531da1dcf98ce47b5191fb7
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | `ubuntu-latest` (GitHub Actions runner) |
| **Target Software/Hardware** | N/A -- CI infrastructure change |
| **Docker Image / Vagrant Setup** | `test/pyenv/Containerfile`, built and published by `pyenv_image_publish.yml` |

## AI Usage Disclosure

Claude Code was used to draft the Containerfile move and the GHCR publish workflow, and to run/validate the end-to-end publish against my fork (both linked runs above are real). All GitHub Actions runs and GHCR publishes referenced above are genuine, not simulated.

## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [ ] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
