### PR TITLE
Fix origin mismatch error for default ports (ghostcms_auth_rce_cve_2026_29053 module)

### DIFF
--- a/modules/exploits/multi/http/ghostcms_auth_rce_cve_2026_29053.rb
+++ b/modules/exploits/multi/http/ghostcms_auth_rce_cve_2026_29053.rb
@@ -100,20 +100,11 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
-  def target_origin
-    host = datastore['VHOST'].present? ? datastore['VHOST'] : rhost
-    proto = ssl ? 'https' : 'http'
-    default_port = ssl ? 443 : 80
-    port_suffix = (rport.to_i == default_port) ? '' : ":#{rport}"
-
-    "#{proto}://#{host}#{port_suffix}"
-  end
-
   def ghost_request_cgi(method, endpoint, data: nil, params: nil, ctype: 'application/json')
     headers = {}
     headers['Authorization'] = "Ghost #{@jwt_token}" if @jwt_token
     headers['Cookie'] = "ghost-admin-api-session=#{@ghost_admin_api_session}" if @ghost_admin_api_session
-    headers['Origin'] = target_origin
+    headers['Origin'] = full_uri('', vhost_uri: true).chomp('/')
 
     request_data = (ctype == 'application/json' && data.is_a?(Hash)) ? data.to_json : data
     res = send_request_cgi({

--- a/modules/exploits/multi/http/ghostcms_auth_rce_cve_2026_29053.rb
+++ b/modules/exploits/multi/http/ghostcms_auth_rce_cve_2026_29053.rb
@@ -100,13 +100,19 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def target_origin
+    host = datastore['VHOST'].present? ? datastore['VHOST'] : rhost
+    proto = ssl ? 'https' : 'http'
+    default_port = ssl ? 443 : 80
+    port_suffix = (rport.to_i == default_port) ? '' : ":#{rport}"
+
+    "#{proto}://#{host}#{port_suffix}"
+  end
+
   def ghost_request_cgi(method, endpoint, data: nil, params: nil, ctype: 'application/json')
     headers = {}
     headers['Authorization'] = "Ghost #{@jwt_token}" if @jwt_token
     headers['Cookie'] = "ghost-admin-api-session=#{@ghost_admin_api_session}" if @ghost_admin_api_session
-
-    proto = ssl ? 'https' : 'http'
-    target_origin = "#{proto}://#{rhost}:#{rport}"
     headers['Origin'] = target_origin
 
     request_data = (ctype == 'application/json' && data.is_a?(Hash)) ? data.to_json : data


### PR DESCRIPTION
Fixes an issue where Ghost CMS rejected requests with an origin mismatch error.

Ghost CMS strictly validates the Origin header against its canonical site URL in compliance with RFC 6454. Previously, the exploit explicitly attached default ports (e.g., [https://site.com:443](https://site.com:443) or [http://site.com:80](http://site.com:80)), causing origin verification to fail.

Standard ports (80 for HTTP, 443 for HTTPS) are now automatically omitted from target_origin, while non-standard ports are preserved.