### PR TITLE
Update contributing documentation for agents

### DIFF
--- a/.github/instructions/library.instructions.md
+++ b/.github/instructions/library.instructions.md
@@ -17,7 +17,7 @@ applyTo: "lib/**/*.rb"
 
 - Add YARD `@param` and `@return` tags to ALL public methods
 - Link to RFC/spec when implementing binary or protocol parsers
-- Add `# frozen_string_literal: true` to new files
+- Add `# frozen_string_literal: true` to new library files; use `String.new` where a mutable string is needed
 
 ## Naming
 

--- a/.github/instructions/modules.instructions.md
+++ b/.github/instructions/modules.instructions.md
@@ -6,16 +6,15 @@ applyTo: "modules/**/*.rb"
 
 ## Structure Order
 
-1. `# frozen_string_literal: true`
-2. Header comment block
-3. `class MetasploitModule < Msf::Exploit::Remote` (or `Msf::Auxiliary`, `Msf::Post`)
-4. `Rank = ExcellentRanking` (exploits only)
-5. Protocol mixins (`include Msf::Exploit::Remote::HttpClient`, etc.)
-6. Utility mixins (`include Msf::Exploit::FileDropper`, etc.)
-7. `prepend Msf::Exploit::Remote::AutoCheck` — ALWAYS LAST
-8. `def initialize` with `update_info`
-9. `def check` (when possible)
-10. `def exploit` or `def run`
+1. Header comment block
+2. `class MetasploitModule < Msf::Exploit::Remote` (or `Msf::Auxiliary`, `Msf::Post`)
+3. `Rank = ExcellentRanking` (exploits only)
+4. Protocol mixins (`include Msf::Exploit::Remote::HttpClient`, etc.)
+5. Utility mixins (`include Msf::Exploit::FileDropper`, etc.)
+6. `prepend Msf::Exploit::Remote::AutoCheck` — ALWAYS LAST
+7. `def initialize` with `update_info`
+8. `def check` (when possible)
+9. `def exploit` or `def run`
 
 ## Required Metadata
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Metasploit Framework is an open-source penetration testing and exploitation fram
 - Ruby (see `.ruby-version` for the current version). Minimum supported: 3.1+
 - Follow the project's `.rubocop.yml` configuration — run `rubocop` on changed files before submitting
 - Run `ruby tools/dev/msftidy.rb <module_file_path>` to catch common module issues
-- Add `# frozen_string_literal: true` to new files (the RuboCop cop is disabled project-wide for legacy code, but new files should include it)
+- `# frozen_string_literal: true` — add to new **library** files (`lib/`); use `String.new` where a mutable string is needed. Do NOT add to module files or spec files (the framework extensively mutates string buffers via instance variables, and the RuboCop cop `Style/FrozenStringLiteralComment` is disabled project-wide). Existing files that already have it are fine to leave
 - No enforced line length limit, but keep code readable
 - Use `%q{}` for long multi-line strings (curly braces preferred for module descriptions)
 - Multiline block comments are acceptable for embedded code snippets/payloads
@@ -36,8 +36,6 @@ Metasploit Framework is an open-source penetration testing and exploitation fram
 New exploit modules should follow this canonical structure and ordering:
 
 ```ruby
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -109,8 +107,6 @@ end
 Auxiliary modules use `def run` (not `exploit`) and inherit from `Msf::Auxiliary`:
 
 ```ruby
-# frozen_string_literal: true
-
 class MetasploitModule < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report
@@ -155,8 +151,6 @@ end
 Post modules inherit from `Msf::Post`, require a session, and declare compatible session types:
 
 ```ruby
-# frozen_string_literal: true
-
 class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Linux::System

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,6 @@ Keeping the following in mind gives your contribution the best chance of landing
 * **Do** include [Module Documentation] showing sample run-throughs.
 * **Do** run `ruby tools/dev/msftidy_docs.rb <documentation_file>` on any module documentation markdown files and ensure it passes with no errors.
 * **Do** ask cve@rapid7.com for a CVE ID if this describes a new vulnerability (remember to mention your PR number!)
-* **Do** add `# frozen_string_literal: true` as the first line of new module files.
 * **Do** use `prepend Msf::Exploit::Remote::AutoCheck` to let the framework handle vulnerability checking before exploitation — this is preferred over manually calling `check` in your exploit method.
 * **Do** include a descriptive reason string when returning CheckCode values (e.g., `CheckCode::Safe("Patched version #{v}")`) — bare constants without reasons are not accepted.
 * **Don't** include more than one module per pull request.


### PR DESCRIPTION
## Description

Clarifies `# frozen_string_literal: true` guidance in AGENTS.md. The previous wording ("add to new files") was overly broad and caused confusion on PR #21574, where a spec file with the pragma crashed against library code that mutates string instance variables.

The new guidance explicitly scopes where frozen string literals should and shouldn't be used:
- **Library files (`lib/`)**: yes, with `String.new` or `+''` for mutable buffers
- **Module files**: no — framework APIs mutate strings via instance variables
- **Spec files**: no

**Related Issue:** Discussion on [#21574](https://github.com/rapid7/metasploit-framework/pull/21574#issuecomment-5258969294)

## Breaking Changes

None — documentation only.

## Verification Steps

1. - [ ] Read the updated bullet point in AGENTS.md and confirm it matches the project's actual `Style/FrozenStringLiteralComment: Enabled: false` configuration
2. - [ ] Confirm `String.new` is listed first (177 files in `lib/` use it vs 46 using `+''`)

## Test Evidence

N/A — documentation change only.

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS |

## AI Usage Disclosure

AI (Kiro/Claude) was used to draft the revised wording based on analysis of existing codebase patterns and the failure observed on PR #21574.

## Pre-Submission Checklist

- [x] No sensitive information in code or documentation
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md)