### PR TITLE
update rsync module to work with protocol 32 (released early 2025)

### DIFF
--- a/documentation/modules/auxiliary/scanner/rsync/modules_list.md
+++ b/documentation/modules/auxiliary/scanner/rsync/modules_list.md
@@ -5,10 +5,10 @@ negotiates with an rsync server, lists the available modules and, optionally, de
 
 ## Vulnerable Application
 
-### Kali rolling with rsync 3.4.4  (protocol 32, August 2026)
+### Kali rolling with rsync 3.4.4 (protocol 32, August 2026)
 
 ```
-# rsync 3.4.4 / protocol 32 — current Kali rolling package
+# rsync 3.4.4 / protocol 32 - current Kali rolling package
 # (the newest daemon; strict handshake with subprotocol + digest list)
 FROM kalilinux/kali-rolling:latest
 
@@ -51,7 +51,7 @@ CMD ["rsync", "--daemon", "--no-detach", "--config", "/etc/rsyncd.conf"]
 ### Debian 12 with rsync 3.2.7 (protocol 32)
 
 ```
-# rsync 3.2.7 / protocol 32 — Debian 12 point-release package
+# rsync 3.2.7 / protocol 32 - Debian 12 point-release package
 # (first protocol-32 daemon; same strict handshake as 3.4.x)
 FROM debian:12
 
@@ -94,8 +94,8 @@ CMD ["rsync", "--daemon", "--no-detach", "--config", "/etc/rsyncd.conf"]
 ### Ubuntu 20.04 with rsync 3.1.3 (protocol 31)
 
 ```
-# rsync 3.1.3 / protocol 31 — Ubuntu 20.04 package
-# (old-style handshake: "@RSYNCD: 31.0", no digest list — the regression case)
+# rsync 3.1.3 / protocol 31 - Ubuntu 20.04 package
+# (old-style handshake: "@RSYNCD: 31.0", no digest list - the regression case)
 FROM ubuntu:20.04
 
 RUN apt-get update \

--- a/documentation/modules/auxiliary/scanner/rsync/modules_list.md
+++ b/documentation/modules/auxiliary/scanner/rsync/modules_list.md
@@ -5,43 +5,134 @@ negotiates with an rsync server, lists the available modules and, optionally, de
 
 ## Vulnerable Application
 
-### Configuring rsync on Kali Linux:
+### Kali rolling with rsync 3.4.4  (protocol 32, August 2026)
 
-Rsync is installed by default on Kali, however we need to configure some modules for the scanner to find.  Step three will
-create the secrets files which we'll use to test the authentication mechanism.  Much of this is based on the guide from
-[atlantic.net](https://www.atlantic.net/cloud-hosting/how-to-setup-rsync-daemon-linux-server/).
+```
+# rsync 3.4.4 / protocol 32 — current Kali rolling package
+# (the newest daemon; strict handshake with subprotocol + digest list)
+FROM kalilinux/kali-rolling:latest
 
-1. ```mkdir /home/public_rsync2; mkdir /home/public_rsync3; mkdir /home/public_rsync```
-2. Create the configuration file: 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends rsync \
+    && rm -rf /var/lib/apt/lists/*
 
-    ```
-    echo -n "[read only files]
-    path = /home/public_rsync
-    comment = Files are read only
-    read only = true
-    timeout = 300
-    
-    [writable]
-    path = /home/public_rsync2
-    comment = Files can be written to
-    read only = false
-    timeout = 300
-    
-    [authenticated]
-    path = /home/public_rsync3
-    comment = Files require authentication
-    read only = true
-    timeout = 300
-    auth users = rsync1,rsync2
+RUN <<'SETUP'
+mkdir -p /srv/share
+echo 'hello from kali-rolling (rsync 3.4.4, protocol 32)' > /srv/share/file.txt
+cat > /etc/rsyncd.secrets <<'SECRETS'
+demouser:secretpw
+SECRETS
+chmod 600 /etc/rsyncd.secrets
+cat > /etc/rsyncd.conf <<'CONF'
+use chroot = no
+reverse lookup = no
+forward lookup = no
+pid file = /tmp/rsyncd.pid
+log file = /tmp/rsyncd.log
+
+[public]
+    path = /srv/share
+    comment = open share
+    read only = yes
+
+[locked]
+    path = /srv/share
+    comment = password-protected share
+    read only = yes
+    auth users = demouser
     secrets file = /etc/rsyncd.secrets
-    " > /etc/rsyncd.conf
-    ```
+CONF
+SETUP
 
-3. ```echo -n "rsync1:9$AZv2%5D29S740k
-rsync2:Xyb#vbfUQR0og0$6
-rsync3:VU&A1We5DEa8M6^8" > /etc/rsyncd.secrets```
-4. ```chmod 600 /etc/rsyncd.secrets```
-5. ```rsync --daemon```
+EXPOSE 873
+CMD ["rsync", "--daemon", "--no-detach", "--config", "/etc/rsyncd.conf"]
+```
+
+### Debian 12 with rsync 3.2.7 (protocol 32)
+
+```
+# rsync 3.2.7 / protocol 32 — Debian 12 point-release package
+# (first protocol-32 daemon; same strict handshake as 3.4.x)
+FROM debian:12
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends rsync \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN <<'SETUP'
+mkdir -p /srv/share
+echo 'hello from debian 12 (rsync 3.2.7, protocol 32)' > /srv/share/file.txt
+cat > /etc/rsyncd.secrets <<'SECRETS'
+demouser:secretpw
+SECRETS
+chmod 600 /etc/rsyncd.secrets
+cat > /etc/rsyncd.conf <<'CONF'
+use chroot = no
+reverse lookup = no
+forward lookup = no
+pid file = /tmp/rsyncd.pid
+log file = /tmp/rsyncd.log
+
+[public]
+    path = /srv/share
+    comment = open share
+    read only = yes
+
+[locked]
+    path = /srv/share
+    comment = password-protected share
+    read only = yes
+    auth users = demouser
+    secrets file = /etc/rsyncd.secrets
+CONF
+SETUP
+
+EXPOSE 873
+CMD ["rsync", "--daemon", "--no-detach", "--config", "/etc/rsyncd.conf"]
+```
+
+### Ubuntu 20.04 with rsync 3.1.3 (protocol 31)
+
+```
+# rsync 3.1.3 / protocol 31 — Ubuntu 20.04 package
+# (old-style handshake: "@RSYNCD: 31.0", no digest list — the regression case)
+FROM ubuntu:20.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends rsync \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN <<'SETUP'
+mkdir -p /srv/share
+echo 'hello from ubuntu 20.04 (rsync 3.1.3, protocol 31)' > /srv/share/file.txt
+cat > /etc/rsyncd.secrets <<'SECRETS'
+demouser:secretpw
+SECRETS
+chmod 600 /etc/rsyncd.secrets
+cat > /etc/rsyncd.conf <<'CONF'
+use chroot = no
+reverse lookup = no
+forward lookup = no
+pid file = /tmp/rsyncd.pid
+log file = /tmp/rsyncd.log
+
+[public]
+    path = /srv/share
+    comment = open share
+    read only = yes
+
+[locked]
+    path = /srv/share
+    comment = password-protected share
+    read only = yes
+    auth users = demouser
+    secrets file = /etc/rsyncd.secrets
+CONF
+SETUP
+
+EXPOSE 873
+CMD ["rsync", "--daemon", "--no-detach", "--config", "/etc/rsyncd.conf"]
+```
 
 ## Verification Steps
 
@@ -62,41 +153,107 @@ rsync3:VU&A1We5DEa8M6^8" > /etc/rsyncd.secrets```
 
 ## Scenarios
 
-### rsyncd on Kali (using above config)
+### Kali rolling with rsync 3.4.4  (protocol 32, August 2026)
 
-With verbose set to `false`:
+```
+docker build -t kali_rsync .
+docker run -p 873:873 kali_rsync
+```
 
-  ```
-  msf > use auxiliary/scanner/rsync/modules_list
-  msf auxiliary(scanner/rsync/modules_list) > set rhosts 10.168.202.216
-  rhosts => 10.168.202.216
-  msf auxiliary(scanner/rsync/modules_list) > run
-  
-  [+] 10.168.202.216:873    - 3 rsync modules found: read only files, writable, authenticated
-  ```
+```
+msf > use auxiliary/scanner/rsync/modules_list
+msf auxiliary(scanner/rsync/modules_list) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf auxiliary(scanner/rsync/modules_list) > set verbose true
+verbose => true
+msf auxiliary(scanner/rsync/modules_list) > set SHOW_MOTD true
+SHOW_MOTD => true
+msf auxiliary(scanner/rsync/modules_list) > set SHOW_VERSION true
+SHOW_VERSION => true
+msf auxiliary(scanner/rsync/modules_list) > run
+[*] 127.0.0.1:873         - rsync version: 32.0
+[+] 127.0.0.1:873         - 2 rsync modules found: public, locked
 
-With verbose set to `true`:
+rsync modules for 127.0.0.1:873        
+=======================================
 
-  ```
-  msf > use auxiliary/scanner/rsync/modules_list
-  msf auxiliary(scanner/rsync/modules_list) > set rhosts 10.168.202.216
-  rhosts => 10.168.202.216
-  msf auxiliary(scanner/rsync/modules_list) > set verbose true
-  verbose => true
-  msf auxiliary(scanner/rsync/modules_list) > run
-  
-  [+] 10.168.202.216:873    - 3 rsync modules found: read only files, writable, authenticated
-  
-  rsync modules for 10.168.202.216:873   
-  =======================================
-  
-     Name             Comment                       Authentication
-     ----             -------                       --------------
-     authenticated    Files require authentication  required
-     read only files  Files are read only           not required
-     writable         Files can be written to       not required
-  
-  ```
+   Name    Comment                   Authentication
+   ----    -------                   --------------
+   locked  password-protected share  required
+   public  open share                not required
+
+
+[*] 127.0.0.1:873         - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Debian 12 with rsync 3.2.7 (protocol 32)
+
+```
+docker build -t debian_rsync .
+docker run -p 873:873 debian_rsync
+```
+
+```
+msf > use auxiliary/scanner/rsync/modules_list
+msf auxiliary(scanner/rsync/modules_list) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf auxiliary(scanner/rsync/modules_list) > set verbose true
+verbose => true
+msf auxiliary(scanner/rsync/modules_list) > set SHOW_MOTD true
+SHOW_MOTD => true
+msf auxiliary(scanner/rsync/modules_list) > set SHOW_VERSION true
+SHOW_VERSION => true
+msf auxiliary(scanner/rsync/modules_list) > run
+[*] 127.0.0.1:873         - rsync protocol version: 32.0
+[+] 127.0.0.1:873         - 2 rsync modules found: public, locked
+
+rsync modules for 127.0.0.1:873        
+=======================================
+
+   Name    Comment                   Authentication
+   ----    -------                   --------------
+   locked  password-protected share  required
+   public  open share                not required
+
+
+[*] 127.0.0.1:873         - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
+
+### Ubuntu 20.04 with rsync 3.1.3 (protocol 31)
+
+```
+docker build -t ubuntu_rsync .
+docker run -p 873:873 ubuntu_rsync
+```
+
+```
+msf > use auxiliary/scanner/rsync/modules_list
+msf auxiliary(scanner/rsync/modules_list) > set rhosts 127.0.0.1
+rhosts => 127.0.0.1
+msf auxiliary(scanner/rsync/modules_list) > set verbose true
+verbose => true
+msf auxiliary(scanner/rsync/modules_list) > set SHOW_MOTD true
+SHOW_MOTD => true
+msf auxiliary(scanner/rsync/modules_list) > set SHOW_VERSION true
+SHOW_VERSION => true
+msf auxiliary(scanner/rsync/modules_list) > run
+[*] 127.0.0.1:873         - rsync protocol version: 31.0
+[+] 127.0.0.1:873         - 2 rsync modules found: public, locked
+
+rsync modules for 127.0.0.1:873        
+=======================================
+
+   Name    Comment                   Authentication
+   ----    -------                   --------------
+   locked  password-protected share  required
+   public  open share                not required
+
+
+[*] 127.0.0.1:873         - Scanned 1 of 1 hosts (100% complete)
+[*] Auxiliary module execution completed
+```
 
 ## Confirming
 

--- a/documentation/modules/auxiliary/scanner/rsync/modules_list.md
+++ b/documentation/modules/auxiliary/scanner/rsync/modules_list.md
@@ -171,7 +171,7 @@ SHOW_MOTD => true
 msf auxiliary(scanner/rsync/modules_list) > set SHOW_VERSION true
 SHOW_VERSION => true
 msf auxiliary(scanner/rsync/modules_list) > run
-[*] 127.0.0.1:873         - rsync version: 32.0
+[*] 127.0.0.1:873         - rsync protocol version: 32.0
 [+] 127.0.0.1:873         - 2 rsync modules found: public, locked
 
 rsync modules for 127.0.0.1:873        

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -17,12 +17,12 @@ class MetasploitModule < Msf::Auxiliary
   def initialize
     super(
       'Name' => 'List Rsync Modules',
-      'Description' => %q(
+      'Description' => %q{
         An rsync module is essentially a directory share.  These modules can
         optionally be protected by a password.  This module connects to and
         negotiates with an rsync server, lists the available modules and,
         optionally, determines if the module requires a password to access.
-      ),
+      },
       'Author' => [
         'ikkini', # original metasploit module
         'Jon Hart <jon_hart[at]rapid7.com>', # improved metasploit module
@@ -105,17 +105,21 @@ class MetasploitModule < Msf::Auxiliary
     greeting_control_lines, greeting_data_lines = rsync_parse_lines(greeting)
 
     # locate the rsync negotiation and complete it by just echo'ing
-    # back the same rsync version that it sent us
+    # back the same greeting line that it sent us.  Older daemons greet
+    # with a bare protocol version (e.g. "@RSYNCD: 29"), while protocol
+    # 32 daemons (rsync 3.2.7+) greet with "@RSYNCD: 32.0 sha512 ..."
+    # and reject a reply that omits the subprotocol and digest list, so
+    # the entire greeting line must be echoed back verbatim.
     version = nil
     greeting_control_lines.map do |greeting_control_line|
-      if /^#{RSYNC_HEADER} (?<version>\d+(\.\d+)?)$/ =~ greeting_control_line
+      if /^#{RSYNC_HEADER} (?<version>\d+(\.\d+)?)/ =~ greeting_control_line
         version = Regexp.last_match('version')
-        sock.puts("#{RSYNC_HEADER} #{version}\n")
+        sock.puts("#{greeting_control_line}\n")
       end
     end
 
     unless version
-      vprint_error("no rsync negotiation found")
+      vprint_error('no rsync negotiation found')
       return
     end
 
@@ -148,7 +152,7 @@ class MetasploitModule < Msf::Auxiliary
       connect
       version, motd = rsync_negotiate
       unless version
-        vprint_error("does not appear to be rsync")
+        vprint_error('does not appear to be rsync')
         disconnect
         return
       end
@@ -167,7 +171,7 @@ class MetasploitModule < Msf::Auxiliary
       name: 'rsync',
       info: info
     )
-    print_status("rsync version: #{version}") if datastore['SHOW_VERSION']
+    print_status("rsync protocol version: #{version}") if datastore['SHOW_VERSION']
     print_status("rsync MOTD: #{motd}") if motd && datastore['SHOW_MOTD']
 
     modules_metadata = {}
@@ -181,25 +185,23 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if modules_metadata.empty?
-      print_status("no rsync modules found")
+      print_status('no rsync modules found')
     else
       modules = modules_metadata.map { |m| m[:name] }
       print_good("#{modules.size} rsync modules found: #{modules.join(', ')}")
 
-      table_columns = %w(Name Comment)
+      table_columns = %w[Name Comment]
       if datastore['TEST_AUTHENTICATION']
         table_columns << 'Authentication'
         modules_metadata.each do |module_metadata|
-          begin
-            connect
-            rsync_negotiate
-            module_metadata[:authentication] = get_rsync_auth_status(module_metadata[:name])
-          rescue *HANDLED_EXCEPTIONS => e
-            vprint_error("error while testing authentication on #{module_metadata[:name]}: #{e}")
-            break
-          ensure
-            disconnect
-          end
+          connect
+          rsync_negotiate
+          module_metadata[:authentication] = get_rsync_auth_status(module_metadata[:name])
+        rescue *HANDLED_EXCEPTIONS => e
+          vprint_error("error while testing authentication on #{module_metadata[:name]}: #{e}")
+          break
+        ensure
+          disconnect
         end
       end
 


### PR DESCRIPTION
## Description

rsync released protocol 32 early in 2025. It changed the banner in a way that broke the current module. This PR updates the module (and documentation) to handle protocol 32.

### Pre

```
msf auxiliary(scanner/rsync/modules_list) > rexploit
[*] Reloading module...
[-] 127.0.0.1:873         - no rsync negotiation found
[-] 127.0.0.1:873         - does not appear to be rsync
[*] 127.0.0.1:873         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

### Post

```
msf auxiliary(scanner/rsync/modules_list) > rexploit
[*] Reloading module...
[*] 127.0.0.1:873         - rsync protocol version: 32.0
[+] 127.0.0.1:873         - 2 rsync modules found: public, locked

rsync modules for 127.0.0.1:873        
=======================================

   Name    Comment                   Authentication
   ----    -------                   --------------
   locked  password-protected share  required
   public  open share                not required


[*] 127.0.0.1:873         - Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

## Verification Steps

Try all 3 docker images and make sure all 3 show 2 shares (locked, and public) as per the docs

1. - [ ] start vuln image
2. - [ ] `./msfconsole`
3. - [ ] `use auxiliary/scanner/rsync/modules_list`
4. - [ ] `set rhosts 127.0.0.1`
5. - [ ] `set verbose true`
6. - [ ] `set SHOW_MOTD true`
7. - [ ] `set SHOW_VERSION true`
8. - [ ] `run`

## AI Usage Disclosure

GLM-5.3 was used to assist