### PR TITLE
Add rubocop rule for redeclaring pre-existing options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,7 @@ require:
   - ./lib/rubocop/cop/lint/redundant_peer_in_print.rb
   - ./lib/rubocop/cop/lint/module_missing_autocheck.rb
   - ./lib/rubocop/cop/lint/module_default_payload.rb
+  - ./lib/rubocop/cop/lint/module_duplicate_option.rb
   - ./lib/rubocop/cop/lint/module_http_fingerprint.rb
 
 Lint/CheckCodeMissingReason:
@@ -733,6 +734,15 @@ Lint/ModuleDefaultPayload:
   Description: >-
     Do not hardcode a default PAYLOAD in DefaultOptions.
     Let the framework choose the most appropriate payload automatically.
+  Enabled: true
+  Severity: warning
+  Include:
+    - 'modules/**/*'
+
+Lint/ModuleDuplicateOption:
+  Description: >-
+    Do not register an option supplied by a mixin just to change its default value.
+    Set the value in the module's DefaultOptions metadata instead.
   Enabled: true
   Severity: warning
   Include:

--- a/lib/rubocop/cop/lint/module_duplicate_option.rb
+++ b/lib/rubocop/cop/lint/module_duplicate_option.rb
@@ -3,9 +3,8 @@
 module RuboCop
   module Cop
     module Lint
-      # Detects module options that are registered again after a mixin has
-      # already registered them. A module that only needs a different default
-      # should use the DefaultOptions metadata instead.
+      # Detects Opt helper calls that supply only a new default for an option
+      # already registered by a mixin. Use the DefaultOptions metadata instead.
       #
       # @example
       #   # bad
@@ -21,10 +20,22 @@ module RuboCop
       #   }
       class ModuleDuplicateOption < Base
         MIXIN_OPTIONS = {
-          'Msf::Auxiliary::Scanner' => %w[RHOSTS THREADS],
-          'Msf::Exploit::Remote::HttpClient' => %w[RHOST RPORT VHOST SSL Proxies],
-          'Msf::Exploit::Remote::Tcp' => %w[RHOST RPORT],
-          'Msf::Exploit::Remote::Udp' => %w[RHOST RPORT]
+          'Msf::Auxiliary::Scanner' => {
+            'RHOSTS' => nil
+          },
+          'Msf::Exploit::Remote::HttpClient' => {
+            'RHOST' => nil,
+            'RPORT' => 80,
+            'Proxies' => nil
+          },
+          'Msf::Exploit::Remote::Tcp' => {
+            'RHOST' => nil,
+            'RPORT' => nil
+          },
+          'Msf::Exploit::Remote::Udp' => {
+            'RHOST' => nil,
+            'RPORT' => nil
+          }
         }.freeze
 
         MSG = 'Do not register the pre-existing %<option>s option again; set its value in DefaultOptions instead.'
@@ -40,7 +51,8 @@ module RuboCop
 
           option_nodes(node).each do |option_node|
             option_name = option_name(option_node)
-            next unless inherited_options.include?(option_name)
+            next unless inherited_options.key?(option_name)
+            next unless only_default_changed?(option_node, inherited_options[option_name])
             next if deregistered_before?(class_node, node, option_name)
 
             add_offense(option_node, message: format(MSG, option: option_name))
@@ -56,7 +68,7 @@ module RuboCop
             send_node.first_argument&.const_name
           end
 
-          MIXIN_OPTIONS.slice(*included_mixins).values.flatten
+          MIXIN_OPTIONS.slice(*included_mixins).values.reduce({}, &:merge)
         end
 
         def option_nodes(register_node)
@@ -74,6 +86,13 @@ module RuboCop
           elsif node.method?(:new) && node.first_argument&.str_type?
             node.first_argument.value
           end
+        end
+
+        def only_default_changed?(node, inherited_default)
+          return false unless node.receiver&.const_name == 'Opt' && node.arguments.one?
+
+          argument = node.first_argument
+          !argument.respond_to?(:value) || argument.value != inherited_default
         end
 
         def deregistered_before?(class_node, register_node, option_name)

--- a/lib/rubocop/cop/lint/module_duplicate_option.rb
+++ b/lib/rubocop/cop/lint/module_duplicate_option.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # Detects module options that are registered again after a mixin has
+      # already registered them. A module that only needs a different default
+      # should use the DefaultOptions metadata instead.
+      #
+      # @example
+      #   # bad
+      #   include Msf::Exploit::Remote::Tcp
+      #
+      #   register_options([Opt::RPORT(4840)])
+      #
+      #   # good
+      #   include Msf::Exploit::Remote::Tcp
+      #
+      #   'DefaultOptions' => {
+      #     'RPORT' => 4840
+      #   }
+      class ModuleDuplicateOption < Base
+        MIXIN_OPTIONS = {
+          'Msf::Auxiliary::Scanner' => %w[RHOSTS THREADS],
+          'Msf::Exploit::Remote::HttpClient' => %w[RHOST RPORT VHOST SSL Proxies],
+          'Msf::Exploit::Remote::Tcp' => %w[RHOST RPORT],
+          'Msf::Exploit::Remote::Udp' => %w[RHOST RPORT]
+        }.freeze
+
+        MSG = 'Do not register the pre-existing %<option>s option again; set its value in DefaultOptions instead.'
+
+        def on_send(node)
+          return unless node.method?(:register_options)
+
+          class_node = node.each_ancestor(:class).first
+          return unless class_node&.identifier&.const_name == 'MetasploitModule'
+
+          inherited_options = inherited_options(class_node)
+          return if inherited_options.empty?
+
+          option_nodes(node).each do |option_node|
+            option_name = option_name(option_node)
+            next unless inherited_options.include?(option_name)
+            next if deregistered_before?(class_node, node, option_name)
+
+            add_offense(option_node, message: format(MSG, option: option_name))
+          end
+        end
+
+        private
+
+        def inherited_options(class_node)
+          included_mixins = class_node.each_descendant(:send).filter_map do |send_node|
+            next unless send_node.method?(:include)
+
+            send_node.first_argument&.const_name
+          end
+
+          MIXIN_OPTIONS.slice(*included_mixins).values.flatten
+        end
+
+        def option_nodes(register_node)
+          argument = register_node.first_argument
+          return [] unless argument
+
+          argument.array_type? ? argument.values : [argument]
+        end
+
+        def option_name(node)
+          return unless node.send_type?
+
+          if node.receiver&.const_name == 'Opt'
+            node.method_name.to_s
+          elsif node.method?(:new) && node.first_argument&.str_type?
+            node.first_argument.value
+          end
+        end
+
+        def deregistered_before?(class_node, register_node, option_name)
+          class_node.each_descendant(:send).any? do |send_node|
+            send_node.method?(:deregister_options) &&
+              send_node.source_range.begin_pos < register_node.source_range.begin_pos &&
+              send_node.arguments.any? { |argument| argument.str_type? && argument.value == option_name }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/lint/module_duplicate_option.rb
+++ b/lib/rubocop/cop/lint/module_duplicate_option.rb
@@ -3,8 +3,9 @@
 module RuboCop
   module Cop
     module Lint
-      # Detects Opt helper calls that supply only a new default for an option
-      # already registered by a mixin. Use the DefaultOptions metadata instead.
+      # Detects options registered by a mixin that are registered again without
+      # providing a more specific description. Use DefaultOptions to change only
+      # the value of an inherited option.
       #
       # @example
       #   # bad
@@ -19,43 +20,54 @@ module RuboCop
       #     'RPORT' => 4840
       #   }
       class ModuleDuplicateOption < Base
+        extend AutoCorrector
+        include RangeHelp
+
         MIXIN_OPTIONS = {
           'Msf::Auxiliary::Scanner' => {
-            'RHOSTS' => nil
+            'RHOSTS' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html' },
+            'THREADS' => { default: 1, description: 'The number of concurrent threads (max one per host)' }
           },
           'Msf::Exploit::Remote::HttpClient' => {
-            'RHOST' => nil,
-            'RPORT' => 80,
-            'Proxies' => nil
+            'RHOST' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html' },
+            'RPORT' => { default: 80, description: 'The target port' },
+            'VHOST' => { default: nil, description: 'HTTP server virtual host' },
+            'SSL' => { default: false, description: 'Negotiate SSL/TLS for outgoing connections' },
+            'Proxies' => { default: nil, description: nil }
           },
           'Msf::Exploit::Remote::Tcp' => {
-            'RHOST' => nil,
-            'RPORT' => nil
+            'RHOST' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html' },
+            'RPORT' => { default: nil, description: 'The target port' }
           },
           'Msf::Exploit::Remote::Udp' => {
-            'RHOST' => nil,
-            'RPORT' => nil
+            'RHOST' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html' },
+            'RPORT' => { default: nil, description: 'The target port' }
           }
         }.freeze
 
         MSG = 'Do not register the pre-existing %<option>s option again; set its value in DefaultOptions instead.'
 
-        def on_send(node)
-          return unless node.method?(:register_options)
-
-          class_node = node.each_ancestor(:class).first
-          return unless class_node&.identifier&.const_name == 'MetasploitModule'
+        def on_class(class_node)
+          return unless class_node.identifier&.const_name == 'MetasploitModule'
 
           inherited_options = inherited_options(class_node)
           return if inherited_options.empty?
 
-          option_nodes(node).each do |option_node|
-            option_name = option_name(option_node)
-            next unless inherited_options.key?(option_name)
-            next unless only_default_changed?(option_node, inherited_options[option_name])
-            next if deregistered_before?(class_node, node, option_name)
+          offenses = class_node.each_descendant(:send).select { |node| node.method?(:register_options) }.flat_map do |register_node|
+            option_nodes(register_node).filter_map do |option_node|
+              option_name = option_name(option_node)
+              next unless inherited_options.key?(option_name)
+              next unless description_unchanged?(option_node, inherited_options[option_name][:description])
+              next if deregistered_before?(class_node, register_node, option_name)
 
-            add_offense(option_node, message: format(MSG, option: option_name))
+              [option_node, option_name, inherited_options[option_name]]
+            end
+          end
+
+          offenses.each_with_index do |(option_node, option_name, _option), index|
+            add_offense(option_node, message: format(MSG, option: option_name)) do |corrector|
+              autocorrect(corrector, class_node, offenses) if index.zero?
+            end
           end
         end
 
@@ -88,11 +100,155 @@ module RuboCop
           end
         end
 
-        def only_default_changed?(node, inherited_default)
-          return false unless node.receiver&.const_name == 'Opt' && node.arguments.one?
+        def description_unchanged?(node, inherited_description)
+          description = if node.receiver&.const_name == 'Opt'
+                          node.arguments[2]
+                        elsif node.method?(:new)
+                          node.arguments[1]&.values&.[](1)
+                        end
 
-          argument = node.first_argument
-          !argument.respond_to?(:value) || argument.value != inherited_default
+          description.nil? || description.nil_type? || (description.str_type? && description.value == inherited_description)
+        end
+
+        def autocorrect(corrector, class_node, offenses)
+          defaults = offenses.filter_map do |option_node, option_name, inherited_option|
+            default_node = option_default(option_node)
+            next if same_default?(default_node, inherited_option[:default])
+
+            [option_name, { source: default_node&.source || 'nil', comment: trailing_comment(option_node) }]
+          end.to_h
+
+          info_hash = info_hash(class_node)
+          return if defaults.any? && info_hash.nil?
+
+          offenses.map(&:first).group_by { |option_node| option_node.each_ancestor(:send).find { |node| node.method?(:register_options) } }.each do |register_node, option_nodes|
+            remove_options(corrector, register_node, option_nodes)
+          end
+          add_defaults(corrector, info_hash, defaults) if defaults.any?
+        end
+
+        def trailing_comment(node)
+          source = node.source_range.source_buffer.source
+          line_end = source.index("\n", node.source_range.end_pos) || source.length
+          source[node.source_range.end_pos...line_end][/#.*$/]
+        end
+
+        def option_default(node)
+          if node.receiver&.const_name == 'Opt'
+            node.first_argument
+          elsif node.method?(:new)
+            node.arguments[1]&.values&.[](2)
+          end
+        end
+
+        def same_default?(node, inherited_default)
+          return inherited_default.nil? if node.nil? || node.nil_type?
+
+          node.respond_to?(:value) && node.value == inherited_default
+        end
+
+        def info_hash(class_node)
+          update_info = class_node.each_descendant(:send).find { |node| node.method?(:update_info) || node.method?(:merge_info) }
+          hash = update_info&.arguments&.find(&:hash_type?)
+          return hash if hash
+
+          initialize_node = class_node.each_descendant(:def).find { |node| node.method_name == :initialize }
+          super_node = initialize_node&.each_descendant(:super)&.first
+          super_node&.arguments&.find(&:hash_type?)
+        end
+
+        def remove_options(corrector, register_node, removed_nodes)
+          array = register_node.first_argument
+          remaining_nodes = array&.array_type? ? array.values - removed_nodes : []
+          if remaining_nodes.empty?
+            remove_expression(corrector, register_node)
+          else
+            removed_nodes.each { |node| remove_array_element(corrector, node) }
+          end
+        end
+
+        def remove_expression(corrector, node)
+          range = node.source_range
+          source = range.source_buffer.source
+          begin_pos = source.rindex("\n", range.begin_pos - 1)&.+(1) || range.begin_pos
+          previous_line_begin = source.rindex("\n", begin_pos - 2)&.+(1) || 0
+          begin_pos = previous_line_begin if source[previous_line_begin...begin_pos].strip.empty?
+          end_pos = source.index("\n", range.end_pos)&.+(1) || range.end_pos
+          corrector.remove(range_between(begin_pos, end_pos))
+        end
+
+        def remove_array_element(corrector, node)
+          siblings = node.parent.values
+          next_node = siblings[siblings.index(node) + 1]
+          if next_node
+            corrector.remove(range_between(node.source_range.begin_pos, next_node.source_range.begin_pos))
+          else
+            previous_node = siblings[siblings.index(node) - 1]
+            corrector.remove(range_between(previous_node.source_range.end_pos, node.source_range.end_pos))
+          end
+        end
+
+        def add_defaults(corrector, hash, defaults)
+          default_pair = hash.pairs.find { |pair| pair.key.str_type? && pair.key.value == 'DefaultOptions' }
+          if default_pair&.value&.hash_type?
+            merge_defaults(corrector, default_pair.value, defaults)
+          else
+            first_pair = hash.pairs.first
+            unless first_pair
+              indent = hash.source_range.column + 2
+              entries = default_entries(defaults, indent + 2)
+              corrector.insert_after(hash.loc.begin, "\n#{' ' * indent}'DefaultOptions' => {\n#{entries}\n#{' ' * indent}}\n#{' ' * (indent - 2)}")
+              return
+            end
+
+            indent = first_pair.source_range.column
+            entries = default_entries(defaults, indent + 2)
+            corrector.insert_before(first_pair, "'DefaultOptions' => {\n#{entries}\n#{' ' * indent}},\n#{' ' * indent}")
+          end
+        end
+
+        def merge_defaults(corrector, hash, defaults)
+          existing = hash.pairs.filter_map { |pair| [pair.key.value, pair] if pair.key.str_type? }.to_h
+          missing = []
+          defaults.each do |name, value|
+            if existing[name]
+              corrector.replace(existing[name].value, value[:source])
+              corrector.insert_before(existing[name], "#{value[:comment]}\n#{' ' * existing[name].source_range.column}") if value[:comment]
+            else
+              missing << [name, value]
+            end
+          end
+          return if missing.empty?
+
+          last_pair = hash.pairs.last
+          if last_pair
+            if hash.single_line?
+              comments = missing.filter_map { |_name, value| value[:comment] }
+              if comments.any?
+                default_pair = hash.parent
+                indent = default_pair.source_range.column
+                corrector.insert_before(default_pair, "#{comments.join("\n#{' ' * indent}")}\n#{' ' * indent}")
+              end
+              entries = missing.map { |name, value| "'#{name}' => #{value[:source]}" }.join(', ')
+              corrector.insert_after(last_pair, ", #{entries}")
+              return
+            end
+
+            indent = last_pair.source_range.column
+            entries = default_entries(missing.to_h, indent)
+            corrector.insert_after(last_pair, ",\n#{entries}")
+          else
+            indent = hash.source_range.column + 2
+            entries = default_entries(missing.to_h, indent)
+            corrector.insert_after(hash.loc.begin, "\n#{entries}\n#{' ' * (indent - 2)}")
+          end
+        end
+
+        def default_entries(defaults, indent)
+          defaults.map do |name, value|
+            comment = value[:comment] ? "#{' ' * indent}#{value[:comment]}\n" : ''
+            "#{comment}#{' ' * indent}'#{name}' => #{value[:source]}"
+          end.join(",\n")
         end
 
         def deregistered_before?(class_node, register_node, option_name)

--- a/lib/rubocop/cop/lint/module_duplicate_option.rb
+++ b/lib/rubocop/cop/lint/module_duplicate_option.rb
@@ -25,27 +25,28 @@ module RuboCop
 
         MIXIN_OPTIONS = {
           'Msf::Auxiliary::Scanner' => {
-            'RHOSTS' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html' },
-            'THREADS' => { default: 1, description: 'The number of concurrent threads (max one per host)' }
+            'RHOSTS' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html', type: 'OptRhosts' },
+            'THREADS' => { default: 1, description: 'The number of concurrent threads (max one per host)', type: 'OptInt' }
           },
           'Msf::Exploit::Remote::HttpClient' => {
-            'RHOST' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html' },
-            'RPORT' => { default: 80, description: 'The target port' },
-            'VHOST' => { default: nil, description: 'HTTP server virtual host' },
-            'SSL' => { default: false, description: 'Negotiate SSL/TLS for outgoing connections' },
-            'Proxies' => { default: nil, description: nil }
+            'RHOST' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html', type: 'OptRhosts' },
+            'RPORT' => { default: 80, description: 'The target port', type: 'OptPort' },
+            'VHOST' => { default: nil, description: 'HTTP server virtual host', type: 'OptString' },
+            'SSL' => { default: false, description: 'Negotiate SSL/TLS for outgoing connections', type: 'OptBool' },
+            'Proxies' => { default: nil, description: nil, type: 'OptProxies' }
           },
           'Msf::Exploit::Remote::Tcp' => {
-            'RHOST' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html' },
-            'RPORT' => { default: nil, description: 'The target port' }
+            'RHOST' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html', type: 'OptRhosts' },
+            'RPORT' => { default: nil, description: 'The target port', type: 'OptPort' }
           },
           'Msf::Exploit::Remote::Udp' => {
-            'RHOST' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html' },
-            'RPORT' => { default: nil, description: 'The target port' }
+            'RHOST' => { default: nil, description: 'The target host(s), see https://docs.metasploit.com/docs/using-metasploit/basics/using-metasploit.html', type: 'OptRhosts' },
+            'RPORT' => { default: nil, description: 'The target port', type: 'OptPort' }
           }
         }.freeze
 
         MSG = 'Do not register the pre-existing %<option>s option again; set its value in DefaultOptions instead.'
+        TYPE_MSG = 'Do not change the type of the pre-existing %<option>s option from %<expected>s to %<actual>s.'
 
         def on_class(class_node)
           return unless class_node.identifier&.const_name == 'MetasploitModule'
@@ -57,16 +58,20 @@ module RuboCop
             option_nodes(register_node).filter_map do |option_node|
               option_name = option_name(option_node)
               next unless inherited_options.key?(option_name)
-              next unless description_unchanged?(option_node, inherited_options[option_name][:description])
+
+              type_changed = type_changed?(option_node, inherited_options[option_name][:type])
+              next unless type_changed || description_unchanged?(option_node, inherited_options[option_name][:description])
               next if deregistered_before?(class_node, register_node, option_name)
 
-              [option_node, option_name, inherited_options[option_name]]
+              [option_node, option_name, inherited_options[option_name], type_changed]
             end
           end
 
-          offenses.each_with_index do |(option_node, option_name, _option), index|
-            add_offense(option_node, message: format(MSG, option: option_name)) do |corrector|
-              autocorrect(corrector, class_node, offenses) if index.zero?
+          correctable_offenses = offenses.reject(&:last)
+          offenses.each do |option_node, option_name, option, type_changed|
+            message = type_changed ? format(TYPE_MSG, option: option_name, expected: option[:type], actual: option_type(option_node)) : format(MSG, option: option_name)
+            add_offense(option_node, message: message) do |corrector|
+              autocorrect(corrector, class_node, correctable_offenses) if !type_changed && option_node == correctable_offenses.first&.first
             end
           end
         end
@@ -108,6 +113,14 @@ module RuboCop
                         end
 
           description.nil? || description.nil_type? || (description.str_type? && description.value == inherited_description)
+        end
+
+        def option_type(node)
+          node.receiver&.const_name if node.method?(:new)
+        end
+
+        def type_changed?(node, inherited_type)
+          option_type(node) && option_type(node) != inherited_type
         end
 
         def autocorrect(corrector, class_node, offenses)

--- a/spec/rubocop/cop/lint/module_duplicate_option_spec.rb
+++ b/spec/rubocop/cop/lint/module_duplicate_option_spec.rb
@@ -22,29 +22,27 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
     RUBY
   end
 
-  it 'flags an inherited option registered with an option class' do
-    expect_offense(<<~RUBY)
+  it 'does not flag an inherited option registered with an option class' do
+    expect_no_offenses(<<~RUBY)
       class MetasploitModule < Msf::Auxiliary
         include Msf::Exploit::Remote::Tcp
 
         def initialize(info = {})
           super
           register_options([OptPort.new('RPORT', [true, 'The target port', 4840])])
-                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
         end
       end
     RUBY
   end
 
-  it 'flags an option already registered by the HTTP client mixin' do
-    expect_offense(<<~RUBY)
+  it 'does not flag an option class already registered by the HTTP client mixin' do
+    expect_no_offenses(<<~RUBY)
       class MetasploitModule < Msf::Auxiliary
         include Msf::Exploit::Remote::HttpClient
 
         def initialize(info = {})
           super
-          register_options([OptBool.new('SSL', [false, 'Use SSL', true])])
-                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing SSL option again; set its value in DefaultOptions instead.
+          register_options([OptBool.new('SSL', [false, 'Negotiate SSL/TLS for outgoing connections', true])])
         end
       end
     RUBY
@@ -64,15 +62,107 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
     RUBY
   end
 
-  it 'flags an option already registered by the scanner mixin' do
+  it 'flags a computed RPORT default used by a real module' do
     expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Exploit::Remote
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super
+          register_options([Opt::RPORT(Rex::Proto::PJL::DEFAULT_PORT)])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
+        end
+      end
+    RUBY
+  end
+
+  it 'flags an RHOST default used by real modules' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::HttpClient
+
+        def initialize(info = {})
+          super
+          register_options([Opt::RHOST('192.168.100.1')])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RHOST option again; set its value in DefaultOptions instead.
+        end
+      end
+    RUBY
+  end
+
+  it 'does not flag an option class already registered by the scanner mixin' do
+    expect_no_offenses(<<~RUBY)
       class MetasploitModule < Msf::Auxiliary
         include Msf::Auxiliary::Scanner
 
         def initialize(info = {})
           super
-          register_options([OptInt.new('THREADS', [true, 'Thread count', 25])])
-                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing THREADS option again; set its value in DefaultOptions instead.
+          register_options([OptInt.new('THREADS', [true, 'The number of concurrent threads (max one per host)', 25])])
+        end
+      end
+    RUBY
+  end
+
+  it 'does not flag an inherited option when its description also changes' do
+    expect_no_offenses(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::HttpClient
+
+        def initialize(info = {})
+          super
+          register_options([OptBool.new('SSL', [false, 'Use SSL', true])])
+        end
+      end
+    RUBY
+  end
+
+  it 'does not flag an inherited option when its required value also changes' do
+    expect_no_offenses(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super
+          register_options([OptPort.new('RPORT', [false, 'The target port', 4840])])
+        end
+      end
+    RUBY
+  end
+
+  it 'does not flag an inherited option when its type also changes' do
+    expect_no_offenses(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super
+          register_options([OptString.new('RPORT', [true, 'The target port', '4840'])])
+        end
+      end
+    RUBY
+  end
+
+  it 'does not flag an identical inherited option' do
+    expect_no_offenses(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::HttpClient
+
+        def initialize(info = {})
+          super
+          register_options([Opt::RPORT(80)])
+        end
+      end
+    RUBY
+  end
+
+  it 'does not flag an Opt helper call that changes requiredness too' do
+    expect_no_offenses(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super
+          register_options([Opt::RPORT(4840, false)])
         end
       end
     RUBY

--- a/spec/rubocop/cop/lint/module_duplicate_option_spec.rb
+++ b/spec/rubocop/cop/lint/module_duplicate_option_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rubocop/cop/lint/module_duplicate_option'
+
+RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+
+  it 'flags an RPORT option already registered by the TCP mixin' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super
+          register_options([Opt::RPORT(4840)])
+                            ^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
+        end
+      end
+    RUBY
+  end
+
+  it 'flags an inherited option registered with an option class' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super
+          register_options([OptPort.new('RPORT', [true, 'The target port', 4840])])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
+        end
+      end
+    RUBY
+  end
+
+  it 'flags an option already registered by the HTTP client mixin' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::HttpClient
+
+        def initialize(info = {})
+          super
+          register_options([OptBool.new('SSL', [false, 'Use SSL', true])])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing SSL option again; set its value in DefaultOptions instead.
+        end
+      end
+    RUBY
+  end
+
+  it 'flags an option already registered by the UDP mixin' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Udp
+
+        def initialize(info = {})
+          super
+          register_options([Opt::RPORT(161)])
+                            ^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
+        end
+      end
+    RUBY
+  end
+
+  it 'flags an option already registered by the scanner mixin' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Auxiliary::Scanner
+
+        def initialize(info = {})
+          super
+          register_options([OptInt.new('THREADS', [true, 'Thread count', 25])])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing THREADS option again; set its value in DefaultOptions instead.
+        end
+      end
+    RUBY
+  end
+
+  it 'does not flag new options' do
+    expect_no_offenses(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super
+          register_options([OptString.new('ENDPOINT', [true, 'Endpoint', '/'])])
+        end
+      end
+    RUBY
+  end
+
+  it 'does not flag RPORT when the TCP mixin is not included' do
+    expect_no_offenses(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        def initialize(info = {})
+          super
+          register_options([Opt::RPORT(4840)])
+        end
+      end
+    RUBY
+  end
+
+  it 'allows an option to be deliberately deregistered and replaced' do
+    expect_no_offenses(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super
+          deregister_options('RPORT')
+          register_options([OptPort.new('RPORT', [true, 'A replacement port'])])
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts DefaultOptions as the way to change the inherited default' do
+    expect_no_offenses(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super(update_info(info, 'DefaultOptions' => { 'RPORT' => 4840 }))
+        end
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/lint/module_duplicate_option_spec.rb
+++ b/spec/rubocop/cop/lint/module_duplicate_option_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'rubocop/cop/lint/module_duplicate_option'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
   subject(:cop) { described_class.new(config) }
 
@@ -22,27 +23,29 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
     RUBY
   end
 
-  it 'does not flag an inherited option registered with an option class' do
-    expect_no_offenses(<<~RUBY)
+  it 'flags an inherited option registered with the same description' do
+    expect_offense(<<~RUBY)
       class MetasploitModule < Msf::Auxiliary
         include Msf::Exploit::Remote::Tcp
 
         def initialize(info = {})
           super
           register_options([OptPort.new('RPORT', [true, 'The target port', 4840])])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
         end
       end
     RUBY
   end
 
-  it 'does not flag an option class already registered by the HTTP client mixin' do
-    expect_no_offenses(<<~RUBY)
+  it 'flags an option class with the inherited description' do
+    expect_offense(<<~RUBY)
       class MetasploitModule < Msf::Auxiliary
         include Msf::Exploit::Remote::HttpClient
 
         def initialize(info = {})
           super
           register_options([OptBool.new('SSL', [false, 'Negotiate SSL/TLS for outgoing connections', true])])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing SSL option again; set its value in DefaultOptions instead.
         end
       end
     RUBY
@@ -90,14 +93,15 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
     RUBY
   end
 
-  it 'does not flag an option class already registered by the scanner mixin' do
-    expect_no_offenses(<<~RUBY)
+  it 'flags an option class already registered by the scanner mixin' do
+    expect_offense(<<~RUBY)
       class MetasploitModule < Msf::Auxiliary
         include Msf::Auxiliary::Scanner
 
         def initialize(info = {})
           super
           register_options([OptInt.new('THREADS', [true, 'The number of concurrent threads (max one per host)', 25])])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing THREADS option again; set its value in DefaultOptions instead.
         end
       end
     RUBY
@@ -116,40 +120,43 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
     RUBY
   end
 
-  it 'does not flag an inherited option when its required value also changes' do
-    expect_no_offenses(<<~RUBY)
+  it 'flags an inherited option when its required value changes but its description does not' do
+    expect_offense(<<~RUBY)
       class MetasploitModule < Msf::Auxiliary
         include Msf::Exploit::Remote::Tcp
 
         def initialize(info = {})
           super
           register_options([OptPort.new('RPORT', [false, 'The target port', 4840])])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
         end
       end
     RUBY
   end
 
-  it 'does not flag an inherited option when its type also changes' do
-    expect_no_offenses(<<~RUBY)
+  it 'flags an inherited option when its type changes but its description does not' do
+    expect_offense(<<~RUBY)
       class MetasploitModule < Msf::Auxiliary
         include Msf::Exploit::Remote::Tcp
 
         def initialize(info = {})
           super
           register_options([OptString.new('RPORT', [true, 'The target port', '4840'])])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
         end
       end
     RUBY
   end
 
-  it 'does not flag an identical inherited option' do
-    expect_no_offenses(<<~RUBY)
+  it 'flags an identical inherited option' do
+    expect_offense(<<~RUBY)
       class MetasploitModule < Msf::Auxiliary
         include Msf::Exploit::Remote::HttpClient
 
         def initialize(info = {})
           super
           register_options([Opt::RPORT(80)])
+                            ^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
         end
       end
     RUBY
@@ -162,7 +169,7 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
 
         def initialize(info = {})
           super
-          register_options([Opt::RPORT(4840, false)])
+          register_options([Opt::RPORT(4840, false, 'The application port')])
         end
       end
     RUBY
@@ -217,4 +224,173 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
       end
     RUBY
   end
+
+  it 'moves a changed default to DefaultOptions' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super(update_info(
+            info,
+            'Name' => 'Example'
+          ))
+          register_options([Opt::RPORT(4840)])
+                            ^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super(update_info(
+            info,
+            'DefaultOptions' => {
+              'RPORT' => 4840
+            },
+            'Name' => 'Example'
+          ))
+        end
+      end
+    RUBY
+  end
+
+  it 'removes an identical option without adding a default' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::HttpClient
+
+        def initialize(info = {})
+          super(update_info(info, 'Name' => 'Example'))
+          register_options([OptString.new('VHOST', [false, 'HTTP server virtual host'])])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing VHOST option again; set its value in DefaultOptions instead.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::HttpClient
+
+        def initialize(info = {})
+          super(update_info(info, 'Name' => 'Example'))
+        end
+      end
+    RUBY
+  end
+
+  it 'merges multiple changed defaults into existing DefaultOptions' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super(update_info(
+            info,
+            'DefaultOptions' => {
+              'RPORT' => 1234,
+              'VERBOSE' => true
+            }
+          ))
+          register_options([
+            Opt::RPORT(8080),
+            ^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
+            Opt::RHOST('127.0.0.1')
+            ^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RHOST option again; set its value in DefaultOptions instead.
+          ])
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super(update_info(
+            info,
+            'DefaultOptions' => {
+              'RPORT' => 8080,
+              'VERBOSE' => true,
+              'RHOST' => '127.0.0.1'
+            }
+          ))
+        end
+      end
+    RUBY
+  end
+
+  it 'keeps unrelated options in the registration array' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super(update_info(
+            info,
+            'Name' => 'Example'
+          ))
+          register_options([
+            Opt::RPORT(4840),
+            ^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
+            OptString.new('PATH', [true, 'A path'])
+          ])
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::Tcp
+
+        def initialize(info = {})
+          super(update_info(
+            info,
+            'DefaultOptions' => {
+              'RPORT' => 4840
+            },
+            'Name' => 'Example'
+          ))
+          register_options([
+            OptString.new('PATH', [true, 'A path'])
+          ])
+        end
+      end
+    RUBY
+  end
+
+  it 'merges a default into legacy super metadata' do
+    expect_offense(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::HttpClient
+
+        def initialize
+          super(
+            'Name' => 'Example',
+            'DefaultOptions' => { 'SSL' => true }
+          )
+          register_options([Opt::RPORT(443)]) # HTTPS port
+                            ^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class MetasploitModule < Msf::Auxiliary
+        include Msf::Exploit::Remote::HttpClient
+
+        def initialize
+          super(
+            'Name' => 'Example',
+            # HTTPS port
+            'DefaultOptions' => { 'SSL' => true, 'RPORT' => 443 }
+          )
+        end
+      end
+    RUBY
+  end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/rubocop/cop/lint/module_duplicate_option_spec.rb
+++ b/spec/rubocop/cop/lint/module_duplicate_option_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
         def initialize(info = {})
           super
           register_options([OptString.new('RPORT', [true, 'The application port', '4840'])])
-                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not change the type of the pre-existing RPORT option from OptPort to OptString.
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not change the type of the pre-existing RPORT option from OptPort to OptString.
         end
       end
     RUBY

--- a/spec/rubocop/cop/lint/module_duplicate_option_spec.rb
+++ b/spec/rubocop/cop/lint/module_duplicate_option_spec.rb
@@ -134,18 +134,20 @@ RSpec.describe RuboCop::Cop::Lint::ModuleDuplicateOption do
     RUBY
   end
 
-  it 'flags an inherited option when its type changes but its description does not' do
+  it 'flags an inherited option when its type and description change without autocorrecting it' do
     expect_offense(<<~RUBY)
       class MetasploitModule < Msf::Auxiliary
         include Msf::Exploit::Remote::Tcp
 
         def initialize(info = {})
           super
-          register_options([OptString.new('RPORT', [true, 'The target port', '4840'])])
-                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not register the pre-existing RPORT option again; set its value in DefaultOptions instead.
+          register_options([OptString.new('RPORT', [true, 'The application port', '4840'])])
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption: Do not change the type of the pre-existing RPORT option from OptPort to OptString.
         end
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'flags an identical inherited option' do


### PR DESCRIPTION
## Description

This adds rubocop rules to catch when a contributor redeclares a pre-existing option and guides them to simply change that option's default value.
It still allows contributors to deregister and then re-register options that are different, but have the same key value.


<!-- Explain why this change is needed. What problem does it solve or what improvement does it provide? -->

@jheysel-r7 has caught me missing this four times in the last week.  I figure it should be a rubocop rule, then I won't look as bad.


**Related Issue:** 

## Breaking Changes

None

## Reviewer Notes

Files that break this rule so you can test:
  - RPORT: modules/auxiliary/admin/appletv/appletv_display_image.rb:36
  - SSL: modules/auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb:40
  - RHOST: modules/auxiliary/client/hwbridge/connect.rb:48
  - VHOST: modules/exploits/unix/webapp/opennetadmin_ping_cmd_injection.rb:50
  - THREADS: modules/auxiliary/scanner/nessus/nessus_xmlrpc_ping.rb:30

## Verification Steps

Run rubocop on the problematic files to verify it works.

## Test Evidence

RuboCop reported 8 offenses across the 5 files.

  1. appletv_display_image.rb

  Opt::RPORT(7000)
  ^^^^^^^^^^^^^^^^ Lint/ModuleDuplicateOption

  Correction:

  'DefaultOptions' => {
    'HttpUsername' => 'AirPlay',
    'RPORT' => 7000
  }

  Remove Opt::RPORT(7000) from register_options.

  2. foreman_openstack_satellite_priv_esc.rb

  Opt::RPORT(443)
  ^^^^^^^^^^^^^^^
  OptBool.new('SSL', [true, 'Use SSL', true])
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  Correction:

  'DefaultOptions' => {
    'RPORT' => 443,
    'SSL' => true
  }

  Remove both registrations.

  3. hwbridge/connect.rb

  Opt::RPORT(8080)
  ^^^^^^^^^^^^^^^^
  Opt::RHOST('127.0.0.1')
  ^^^^^^^^^^^^^^^^^^^^^^^

  Correction:

  'DefaultOptions' => {
    'RHOST' => '127.0.0.1',
    'RPORT' => 8080
  }

  Remove both registrations.

  4. opennetadmin_ping_cmd_injection.rb

  OptString.new('VHOST', [false, 'HTTP server virtual host'])
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  This does not change the default, so the correction is simply to remove the redundant registration. No DefaultOptions entry is
  needed.

  5. nessus_xmlrpc_ping.rb

  Opt::RPORT(8834)
  ^^^^^^^^^^^^^^^^
  OptInt.new('THREADS', [true, "The number of concurrent threads", 25])
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  Correction:

  'DefaultOptions' => {
    'SSL' => true,
    'RPORT' => 8834,
    'THREADS' => 25
  }

## AI Usage Disclosure

gpt-5.6 generated the rules and tested them
