### PR TITLE
Fix two crashes in the default DNS forward/cache path

### DIFF
--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -185,10 +185,10 @@ class Server
     # Finalize answers in response
     # Check for empty response prior to sending
     if req.answer.size < 1
-      req.header.rCode = Dnsruby::RCode::NOERROR
+      req.header.rcode = Dnsruby::RCode::NOERROR
     end
     req.header.qr = true # Set response bit
-    send_response(cli, req.data)
+    send_response(cli, req.encode)
   end
 
   #

--- a/spec/lib/rex/proto/dns/server_spec.rb
+++ b/spec/lib/rex/proto/dns/server_spec.rb
@@ -1,0 +1,40 @@
+require 'rex/proto/dns'
+
+RSpec.describe Rex::Proto::DNS::Server do
+  subject(:server) { described_class.new }
+
+  let(:cli) { double('client', write: nil) }
+
+  # a real, encodable query for a name that is in neither the cache nor
+  # anything the stubbed resolver knows about
+  def query_for(name)
+    query = Dnsruby::Message.new
+    query.add_question(Dnsruby::Name.create("#{name}."), Dnsruby::Types::A)
+    query.encode
+  end
+
+  describe '#default_dispatch_request' do
+    context 'when the forwarded response carries no answers' do
+      before do
+        # the resolver forwards the query and comes back empty, which is the
+        # path that finalizes an empty response - the one that crashed
+        empty_response = Dnsruby::Message.new
+        server.fwd_res = double('resolver', send: empty_response)
+      end
+
+      it 'does not raise' do
+        expect { server.default_dispatch_request(cli, query_for('empty.example.com')) }.not_to raise_error
+      end
+
+      it 'sends a well formed, encoded response back to the client' do
+        expect(cli).to receive(:write) do |data|
+          expect(data).to be_a(String)
+          reply = Dnsruby::Message.decode(data)
+          expect(reply.header.get_header_rcode).to eq(Dnsruby::RCode::NOERROR)
+          expect(reply.header.qr).to eq(true)
+        end
+        server.default_dispatch_request(cli, query_for('empty.example.com'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

`Rex::Proto::DNS::Server#default_dispatch_request` crashes the moment it has to finalize an empty response. That happens on any query that misses the cache and gets forwarded to the resolver with no answer coming back, which in practice includes any out-of-scope query being forwarded through unchanged, such as the PTR reverse lookup a real client sends before its actual query. The exception is uncaught, so it kills the listener thread and stops the whole server, silently, on the very first such query.

Two mistakes in the same two lines, both against `Dnsruby::Message`, the type `Packet.encode_drb` documents `req` as being:

```ruby
if req.answer.size < 1
  req.header.rCode = Dnsruby::RCode::NOERROR
end
req.header.qr = true
send_response(cli, req.data)
```

- `req.header.rCode=` does not exist on `Dnsruby::Header`; the setter is `rcode=` (lowercase). The same directory already uses the correct setter and reader — `lib/rex/proto/dns/packet.rb:155` and `:158` set `packet.header.rcode = Dnsruby::RCode::NXDOMAIN` / `NOERROR`, and `:157` reads via `get_header_rcode` — so this fix just aligns the crashing path with the file's own established convention.
- `req.data` does not exist on `Dnsruby::Message`. The real serializer is `#encode`. `Packet.encode_raw`, a few lines above in this same file, already gets this right:
  ```ruby
  (packet.respond_to?(:data) ? packet.data : packet.encode).force_encoding('binary')
  ```
  `default_dispatch_request` just used the wrong branch of the same `data`/`encode` distinction this file already knows how to make.

No spec covered this path, so both shipped and stayed live.

## Live reproduction

I hit this while building an IPv6 DNS-takeover module. Once the crash was fixed I could see it happening: with only the first fix applied, the second line raised immediately on the next real query.

```
[-] Auxiliary failed: NoMethodError undefined method `rCode=' for an instance of Dnsruby::Header
[-]   .../lib/rex/proto/dns/server.rb:188:in `default_dispatch_request'
[-]   .../lib/msf/core/exploit/remote/dns/name_poisoner.rb:54:in `on_dispatch_request'
[*] Server stopped.
```

```
[-] Auxiliary failed: NoMethodError undefined method `data' for an instance of Dnsruby::Message
[-]   .../lib/rex/proto/dns/server.rb:191:in `default_dispatch_request'
[-]   .../lib/msf/core/exploit/remote/dns/name_poisoner.rb:54:in `on_dispatch_request'
[*] Server stopped.
```

With both fixed, the same real client's query is handled and forwarded correctly, and the server survives.

## Testing

Added `spec/lib/rex/proto/dns/server_spec.rb`, covering the path that crashed: a forwarded query whose response carries no answers. Confirmed the new spec fails against the pre-fix code with the exact errors above, and passes with the fix.

```
$ bundle exec rspec spec/lib/rex/proto/dns/
53 examples, 0 failures
```

## Breaking Changes

None. Both lines were unreachable without raising; nothing depended on the old behavior.
