### PR TITLE
Fix ssh_version for anchient ssh

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -37,6 +37,14 @@ class MetasploitModule < Msf::Auxiliary
       ],
       self.class
     )
+
+    register_advanced_options(
+      [
+        OptString.new('KEX', [false, 'Comma separated list of key exchange algorithms to offer, in preference order. Example: diffie-hellman-group1-sha1 for old embedded devices. Prefix an entry with + to enable every algorithm the library supports', nil]),
+        OptBool.new('APPEND_ALL_SUPPORTED', [false, 'Offer all algorithms the net-ssh library supports, including deprecated ones (diffie-hellman-group1-sha1, ssh-dss, CBC ciphers, MD5 HMACs)', false])
+      ],
+      self.class
+    )
   end
 
   def timeout
@@ -223,9 +231,30 @@ class MetasploitModule < Msf::Auxiliary
     table
   end
 
+  # Opens a transport session for fingerprinting. Servers that only offer
+  # deprecated algorithms (e.g. old embedded devices speaking only
+  # diffie-hellman-group1-sha1) cannot negotiate against the net-ssh defaults,
+  # which offer no deprecated algorithms, so a failure to agree on algorithms
+  # is retried once with every library supported algorithm enabled.
+  def ssh_transport(target_host)
+    options = { port: rport }
+    options[:append_all_supported_algorithms] = true if datastore['APPEND_ALL_SUPPORTED']
+    kex = datastore['KEX'].to_s.split(',').map(&:strip).reject(&:empty?)
+    options[:kex] = kex unless kex.empty?
+
+    begin
+      Net::SSH::Transport::Session.new(target_host, options)
+    rescue Net::SSH::Exception => e
+      raise unless e.message.include?('could not settle on') && !options[:append_all_supported_algorithms] && options[:kex].nil?
+
+      print_status("#{target_host} - #{e.message.lines.first.strip}, retrying with deprecated algorithms enabled")
+      Net::SSH::Transport::Session.new(target_host, options.merge(append_all_supported_algorithms: true))
+    end
+  end
+
   def run_host(target_host)
     ::Timeout.timeout(timeout) do
-      transport = Net::SSH::Transport::Session.new(target_host, { port: rport })
+      transport = ssh_transport(target_host)
 
       server_data = transport.algorithms.instance_variable_get(:@server_data)
       host_keys = transport.algorithms.session.instance_variable_get(:@host_keys).instance_variable_get(:@host_keys)
@@ -274,9 +303,13 @@ class MetasploitModule < Msf::Auxiliary
 
       print_status("#{target_host} - #{table}")
     end
-  rescue EOFError, Rex::ConnectionError => e
+  rescue EOFError, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH, Rex::ConnectionError => e
     vprint_error("#{target_host} - #{e.message}") # This may be a little noisy, but it is consistent
   rescue Timeout::Error
     vprint_warning("#{target_host} - Timed out after #{timeout} seconds. Skipping.")
+  rescue Net::SSH::Exception => e
+    # includes the server's algorithm preferences, which is the interesting
+    # fingerprint data when the library simply cannot talk to the server
+    print_error("#{target_host} - SSH session failed: #{e.class}: #{e.message}")
   end
 end


### PR DESCRIPTION
Fixes #21815 

## Description

Fixes SSH Version scanner to work on ancient versions of SSH.

**Related Issue:** #21815

## Verification Steps

The following docker file should create a vuln image to scan:

```
# Legacy-crypto-only sshd — standalone test target for SSH scanner modules
# (auxiliary/scanner/ssh/ssh_version, nmap ssh2-enum-algos, ssh-audit, ...).
#
# ONLY the pre-2010 SSH stack is negotiated:
#   kex      diffie-hellman-group1-sha1   1024-bit DH + SHA-1 (default-off since OpenSSH 7.0)
#   hostkey  ssh-rsa                      SHA-1-signed host keys (default-off since OpenSSH 8.8)
#   cipher   aes128-cbc                   CBC, no encrypt-then-MAC (default-off since OpenSSH 6.7)
#
# A stock modern client is refused outright ("no matching key exchange
# method"); connecting at all requires opting in to all three:
#   ssh -o KexAlgorithms=+diffie-hellman-group1-sha1 \
#       -o HostKeyAlgorithms=+ssh-rsa \
#       -o Ciphers=+aes128-cbc root@<host>
#
# bookworm ships OpenSSH 9.2 — recent enough to build cleanly, old enough
# that all three algorithms are still compiled in (just not offered by
# default). If you bump the base image, verify inside the container:
#   ssh -Q kex | grep group1-sha1; ssh -Q cipher | grep cbc; ssh -Q key | grep ssh-rsa
#
# Build/run:
#   docker build -t legacy-ssh .
#   docker run -d --name legacy-ssh -p 2222:22 legacy-ssh
#
# Creds: root / root. Local test target only — do not expose to any real network.

FROM debian:bookworm-slim
RUN apt-get update && apt-get install -y --no-install-recommends openssh-server \
    && rm -rf /var/lib/apt/lists/*

# Only ssh-rsa host-key signatures are offered, so sshd only needs an RSA key.
# Drop the keys the package postinst generated (regenerating ours) so nothing
# modern is even loadable.
RUN rm -f /etc/ssh/ssh_host_*_key* \
    && ssh-keygen -t rsa -b 2048 -f /etc/ssh/ssh_host_rsa_key -N ''

# The three algorithm lines *replace* (not extend) the OpenSSH defaults, so
# exactly this set is offered and nothing else. MACs/auth/logging stay stock.
RUN <<'OUTER'
cat > /etc/ssh/sshd_config <<'CONF'
Port 22
ListenAddress 0.0.0.0
HostKey /etc/ssh/ssh_host_rsa_key

# --- legacy crypto only ---
KexAlgorithms diffie-hellman-group1-sha1
HostKeyAlgorithms ssh-rsa
Ciphers aes128-cbc
# pubkey auth (if you try it) signs with SHA-1 too
PubkeyAcceptedAlgorithms ssh-rsa

# --- test-target auth ---
PermitRootLogin yes
PasswordAuthentication yes
UsePAM yes
PrintMotd no
LogLevel VERBOSE
CONF
OUTER

RUN echo 'root:root' | chpasswd \
    && mkdir -p /run/sshd \
    && /usr/sbin/sshd -t          # fail the build if config/keys are bad

EXPOSE 22
CMD ["sh", "-c", "mkdir -p /run/sshd && exec /usr/sbin/sshd -D -e"]

```



## Test Evidence

### Pre

```
msf auxiliary(scanner/ssh/ssh_version) > run
[-] Auxiliary failed: Net::SSH::Exception could not settle on kex algorithm
Server kex preferences: diffie-hellman-group1-sha1
Client kex preferences: ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1
[-] Call stack:
[-]   /var/lib/gems/3.3.0/gems/net-ssh-7.3.0/lib/net/ssh/transport/algorithms.rb:419:in `negotiate'
[-]   /var/lib/gems/3.3.0/gems/net-ssh-7.3.0/lib/net/ssh/transport/algorithms.rb:392:in `negotiate_algorithms'
[-]   /var/lib/gems/3.3.0/gems/net-ssh-7.3.0/lib/net/ssh/transport/algorithms.rb:256:in `proceed!'
[-]   /var/lib/gems/3.3.0/gems/net-ssh-7.3.0/lib/net/ssh/transport/algorithms.rb:196:in `accept_kexinit'
[-]   /var/lib/gems/3.3.0/gems/net-ssh-7.3.0/lib/net/ssh/transport/session.rb:210:in `block in poll_message'
[-]   <internal:kernel>:187:in `loop'
[-]   /var/lib/gems/3.3.0/gems/net-ssh-7.3.0/lib/net/ssh/transport/session.rb:190:in `poll_message'
[-]   /var/lib/gems/3.3.0/gems/net-ssh-7.3.0/lib/net/ssh/transport/session.rb:227:in `block in wait'
[-]   <internal:kernel>:187:in `loop'
[-]   /var/lib/gems/3.3.0/gems/net-ssh-7.3.0/lib/net/ssh/transport/session.rb:224:in `wait'
[-]   /var/lib/gems/3.3.0/gems/net-ssh-7.3.0/lib/net/ssh/transport/session.rb:89:in `initialize'
[-]   /root/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_version.rb:228:in `new'
[-]   /root/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_version.rb:228:in `block in run_host'
[-]   /var/lib/gems/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:185:in `block in timeout'
[-]   /var/lib/gems/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:38:in `handle_timeout'
[-]   /var/lib/gems/3.3.0/gems/timeout-0.4.3/lib/timeout.rb:194:in `timeout'
[-]   /root/metasploit-framework/modules/auxiliary/scanner/ssh/ssh_version.rb:227:in `run_host'
[-]   /root/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:130:in `block (2 levels) in run'
[-]   /root/metasploit-framework/lib/msf/core/thread_manager.rb:105:in `block in spawn'
[*] Auxiliary module execution completed
```

### Post

I also scanned a Kali box to show it isn't broken on the newer version

```
msf auxiliary(scanner/ssh/ssh_version) > set rhosts 127.0.0.1 111.111.1.111
rhosts => 127.0.0.1 111.111.1.111
msf auxiliary(scanner/ssh/ssh_version) > run
[*] 127.0.0.1 - Key Fingerprint: ssh-ed25519 AAAAA3AzaA1lZDI1NTE5AAAAIHaJ4q4WCUpSppx9WA/ot4v8qaaaaA3AAA1mAAJYK0aa
[*] 127.0.0.1 - SSH server version: SSH-2.0-OpenSSH_10.4p1 Debian-4
[*] 127.0.0.1 - Server Information and Encryption
=================================

  Type                     Value                               Note
  ----                     -----                               ----
  encryption.compression   none
  encryption.compression   zlib@openssh.com
  encryption.encryption    chacha20-poly1305@openssh.com
  encryption.encryption    aes128-gcm@openssh.com
  encryption.encryption    aes256-gcm@openssh.com
  encryption.encryption    aes128-ctr
  encryption.encryption    aes192-ctr
  encryption.encryption    aes256-ctr
  encryption.hmac          umac-64-etm@openssh.com
  encryption.hmac          umac-128-etm@openssh.com
  encryption.hmac          hmac-sha2-256-etm@openssh.com
  encryption.hmac          hmac-sha2-512-etm@openssh.com
  encryption.hmac          hmac-sha1-etm@openssh.com
  encryption.hmac          umac-64@openssh.com
  encryption.hmac          umac-128@openssh.com
  encryption.hmac          hmac-sha2-256
  encryption.hmac          hmac-sha2-512
  encryption.hmac          hmac-sha1
  encryption.host_key      rsa-sha2-512
  encryption.host_key      rsa-sha2-256
  encryption.host_key      ecdsa-sha2-nistp256                 Weak elliptic curve
  encryption.host_key      ssh-ed25519
  encryption.key_exchange  mlkem768x25519-sha256
  encryption.key_exchange  sntrup761x25519-sha512
  encryption.key_exchange  sntrup761x25519-sha512@openssh.com
  encryption.key_exchange  curve25519-sha256
  encryption.key_exchange  curve25519-sha256@libssh.org
  encryption.key_exchange  ecdh-sha2-nistp256
  encryption.key_exchange  ecdh-sha2-nistp384
  encryption.key_exchange  ecdh-sha2-nistp521
  encryption.key_exchange  ext-info-s
  encryption.key_exchange  kex-strict-s-v00@openssh.com
  fingerprint_db           ssh.banner
  openssh.comment          Debian-4
  os.cpe23                 cpe:/o:debian:debian_linux:7.0
  os.family                Linux
  os.product               Linux
  os.vendor                Debian
  os.version               7.0
  service.cpe23            cpe:/a:openbsd:openssh:10.4p1
  service.family           OpenSSH
  service.product          OpenSSH
  service.protocol         ssh
  service.vendor           OpenBSD
  service.version          10.4p1

[*] Scanned 1 of 2 hosts (50% complete)
[*] 111.111.1.111 - could not settle on kex algorithm, retrying with deprecated algorithms enabled
[*] 111.111.1.111 - Key Fingerprint: ssh-rsa AAAAA3AaaA1yc2EAAAADAQABAAABAQDSh+K5jATdmMN6ZOU+o8mFsMUg3mhOX3B+pb/9LCwyjr485kT8ZO7oidm5SAzItOTIweXNa+/wXFkbrAKP5ctPnM8uZ6Zaa7jwcY1sMkMxQgafQhlAMdBALVg9vocPlFPYNqK5ipCKpQzD0QH0icanQuTYFyOvV/xZY6j1sVwjehnNTEsa4PvxdAAAp8Y++BNeVqFaaGJM9xJQ1deJ6a89KUBMzb5zFbfm0cnTY5nAxDetD/ieFnW87R1D0nAaaX2qrtlxKLoIgWdDljDAQsbts5GaaaNd5LMOtvAdCLYG5V5xR9kvkAA70AlDtn3f4JcjAA3F/jaW/ymTqKc6AAAd
[*] 111.111.1.111 - SSH server version: SSH-1.99-Cisco-1.25
[*] 111.111.1.111 - Server Information and Encryption
=================================

  Type                     Value                       Note
  ----                     -----                       ----
  encryption.compression   none
  encryption.encryption    aes128-cbc                  Deprecated
  encryption.encryption    aes192-cbc                  Deprecated
  encryption.encryption    aes256-cbc                  Deprecated
  encryption.encryption    aes128-ctr
  encryption.hmac          hmac-sha1
  encryption.hmac          hmac-sha1-96                Deprecated
  encryption.host_key      ssh-rsa
  encryption.key_exchange  diffie-hellman-group1-sha1  Deprecated
  fingerprint_db           ssh.banner
  os.certainty             0.8
  os.cpe23                 cpe:/o:cisco:ios:-
  os.product               IOS
  os.vendor                Cisco
  service.product          SSH
  service.protocol         ssh
  service.vendor           Cisco
  service.version          1.25

[*] Scanned 2 of 2 hosts (100% complete)
```

## AI Usage Disclosure

KLM-5.3 assisted