### PR TITLE
Fix DNS forward/cache path for relay-driven poisoning

### DIFF
--- a/lib/rex/proto/dns/cache.rb
+++ b/lib/rex/proto/dns/cache.rb
@@ -57,7 +57,7 @@ module DNS
       end
 
       unless record.name.to_s.match(MATCH_HOSTNAME)
-        raise "Invalid record for cache entry (invalid hostname) - #{record.inspect}"
+        return # skip non-cacheable record: " - #{record.inspect}"
       end
 
       add(record, expire ? (::Time.now.to_i + record.ttl) : 0)

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -163,32 +163,35 @@ class Server
     return if data.strip.empty?
     req = Packet.encode_drb(data)
     forward = req.dup
-    # Find cached items, remove request from forwarded packet
+    # Dnsruby#dup is shallow - req and forward share the same @question Array.
+    # Give forward its own copy so deleting forwarded questions doesn't also
+    # empty req.question, which we need intact when echoing it in the response.
+    forward.instance_variable_set(:@question, req.question.dup)
+    answers = []
+    # Find cached items, remove question from forwarded packet
     req.question.each do |ques|
       cached = self.cache.find(ques.qname, ques.qtype)
-      if cached.empty?
-        next
-      else
-        req.instance_variable_set(:@answer, (req.answer + cached).uniq)
+      unless cached.empty?
+        answers.concat(cached)
         forward.question.delete(ques)
       end
     end
     # Forward remaining requests, cache responses
-    if forward.question.count > 0 and @fwd_res
+    if forward.question.count > 0 && @fwd_res
       forwarded = self.fwd_res.send(forward)
-      req.instance_variable_set(:@answer, (req.answer + forwarded.answer).uniq)
-      forwarded.answer.each do |ans|
-        self.cache.cache_record(ans)
-      end
-      req.header.ra = true # Set recursion bit
+      answers.concat(forwarded.answer)
+      forwarded.answer.each { |ans| self.cache.cache_record(ans) }
     end
-    # Finalize answers in response
-    # Check for empty response prior to sending
-    if req.answer.size < 1
-      req.header.rcode = Dnsruby::RCode::NOERROR
-    end
-    req.header.qr = true # Set response bit
-    send_response(cli, req.encode)
+    # Build a fresh response message to avoid a Dnsruby stale-state encoding bug
+    # where instance_variable_set(:@answer) on a decoded request appends answer
+    # bytes after the packet end rather than inside the answer section.
+    resp = Dnsruby::Message.new
+    resp.header.id = req.header.id
+    resp.header.qr = true
+    resp.header.ra = req.header.rd
+    req.question.each { |q| resp.add_question(q.qname, q.qtype, q.qclass) }
+    answers.uniq.each { |a| resp.add_answer(a) }
+    send_response(cli, resp.encode)
   end
 
   #
@@ -220,8 +223,12 @@ protected
       r,_,_ = ::IO.select(rds,wds,eds,1)
 
       if (r != nil and r[0] == self.udp_sock)
-        buf, addr = self.udp_sock.recvfrom(65535)
-        host, port = addr[3], addr[1]
+        buf, addr, source_port = self.udp_sock.recvfrom(65535)
+        if source_port
+          host, port = addr, source_port
+        else
+          host, port = addr[3], addr[1]
+        end
         # Mock up a client object for sending back data
         cli = MockDnsClient.new(host, port, r[0])
         dispatch_request(cli, buf)

--- a/lib/rex/proto/dns/server.rb
+++ b/lib/rex/proto/dns/server.rb
@@ -188,7 +188,8 @@ class Server
     resp = Dnsruby::Message.new
     resp.header.id = req.header.id
     resp.header.qr = true
-    resp.header.ra = req.header.rd
+    resp.header.rd = req.header.rd      # echo Recursion Desired back to the client
+    resp.header.ra = !self.fwd_res.nil? # Recursion Available when we can forward upstream
     req.question.each { |q| resp.add_question(q.qname, q.qtype, q.qclass) }
     answers.uniq.each { |a| resp.add_answer(a) }
     send_response(cli, resp.encode)

--- a/spec/lib/rex/proto/dns/cache_spec.rb
+++ b/spec/lib/rex/proto/dns/cache_spec.rb
@@ -1,0 +1,26 @@
+require 'rex/proto/dns'
+
+RSpec.describe Rex::Proto::DNS::Cache do
+  subject(:cache) { described_class.new }
+
+  # cache_record no-ops unless the monitor is running; pretend it is so the
+  # validation path actually runs during the test
+  before { cache.instance_variable_set(:@monitor_thread, true) }
+
+  describe '#cache_record' do
+    it 'caches a record whose name is a valid hostname' do
+      record = Dnsruby::RR.create(name: 'good.example.com.', type: 'A', address: '192.0.2.10')
+      cache.cache_record(record)
+      expect(cache.records.keys).to include(record)
+    end
+
+    it 'skips a forwarded record whose name is not a valid hostname instead of raising' do
+      # Regression: real upstream responses carry records whose names fail
+      # MATCH_HOSTNAME (e.g. SRV-style underscore labels). Caching them used to
+      # raise and kill the dispatch thread; they must be skipped silently.
+      record = Dnsruby::RR.create(name: '_ldap._tcp.example.com.', type: 'A', address: '192.0.2.20')
+      expect { cache.cache_record(record) }.not_to raise_error
+      expect(cache.records).to be_empty
+    end
+  end
+end

--- a/spec/lib/rex/proto/dns/server_spec.rb
+++ b/spec/lib/rex/proto/dns/server_spec.rb
@@ -96,5 +96,73 @@ RSpec.describe Rex::Proto::DNS::Server do
         server.default_dispatch_request(cli, query.encode)
       end
     end
+
+    context 'response header flags' do
+      # dispatch a query with a known Recursion Desired bit and decode the reply
+      def dispatch_and_decode(rd:)
+        query = Dnsruby::Message.new
+        query.add_question(Dnsruby::Name.create('flags.example.com.'), Dnsruby::Types::A)
+        query.header.rd = rd
+        captured = nil
+        allow(cli).to receive(:write) { |data| captured = Dnsruby::Message.decode(data) }
+        server.default_dispatch_request(cli, query.encode)
+        captured
+      end
+
+      it 'echoes the request Recursion Desired bit back to the client' do
+        # Regression: the fresh response defaulted RD to false, dropping the
+        # request's RD bit instead of echoing it.
+        server.fwd_res = double('resolver', send: Dnsruby::Message.new)
+        expect(dispatch_and_decode(rd: true).header.rd).to eq(true)
+        expect(dispatch_and_decode(rd: false).header.rd).to eq(false)
+      end
+
+      it 'advertises Recursion Available when a forwarder is configured' do
+        server.fwd_res = double('resolver', send: Dnsruby::Message.new)
+        expect(dispatch_and_decode(rd: true).header.ra).to eq(true)
+      end
+
+      it 'does not advertise Recursion Available when forwarding is disabled' do
+        server.fwd_res = nil
+        expect(dispatch_and_decode(rd: true).header.ra).to eq(false)
+      end
+    end
+  end
+
+  describe '#monitor_listener' do
+    let(:udp_sock) { double('udp_sock') }
+
+    before do
+      allow(server).to receive(:udp_sock).and_return(udp_sock)
+      # make the otherwise-infinite loop run exactly one iteration
+      allow(::IO).to receive(:select).and_return([[udp_sock], [], []])
+    end
+
+    def capture_client
+      captured = nil
+      allow(server).to receive(:dispatch_request) do |client, _data|
+        captured = client
+        throw :stop_listener
+      end
+      catch(:stop_listener) { server.send(:monitor_listener) }
+      captured
+    end
+
+    it 'addresses the reply using the three-value recvfrom form (data, host, port)' do
+      # Rex sockets return [data, host, port]; the reply must go to that host/port.
+      allow(udp_sock).to receive(:recvfrom).with(65535).and_return(['REQ', '192.0.2.77', 5353])
+      client = capture_client
+      expect(client.peerhost).to eq('192.0.2.77')
+      expect(client.peerport).to eq(5353)
+    end
+
+    it 'addresses the reply using the two-value recvfrom form (data, sockaddr array)' do
+      # Raw Ruby UDPSocket returns [data, [family, port, name, ip]]; host/port
+      # come out of the sockaddr array instead.
+      allow(udp_sock).to receive(:recvfrom).with(65535).and_return(['REQ', ['AF_INET', 5353, 'host', '192.0.2.88']])
+      client = capture_client
+      expect(client.peerhost).to eq('192.0.2.88')
+      expect(client.peerport).to eq(5353)
+    end
   end
 end

--- a/spec/lib/rex/proto/dns/server_spec.rb
+++ b/spec/lib/rex/proto/dns/server_spec.rb
@@ -36,5 +36,65 @@ RSpec.describe Rex::Proto::DNS::Server do
         server.default_dispatch_request(cli, query_for('empty.example.com'))
       end
     end
+
+    context 'when the forwarded response carries an answer' do
+      let(:answer) do
+        Dnsruby::RR.create(name: 'poisoned.example.com.', type: 'A', address: '192.0.2.10')
+      end
+
+      before do
+        # the resolver forwards the query and returns one answer, which is the
+        # path that has to survive re-encoding intact
+        forwarded = Dnsruby::Message.new
+        forwarded.add_answer(answer)
+        server.fwd_res = double('resolver', send: forwarded)
+      end
+
+      it 'encodes the answer inside the answer section rather than past the packet end' do
+        # Regression: mutating a decoded request's @answer and re-encoding it
+        # appended the answer bytes after the packet, so the reply decoded with
+        # zero answers. Building a fresh response keeps the answer readable.
+        expect(cli).to receive(:write) do |data|
+          reply = Dnsruby::Message.decode(data)
+          expect(reply.answer.count).to eq(1)
+          expect(reply.answer.first.address.to_s).to eq('192.0.2.10')
+        end
+        server.default_dispatch_request(cli, query_for('poisoned.example.com'))
+      end
+    end
+
+    context 'when one of several questions is served from cache' do
+      it 'forwards only the uncached question and keeps the request questions intact' do
+        # Regression: Dnsruby#dup is shallow, so deleting a served question from
+        # the forwarded packet also emptied the original request's question list.
+        # Only the uncached question should be forwarded, and both questions must
+        # still be echoed back in the response.
+        cached_answer = Dnsruby::RR.create(name: 'a.example.com.', type: 'A', address: '192.0.2.30')
+        allow(server.cache).to receive(:find) do |qname, _qtype|
+          qname.to_s == 'a.example.com' ? [cached_answer] : []
+        end
+
+        forwarded = Dnsruby::Message.new
+        forwarded.add_answer(Dnsruby::RR.create(name: 'b.example.com.', type: 'A', address: '192.0.2.20'))
+        resolver = double('resolver')
+        server.fwd_res = resolver
+
+        query = Dnsruby::Message.new
+        query.add_question(Dnsruby::Name.create('a.example.com.'), Dnsruby::Types::A)
+        query.add_question(Dnsruby::Name.create('b.example.com.'), Dnsruby::Types::A)
+
+        expect(resolver).to receive(:send) do |fwd|
+          expect(fwd.question.map { |q| q.qname.to_s }).to eq(['b.example.com'])
+          forwarded
+        end
+
+        expect(cli).to receive(:write) do |data|
+          reply = Dnsruby::Message.decode(data)
+          expect(reply.question.map { |q| q.qname.to_s }).to contain_exactly('a.example.com', 'b.example.com')
+          expect(reply.answer.map { |a| a.address.to_s }).to contain_exactly('192.0.2.30', '192.0.2.20')
+        end
+        server.default_dispatch_request(cli, query.encode)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

Three fixes to the core `Rex::Proto::DNS` forward/cache path that surface once the DNS server is used as a selective poisoner in front of a real upstream resolver (the Kerberos relay coercion workflow in #21693). Identified during @jheysel-r7's ESC8 relay testing.

Each is small and independent:

1. **`Cache#cache_record` crashed on non-cacheable forwarded records.** Real upstream responses carry records whose names do not match `MATCH_HOSTNAME`; caching them raised and killed the dispatch thread. Skip the record instead of raising.

2. **Shallow `dup` shared the question array.** `Dnsruby::Message#dup` is shallow, so `req.question` and `forward.question` referenced the same `Array`. Deleting a cache-served question from the forwarded packet also emptied the original request's question list, so the echoed response lost its questions. `forward` now gets its own copy.

3. **Mutating a decoded request's `@answer` produced a malformed packet.** Building the reply by `instance_variable_set(:@answer, ...)` on the decoded request and re-encoding appended the answer bytes *after* the packet end, so clients decoded zero answers (surfaces as "Bad DNS packet" on Windows). The response is now built as a fresh `Dnsruby::Message`.

Also handles `udp_sock.recvfrom` returning an explicit source port so the reply is addressed to the right host/port across socket variants.

## Verification

Both non-obvious bugs (2 and 3) were confirmed empirically against the pinned `dnsruby` before and after the fix, and are covered by new regression specs.

```
$ bundle exec rspec spec/lib/rex/proto/dns/server_spec.rb spec/lib/rex/proto/dns/cache_spec.rb
18 examples, 0 failures
```

The existing coverage from #21784 (empty-forward response) still passes.

## Related
                                           
- #21693 — Native Kerberos relay via DNS CNAME abuse (CVE-2026-20929)
- Follows #21784 (empty forward/cache response fix) in the same file.

