### PR TITLE
Fix misspelled gemspec filename in acceptance workflow path filters

### DIFF
--- a/.github/workflows/ldap_acceptance.yml
+++ b/.github/workflows/ldap_acceptance.yml
@@ -30,7 +30,7 @@ on:
     branches:
       - '*'
     paths:
-      - 'metsploit-framework.gemspec'
+      - 'metasploit-framework.gemspec'
       - 'Gemfile.lock'
       - '**/**ldap**'
       - 'lib/metasploit/framework/tcp/**'

--- a/.github/workflows/meterpreter_acceptance.yml
+++ b/.github/workflows/meterpreter_acceptance.yml
@@ -40,7 +40,7 @@ on:
     branches:
       - '*'
     paths:
-      - 'metsploit-framework.gemspec'
+      - 'metasploit-framework.gemspec'
       - 'Gemfile.lock'
       - 'data/templates/**'
       - 'modules/payloads/**'

--- a/.github/workflows/mssql_acceptance.yml
+++ b/.github/workflows/mssql_acceptance.yml
@@ -30,7 +30,7 @@ on:
     branches:
       - '*'
     paths:
-      - 'metsploit-framework.gemspec'
+      - 'metasploit-framework.gemspec'
       - 'Gemfile.lock'
       - '**/**mssql**'
       - 'spec/acceptance/**'

--- a/.github/workflows/mysql_acceptance.yml
+++ b/.github/workflows/mysql_acceptance.yml
@@ -30,7 +30,7 @@ on:
     branches:
       - '*'
     paths:
-      - 'metsploit-framework.gemspec'
+      - 'metasploit-framework.gemspec'
       - 'Gemfile.lock'
       - '**/**mysql**'
       - 'spec/acceptance/**'

--- a/.github/workflows/postgres_acceptance.yml
+++ b/.github/workflows/postgres_acceptance.yml
@@ -30,7 +30,7 @@ on:
     branches:
       - '*'
     paths:
-      - 'metsploit-framework.gemspec'
+      - 'metasploit-framework.gemspec'
       - 'Gemfile.lock'
       - '**/**postgres**'
       - 'lib/metasploit/framework/tcp/**'

--- a/.github/workflows/smb_acceptance.yml
+++ b/.github/workflows/smb_acceptance.yml
@@ -30,7 +30,7 @@ on:
     branches:
       - '*'
     paths:
-      - 'metsploit-framework.gemspec'
+      - 'metasploit-framework.gemspec'
       - 'Gemfile.lock'
       - '**/**smb**'
       - 'spec/acceptance/**'


### PR DESCRIPTION
## Description

Six acceptance workflows (`ldap`, `meterpreter`, `mssql`, `mysql`, `postgres`, and `smb`) list `metsploit-framework.gemspec` in their `paths:` filters.

The file in the repository is actually named `metasploit-framework.gemspec`, so a PR that only changes the gemspec does not trigger any of these six workflows through this path entry.

The misspelling was introduced in `c0c2bf3771` on 2024-04-09. Since then, the gemspec has been edited 90 times, but none of those changes could trigger these six workflows through this path entry.

This PR fixes the typo in all six workflow files.

## Breaking Changes

None.

## Verification Steps

* [ ] Run `git ls-files '*.gemspec'` and confirm the only file is `metasploit-framework.gemspec`
* [ ] Run `grep -rn "metsploit" .github/workflows/` and confirm it produces no output after this change
* [ ] Confirm that a PR editing `metasploit-framework.gemspec` now triggers the six acceptance workflows

## Test Evidence

```text
$ git ls-files '*.gemspec'
metasploit-framework.gemspec

$ grep -rn "metsploit" .github/workflows/
(no output after the change)
```

## AI Usage Disclosure

The stale entries were found using a tool I built: https://github.com/DanielSwift1992/gate. My search workflow around it is AI-assisted.

## Pre-Submission Checklist

* [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
* [x] Read the [[contributing guidelines](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md)](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [[module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)