### PR TITLE
Update SECURITY.md to include correct URL for disclosure

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -30,6 +30,6 @@ is kind of mean, even when it's well-intentioned, since you end up
 dropping 0-day on pretty much everyone right out of the gate. We'd prefer
 you didn't!
 
-[r7-vulns]:https://www.rapid7.com/security/disclosure/
+[r7-vulns]:https://www.rapid7.com/security/vulnerability-disclosure-policy/
 [pgp]:https://keybase.io/rapid7/pgp_keys.asc?fingerprint=9a90aea0576cbcafa39c502ba5e16807959d3eda
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -5,12 +5,12 @@ that you have found a security issue involving Metasploit, Meterpreter,
 Recog, or any other Rapid7 open source project, you are welcome to let
 us know in the way that's most comfortable for you.
 
-## Via ZenDesk
+## Via FreshDesk
 
 You can click on the big orange button at [Rapid7's Vulnerability
 Disclosure][r7-vulns] page, which will get you to our general
-vulnerability reporting system. While this does require a (free) ZenDesk
-account to use, you'll get regular updates on your issue as our software
+vulnerability reporting system. When you submit a ticket with your email
+address you'll get regular updates on your issue as our software
 support teams work through it. As it happens [that page][r7-vulns] also
 will tell you what to expect when it comes to reporting vulns, how fast
 we'll fix and respond, and all the rest, so it's a pretty good read


### PR DESCRIPTION
## Description

The original page linked doesn't have an orange button to click to report a vulnerability.  Took a bit to find the right page this will help save future reporters some time.




## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
