### PR TITLE
Add automatic payload selection for incompatible targets

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2243,6 +2243,18 @@ class Core
     # Set PAYLOAD from TARGET
     if name.upcase == 'TARGET' && active_module && (active_module.exploit? || active_module.evasion?)
       active_module.import_target_defaults
+
+      # If the currently-configured payload is not compatible with the new
+      # target's platform/arch, try to auto-select a compatible one — mirrors
+      # the default payload selection performed when the module is first used.
+      current_payload = active_module.datastore['PAYLOAD']
+      unless current_payload && active_module.compatible_payloads.any? { |payload_name, _| payload_name == current_payload }
+        chosen_payload = Msf::Payload.choose_payload(active_module)
+        new_payload = active_module.datastore['PAYLOAD']
+        if chosen_payload && new_payload == chosen_payload && new_payload != current_payload
+          print_status("Payload not compatible with target, defaulting to #{chosen_payload}")
+        end
+      end
     end
 
     # If the new SSL value already set in datastore[name] is different from the old value, warn the user

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2244,8 +2244,8 @@ class Core
     if name.upcase == 'TARGET' && active_module && (active_module.exploit? || active_module.evasion?)
       active_module.import_target_defaults
 
-      # If the currently-configured payload is not compatible with the new
-      # target's platform/arch, try to auto-select a compatible one — mirrors
+      # If the currently configured payload is not compatible with the new
+      # target's platform/arch, try to auto-select a compatible one. mirrors
       # the default payload selection performed when the module is first used.
       current_payload = active_module.datastore['PAYLOAD']
       unless current_payload && active_module.compatible_payloads.any? { |payload_name, _| payload_name == current_payload }


### PR DESCRIPTION
fixes: https://github.com/rapid7/metasploit-framework/issues/21798

```
       =[ metasploit v6.5.3-dev-73737ce70a                      ]
+ -- --=[ 2,677 exploits - 1,344 auxiliary - 2,599 payloads     ]
+ -- --=[ 435 post - 57 encoders - 14 nops - 12 evasion         ]

Metasploit Documentation: https://docs.metasploit.com/
The Metasploit Framework is a Rapid7 Open Source Project

msf exploit(windows/smb/psexec) > use multi/http/jenkins_xstream_deserialize
[*] No payload configured, defaulting to cmd/unix/php/meterpreter/reverse_tcp
msf exploit(multi/http/jenkins_xstream_deserialize) > set target 1
[*] Payload not compatible with target, defaulting to python/meterpreter/reverse_tcp
target => 1
msf exploit(multi/http/jenkins_xstream_deserialize) > exit
```