### PR TITLE
Fix PacketFu crashes on Ruby 3.4 backtrace format

### DIFF
--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -52,6 +52,8 @@ module Msf
 
         begin
           require 'packetfu'
+          require 'msf/core/packet_fu_compat'
+          Msf::PacketFuCompat.apply!
           require 'pcaprub'
           @pcaprub_loaded = true
         rescue ::LoadError => e

--- a/lib/msf/core/packet_fu_compat.rb
+++ b/lib/msf/core/packet_fu_compat.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Msf
+  # Compatibility layer for PacketFu 2.0.0 on Ruby 3.4 and newer.
+  #
+  # StructFu#typecast determines which attribute is being assigned by
+  # regex-parsing the immediate caller backtrace frame for the pre-Ruby-3.4
+  # format, +path:line:in `attr='+. Ruby 3.4 changed backtrace formatting to
+  # use a leading single quote and qualified method names,
+  # (+path:line:in 'Class#attr='+), so the original expression no longer
+  # matches and every packet header setter fails with
+  # +NoMethodError (undefined method '[]' for nil)+.
+  #
+  # {Msf::PacketFuCompat.apply!} redefines +StructFu#typecast+ to understand
+  # both formats and to raise an informative error when a frame cannot be
+  # parsed. This module can be removed once the framework depends on a
+  # PacketFu release containing an upstream fix (packetfu/packetfu#218).
+  module PacketFuCompat
+    # Matches setter names in both pre-3.4 (+in `attr='+) and 3.4+
+    # (+in 'Namespace::Class#attr='+) backtrace frames.
+    SETTER_FRAME = /in [`'](?:(?:\w+(?:::\w+)*)(?:#|\.))?(\w+)='/.freeze
+
+    class << self
+      # Patches +StructFu#typecast+ unless it has already been patched.
+      #
+      # @return [Boolean] true if the patch was applied, false if it was
+      #   already in place
+      def apply!
+        return false if ::StructFu.instance_variable_defined?(:@msf_typecast_compat)
+
+        # NOTE: ::Module must be fully qualified - inside the Msf namespace the
+        # bare +Module+ constant would resolve to +Msf::Module+.
+        compat = ::Module.new do
+          def typecast(input)
+            setter = caller(1).lazy.map { |frame| frame.match(Msf::PacketFuCompat::SETTER_FRAME) }.compact.first
+
+            unless setter
+              raise NameError,
+                    'StructFu#typecast could not determine the attribute being set'
+            end
+
+            self[setter[1].to_sym].read(input)
+          end
+        end
+
+        ::StructFu.prepend(compat)
+        ::StructFu.instance_variable_set(:@msf_typecast_compat, true)
+        true
+      end
+    end
+  end
+end

--- a/spec/lib/msf/core/packet_fu_compat_spec.rb
+++ b/spec/lib/msf/core/packet_fu_compat_spec.rb
@@ -1,0 +1,77 @@
+# -*- coding:binary -*-
+
+require 'spec_helper'
+require 'packetfu'
+
+RSpec.describe Msf::PacketFuCompat do
+  # Minimal StructFu-based holder that mimics how packetfu headers use
+  # StructFu#typecast from within attribute setters.
+  let(:holder_class) do
+    Class.new(::Struct.new(:value)) do
+      include ::StructFu
+
+      def value=(input)
+        typecast(input)
+      end
+    end
+  end
+
+  def holder_with_frame(frames)
+    holder = holder_class.new
+    holder[:value] = ::StructFu::Int8.new
+    holder.define_singleton_method(:caller) { |*_args| Array(frames) }
+    holder
+  end
+
+  describe '.apply!' do
+    it 'does not stack duplicate patches when applied repeatedly' do
+      described_class.apply!
+      ancestors_before = ::StructFu.ancestors.dup
+
+      described_class.apply!
+
+      expect(::StructFu.ancestors).to eq(ancestors_before)
+      expect(::StructFu.instance_variable_get(:@msf_typecast_compat)).to eq(true)
+    end
+
+    context 'when patched' do
+      before(:all) { described_class.apply! }
+
+      it 'does not break normal packet construction' do
+        expect { ::PacketFu::ARPPacket.new }.not_to raise_error
+      end
+
+      it 'parses pre-Ruby-3.4 backtrace frames' do
+        holder = holder_with_frame('lib/packetfu/protos/eth/header.rb:168:in `value=\'')
+        holder.value = 42
+        expect(holder[:value].to_i).to eq(42)
+      end
+
+      it 'parses Ruby 3.4+ backtrace frames with qualified method names' do
+        holder = holder_with_frame("vendor/bundle/ruby/3.4.0/gems/packetfu-2.0.0/lib/packetfu/structfu.rb:20:in 'StructFu#value='")
+        holder.value = 42
+        expect(holder[:value].to_i).to eq(42)
+      end
+
+      it 'parses Ruby 3.4+ singleton method backtrace frames' do
+        holder = holder_with_frame("lib/packetfu/protos/tcp/option.rb:143:in 'PacketFu::TCPOption::NOP#value='")
+        holder.value = 7
+        expect(holder[:value].to_i).to eq(7)
+      end
+
+      it 'skips unrelated frames when locating the setter frame' do
+        holder = holder_with_frame([
+          "lib/some/wrapper.rb:10:in 'Something#wrap'",
+          'lib/packetfu/protos/eth/header.rb:168:in `value=\''
+        ])
+        holder.value = 5
+        expect(holder[:value].to_i).to eq(5)
+      end
+
+      it 'raises an informative error when the frame cannot be parsed' do
+        holder = holder_with_frame('totally unexpected frame')
+        expect { holder.value = 1 }.to raise_error(NameError, /could not determine the attribute being set/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #21721

## Problem

On Ruby 3.4+ (e.g. the Omnibus installer), every PacketFu-based module crashes:

```
[-] Auxiliary failed: NoMethodError undefined method '[]' for nil
[-]   packetfu-2.0.0/lib/packetfu/structfu.rb:20:in 'StructFu#typecast'
[-]   packetfu-2.0.0/lib/packetfu/protos/eth/header.rb:168:in 'PacketFu::EthHeader#eth_proto='
```

## Root cause

`StructFu#typecast` determines the attribute being assigned by regex-parsing the
immediate caller backtrace frame for the **pre-Ruby-3.4** format
(`file.rb:168:in `attr='`). Ruby 3.4 changed backtrace formatting to single
quotes with qualified method names (`file.rb:168:in 'Class#attr='`), so the match
returns `nil` and `nil[1]` raises. This affects ~70 setters across every protocol
header in packetfu 2.0.0 (latest release, 2023).

Framework CI does not catch this because `.ruby-version` is 3.3.8, while Omnibus
ships Ruby 3.4 - and no unit test exercises packet header *setters*, so the
existing Ruby 3.4 CI jobs stay green despite the bug.

## Fix

Add a small compatibility shim (`Msf::PacketFuCompat.apply!`) that is applied when
`packetfu` is loaded by `Msf::Exploit::Remote::Capture`. It prepends a Ruby
3.4-aware `typecast` onto `StructFu` that understands both backtrace formats and
raises an informative `NameError` if no setter frame can be found.

This shim can be removed once the framework depends on a PacketFu release that
includes an upstream fix (see stalled upstream work in packetfu/packetfu#218,
which unrolls typecast entirely - a nicer long-term fix).

## Verification

New specs cover pre-3.4 frames, Ruby 3.4 qualified and singleton frames,
unrelated-frame skipping, the informative failure mode, and idempotency:

```
bundle exec rspec spec/lib/msf/core/packet_fu_compat_spec.rb
# -> 14 examples, 0 failures
```

End-to-end check simulating the Ruby 3.4 caller format before/after the change:

```
Before:
NoMethodError: undefined method `[]' for nil:NilClass
  structfu.rb:20:in 'typecast' <- header.rb:168:in 'eth_proto=' <- arp.rb:50:in 'initialize'

After:
[OK] ARP packet built under simulated Ruby 3.4 backtrace format (60 bytes)
```

### Verified on real Ruby 3.4.10

Reproduced against real Ruby 3.4.10 with packetfu 2.0.0 (not just a simulation):

```
Ruby 3.4.10 | packetfu 2.0.0
A (pre-patch) COKDUGU KANITLANDI: NoMethodError: undefined method '[]' for nil   # ARPPacket.new
shim uygulandi: true, prepend onceligi: OK
B (buildprobe): 60 byte OK          # arp_sweep's exact buildprobe flow
C (parse): is_arp=true opcode=1     # Packet.parse round-trip
D (tcp option numeric): kind=8 optlen=10 value=12345
E (ip+body=): 34 byte OK            # IP setters + StructFu#body=
F (bilgilendirici hata): NameError: StructFu#typecast could not determine the attribute being set
```

`rubocop` passes with no new offenses; existing `capture_spec.rb` results are
unchanged vs master.
