### PR TITLE
Fix smb report service crash

### DIFF
--- a/lib/msf/core/exploit/remote/smb/client.rb
+++ b/lib/msf/core/exploit/remote/smb/client.rb
@@ -11,6 +11,7 @@ module Msf
 
       include Msf::Exploit::Remote::Tcp
       include Msf::Exploit::Remote::NTLM::Client
+      include Msf::Auxiliary::Report
 
       # These constants are unused here, but may be used in some code that
       # includes this. Local definitions should be preferred.


### PR DESCRIPTION
Fixes the following crash:

```
[-] [2026.08.07-21:05:13] [0677] [exploit/linux/samba/trans2open] 10.140.106.183:445 - 10.140.106.183 undefined method `report_service' for #<Msf::Modules::Exploit__Linux__Samba__Trans2open::MetasploitModule:0x00007fee9fe444c8>
```

Caused by the implicit requirement of `report_service` here: https://github.com/adfoster-r7/metasploit-framework/blob/5bd2763acb43e8899df2a0cbc9ed6d010884f1a5/lib/msf/core/exploit/remote/smb/client.rb#L946-L958