### PR TITLE
add count command line flag

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -44,6 +44,8 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
     case parsed_options.options.subcommand
     when :version
       $stderr.puts "Framework Version: #{Metasploit::Framework::VERSION}"
+    when :count
+      print_module_counts
     else
       unless parsed_options.options.console.quiet
         colorizor = Struct.new(:supports_color?).new(false).extend(Rex::Text::Color)
@@ -56,6 +58,50 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
   end
 
   private
+
+  # Prints the module counts shown in the startup banner (exploits, auxiliary,
+  # payloads, post, encoders, nops, evasion) without starting the console.
+  #
+  # Mirrors the boot sequence of Msf::Ui::Console::Driver: when module files
+  # have changed since the metadata cache was built, the cache is rebuilt from
+  # the module files (exactly as a full console boot would do); otherwise the
+  # counts are read straight from the on-disk metadata store.
+  #
+  # @return [void]
+  def print_module_counts
+    # Defer module loading while the framework is created; whether modules
+    # must be loaded eagerly is decided below from the cache checksum.
+    framework = Msf::Simple::Framework.create('DeferModuleLoads' => true)
+
+    has_modified_module_files = !Msf::Modules::Metadata::Store.valid_checksum?
+    if has_modified_module_files
+      Msf::Modules::Metadata::Store.update_cache_checksum(Msf::Modules::Metadata::Store.get_current_checksum)
+      framework.init_module_paths(
+          module_paths: parsed_options.options.modules.path,
+          defer_module_loads: false
+      )
+      framework.modules.refresh_cache_from_module_files
+    else
+      framework.init_module_paths(
+          module_paths: parsed_options.options.modules.path,
+          defer_module_loads: true
+      )
+    end
+
+    stats = framework.stats
+    counts = {
+        'exploits'  => stats.num_exploits,
+        'auxiliary' => stats.num_auxiliary,
+        'payloads'  => stats.num_payloads,
+        'post'      => stats.num_post,
+        'encoders'  => stats.num_encoders,
+        'nops'      => stats.num_nops,
+        'evasion'   => stats.num_evasion
+    }
+    counts.each do |type, count|
+      $stdout.puts "#{type}: #{count.to_fs(:delimited)}"
+    end
+  end
 
   # The console UI driver.
   #

--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -44,7 +44,7 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
     case parsed_options.options.subcommand
     when :version
       $stderr.puts "Framework Version: #{Metasploit::Framework::VERSION}"
-    when :count
+    when :module_count
       print_module_counts
     else
       unless parsed_options.options.console.quiet

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -40,6 +40,10 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
           options.console.confirm_exit = true
         end
 
+        option_parser.on('--count', 'Print module counts and exit') do
+          options.subcommand = :count
+        end
+
         option_parser.on('-H', '--history-file FILE', 'Save command history to the specified file') do |file|
           options.console.histfile = file
         end

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -40,8 +40,8 @@ class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::Par
           options.console.confirm_exit = true
         end
 
-        option_parser.on('--count', 'Print module counts and exit') do
-          options.subcommand = :count
+        option_parser.on('--module-count', 'Print module counts and exit') do
+          options.subcommand = :module_count
         end
 
         option_parser.on('-H', '--history-file FILE', 'Save command history to the specified file') do |file|

--- a/spec/lib/metasploit/framework/parsed_options/console_spec.rb
+++ b/spec/lib/metasploit/framework/parsed_options/console_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Metasploit::Framework::ParsedOptions::Console do
   describe '#option_parser' do
     it 'parses --module-count as the count subcommand' do
       parsed_options.send(:option_parser).parse(['--module-count'])
-      expect(parsed_options.options.subcommand).to eq :count
+      expect(parsed_options.options.subcommand).to eq :module_count
     end
 
     it 'does not set a subcommand by default' do

--- a/spec/lib/metasploit/framework/parsed_options/console_spec.rb
+++ b/spec/lib/metasploit/framework/parsed_options/console_spec.rb
@@ -4,6 +4,18 @@ require 'metasploit/framework/parsed_options'
 RSpec.describe Metasploit::Framework::ParsedOptions::Console do
   subject(:parsed_options) { described_class.allocate }
 
+  describe '#option_parser' do
+    it 'parses --count as the count subcommand' do
+      parsed_options.send(:option_parser).parse(['--count'])
+      expect(parsed_options.options.subcommand).to eq :count
+    end
+
+    it 'does not set a subcommand by default' do
+      parsed_options.send(:option_parser).parse([])
+      expect(parsed_options.options.subcommand).to be_nil
+    end
+  end
+
   describe '#split_commands' do
     # split_commands is private, so we use send
     let(:result) { parsed_options.send(:split_commands, input) }

--- a/spec/lib/metasploit/framework/parsed_options/console_spec.rb
+++ b/spec/lib/metasploit/framework/parsed_options/console_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Metasploit::Framework::ParsedOptions::Console do
   subject(:parsed_options) { described_class.allocate }
 
   describe '#option_parser' do
-    it 'parses --count as the count subcommand' do
-      parsed_options.send(:option_parser).parse(['--count'])
+    it 'parses --module-count as the count subcommand' do
+      parsed_options.send(:option_parser).parse(['--module-count'])
       expect(parsed_options.options.subcommand).to eq :count
     end
 


### PR DESCRIPTION
## Description

This adds a new command line flag to print the count of modules (similar to the current banner) and exit. This prevents doing funky regex magic against the banner.

I wanted this feature to keep track of numbers for another project, and seemed like an easy win

## Verification Steps

1. - [x]  `./msfconsole --count` and see the counts

## AI Usage Disclosure

GLM-5.2