### PR TITLE
Fix HTTPClient::ConnectTimeoutError in ldap_esc_vulnerable_cert_finder

### DIFF
--- a/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
+++ b/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb
@@ -1103,7 +1103,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if version_raw.blank?
-      print_error("Could not retrieve Windows version string from #{datastore['RHOSTS']} via WinRM.")
+      print_error("Could not retrieve Windows version string from #{datastore['RHOSTS']} via WinRM. Results may contain false positives.")
+      return
     end
 
     version_obj = Rex::Version.new(version_raw)
@@ -1130,7 +1131,7 @@ class MetasploitModule < Msf::Auxiliary
       end
     end
 
-    print_error("Could not map detected Windows version #{version_obj} to a known product range.")
+    print_error("Could not map detected Windows version #{version_obj} to a known product range. Results may contain false positives.")
   end
 
   def set_can_enroll_flags
@@ -1173,8 +1174,8 @@ class MetasploitModule < Msf::Auxiliary
       # longer accepts weak certificate mappings regardless of the StrongCertificateBindingEnforcement/ CertificaateMappingMethod registry key.
       begin
         domain_controller_version_check
-      rescue WinRM::WinRMAuthorizationError => e
-        print_warning("Unable to determine the version of Window so these all might be false postives! WinRM authorization error: #{e.message}")
+      rescue WinRM::WinRMError, HTTPClient::TimeoutError, SystemCallError => e
+        print_warning("Unable to determine the Windows version via WinRM: #{e.message}. Results may contain false positives.")
       end
 
       templates = query_ldap_server('(objectClass=pkicertificatetemplate)', CERTIFICATE_ATTRIBUTES, base_prefix: CERTIFICATE_TEMPLATES_BASE)


### PR DESCRIPTION
## Summary

The LDAP ESC vulnerable certificate finder queries the Domain Controller's Windows build over WinRM so it can account for the September 2025 certificate-mapping changes. This check runs before certificate-template enumeration.

Previously, the caller only rescued `WinRM::WinRMAuthorizationError`. Network failures raised outside that hierarchy, including `HTTPClient::ConnectTimeoutError`, escaped the check and aborted the module. This change treats WinRM, HTTP timeout, and system socket errors as an unavailable optional version check. The module warns that its results may contain false positives and continues LDAP certificate-template discovery.

The rescue now handles:

```ruby
WinRM::WinRMError, HTTPClient::TimeoutError, SystemCallError
```

## Breaking Changes

None

## Verification Steps

Verify that catching an error that was not caught before will solve this issue

## Test Evidence
### Before
```
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] user: Administrator, domain: kerberos.issue
[-] Auxiliary failed: HTTPClient::ConnectTimeoutError execution expired
[-] Call stack:
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient/session.rb:611:in `initialize'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient/session.rb:611:in `new'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient/session.rb:611:in `create_socket'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient/session.rb:755:in `block in connect'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/timeout-0.4.3/lib/timeout.rb:185:in `block in timeout'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/timeout-0.4.3/lib/timeout.rb:192:in `timeout'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient/session.rb:748:in `connect'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient/session.rb:511:in `query'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient/session.rb:177:in `query'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient.rb:1246:in `do_get_block'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient.rb:1023:in `block in do_request'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient.rb:1137:in `protect_keep_alive_disconnected'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient.rb:1018:in `do_request'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient.rb:860:in `request'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/httpclient-2.9.0/lib/httpclient.rb:769:in `post'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/http/transport.rb:238:in `init_auth'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/http/transport.rb:170:in `send_request'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/power_shell.rb:149:in `max_envelope_size_kb'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/power_shell.rb:74:in `max_fragment_blob_size'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/power_shell.rb:198:in `fragmenter'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/power_shell.rb:162:in `block in open_shell_payload'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/power_shell.rb:161:in `map'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/power_shell.rb:161:in `open_shell_payload'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/power_shell.rb:119:in `open_shell'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/base.rb:174:in `block in open'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/retryable.rb:35:in `retryable'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/base.rb:172:in `open'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/base.rb:132:in `with_command_shell'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/shells/base.rb:79:in `run'
[-]   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:1100:in `block in domain_controller_version_check'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/winrm-2.3.9/lib/winrm/connection.rb:42:in `shell'
[-]   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:1093:in `domain_controller_version_check'
[-]   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:1176:in `block in run'
[-]   /Users/jheysel/rapid7/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:177:in `block in ldap_open'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/net-ldap-0.20.0/lib/net/ldap.rb:647:in `block in open'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/net-ldap-0.20.0/lib/net/ldap.rb:719:in `block in open'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/net-ldap-0.20.0/lib/net/ldap/instrumentation.rb:19:in `instrument'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/net-ldap-0.20.0/lib/net/ldap.rb:714:in `open'
[-]   /Users/jheysel/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/net-ldap-0.20.0/lib/net/ldap.rb:647:in `open'
[-]   /Users/jheysel/rapid7/metasploit-framework/lib/msf/core/exploit/remote/ldap.rb:174:in `ldap_open'
[-]   /Users/jheysel/rapid7/metasploit-framework/lib/msf/core/optional_session/ldap.rb:53:in `ldap_connect'
[-]   /Users/jheysel/rapid7/metasploit-framework/modules/auxiliary/gather/ldap_esc_vulnerable_cert_finder.rb:1158:in `run'
[*] Auxiliary module execution completed
```

### After
```
[*] Running module against 172.16.199.200
[*] Discovering base DN automatically
[*] user: Administrator, domain: kerberos.issue
[!] Unable to determine the Windows version via WinRM: execution expired. Results may contain false positives.
[-] Failed to query all registry values. Ensure the user has sufficient privileges to query the Domain Controller and Certificate Authorities: execution expired.
[!] Couldn't find any vulnerable ESC13 templates!
[+] Template: Copy of User
[*]   Distinguished Name: CN=Copy of User,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=kerberos,DC=issue
[*]   Manager Approval: Disabled
[*]   Required Signatures: 0
[+]   Vulnerable to: ESC1, ESC2, ESC4
[*]   Permissions: READ, WRITE, ENROLL
[*]   Notes:
[*]     * ESC1: Request can specify a subjectAltName (msPKI-Certificate-Name-Flag) and EKUs permit authentication
[*]     * ESC2: Template defines the Any Purpose OID or no EKUs (PkiExtendedKeyUsage)
[*]     * ESC4: The account: Administrator has edit permissions over the template Copy of User.
[*]   Certificate Template Write-Enabled SIDs:
```

## Environment

- Windows Server 2019 Domain Controller and Certificate Authority
- LDAP TCP/389 reachable from Metasploit
- WinRM TCP/5985 deliberately dropped by a temporary inbound firewall rule
