### PR TITLE
Vsftpd dual target

### DIFF
--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -39,11 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Payload' => {
           'Space' => 2000,
           'BadChars' => '',
-          'DisableNops' => true,
-          'Compat' => {
-               'PayloadType'    => 'cmd_interact',
-               'ConnectionType' => 'find'
-          }
+          'DisableNops' => true
         },
         'Targets' => [
           [
@@ -51,7 +47,23 @@ class MetasploitModule < Msf::Exploit::Remote
             {
               'Type' => :unix_cmd,
               'DefaultOptions' => {
-                # This exploit also supports direct interaction with the backdoor using cmd/unix/interact payload
+                'PAYLOAD' => 'cmd/linux/http/x86/meterpreter_reverse_tcp'
+              }
+            }
+          ],
+          [
+            'Backdoor Command Shell',
+            {
+              'Type' => :unix_cmd,
+              # Direct interaction with the backdoor over the already-established
+              # connection on 6200/TCP, instead of a fetch-based meterpreter stager.
+              'Payload' => {
+                'Compat' => {
+                  'PayloadType'    => 'cmd_interact',
+                  'ConnectionType' => 'find'
+                }
+              },
+              'DefaultOptions' => {
                 'PAYLOAD' => 'cmd/unix/interact'
               }
             }

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -39,7 +39,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Payload' => {
           'Space' => 2000,
           'BadChars' => '',
-          'DisableNops' => true
+          'DisableNops' => true,
+          'Compat' => {
+               'PayloadType'    => 'cmd_interact',
+               'ConnectionType' => 'find'
+          }
         },
         'Targets' => [
           [
@@ -48,7 +52,7 @@ class MetasploitModule < Msf::Exploit::Remote
               'Type' => :unix_cmd,
               'DefaultOptions' => {
                 # This exploit also supports direct interaction with the backdoor using cmd/unix/interact payload
-                'PAYLOAD' => 'cmd/linux/http/x86/meterpreter_reverse_tcp'
+                'PAYLOAD' => 'cmd/unix/interact'
               }
             }
           ]


### PR DESCRIPTION
## Description

Addresses bwatters-r7's review feedback on rapid7/metasploit-framework#21792 ("Fix #21780: Fix vsftpd_234_backdoor: restore cmd/unix/interact payload compatibility"), applied on top of `fix-vsftpd-234-payload-compat` so it can be merged into that PR before it lands upstream.

The original PR added a module-level `'Payload' => { 'Compat' => { 'PayloadType' => 'cmd_interact', 'ConnectionType' => 'find' } }` block and switched the default `PAYLOAD` to `cmd/unix/interact`. Because that `Compat` block lives at the module level, it applies to every target — narrowing payload selection to `cmd_interact`-type payloads only, for all users, and dropping support for the existing `cmd/linux/*` fetch-based payloads (e.g. `cmd/linux/http/x86/meterpreter_reverse_tcp`) that legacy-target users still rely on.

Per bwatters-r7:

> "this PR needs to be changed so it keeps supporting all the current cmd/linux payloads as well as the interact payloads... the best way to support both would be to add a second target."

This PR does that:

- Removed the module-level `Compat` block; the top-level `Payload` hash is back to its current-master shape (`Space`, `BadChars`, `DisableNops` only).
- **Target 0, "Linux/Unix Command"** (default, `DefaultTarget => 0`, unchanged from current master): `DefaultOptions['PAYLOAD']` stays `cmd/linux/http/x86/meterpreter_reverse_tcp` — the fetch-payload path works exactly as it does today.
- **Target 1, "Backdoor Command Shell"** (new): scoped `'Payload' => { 'Compat' => { 'PayloadType' => 'cmd_interact', 'ConnectionType' => 'find' } }` plus `DefaultOptions['PAYLOAD'] => 'cmd/unix/interact'`, restoring direct interaction with the backdoor for users who select this target.

This relies on `Msf::Module::Compatibility#compatible?` merging `target['Payload']['Compat']` on top of the module-level `Compat` hash only when that specific target is selected (`lib/msf/core/module/compatibility.rb`, the `if self.respond_to?("target") and self.target and self.target['Payload'] and self.target['Payload']['Compat']` branch) — so the `cmd_interact` restriction only kicks in for Target 1, not globally.

**Related Issue:** Addresses review comments on rapid7/metasploit-framework#21792 (fixes #21780)

## Breaking Changes

None for Target 0 users (default target, default payload unchanged from current master). Target 1 is new; anyone currently relying on the single-target behavior added by the original PR (`cmd/unix/interact` as the sole default) will need to explicitly `set TARGET 1` to get that behavior back — but that behavior wasn't in master yet, only in the still-open PR this builds on.

## Reviewer Notes

Single-file diff, `modules/exploits/unix/ftp/vsftpd_234_backdoor.rb` only. Worth double-checking the `Compat` merge behavior in `lib/msf/core/module/compatibility.rb` against this module directly in a console (`use`, `set TARGET 1`, `show payloads`) to confirm Target 1 narrows to `cmd/unix/interact`-type payloads while Target 0 still lists the full `cmd/linux/*` set.

## Verification Steps

1. - [ ] `ruby -c modules/exploits/unix/ftp/vsftpd_234_backdoor.rb` — confirms syntax (already run, passes).
2. - [ ] `use exploit/unix/ftp/vsftpd_234_backdoor; show targets` — confirm both targets are listed.
3. - [ ] `set TARGET 0; show payloads` — confirm `cmd/linux/*` fetch payloads are listed and `cmd/linux/http/x86/meterpreter_reverse_tcp` is the default.
4. - [ ] `set TARGET 1; show payloads` — confirm the list narrows to `cmd_interact`-type payloads and `cmd/unix/interact` is the default.
5. - [ ] Full run against Metasploitable 2 (or equivalent legacy target) on both targets, confirming Target 0 still gets a fetch-based meterpreter session and Target 1 gets a direct interactive shell.

## Test Evidence

`ruby -c` passes clean (see Verification Step 1). **Flagging a gap honestly:** I could not run `tools/dev/msftidy.rb` in this environment — it hard-requires the `rubocop` gem, which isn't installed here, and `bundle exec` also fails because the bundle isn't fully set up in this sandbox. I have not run this against a live FTP/vsftpd 2.3.4 target (e.g. Metasploitable 2) either — steps 2–5 above still need real console output from testing before this should be considered fully verified. Please run `rubocop -a` / `msftidy.rb` locally before merge.

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | *(fill in your dev OS)* |
| **Target Software/Hardware** | vsftpd 2.3.4 backdoor — *(fill in test target, e.g. Metasploitable 2 / Ubuntu 8.04)* |
| **Docker Image / Vagrant Setup** | *(fill in if used, otherwise remove this row)* |

## AI Usage Disclosure

Claude (Anthropic) was used to design and implement the dual-target fix requested in review: tracing the framework's `Compat` merge logic to confirm a per-target `Payload => Compat` override actually works as bwatters-r7 described, then restructuring the module's `Targets` block accordingly. This has been syntax-checked only (see Test Evidence) — it has **not** been run against a live target or through the project's full `msftidy`/rubocop lint due to environment limitations in this session.

## Pre-Submission Checklist

- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [ ] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes — n/a, no `lib/` changes here)_
- [ ] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)
- [ ] Ran `tools/dev/msftidy.rb` / `rubocop -a` locally and resolved all issues (not runnable in this session — see Test Evidence)
