### PR TITLE
Fix trans2open report_service compatibility

### DIFF
--- a/modules/exploits/linux/samba/trans2open.rb
+++ b/modules/exploits/linux/samba/trans2open.rb
@@ -9,6 +9,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::SMB::Client
   include Msf::Exploit::Brute
+  include Msf::Auxiliary::Report
 
   def initialize(info = {})
     super(


### PR DESCRIPTION
Thank you for contributing to Metasploit Framework! Your time and effort help make this project better for the entire security community. If you have questions at any point, reach out on [GitHub Discussions](https://github.com/rapid7/metasploit-framework/discussions) or the [Metasploit Slack](https://metasploit.com/slack).

<!-- For trivial changes (typo fixes, comment corrections, minor doc edits): you may delete sections that don't apply. -->

<!-- PRs missing a description, verification steps, or test evidence will be closed. Each PR should address a single module, bug fix, or cohesive logical change. For full guidance, see CONTRIBUTING.md and the module acceptance guidelines linked below. If your PR is not yet complete, mark it as a draft. -->

## Description

<!-- Describe what this change does. Be specific about the behavior being added or modified. -->
The `exploit/linux/samba/trans2open` module currently fails during
execution with a `NoMethodError` for `report_service`.

The error occurs when running the module against the vulnerable Samba
version used by the Kioptrix lab:

    undefined method `report_service' for
    #<Msf::Modules::Exploit__Linux__Samba__Trans2open::MetasploitModule>

This prevents the module from completing its exploitation routine.


<!-- Explain why this change is needed. What problem does it solve or what improvement does it provide? -->
Add the required reporting mixin so that `report_service` is available
to the module so the exploit can run and not keep erroring



<!-- Reference any related GitHub issue(s) below (e.g., "Fixes #1234" or "Related to #5678"). Delete this line if not applicable. -->

**Related Issue:** 
Fixes #21811 

## Breaking Changes

<!-- Does this PR change existing behavior, remove options, rename datastore settings, or alter API/mixin interfaces? If yes, describe what breaks and how users should adapt. Write "None" if not applicable. -->

None

## Reviewer Notes

<!-- (Optional) Guide the reviewer: where to start reading, what the key change is, what's intentionally left out or deferred. Delete this section if not needed. -->
changed the code in modules/exploits/linux/samba/trans2open.rb to include the module "include Msf::Auxiliary::Report"

## Verification Steps

<!-- Provide specific, numbered steps a reviewer can follow to verify this change works as intended. At least one step must describe the expected observable outcome. Generic steps such as "verify it works" will result in the PR being closed. -->


1. - [running the trans2open exploit on an applicable target will run without any error, compared to being bombarded with the undefined method 'report_service'] 


## Test Evidence

<!-- Paste console output, screenshots, or links to screen recordings. Redact sensitive information. -->
Tested against the Kioptrix vulnerable VM running the Samba version
targeted by `exploit/linux/samba/trans2open`.

Before the change, the module fails with:

    192.168.57.5:139 - Trying return address 0xbffffcfc... [-] 192.168.57.5:139 - 192.168.57.5 undefined method report_service' for #<Msf::Modules::Exploit__Linux__Samba__Trans2open::MetasploitModule:0x00007f241d57c1d0>

After the change, the module proceeds past the `report_service`
exception and continues with the exploitation attempt.


<!-- For new modules: include output from the module's `check` method (if applicable) AND successful exploitation or execution against a controlled lab/test environment target. -->

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Kali Linux 2026.4 |
| **Target Software/Hardware** | Metasploit version: 6.5.x |


## AI Usage Disclosure

<!-- Was AI used in the creation of this PR? If so, describe what tools were used and how (e.g., code generation, documentation drafting, test writing). Write "None" if no AI tools were used. -->
I simply fixed the issue using Chatgpt and some coding knowledge


<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
