### PR TITLE
Fix #21780: Fix vsftpd_234_backdoor: restore cmd/unix/interact payload compatibility

### DIFF
--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -39,7 +39,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Payload' => {
           'Space' => 2000,
           'BadChars' => '',
-          'DisableNops' => true
+          'DisableNops' => true,
+          'Compat' => {
+               'PayloadType'    => 'cmd_interact',
+               'ConnectionType' => 'find'
+          }
         },
         'Targets' => [
           [
@@ -48,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Type' => :unix_cmd,
               'DefaultOptions' => {
                 # This exploit also supports direct interaction with the backdoor using cmd/unix/interact payload
-                'PAYLOAD' => 'cmd/linux/http/x86/meterpreter_reverse_tcp'
+                'PAYLOAD' => 'cmd/unix/interact'
               }
             }
           ]


### PR DESCRIPTION
Fixes #21780

Problem

**exploit/unix/ftp/vsftpd_234_backdoor** no longer supports direct interaction with the backdoor via **cmd/unix/interact**, despite this being the documented and historically expected behavior for this module. This breaks exploitation against older/legacy targets (e.g. Metasploitable 2, Ubuntu 8.04) that cannot run modern fetch-based meterpreter payloads due to glibc version incompatibility.

Root cause

Two issues in **modules/exploits/unix/ftp/vsftpd_234_backdoor.rb**:

1.**Wrong default payload**. The target's **DefaultOptions** sets PAYLOAD to **cmd/linux/http/x86/meterpreter_reverse_tcp**, which requires LHOST and relies on fetching/executing a compiled meterpreter binary on the target. This fails against targets with older glibc versions, since current meterpreter builds require glibc 2.17+.

2.**cmd/unix/interact** is not selectable at all. The module's Payload block does not declare a Compat stanza (PayloadType => 'cmd_interact'), which is required for Metasploit's payload-compatibility filter to recognize cmd/unix/interact as valid for this module. Without it, the payload is absent from show payloads, and manually running set PAYLOAD cmd/unix/interact fails with The value specified for PAYLOAD is not valid.
Fix
Added the missing **Compat => { 'PayloadType' => 'cmd_interact', 'ConnectionType' => 'find' }** stanza to the module's Payload block, restoring **cmd/unix/interact** as a recognized compatible payload.
Changed **DefaultOptions['PAYLOAD']** back to **cmd/unix/interact**, matching the module's own inline comment and existing documentation/tutorials.

Verification

Tested locally against a Metasploitable 2 (Ubuntu 8.04, vsftpd 2.3.4) lab target:
<img width="1121" height="604" alt="Screenshot 2026-08-18 132824" src="https://github.com/user-attachments/assets/f8547871-c167-43cb-8366-90aff83db94b" />

<img width="526" height="214" alt="image" src="https://github.com/user-attachments/assets/a3d700ce-c2f4-4ea5-a2d0-f7e0653b4bcc" />


show payloads now lists cmd/unix/interact as the sole compatible payload (screenshot attached).
Running the module with defaults (no LHOST set) successfully triggers the backdoor and opens a command shell session on port 6200.
Confirmed root access via whoami / id inside the resulting session (screenshot attached).