### PR TITLE
docs: fix typo dependancy -> dependency

### DIFF
--- a/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
+++ b/modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb
@@ -163,7 +163,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   # task scheduler is pretty bad at handling binary files and likes to mess up our meterpreter :-(
   # instead we use a CFML filedropper to embed our payload and execute it.
-  # this also removes the dependancy of using the probe.cfm to execute the file.
+  # this also removes the dependency of using the probe.cfm to execute the file.
 
   def gen_file_dropper
     rand_var = rand_text_alpha(rand(8..15))


### PR DESCRIPTION
Corrects the misspelling `dependancy` -> `dependency` in `modules/exploits/multi/http/coldfusion_rds_auth_bypass.rb`.

Documentation only, no behaviour change.