### PR TITLE
Prevent ThreadFactory from delegating to a framework ThreadManager in server specs

### DIFF
--- a/spec/lib/rex/proto/ftp/server_spec.rb
+++ b/spec/lib/rex/proto/ftp/server_spec.rb
@@ -6,17 +6,6 @@ require 'rex/proto/ftp/server'
 RSpec.describe Rex::Proto::Ftp::Server do
   subject(:server) { described_class.new(0, '127.0.0.1') }
 
-  # Prevent ThreadFactory from delegating to a framework ThreadManager,
-  # which would spawn a "Thread Monitor" thread that outlives this spec.
-  before(:all) do
-    @original_thread_factory_provider = Rex::ThreadFactory.class_variable_get(:@@provider)
-    Rex::ThreadFactory.provider = nil
-  end
-
-  after(:all) do
-    Rex::ThreadFactory.provider = @original_thread_factory_provider
-  end
-
   # ---------------------------------------------------------------------------
   # Helpers
   # ---------------------------------------------------------------------------

--- a/spec/lib/rex/proto/ftp/server_spec.rb
+++ b/spec/lib/rex/proto/ftp/server_spec.rb
@@ -6,6 +6,17 @@ require 'rex/proto/ftp/server'
 RSpec.describe Rex::Proto::Ftp::Server do
   subject(:server) { described_class.new(0, '127.0.0.1') }
 
+  # Prevent ThreadFactory from delegating to a framework ThreadManager,
+  # which would spawn a "Thread Monitor" thread that outlives this spec.
+  before(:all) do
+    @original_thread_factory_provider = Rex::ThreadFactory.class_variable_get(:@@provider)
+    Rex::ThreadFactory.provider = nil
+  end
+
+  after(:all) do
+    Rex::ThreadFactory.provider = @original_thread_factory_provider
+  end
+
   # ---------------------------------------------------------------------------
   # Helpers
   # ---------------------------------------------------------------------------

--- a/spec/support/shared/contexts/msf/simple/framework.rb
+++ b/spec/support/shared/contexts/msf/simple/framework.rb
@@ -23,6 +23,11 @@ RSpec.shared_context 'Msf::Simple::Framework' do
   end
 
   after(:example) do
+    # Prevent orphan ThreadManager monitor threads from leaking into later specs.
+    # Framework.new sets Rex::ThreadFactory.provider globally but nothing ever
+    # unsets it, so a later spec calling Rex::ThreadFactory.spawn would lazily
+    # create a new ThreadManager whose monitor thread outlives the example.
+    Rex::ThreadFactory.provider = nil
     FileUtils.rm_rf(dummy_pathname)
   end
 end


### PR DESCRIPTION
## Description

Fix intermittent `after(:suite)` thread leak failures in CI by resetting `Rex::ThreadFactory.provider` in the `'Msf::Simple::Framework'` shared context's `after(:example)` block.

`Msf::Framework#initialize` sets `Rex::ThreadFactory.provider` to a global class variable that is never unset. When a later spec calls `Rex::ThreadFactory.spawn` (e.g. starting a server, creating a session, or writing history), the provider lazily creates a new `Msf::ThreadManager` with a persistent "Thread Monitor" thread that no cleanup path kills. The `after(:suite)` thread count check fires when these orphans push the total above `EXPECTED_THREAD_COUNT_AROUND_SUITE`.

The fix adds one line to the shared Framework context's `after(:example)`: `Rex::ThreadFactory.provider = nil`. Since the context uses `let(:framework)` (per-example scoped), the provider is re-armed on next access -- but between examples it's nil, so unrelated specs that call `ThreadFactory.spawn` create plain threads that their own cleanup can kill.

This single change fixes all 4 identified thread leak offenders:
- `spec/lib/rex/proto/ftp/server_spec.rb:209` — `server.start`
- `spec/lib/msf/exploit/local_spec.rb:38` — `Meterpreter_x86_Win.new`
- `spec/lib/rex/ui/subscriber_spec.rb:51` — `Input::Buffer.new`
- `spec/lib/rex/ui/text/shell/history_manager_spec.rb:162` — `write_history_file`

**Related Issue:** Fixes intermittent CI failure on unrelated PRs (e.g., #21824, #21828)

## Breaking Changes

None

## Reviewer Notes

- The failure is non-deterministic: it requires RSpec's randomized seed to place a Framework-creating spec before one of the 4 offending specs. With 57+ specs using this shared context and 4 trigger specs, the probability per run is high enough to hit multiple PRs per week.
- Nothing in the thread infrastructure changed recently. The flake rate increased because new specs (June–July 2026) added more trigger paths: FTP server spec (June 3), subscriber spec (June 15), local exploit spec modifications (July 7/24).
- Precedent: `spec/lib/msf/base/sessions/modem_spec.rb` and `modem/quectel_spec.rb` use the same save/restore pattern per-spec. This fix applies the same principle at the shared context level.
- The thread count check is preserved as a real safety net — this prevents the leak, not masks it.
- Not a runtime issue: in normal msfconsole usage there's one Framework per process, one ThreadManager, and the monitor thread lives until exit. The problem is test-only (many Frameworks in one process).

## Verification Steps

1. - [ ] Run specs using the shared Framework context: `bundle exec rspec spec/lib/msf/core/module_manager_spec.rb spec/lib/msf/core/payload_generator_spec.rb` — all pass
2. - [ ] Run offending specs after a Framework-creating spec:
   ```
   bundle exec rspec spec/lib/msf/core/exploit/remote/cert_request_spec.rb spec/lib/rex/proto/ftp/server_spec.rb spec/lib/msf/exploit/local_spec.rb spec/lib/rex/ui/subscriber_spec.rb --order defined
   ```
   No thread leak errors.
3. - [ ] Full CI suite (`bundle exec rake rspec-rerun:spec REMOTE_DB=1`) — `after(:suite)` thread count check passes

## Test Evidence

```
$ bundle exec ruby -I spec -I lib scripts/thread_leak_demo.rb                                                                                                                                                               ‹ruby-3.3.8@metasploit-framework›

============================================================
Rex::ThreadFactory Thread Leak Demonstration
============================================================

Baseline threads: 1

--- WITHOUT FIX: provider stays armed after Framework creation ---
  Rex::ThreadFactory.provider = Metasploit::Framework::ThreadFactoryProvider
  Threads after server.stop: 2 ["(main)", "Thread Monitor"]
  LEAKED: 1 orphan thread(s)

--- WITH FIX: provider reset to nil (what the shared context now does) ---
  Rex::ThreadFactory.provider = nil
  Threads after server.stop: 1 ["(main)"]
  LEAKED: 0 orphan thread(s)

============================================================
PASS: Leak confirmed without fix (1 extra), clean with fix.
============================================================
```
CI failure on PR #21828 (Ruby 3.4, REMOTE_DB=1) hit all 4 offenders simultaneously:
```
RuntimeError: 8 threads exist(s) when only 7 threads expected after suite runs:
  Thread 5/8: "Thread Monitor" via spec/lib/rex/ui/subscriber_spec.rb:51
  Thread 6/8: "Thread Monitor" via spec/lib/rex/proto/ftp/server_spec.rb:209
  Thread 7/8: "Thread Monitor" via spec/lib/msf/exploit/local_spec.rb:38
  Thread 8/8: "Thread Monitor" via spec/lib/rex/ui/text/shell/history_manager_spec.rb:162
```

<details>
<summary>Standalone reproduction script</summary>

```ruby
# bundle exec ruby -I spec -I lib thread_leak_demo.rb
require 'msfenv'

framework = Msf::Simple::Framework.create(
  'ConfigDirectory' => '/tmp/msf_test_config',
  'DeferModuleLoads' => true
)

server = Rex::Proto::Ftp::Server.new(0, '127.0.0.1')
server.start
server.stop
sleep 0.2

puts "Threads after stop: #{Thread.list.count}"
Thread.list.each { |t| puts "  #{t[:tm_name] || t.class.name} status=#{t.status}" }
# Output: 2 threads — "Thread Monitor" leaked

Rex::ThreadFactory.provider = nil  # <-- the fix

server2 = Rex::Proto::Ftp::Server.new(0, '127.0.0.1')
server2.start
server2.stop
sleep 0.2

puts "Threads after stop: #{Thread.list.count}"
# Output: 1 thread — clean
```

</details>

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Ubuntu 24.04 (CI), macOS 14 (local) |
| **Target Software/Hardware** | metasploit-framework test suite, Ruby 3.2/3.3/3.4 |

## AI Usage Disclosure

Kiro (diagnosis, fix, verification)

## Pre-Submission Checklist

- [ ] ~~Included a corresponding documentation markdown file in `documentation/modules`~~ _(not applicable — test infrastructure change)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] ~~Included RSpec tests for library changes~~ _(this IS the test infrastructure fix)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)