### PR TITLE
Add checks for UNKNOWN_* sentinel values in module notes

### DIFF
--- a/lib/rubocop/cop/lint/module_enforce_notes.rb
+++ b/lib/rubocop/cop/lint/module_enforce_notes.rb
@@ -7,7 +7,13 @@ module RuboCop
 
         NO_NOTES_MSG = 'Module is missing the Notes section which must include Stability, Reliability and SideEffects] - https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html'
         MISSING_KEY_MSG = 'Module is missing %s from the Notes section - https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html'
+        UNKNOWN_SENTINEL_MSG = '%s uses the sentinel value %s which is not a valid metadata value. ' \
+                               'Replace it with the correct values from lib/msf/core/constants.rb - ' \
+                               'https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html'
         REQUIRED_KEYS = %w[Stability Reliability SideEffects]
+
+        # Sentinel constants that exist only as placeholders -- never valid in module metadata
+        SENTINEL_CONSTANTS = %i[UNKNOWN_STABILITY UNKNOWN_SIDE_EFFECTS UNKNOWN_RELIABILITY].freeze
 
         def_node_matcher :find_update_info_node, <<~PATTERN
           (def :initialize _args (begin (super $(send nil? {:update_info :merge_info} (lvar :info) (hash ...))) ...))
@@ -45,9 +51,10 @@ module RuboCop
         def check_for_required_keys(notes)
           last_key = nil
           keys_present = []
-          notes.each_pair do |key, _value|
+          notes.each_pair do |key, value|
             if REQUIRED_KEYS.include? key.value
               keys_present << key.value
+              check_for_sentinel_values(key, value)
             end
             last_key = key
           end
@@ -61,6 +68,33 @@ module RuboCop
             end
             add_offense(last_key || notes, message: MISSING_KEY_MSG % msg)
           end
+        end
+
+        # Flag UNKNOWN_* sentinel constants used as Notes values
+        def check_for_sentinel_values(key, value)
+          sentinel_nodes = collect_sentinel_nodes(value)
+          sentinel_nodes.each do |sentinel_node|
+            add_offense(
+              sentinel_node,
+              message: UNKNOWN_SENTINEL_MSG % [key.value, sentinel_node.children[1]]
+            )
+          end
+        end
+
+        # Collect any sentinel constant references from a value node (handles both
+        # bare constants and array literals containing constants)
+        def collect_sentinel_nodes(node)
+          sentinels = []
+          if node.const_type? && SENTINEL_CONSTANTS.include?(node.children[1])
+            sentinels << node
+          elsif node.array_type?
+            node.children.each do |child|
+              if child.const_type? && SENTINEL_CONSTANTS.include?(child.children[1])
+                sentinels << child
+              end
+            end
+          end
+          sentinels
         end
 
         def hash_arg?(node)

--- a/spec/rubocop/cop/lint/module_enforce_notes_spec.rb
+++ b/spec/rubocop/cop/lint/module_enforce_notes_spec.rb
@@ -245,4 +245,143 @@ RSpec.describe RuboCop::Cop::Lint::ModuleEnforceNotes do
       end
     RUBY
   end
+
+  context 'with UNKNOWN_* sentinel values' do
+    it 'flags UNKNOWN_STABILITY used as a bare constant' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Simple module name',
+                'Description' => 'Lorem ipsum dolor sit amet',
+                'Author' => [ 'example1', 'example2' ],
+                'License' => MSF_LICENSE,
+                'Platform' => 'win',
+                'Arch' => ARCH_X86,
+                'Notes' => {
+                  'Stability' => UNKNOWN_STABILITY,
+                                 ^^^^^^^^^^^^^^^^^ Stability uses the sentinel value UNKNOWN_STABILITY [...]
+                  'SideEffects' => [IOC_IN_LOGS],
+                  'Reliability' => [FIRST_ATTEMPT_FAIL]
+                }
+              )
+            )
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+
+    it 'flags UNKNOWN_SIDE_EFFECTS inside an array' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Simple module name',
+                'Description' => 'Lorem ipsum dolor sit amet',
+                'Author' => [ 'example1', 'example2' ],
+                'License' => MSF_LICENSE,
+                'Platform' => 'win',
+                'Arch' => ARCH_X86,
+                'Notes' => {
+                  'Stability' => [CRASH_SAFE],
+                  'SideEffects' => [UNKNOWN_SIDE_EFFECTS],
+                                    ^^^^^^^^^^^^^^^^^^^^ SideEffects uses the sentinel value UNKNOWN_SIDE_EFFECTS [...]
+                  'Reliability' => [FIRST_ATTEMPT_FAIL]
+                }
+              )
+            )
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+
+    it 'flags UNKNOWN_RELIABILITY inside an array' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Simple module name',
+                'Description' => 'Lorem ipsum dolor sit amet',
+                'Author' => [ 'example1', 'example2' ],
+                'License' => MSF_LICENSE,
+                'Platform' => 'win',
+                'Arch' => ARCH_X86,
+                'Notes' => {
+                  'Stability' => [CRASH_SAFE],
+                  'SideEffects' => [IOC_IN_LOGS],
+                  'Reliability' => [UNKNOWN_RELIABILITY]
+                                    ^^^^^^^^^^^^^^^^^^^ Reliability uses the sentinel value UNKNOWN_RELIABILITY [...]
+                }
+              )
+            )
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+
+    it 'flags all three UNKNOWN_* sentinels in the same module' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Simple module name',
+                'Description' => 'Lorem ipsum dolor sit amet',
+                'Author' => [ 'example1', 'example2' ],
+                'License' => MSF_LICENSE,
+                'Platform' => 'win',
+                'Arch' => ARCH_X86,
+                'Notes' => {
+                  'Stability' => UNKNOWN_STABILITY,
+                                 ^^^^^^^^^^^^^^^^^ Stability uses the sentinel value UNKNOWN_STABILITY [...]
+                  'SideEffects' => UNKNOWN_SIDE_EFFECTS,
+                                   ^^^^^^^^^^^^^^^^^^^^ SideEffects uses the sentinel value UNKNOWN_SIDE_EFFECTS [...]
+                  'Reliability' => UNKNOWN_RELIABILITY
+                                   ^^^^^^^^^^^^^^^^^^^ Reliability uses the sentinel value UNKNOWN_RELIABILITY [...]
+                }
+              )
+            )
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+
+    it 'does not flag valid constants alongside sentinels (sentinel still flagged)' do
+      expect_offense(<<~RUBY)
+        class DummyModule
+          def initialize(info = {})
+            super(
+              update_info(
+                info,
+                'Name' => 'Simple module name',
+                'Description' => 'Lorem ipsum dolor sit amet',
+                'Author' => [ 'example1', 'example2' ],
+                'License' => MSF_LICENSE,
+                'Platform' => 'win',
+                'Arch' => ARCH_X86,
+                'Notes' => {
+                  'Stability' => [CRASH_SAFE, UNKNOWN_STABILITY],
+                                              ^^^^^^^^^^^^^^^^^ Stability uses the sentinel value UNKNOWN_STABILITY [...]
+                  'SideEffects' => [IOC_IN_LOGS],
+                  'Reliability' => [FIRST_ATTEMPT_FAIL]
+                }
+              )
+            )
+          end
+        end
+      RUBY
+      expect_no_corrections
+    end
+  end
 end


### PR DESCRIPTION

## Description

Extends the existing `Lint/ModuleEnforceNotes` RuboCop cop to detect and flag `UNKNOWN_STABILITY`, `UNKNOWN_SIDE_EFFECTS`, and `UNKNOWN_RELIABILITY` sentinel constants when used in module Notes metadata.

These sentinel values were introduced in PR #20343 as internal placeholders for modules that hadn't yet been classified. They are not valid metadata — if a contributor copies an existing module that uses them, the mistake currently isn't caught until rspec fails. This change surfaces the error at lint time with a clear message directing the author to pick the correct values from `lib/msf/core/constants.rb`.

**Related Issue:** Fixes #21818

## Breaking Changes

Existing modules that use `UNKNOWN_*` sentinels (approximately 6,127 occurrences across legacy modules) will now receive a warning-severity offense. Since `ModuleEnforceNotes` is scoped to `modules/exploits/**`, `modules/auxiliary/**`, and `modules/post/**` and the project uses `NewCops: disable`, this will not affect CI for unchanged files. Only newly authored or modified modules will be flagged.

## Reviewer Notes

The change lives entirely within the existing `ModuleEnforceNotes` cop rather than creating a new cop. The sentinel check runs inside `check_for_required_keys` after confirming the key is one of the three required Notes keys, so it handles both bare constant assignment (`'Stability' => UNKNOWN_STABILITY`) and array-wrapped usage (`'Stability' => [UNKNOWN_STABILITY]`).

## Verification Steps

1. - [ ] Run the cop against a module known to use sentinels:
   ```
   bundle exec rubocop --only Lint/ModuleEnforceNotes modules/exploits/osx/misc/ufo_ai.rb
   ```
   Expected: 3 offenses reported (one per sentinel constant).

2. - [ ] Run the cop against a module with valid Notes values:
   ```
    bundle exec rubocop --only Lint/ModuleEnforceNotes modules/exploits/linux/http/f5_icontrol_rest_ssrf_rce.rb
   ```
   Expected: 0 offenses.

3. - [ ] CI passes

## Test Evidence

```
$ bundle exec rubocop --only Lint/ModuleEnforceNotes modules/exploits/osx/misc/ufo_ai.rb                                                                                                                                    ‹ruby-3.3.8@metasploit-framework›
Inspecting 1 file
W

Offenses:

modules/exploits/osx/misc/ufo_ai.rb:54:28: W: Lint/ModuleEnforceNotes: Reliability uses the sentinel value UNKNOWN_RELIABILITY which is not a valid metadata value. Replace it with the correct values from lib/msf/core/constants.rb - https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
          'Reliability' => UNKNOWN_RELIABILITY,
                           ^^^^^^^^^^^^^^^^^^^
modules/exploits/osx/misc/ufo_ai.rb:55:26: W: Lint/ModuleEnforceNotes: Stability uses the sentinel value UNKNOWN_STABILITY which is not a valid metadata value. Replace it with the correct values from lib/msf/core/constants.rb - https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
          'Stability' => UNKNOWN_STABILITY,
                         ^^^^^^^^^^^^^^^^^
modules/exploits/osx/misc/ufo_ai.rb:56:28: W: Lint/ModuleEnforceNotes: SideEffects uses the sentinel value UNKNOWN_SIDE_EFFECTS which is not a valid metadata value. Replace it with the correct values from lib/msf/core/constants.rb - https://docs.metasploit.com/docs/development/developing-modules/module-metadata/definition-of-module-reliability-side-effects-and-stability.html
          'SideEffects' => UNKNOWN_SIDE_EFFECTS
                           ^^^^^^^^^^^^^^^^^^^^

1 file inspected, 3 offenses detected
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | macOS  |
| **Target Software/Hardware** | metasploit-framework RuboCop custom cops |

## AI Usage Disclosure
 Kiro

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
