### PR TITLE
Update json rpc auth logic

### DIFF
--- a/docs/metasploit-framework.wiki/How-to-use-Metasploit-JSON-RPC.md
+++ b/docs/metasploit-framework.wiki/How-to-use-Metasploit-JSON-RPC.md
@@ -11,17 +11,22 @@ Note that both the messagepack and JSON RPC services provide very similar operat
 
 ## Starting the JSON API Server
 
-The pre-requisite to running the JSON API Server is to run your Metasploit database. This can be initialized with `msfdb`.
-Note that `msfdb` will ask if you wish to run the JSON RPC web service - but it is not required for this guide which
-shows how to run the JSON service directly with [thin](https://github.com/macournoyer/thin) or [Puma](https://github.com/puma/puma): 
+A Metasploit database is recommended but not required. Without one, module search, execution and result
+polling all work and only the `db.*` methods are unavailable.
 
-First run the Metasploit database:
+Authentication is required either way, and is covered under [Authentication](#authentication). Without a
+database there are no user accounts to authenticate against, so `MSF_WS_JSON_RPC_API_TOKEN` has to be set.
+Setting it does not disable the database - the service still connects to whatever is configured, and `db.*`
+stays available.
+
+If you do want database support, initialize it with `msfdb`. Note that `msfdb` will ask if you wish to run
+the JSON RPC web service - but it is not required for this guide:
 
 ```
 msfdb init
 ```
 
-After configuring the database the JSON RPC service can be initialized with the [thin](https://github.com/macournoyer/thin) Ruby web server:
+The JSON RPC service can then be initialized with the [thin](https://github.com/macournoyer/thin) Ruby web server:
 
 ```
 bundle exec thin --rackup msf-json-rpc.ru --address 0.0.0.0 --port 8081 --environment production --tag msf-json-rpc start
@@ -32,6 +37,73 @@ Or with [Puma](https://github.com/puma/puma):
 ```
 bundle exec puma msf-json-rpc.ru --port 8081 --environment production --tag msf-json-rpc start
 ```
+
+### Authentication
+
+Authentication is mandatory. Every request must carry an API token in an `Authorization: Bearer <token>`
+header. Tokens are not accepted from the query string, as query strings end up in access logs.
+
+There are two ways to configure the token, and the service refuses to start if neither is available.
+
+#### Option 1: a static token
+
+Set `MSF_WS_JSON_RPC_API_TOKEN` to a token of at least 16 characters. No database is needed to validate it,
+and it takes precedence - while it is set, database user tokens are not accepted:
+
+```sh
+export MSF_WS_JSON_RPC_API_TOKEN=$(ruby -rsecurerandom -e 'puts SecureRandom.hex(32)')
+echo "Auth token: $MSF_WS_JSON_RPC_API_TOKEN"
+bundle exec thin --rackup msf-json-rpc.ru --address 0.0.0.0 --port 8081 --environment production --tag msf-json-rpc start
+```
+
+#### Option 2: a database user's token
+
+This needs a reachable database holding at least one user. `msfdb init` sets one up as part of configuring
+the web service, and tokens can then be reissued via `POST /api/v1/auth/generate-token`.
+
+To create a user and issue a token directly, without running the web service:
+
+```sh
+bundle exec msfconsole -qx 'irb -e "pass = SecureRandom.base64(32); u = framework.db.report_user(username: %q{jsonrpc_test}, password: pass, admin: true); puts %q{username: } + u.username; puts %q{password: } + pass; puts %q{token:    } + framework.db.create_new_user_token(id: u.id, token_length: 40)"; exit'
+```
+
+```
+username: jsonrpc_test
+password: ...a 44 character random password...
+token:    ...an 80 character hex token...
+```
+
+Only the token is needed for JSON-RPC. The password is there for signing in to the account page at
+`/api/v1/auth/account` on the data service, so it is generated randomly rather than being a value worth
+reusing - copy it now if you want it, as only its bcrypt hash is stored.
+
+Start the service with `MSF_WS_JSON_RPC_API_TOKEN` unset, otherwise the static token takes precedence and
+this token is rejected:
+
+```sh
+unset MSF_WS_JSON_RPC_API_TOKEN
+bundle exec thin --rackup msf-json-rpc.ru --address 0.0.0.0 --port 8081 --environment production --tag msf-json-rpc start
+```
+
+Remove the user once you are finished with it:
+
+```sh
+bundle exec msfconsole -qx 'irb -e "u = framework.db.users(username: %q{jsonrpc_test}).first; framework.db.delete_user(ids: [u.id]) if u; puts %q{remaining: } + framework.db.users(username: %q{jsonrpc_test}).count.to_s"; exit'
+```
+
+Note that removing the last remaining user means the service will refuse to start unless a static token is
+configured instead.
+
+Every `curl` example below sends `Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN`, so export your token
+in the same shell you run them from:
+
+```sh
+export MSF_WS_JSON_RPC_API_TOKEN='...add your token here...'
+```
+
+If that variable is empty the header is sent with no token and the service replies `401` with
+`Invalid API token. Authenticate to access this resource.` - check the variable is set before looking
+anywhere else.
 
 ### Development
 
@@ -48,7 +120,7 @@ bundle exec ruby ./msfdb --component webservice --no-daemon start
 
 ### RPC Logging
 
-You can configure the RPC service logging with the `MSF_WS_DATA_SERVICE_LOGGER` environment variable. 
+You can configure the RPC service logging with the `MSF_WS_DATA_SERVICE_LOGGER` environment variable.
 
 The list of supported loggers is viewable with `msfconsole --help`. The list at the time of writing is:
 
@@ -79,9 +151,17 @@ The Metasploit RPC aims to follow the [jsonrpc specification](https://www.jsonrp
 - Each JSON RPC request should provide a unique message ID which the client and server can use to correlate requests and responses
 - Metasploit may return the following [error codes](https://github.com/rapid7/metasploit-framework/blob/87b1f3b602753e39226a475a5d737fb50200957d/lib/msf/core/rpc/json/error.rb#L3-L13).
 
-## Examples 
+## Examples
 
-First ensure you are running the Metasploit database, and are running the JSON service before running these examples
+First ensure the JSON service is running before running these examples. The `db.*` examples additionally
+need a Metasploit database; the rest work without one.
+
+Each example authenticates with the token described under [Authentication](#authentication), so export it
+in the shell you run them from:
+
+```sh
+export MSF_WS_JSON_RPC_API_TOKEN='...add your token here...'
+```
 
 ### Querying
 
@@ -92,6 +172,7 @@ Request:
 ```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'Content-Type: application/json' \
   --data '{
         "jsonrpc": "2.0",
@@ -121,6 +202,7 @@ Request:
 ```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'Content-Type: application/json' \
   --data '{
         "jsonrpc": "2.0",
@@ -158,6 +240,7 @@ Request:
 ```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'content-type: application/json' \
   --data '{ "jsonrpc": "2.0", "method": "module.search", "id": 1, "params": ["psexec author:egypt arch:x64"] }'
 ```
@@ -188,6 +271,7 @@ auxiliary module against a target. For instance, with an Auxiliary module check 
 ```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'Content-Type: application/json' \
   --data '{
     "jsonrpc": "2.0",
@@ -208,6 +292,7 @@ Or an Exploit module check request:
 ```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'content-type: application/json' \
   --data '{
     "jsonrpc": "2.0",
@@ -243,6 +328,7 @@ Request:
 ```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'Content-Type: application/json' \
   --data '{
     "jsonrpc": "2.0",
@@ -255,7 +341,7 @@ curl --request POST \
 The response will include the following keys:
 - waiting - modules that are queued up, but have not started to run yet
 - running - currently running modules
-- results - the module has completed or failed, and the results can be retrieved and acknowledged 
+- results - the module has completed or failed, and the results can be retrieved and acknowledged
 
 Response:
 
@@ -265,7 +351,7 @@ Response:
   "result": {
     "waiting": [
       "NkJvf4kp4JxcuFCz7rjSuHL1",
-      "wRnMQuJ8gzMTp5CaHu18bHdV"      
+      "wRnMQuJ8gzMTp5CaHu18bHdV"
     ],
     "running": [
       "b7hIX6G4ZtwvRVRDOXk5ylSx",
@@ -291,6 +377,7 @@ Request:
 ```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'Content-Type: application/json' \
   --data '{
     "jsonrpc": "2.0",
@@ -306,7 +393,7 @@ Example response when the module is has not yet complete:
 {
   "jsonrpc": "2.0",
   "result": {
-    "status": "running"  
+    "status": "running"
   },
   "id": 1
 }
@@ -349,13 +436,14 @@ Example success response:
 #### acknowledge module results
 
 This command will also allow Metasploit to remove the result resources from memory. Not acknowledging module results will lead to a memory leak,
-but the memory is limited to 35mb as the memory datastore used is implemented by [`ActiveSupport::Cache::MemoryStore`](https://github.com/rapid7/metasploit-framework/pull/13036/files#diff-6e31832215e40b17a184a7f7b82d2aabfbaa8d98fabb3c43033dd8579ad3caaeR102) 
+but the memory is limited to 35mb as the memory datastore used is implemented by [`ActiveSupport::Cache::MemoryStore`](https://github.com/rapid7/metasploit-framework/pull/13036/files#diff-6e31832215e40b17a184a7f7b82d2aabfbaa8d98fabb3c43033dd8579ad3caaeR102)
 
 Request:
 
 ```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'Content-Type: application/json' \
   --data '{
     "jsonrpc": "2.0",
@@ -385,7 +473,7 @@ First report a host:
 ```bash
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
-  --header 'Authorization: Bearer ' \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'Content-Type: application/json' \
   --data '{
     "jsonrpc": "2.0",
@@ -404,7 +492,7 @@ curl --request POST \
             "mac": "97-42-51-F2-A7-A7",
             "scope": "eth2",
             "virtual_host": "VMWare"
-        }    
+        }
     ]
 }'
 
@@ -416,7 +504,7 @@ Report the host vulnerabilities:
 ```bash
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
-  --header 'Authorization: Bearer ' \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'Content-Type: application/json' \
   --data '{
     "jsonrpc": "2.0",
@@ -448,7 +536,7 @@ Run the analyze command:
 ```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
-  --header 'Authorization: Bearer ' \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'Content-Type: application/json' \
   --data '{
     "jsonrpc": "2.0",
@@ -494,7 +582,7 @@ When analyzing a host, it is also possible to specify payload requirements for a
 ```sh
 curl --request POST \
   --url http://localhost:8081/api/v1/json-rpc \
-  --header 'Authorization: Bearer ' \
+  --header "Authorization: Bearer $MSF_WS_JSON_RPC_API_TOKEN" \
   --header 'Content-Type: application/json' \
   --data '{
     "jsonrpc": "2.0",

--- a/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb
+++ b/lib/metasploit/framework/data_service/remote/managed_remote_data_service.rb
@@ -41,7 +41,12 @@ class ManagedRemoteDataService
       puts "Started process with pid #{@pid}"
 
       endpoint = "http://#{opts[:host]}:#{opts[:port]}"
-      @remote_host_data_service = Metasploit::Framework::DataService::RemoteHTTPDataService.new(endpoint)
+      # The data service enforces authentication, so opts[:api_token] must carry the token of
+      # an existing user or every request below - including the readiness check - gets a 401.
+      @remote_host_data_service = Metasploit::Framework::DataService::RemoteHTTPDataService.new(
+        endpoint,
+        api_token: opts[:api_token]
+      )
 
       count = 0
       loop do

--- a/lib/msf/core/web_services/authentication/strategies/api_token.rb
+++ b/lib/msf/core/web_services/authentication/strategies/api_token.rb
@@ -1,38 +1,67 @@
+require 'rack/utils'
+
 module Msf::WebServices::Authentication
   module Strategies
     class ApiToken < Warden::Strategies::Base
       AUTHORIZATION = 'HTTP_AUTHORIZATION'
       AUTHORIZATION_SCHEME = 'Bearer'
-      TOKEN_QUERY_PARAM = 'token'
+      AUTHORIZATION_PATTERN = /\A#{AUTHORIZATION_SCHEME}\s+(?<token>\S.*)\z/.freeze
 
       # Check if request contains valid data and should be authenticated.
       # @return [Boolean] true if strategy should be run for the request; otherwise, false.
       def valid?
-        auth_initialized = request.env['msf.auth_initialized']
-        authorization = request.env[AUTHORIZATION]
-        !auth_initialized || (authorization.is_a?(String) && authorization.start_with?(AUTHORIZATION_SCHEME)) || !params[TOKEN_QUERY_PARAM].nil?
+        # Run the strategy so that #authenticate! can grant the bootstrap exemption.
+        return true unless auth_initialized?
+
+        !bearer_token.nil?
       end
 
       # Authenticate the request.
       def authenticate!
-        auth_initialized = request.env['msf.auth_initialized']
-        authorization = request.env[AUTHORIZATION]
-        if !auth_initialized
-          success!({message: "Initialize authentication by creating an initial user account."})
-        else
-          if authorization.is_a?(String) && authorization.start_with?(AUTHORIZATION_SCHEME)
-            token = authorization.sub(/^#{AUTHORIZATION_SCHEME}\s+/, '')
-          else
-            token = params[TOKEN_QUERY_PARAM]
-          end
-
-          request.env['msf.api_token'].nil? ? auth_from_db(token) : auth_from_env(token)
+        unless auth_initialized?
+          return success!({ message: 'Initialize authentication by creating an initial user account.' })
         end
+
+        token = bearer_token
+        throw(:warden, message: 'Invalid API token.', code: 401) if blank_token?(token)
+
+        request.env['msf.api_token'].nil? ? auth_from_db(token) : auth_from_env(token)
+      end
+
+      # Whether the application has completed authentication bootstrapping.
+      #
+      # An application opts into the unauthenticated bootstrap flow - which allows an
+      # initial user account to be created before any credentials exist - by explicitly
+      # setting 'msf.auth_initialized' to false. Any other value, including the key
+      # being absent, requires authentication so that the strategy fails closed for
+      # applications that never advertise this state.
+      #
+      # @return [Boolean] true if authentication must be enforced; otherwise, false.
+      def auth_initialized?
+        request.env['msf.auth_initialized'] != false
+      end
+
+      # The token carried by an Authorization header using the Bearer scheme. Tokens are
+      # only accepted here, never from the query string, so that they stay out of access logs.
+      #
+      # @return [String, nil] the token, or nil if the header is absent, uses a different
+      #   scheme, or carries no token.
+      def bearer_token
+        authorization = request.env[AUTHORIZATION]
+        return unless authorization.is_a?(String)
+
+        AUTHORIZATION_PATTERN.match(authorization)&.[](:token)
       end
 
       # Authenticates the user associated with the API token from the DB
       def auth_from_db(token)
         db_manager = env['msf.db_manager']
+
+        # Reached when the application was never able to establish a database
+        # connection. Reject rather than raising a 500 from a nil db_manager.
+        throw(:warden, message: 'Authentication is not configured.', code: 401) if db_manager.nil?
+        throw(:warden, message: 'Invalid API token.', code: 401) if blank_token?(token)
+
         user = db_manager.users(persistence_token: token).first
 
         validation_data = validate_user(user)
@@ -55,11 +84,19 @@ module Msf::WebServices::Authentication
 
       # Authenticates the API token from an environment variable
       def auth_from_env(token)
-        if token == request.env['msf.api_token']
+        expected_token = request.env['msf.api_token']
+
+        # Compared in constant time to avoid leaking the token a byte at a time.
+        if !blank_token?(token) && !blank_token?(expected_token) && Rack::Utils.secure_compare(token, expected_token)
           success!(message: "Successful auth from token")
         else
           throw(:warden, message: 'Invalid API token.', code: 401)
         end
+      end
+
+      # @return [Boolean] true if the token is missing or contains no usable characters.
+      def blank_token?(token)
+        !token.is_a?(String) || token.strip.empty?
       end
     end
   end

--- a/lib/msf/core/web_services/framework_extension.rb
+++ b/lib/msf/core/web_services/framework_extension.rb
@@ -59,8 +59,13 @@ module Msf::WebServices
       })
     end
 
+    # Raised when an explicitly configured data service cannot be reached.
+    class DataServiceError < StandardError; end
+
     def self.db_connect(framework, app)
-      if !app.settings.data_service_url.nil? && !app.settings.data_service_url.empty?
+      remote_data_service = !app.settings.data_service_url.nil? && !app.settings.data_service_url.empty?
+
+      if remote_data_service
         options = {
           url: app.settings.data_service_url,
           api_token: app.settings.data_service_api_token,
@@ -72,9 +77,23 @@ module Msf::WebServices
         db_result = Msf::DbConnector.db_connect_from_config(framework)
       end
 
-      if db_result[:error]
-        raise db_result[:error]
+      return unless db_result[:error]
+
+      # A remote data service is only ever used because the operator named it, so a failed
+      # connection is fatal. Continuing would leave the local database that Msf::DbConnector
+      # requires as an Active Record prerequisite registered as the current data service,
+      # silently serving and authenticating against a different backend than the one asked for.
+      if remote_data_service
+        raise DataServiceError, "Failed to connect to the configured data service " \
+                                "#{app.settings.data_service_url}: #{db_result[:error]}"
       end
+
+      # Without a configured data service a database is optional: module search, execution
+      # and result polling are all held in memory, so a failed connection must not stop the
+      # service from starting. Only the db.* RPC methods depend on it.
+      elog("Web service failed to connect to the database: #{db_result[:error]}")
+      warn "[!] Failed to connect to the database: #{db_result[:error]}\n" \
+           '[!] Starting without database support - db.* RPC methods will be unavailable.'
     end
 
     private

--- a/lib/msf/core/web_services/json_rpc_app.rb
+++ b/lib/msf/core/web_services/json_rpc_app.rb
@@ -33,23 +33,126 @@ module Msf::WebServices
       set :sessions, {key: 'msf-ws.session', expire_after: 300}
       set :session_secret, ENV.fetch('MSF_WS_SESSION_SECRET', SecureRandom.hex(32))
       set :api_token, ENV.fetch('MSF_WS_JSON_RPC_API_TOKEN', nil)
+
+      # The store used to validate incoming API tokens, not the service's database handle -
+      # it stays nil when a static token is configured, even though the framework is still
+      # connected to a database and db.* remains available. Populated once by boot! before
+      # the server accepts connections, so every request reads it with no DB calls.
+      set :db_manager, nil
+    end
+
+    # Raised when a usable authentication configuration cannot be established at startup.
+    class BootError < StandardError; end
+
+    # Shortest static API token accepted from the environment.
+    MIN_API_TOKEN_LENGTH = 16
+
+    # Appended to every BootError so the operator knows both ways out.
+    REMEDY = 'Set MSF_WS_JSON_RPC_API_TOKEN to a token of at least ' \
+             "#{MIN_API_TOKEN_LENGTH} characters, which needs no database, " \
+             "or run 'msfdb init' and create a user to authenticate with database API tokens.".freeze
+
+    # Appended when only the static token route is available.
+    REMEDY_TOKEN_ONLY = 'Set MSF_WS_JSON_RPC_API_TOKEN to a token of at least ' \
+                        "#{MIN_API_TOKEN_LENGTH} characters.".freeze
+
+    # Appended when the database holds users but none of them have an API token. Creating a
+    # user does not issue one - report_user leaves persistence_token unset - so this is a
+    # reachable state rather than a theoretical one.
+    REMEDY_NO_USER_TOKEN = "Issue one with 'POST /api/v1/auth/generate-token' on the data service, " \
+                           'or set MSF_WS_JSON_RPC_API_TOKEN to a token of at least ' \
+                           "#{MIN_API_TOKEN_LENGTH} characters instead.".freeze
+
+    # Initialise auth and DB state once at startup.
+    # Called from the warmup block in msf-json-rpc.ru, after the framework is
+    # ready but before the socket is bound and connections are accepted.
+    #
+    # A database is not required, but authentication is. It is resolved from either:
+    #
+    #   1. a static token supplied via MSF_WS_JSON_RPC_API_TOKEN
+    #   2. API tokens belonging to users in the database, when it is reachable
+    #
+    # If neither is available the service refuses to start, rather than accepting
+    # unauthenticated requests.
+    #
+    # Only option 2 needs a database to authenticate against. Which option is in use says
+    # nothing about whether a database is connected: the framework connects regardless of
+    # the token, so db.* works alongside a static token whenever a database is configured.
+    #
+    # @raise [BootError] if authentication is not configured usably.
+    # @raise [FrameworkExtension::DataServiceError] if a configured data service is unreachable.
+    def self.boot!
+      # Build the framework up front so that connecting to the database, and any failure
+      # doing so, happens here rather than on the first request to reach the service.
+      settings.framework
+
+      token = settings.api_token
+      unless blank_token?(token)
+        if token.length < MIN_API_TOKEN_LENGTH
+          raise BootError, 'JSON-RPC server cannot start: MSF_WS_JSON_RPC_API_TOKEN must be at least ' \
+                           "#{MIN_API_TOKEN_LENGTH} characters."
+        end
+
+        return
+      end
+
+      # A blank token would otherwise authenticate any request presenting an equally
+      # blank token, so discard it and fall back to database authentication.
+      settings.api_token = nil
+
+      # User accounts of a remote data service live on that service, not locally, so its
+      # API tokens cannot be validated here. The local database that Active Record requires
+      # alongside it holds a different set of users, and authenticating against those would
+      # grant access on credentials the operator never issued for this service.
+      unless settings.data_service_url.nil? || settings.data_service_url.empty?
+        raise BootError, 'JSON-RPC server cannot start: no API token is configured and API tokens cannot ' \
+                         "be validated against the remote data service #{settings.data_service_url}. " \
+                         "#{REMEDY_TOKEN_ONLY}"
+      end
+
+      db = settings.framework.db
+      unless db.active
+        raise BootError, 'JSON-RPC server cannot start: no API token is configured and the database is ' \
+                         "not available. #{REMEDY}"
+      end
+
+      begin
+        users = db.users({})
+        # A nil list means no data service is registered at all, which is indistinguishable
+        # here from an empty users table and reported the same way.
+        tokens = users.nil? ? [] : users.map(&:persistence_token)
+      rescue StandardError => e
+        raise BootError, 'JSON-RPC server cannot start: no API token is configured and the database ' \
+                         "could not be queried (#{e.class}: #{e.message}). #{REMEDY}"
+      end
+
+      if tokens.empty?
+        raise BootError, 'JSON-RPC server cannot start: no API token is configured and the database ' \
+                         "holds no users. #{REMEDY}"
+      end
+
+      # Existing users are not enough: this application only authenticates persistence_token,
+      # so a database of password-only accounts would start a service that 401s every request.
+      if tokens.all? { |user_token| blank_token?(user_token) }
+        raise BootError, 'JSON-RPC server cannot start: no API token is configured and no user in the ' \
+                         "database has an API token to authenticate with. #{REMEDY_NO_USER_TOKEN}"
+      end
+
+      settings.db_manager = db
+    end
+
+    # @return [Boolean] true if the token is missing or contains no usable characters.
+    def self.blank_token?(token)
+      !token.is_a?(String) || token.strip.empty?
     end
 
     before do
-      db = get_db
-      @@auth_initialized = false
-      if db_initialized(db)
-        # store DBManager in request environment so that it is available to Warden
-        request.env['msf.db_manager'] = db
-        @@auth_initialized ||= get_db.users({}).count > 0
-      end
-      if !settings.api_token.nil?
-        @@auth_initialized = true
-        request.env['msf.api_token'] = settings.api_token
-      end
-
-      # store flag indicating whether authentication is initialized in the request environment
-      request.env['msf.auth_initialized'] = @@auth_initialized
+      request.env['msf.db_manager'] = settings.db_manager if settings.db_manager
+      request.env['msf.api_token'] = settings.api_token unless settings.api_token.nil?
+      # This application has no unauthenticated bootstrap flow: boot! guarantees either a
+      # static token or a database user before connections are accepted, so authentication
+      # is always enforced. See Authentication::Strategies::ApiToken#auth_initialized?.
+      request.env['msf.auth_initialized'] = true
     end
 
     use Warden::Manager do |config|
@@ -82,13 +185,6 @@ module Msf::WebServices
                             strategies: [:admin_api_token],
                             # action (route) of the failure application
                             action: AuthServlet.api_unauthenticated_path
-    end
-
-    def db_initialized(db)
-      db.check
-      true
-    rescue
-      false
     end
 
     def self.setup_default_middleware(builder)

--- a/lib/msf/core/web_services/metasploit_api_app.rb
+++ b/lib/msf/core/web_services/metasploit_api_app.rb
@@ -43,9 +43,14 @@ class Msf::WebServices::MetasploitApiApp < Sinatra::Base
   before do
     # store DBManager in request environment so that it is available to Warden
     request.env['msf.db_manager'] = get_db
-    # store flag indicating whether authentication is initialized in the request environment
+    # Once a user exists the flag latches on for the lifetime of the process.
     @@auth_initialized ||= get_db.users({}).count > 0
-    request.env['msf.auth_initialized'] = @@auth_initialized
+    # While no users exist an initial account has to be creatable before any credentials
+    # exist - msfdb relies on this to POST the first user to /api/v1/users. The exemption is
+    # limited to that one route, so a database that reports no users for any other reason -
+    # an empty database restored under the service, a failover onto a fresh instance - cannot
+    # expose the rest of the API unauthenticated.
+    request.env['msf.auth_initialized'] = @@auth_initialized || !initial_account_creation?
   end
 
   use Warden::Manager do |config|
@@ -78,6 +83,14 @@ class Msf::WebServices::MetasploitApiApp < Sinatra::Base
                           strategies: [:admin_api_token],
                           # action (route) of the failure application
                           action: Msf::WebServices::AuthServlet.api_unauthenticated_path
+  end
+
+  # Whether the request is the one that creates a user account, which is the only request
+  # permitted to run unauthenticated before any account exists.
+  #
+  # @return [Boolean] true if the request creates a user account; otherwise, false.
+  def initial_account_creation?
+    request.post? && request.path_info.chomp('/') == Msf::WebServices::UserServlet.api_path
   end
 
 end

--- a/msf-json-rpc.ru
+++ b/msf-json-rpc.ru
@@ -23,6 +23,9 @@ run Msf::WebServices::JsonRpcApp
 # requests failing.
 #
 warmup do |app|
+  # Initialise DB and auth state once before the server begins accepting connections.
+  Msf::WebServices::JsonRpcApp.boot!
+
   client = Rack::MockRequest.new(app)
   response = client.get('/api/v1/health')
 

--- a/spec/api/json_rpc_spec.rb
+++ b/spec/api/json_rpc_spec.rb
@@ -20,16 +20,35 @@ RSpec.describe "Metasploit's json-rpc" do
   let(:a_valid_result_uuid) { { result: hash_including({ uuid: match(/\w+/) }) } }
   let(:app) { ::Msf::WebServices::JsonRpcApp.new }
 
+  # Static token used to authenticate all requests in this suite.
+  # Using the api_token path avoids needing a real DB user for the non-auth tests.
+  let(:suite_token) { 'test_suite_token_abc123' }
+
+  # Sinatra settings are class level, so capture the real values and restore them
+  # afterwards rather than resetting to nil, which would discard the environment
+  # derived configuration for the remainder of the process.
+  let!(:original_api_token) { ::Msf::WebServices::JsonRpcApp.settings.api_token }
+  let!(:original_db_manager) { ::Msf::WebServices::JsonRpcApp.settings.db_manager }
+
   before(:example) do
     framework.modules.add_module_path(File.join(FILE_FIXTURES_PATH, 'json_rpc'))
     app.settings.framework = framework
     # Rack 3 / rack-test requires explicit content type for raw JSON bodies
     header 'Content-Type', 'application/json'
+
+    # Configure auth directly rather than calling boot!, which is covered by its own
+    # unit spec. Here we just want the settings in a known state so the HTTP layer
+    # behaves as it would in production, with auth enforced via a static token.
+    app.settings.api_token = suite_token
+    app.settings.db_manager = nil
+    header 'Authorization', "Bearer #{suite_token}"
   end
 
   after(:example) do
     # Sinatra's settings are implemented as a singleton, and must be explicitly reset between runs
     app.settings.dispatchers.clear
+    app.settings.api_token = original_api_token
+    app.settings.db_manager = original_db_manager
   end
 
   def report_host(host)
@@ -122,6 +141,133 @@ RSpec.describe "Metasploit's json-rpc" do
         mock_rack_env_value
       else
         original_env[key]
+      end
+    end
+  end
+
+  describe 'authentication' do
+    context 'when a valid Bearer token is provided' do
+      it 'allows the request through' do
+        # suite_token header already set by outer before block
+        post rpc_url, { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.status).not_to eq(401)
+      end
+    end
+
+    context 'when no token is provided' do
+      before { header 'Authorization', nil }
+
+      it 'returns 401' do
+        post rpc_url, { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.status).to eq(401)
+      end
+
+      it 'returns a JSON error body' do
+        post rpc_url, { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        json = JSON.parse(last_response.body)
+        expect(json).to have_key('error')
+        expect(json['error']['message']).to include('Authenticate to access this resource')
+      end
+    end
+
+    context 'when an invalid token is provided' do
+      before { header 'Authorization', 'Bearer invalid_token' }
+
+      it 'returns 401' do
+        post rpc_url, { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.status).to eq(401)
+      end
+    end
+
+    # Query strings end up in access logs, so a token is never accepted from one -
+    # not even a correct one.
+    context 'when the token is supplied as a query parameter' do
+      before { header 'Authorization', nil }
+
+      it 'returns 401 even for the correct token' do
+        post "#{rpc_url}?token=#{suite_token}", { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.status).to eq(401)
+      end
+
+      it 'does not echo the supplied token back in the response' do
+        post "#{rpc_url}?token=#{suite_token}", { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.body).not_to include(suite_token)
+      end
+    end
+
+    context 'when the Authorization header uses an unsupported scheme' do
+      before { header 'Authorization', "Basic #{suite_token}" }
+
+      it 'returns 401' do
+        post rpc_url, { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.status).to eq(401)
+      end
+    end
+
+    # A blank configured token must never match a blank supplied token, otherwise
+    # anyone can authenticate with an empty credential.
+    context 'when the configured token is blank' do
+      before do
+        app.settings.api_token = ''
+      end
+
+      it 'returns 401 for an empty Bearer token' do
+        header 'Authorization', 'Bearer '
+        post rpc_url, { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.status).to eq(401)
+      end
+
+      it 'returns 401 for a whitespace Bearer token' do
+        header 'Authorization', 'Bearer    '
+        post rpc_url, { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.status).to eq(401)
+      end
+    end
+
+    # boot! normally guarantees one of these is configured, but the auth layer must
+    # fail closed with a 401 rather than a 500 if it was bypassed.
+    context 'when neither a token nor a database is configured' do
+      before do
+        app.settings.api_token = nil
+        app.settings.db_manager = nil
+      end
+
+      it 'returns 401' do
+        post rpc_url, { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.status).to eq(401)
+      end
+    end
+
+    # Validating a token against database users needs the local database - users(persistence_token:)
+    # and create_new_user_token are not part of the remote data service API. That is the same
+    # reason boot! refuses database backed authentication when a remote data service is
+    # configured, so this path does not exist under REMOTE_DB rather than merely being awkward
+    # to set up there.
+    context 'when a DB user token is used', if: ENV['REMOTE_DB'].nil? do
+      let(:user) do
+        Mdm::User.where(username: 'test_user').first_or_create!(
+          crypted_password: BCrypt::Password.create('test_password'),
+          admin: false
+        )
+      end
+      let(:user_token) { framework.db.create_new_user_token(id: user.id, token_length: 40) }
+
+      before do
+        # Mirrors the production wiring in boot!, which stores framework.db itself.
+        app.settings.api_token = nil
+        app.settings.db_manager = framework.db
+      end
+
+      it 'allows requests with the correct user token' do
+        header 'Authorization', "Bearer #{user_token}"
+        post rpc_url, { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.status).not_to eq(401)
+      end
+
+      it 'rejects requests with an invalid token' do
+        header 'Authorization', 'Bearer invalid_token'
+        post rpc_url, { jsonrpc: '2.0', method: 'health.check', id: 1, params: [] }.to_json
+        expect(last_response.status).to eq(401)
       end
     end
   end

--- a/spec/api/metasploit_api_app_spec.rb
+++ b/spec/api/metasploit_api_app_spec.rb
@@ -39,6 +39,43 @@ RSpec.describe Msf::WebServices::MetasploitApiApp do
     end
   end
 
+  describe 'initial account bootstrap' do
+    # msfdb creates the first web service user by POSTing to /api/v1/users before any
+    # credentials exist, so the API must allow unauthenticated access while no users are
+    # present. Regression test for that flow.
+    # rubocop:disable Style/ClassVars -- the app memoises this in a class variable,
+    # so the test has to reach for it directly to exercise the uninitialized state.
+    before do
+      Mdm::User.delete_all
+      # The app latches this on for the lifetime of the process, so reset it here.
+      described_class.class_variable_set(:@@auth_initialized, false)
+    end
+
+    after do
+      described_class.class_variable_set(:@@auth_initialized, false)
+    end
+    # rubocop:enable Style/ClassVars
+
+    it 'allows the initial user account to be created unauthenticated' do
+      post '/api/v1/users', { username: 'bootstrap_user', password: 'bootstrap_password' }.to_json,
+           { 'CONTENT_TYPE' => 'application/json' }
+      expect(last_response.status).not_to eq(401)
+    end
+
+    # The exemption exists only so that msfdb can create the first account. Anything else
+    # must still be authenticated, otherwise an unexpectedly empty users table - a restored
+    # blank database, a failover onto a fresh instance - exposes the whole API.
+    it 'still requires authentication for other endpoints while no users exist' do
+      get '/api/v1/hosts'
+      expect(last_response.status).to eq(401)
+    end
+
+    it 'still requires authentication to list users while no users exist' do
+      get '/api/v1/users'
+      expect(last_response.status).to eq(401)
+    end
+  end
+
   describe 'response headers' do
     it 'uses lowercase header keys' do
       get '/api/v1/hosts'

--- a/spec/lib/msf/core/web_services/framework_extension_spec.rb
+++ b/spec/lib/msf/core/web_services/framework_extension_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::WebServices::FrameworkExtension do
+  describe '.db_connect' do
+    let(:framework) { double('framework') }
+    let(:settings) { double('settings', data_service_url: data_service_url) }
+    let(:app) { double('app', settings: settings) }
+    let(:data_service_url) { nil }
+
+    before do
+      allow(described_class).to receive(:warn)
+    end
+
+    context 'when the database connects successfully' do
+      before do
+        allow(Msf::DbConnector).to receive(:db_connect_from_config).with(framework).and_return({ result: 'Connected' })
+      end
+
+      it 'does not raise' do
+        expect { described_class.db_connect(framework, app) }.not_to raise_error
+      end
+
+      it 'does not warn' do
+        expect(described_class).not_to receive(:warn)
+        described_class.db_connect(framework, app)
+      end
+    end
+
+    # The JSON-RPC service supports running without a database, so a failed connection
+    # must not prevent the framework - and therefore the service - from starting.
+    context 'when the database is unavailable' do
+      before do
+        allow(Msf::DbConnector).to receive(:db_connect_from_config)
+          .with(framework)
+          .and_return({ error: 'Failed to connect to the Postgres data service: connection refused' })
+      end
+
+      it 'does not raise' do
+        expect { described_class.db_connect(framework, app) }.not_to raise_error
+      end
+
+      it 'warns that the service is starting without database support' do
+        expect(described_class).to receive(:warn).with(/without database support/)
+        described_class.db_connect(framework, app)
+      end
+    end
+
+    # Msf::DbConnector requires a live local database before it will attempt a remote
+    # connection, and leaves it registered as the current data service when the remote one
+    # fails. Continuing would silently serve and authenticate against that local database
+    # instead of the service the operator named.
+    context 'when a remote data service is configured but unreachable' do
+      let(:data_service_url) { 'https://192.0.2.1:5443' }
+
+      before do
+        allow(settings).to receive(:data_service_api_token).and_return('token')
+        allow(settings).to receive(:data_service_cert).and_return(nil)
+        allow(settings).to receive(:data_service_skip_verify).and_return(false)
+        allow(Msf::DbConnector).to receive(:db_connect).and_return({ error: 'Failed to connect' })
+      end
+
+      it 'raises rather than falling back to the local database' do
+        expect { described_class.db_connect(framework, app) }
+          .to raise_error(described_class::DataServiceError, /Failed to connect/)
+      end
+
+      it 'names the data service that could not be reached' do
+        expect { described_class.db_connect(framework, app) }
+          .to raise_error(described_class::DataServiceError, /#{Regexp.escape(data_service_url)}/)
+      end
+
+      it 'does not report it as starting without database support' do
+        expect(described_class).not_to receive(:warn)
+        expect { described_class.db_connect(framework, app) }.to raise_error(described_class::DataServiceError)
+      end
+    end
+
+    context 'when a remote data service is configured and reachable' do
+      let(:data_service_url) { 'https://192.0.2.1:5443' }
+
+      before do
+        allow(settings).to receive(:data_service_api_token).and_return('token')
+        allow(settings).to receive(:data_service_cert).and_return(nil)
+        allow(settings).to receive(:data_service_skip_verify).and_return(false)
+        allow(Msf::DbConnector).to receive(:db_connect).and_return({ result: 'Connected' })
+      end
+
+      it 'does not raise' do
+        expect { described_class.db_connect(framework, app) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/web_services/json_rpc_app_spec.rb
+++ b/spec/lib/msf/core/web_services/json_rpc_app_spec.rb
@@ -1,0 +1,241 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::WebServices::JsonRpcApp do
+  # Sinatra settings are class level, so capture and restore the real values rather
+  # than resetting to nil, which would discard the environment derived configuration
+  # for the remainder of the process.
+  let!(:original_api_token) { described_class.settings.api_token }
+  let!(:original_db_manager) { described_class.settings.db_manager }
+  let!(:original_data_service_url) { described_class.settings.data_service_url }
+
+  after do
+    described_class.settings.api_token = original_api_token
+    described_class.settings.db_manager = original_db_manager
+    described_class.settings.data_service_url = original_data_service_url
+  end
+
+  describe '.boot!' do
+    let(:db) { instance_double(Msf::DBManager) }
+    let(:framework) { double('framework', db: db) }
+
+    before do
+      allow(described_class.settings).to receive(:framework).and_return(framework)
+      described_class.settings.api_token = nil
+      described_class.settings.db_manager = nil
+      described_class.settings.data_service_url = nil
+    end
+
+    context 'when an API token is configured' do
+      before do
+        described_class.settings.api_token = 'static_token_abc123'
+      end
+
+      it 'does not raise' do
+        expect { described_class.boot! }.not_to raise_error
+      end
+
+      it 'does not touch the database' do
+        expect(db).not_to receive(:active)
+        expect(db).not_to receive(:users)
+        described_class.boot!
+      end
+
+      it 'leaves db_manager nil' do
+        described_class.boot!
+        expect(described_class.settings.db_manager).to be_nil
+      end
+
+      it 'retains the token' do
+        described_class.boot!
+        expect(described_class.settings.api_token).to eq('static_token_abc123')
+      end
+    end
+
+    context 'when the API token is too short' do
+      before do
+        described_class.settings.api_token = 'short'
+      end
+
+      it 'raises rather than accepting a guessable token' do
+        expect { described_class.boot! }.to raise_error(
+          described_class::BootError,
+          /must be at least #{described_class::MIN_API_TOKEN_LENGTH} characters/
+        )
+      end
+    end
+
+    # An empty MSF_WS_JSON_RPC_API_TOKEN would otherwise authenticate any request
+    # presenting an equally empty token.
+    ['', '   '].each do |blank|
+      context "when the API token is blank (#{blank.inspect})" do
+        before do
+          described_class.settings.api_token = blank
+          allow(db).to receive(:active).and_return(true)
+          allow(db).to receive(:users).with({}).and_return([instance_double(Mdm::User, persistence_token: SecureRandom.hex(20))])
+        end
+
+        it 'discards the token' do
+          described_class.boot!
+          expect(described_class.settings.api_token).to be_nil
+        end
+
+        it 'falls back to database authentication' do
+          described_class.boot!
+          expect(described_class.settings.db_manager).to eq(db)
+        end
+      end
+    end
+
+    context 'when the database is available and has users' do
+      before do
+        allow(db).to receive(:active).and_return(true)
+        allow(db).to receive(:users).with({}).and_return([instance_double(Mdm::User, persistence_token: SecureRandom.hex(20))])
+      end
+
+      it 'does not raise' do
+        expect { described_class.boot! }.not_to raise_error
+      end
+
+      it 'sets db_manager' do
+        described_class.boot!
+        expect(described_class.settings.db_manager).to eq(db)
+      end
+
+      it 'leaves the API token unset' do
+        described_class.boot!
+        expect(described_class.settings.api_token).to be_nil
+      end
+    end
+
+    # Refusing to start is deliberate: the alternative is serving RPC unauthenticated.
+    shared_examples 'refuses to start' do |reason, remedy = /Set MSF_WS_JSON_RPC_API_TOKEN.*or run 'msfdb init'/m|
+      it 'raises a BootError' do
+        expect { described_class.boot! }.to raise_error(described_class::BootError, reason)
+      end
+
+      it 'explains how to configure authentication' do
+        expect { described_class.boot! }.to raise_error(described_class::BootError, remedy)
+      end
+
+      it 'does not set db_manager' do
+        expect { described_class.boot! }.to raise_error(described_class::BootError)
+        expect(described_class.settings.db_manager).to be_nil
+      end
+
+      it 'does not invent a token' do
+        expect { described_class.boot! }.to raise_error(described_class::BootError)
+        expect(described_class.settings.api_token).to be_nil
+      end
+    end
+
+    context 'when the database is unavailable' do
+      before do
+        allow(db).to receive(:active).and_return(false)
+      end
+
+      include_examples 'refuses to start', /the database is not available/
+
+      it 'does not try to read users from an inactive database' do
+        expect(db).not_to receive(:users)
+        expect { described_class.boot! }.to raise_error(described_class::BootError)
+      end
+    end
+
+    context 'when the database is active but cannot be queried' do
+      before do
+        allow(db).to receive(:active).and_return(true)
+        allow(db).to receive(:users).with({}).and_raise(StandardError, 'connection refused')
+      end
+
+      include_examples 'refuses to start', /could not be queried/
+
+      it 'includes the underlying error' do
+        expect { described_class.boot! }.to raise_error(described_class::BootError, /connection refused/)
+      end
+    end
+
+    context 'when the database is available but has no users' do
+      before do
+        allow(db).to receive(:active).and_return(true)
+        allow(db).to receive(:users).with({}).and_return([])
+      end
+
+      include_examples 'refuses to start', /the database holds no users/
+    end
+
+    # A data proxy with no registered data service answers every call with nil rather
+    # than raising, so a nil user list must not be mistaken for a usable database.
+    context 'when the database returns no user list at all' do
+      before do
+        allow(db).to receive(:active).and_return(true)
+        allow(db).to receive(:users).with({}).and_return(nil)
+      end
+
+      include_examples 'refuses to start', /the database holds no users/
+    end
+
+    # report_user does not issue an API token, so a database of password-only accounts is
+    # reachable. This application only validates persistence_token, so starting against one
+    # would 401 every request.
+    [nil, '', '   '].each do |token|
+      context "when the only user has no usable API token (#{token.inspect})" do
+        before do
+          allow(db).to receive(:active).and_return(true)
+          allow(db).to receive(:users).with({})
+                                      .and_return([instance_double(Mdm::User, persistence_token: token)])
+        end
+
+        include_examples 'refuses to start',
+                         /no user in the database has an API token/,
+                         %r{POST /api/v1/auth/generate-token}
+      end
+    end
+
+    context 'when only some users have an API token' do
+      before do
+        allow(db).to receive(:active).and_return(true)
+        allow(db).to receive(:users).with({}).and_return(
+          [
+            instance_double(Mdm::User, persistence_token: nil),
+            instance_double(Mdm::User, persistence_token: SecureRandom.hex(20))
+          ]
+        )
+      end
+
+      it 'starts, because one usable token is enough' do
+        described_class.boot!
+        expect(described_class.settings.db_manager).to eq(db)
+      end
+    end
+
+    # User accounts of a remote data service live on that service, so its tokens cannot be
+    # validated here. The local database Active Record needs alongside it holds a different
+    # set of users, and authenticating against those would accept credentials that were
+    # never issued for this service.
+    context 'when a remote data service is configured' do
+      before do
+        described_class.settings.data_service_url = 'https://192.0.2.1:5443'
+      end
+
+      it 'refuses to start without a static token' do
+        expect { described_class.boot! }.to raise_error(
+          described_class::BootError,
+          %r{cannot be validated against the remote data service https://192.0.2.1:5443}
+        )
+      end
+
+      it 'does not authenticate against the local database' do
+        expect(db).not_to receive(:users)
+        expect { described_class.boot! }.to raise_error(described_class::BootError)
+        expect(described_class.settings.db_manager).to be_nil
+      end
+
+      it 'starts when a static token is configured' do
+        described_class.settings.api_token = 'static_token_abc123'
+        expect { described_class.boot! }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -167,12 +167,28 @@ RSpec.configure do |config|
     opts[:host] = 'localhost'
     opts[:port] = '8080'
 
+    # Username of the account the remote data service client authenticates as. Created outside
+    # of the per example transaction so that the separate web service process can see it.
+    remote_db_username = 'rspec_remote_db'
+
     config.before(:suite) do
+      # The data service requires authentication, so the client needs an API token belonging
+      # to a real user. Created directly rather than over HTTP: the only route that runs
+      # unauthenticated is the one creating the first account, and the client needs its token
+      # before it can issue any request at all, including the readiness check in #start.
+      user = Mdm::User.where(username: remote_db_username).first_or_create!(
+        crypted_password: BCrypt::Password.create(SecureRandom.hex(16)),
+        admin: true
+      )
+      user.update!(persistence_token: SecureRandom.hex(20))
+      opts[:api_token] = user.persistence_token
+
       Metasploit::Framework::DataService::ManagedRemoteDataService.instance.start(opts)
     end
 
     config.after(:suite) do
       Metasploit::Framework::DataService::ManagedRemoteDataService.instance.stop
+      Mdm::User.where(username: remote_db_username).delete_all
     end
   end
 


### PR DESCRIPTION
## Description

Update the default auth logic in the JSON RPC support to now require auth by default, either via the database with user creds or an auth token

## Testing

- Ensure CI passes
- Ensure the documentation steps for running the JSON RPC service still work as expected