### PR TITLE
Update Ruby version requirements to 3.2+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@
 # inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   SuggestExtensions: false
   NewCops: disable
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Metasploit Framework is an open-source penetration testing and exploitation fram
 
 ## Coding Conventions
 
-- Ruby (see `.ruby-version` for the current version). Minimum supported: 3.1+
+- Ruby (see `.ruby-version` for the current version). Minimum supported: 3.2+
 - Follow the project's `.rubocop.yml` configuration — run `rubocop` on changed files before submitting
 - Run `ruby tools/dev/msftidy.rb <module_file_path>` to catch common module issues
 - `# frozen_string_literal: true` — add to new **library** files (`lib/`); use `String.new` where a mutable string is needed. Do NOT add to module files or spec files (the framework extensively mutates string buffers via instance variables, and the RuboCop cop `Style/FrozenStringLiteralComment` is disabled project-wide). Existing files that already have it are fine to leave

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.2'
 
   # Database support
   spec.add_runtime_dependency 'activerecord', *Metasploit::Framework::RailsVersionConstraint::RAILS_VERSION
@@ -124,9 +124,7 @@ Gem::Specification.new do |spec|
   # Library for interpreting Windows error codes and strings
   spec.add_runtime_dependency 'windows_error'
   # This used to be depended on by nokogiri, depended on by wmap
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
-    spec.add_runtime_dependency 'xmlrpc'
-  end
+  spec.add_runtime_dependency 'xmlrpc'
   # Gem for handling Cookies
   spec.add_runtime_dependency 'http-cookie'
   # Needed for some modules (polkit_auth_bypass.rb)


### PR DESCRIPTION
This just updates our minimum target version in gemspec/rubocop we already had a minimum target of 3.2+ as defined by the github actions test suite so this doesn't actually cange anything it had just fallen out of lock step with what we actually were doing