### PR TITLE
Spike services command improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,3 +56,5 @@ group :test do
   # stub and set expectations on HTTP requests
   gem 'webmock', '~> 3.18'
 end
+
+gem 'rex-text', '0.2.65', git: 'https://github.com/sjanusz-r7/rex-text.git', branch: 'add-hierarchy-table'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,14 @@ GIT
       with_env (= 1.1.0)
       xml-simple (~> 1.1.9)
 
+GIT
+  remote: https://github.com/sjanusz-r7/rex-text.git
+  revision: 0b25056c56d0bea64207d7781364ef08db22313c
+  branch: add-hierarchy-table
+  specs:
+    rex-text (0.2.65)
+      bigdecimal
+
 PATH
   remote: .
   specs:
@@ -559,8 +567,6 @@ GEM
       rex-socket
       rex-text
     rex-struct2 (0.1.5)
-    rex-text (0.2.63)
-      bigdecimal
     rex-zip (0.1.6)
       rex-text
     rexml (3.4.1)
@@ -719,6 +725,7 @@ DEPENDENCIES
   pry-byebug
   rake
   redcarpet
+  rex-text (= 0.2.65)!
   rspec-rails
   rspec-rerun
   rubocop (= 1.75.7)

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -23,6 +23,19 @@ class Db
 
   DB_CONFIG_PATH = 'framework/database'
 
+  # The most characters of a service's info shown by `services --tree`. The tree is
+  # there to show the shape of the service hierarchy, and one long info, such as an
+  # rpcbind dump, is enough to push every column after it off screen. The whole
+  # value is still available from `services` without --tree.
+  SERVICE_TREE_INFO_MAX_CHARS = 40
+
+  # The connector sets `services --tree-style` accepts. Keep this sourced from
+  # HierarchyTable so new rex-text styles are available without Framework changes.
+  SERVICE_TREE_STYLES = Rex::Text::HierarchyTable.hierarchy_styles.map(&:to_s).freeze
+
+  # Source columns that `services --tree-group` promotes to hierarchy levels.
+  SERVICE_TREE_GROUP_COLUMNS = %w[host port proto].freeze
+
   #
   # The dispatcher's name.
   #
@@ -683,6 +696,8 @@ class Db
     case words[-1]
     when '-c', '--column'
       return @@services_columns
+    when '--tree-style'
+      return SERVICE_TREE_STYLES
     when '-O', '--order'
       return []
     when '-o', '--output'
@@ -697,7 +712,7 @@ class Db
   end
 
   def cmd_services_help
-    print_line "Usage: services [-h] [-u] [-a] [-r <proto>] [-p <port1,port2>] [-s <name1,name2>] [-o <filename>] [addr1 addr2 ...]"
+    print_line "Usage: services [-h] [-u] [-a] [-r <proto>] [-p <port1,port2>] [-s <name1,name2>] [-t] [-o <filename>] [addr1 addr2 ...]"
     print_line
     print @@services_opts.usage
     print_line
@@ -720,6 +735,13 @@ class Db
     [ '-O', '--order' ] => [ true, 'Order rows by specified column number.', '<column id>' ],
     [ '-R', '--rhosts' ] => [ false, 'Set RHOSTS from the results of the search.' ],
     [ '-S', '--search' ] => [ true, 'Search string to filter by.', '<filter>' ],
+    [ '-t', '--tree' ] => [ false, 'Nest each service underneath the service it runs on top of.' ],
+    [ '--tree-style' ] => [
+      true,
+      "Connectors --tree draws the hierarchy with. Defaults to #{Rex::Text::HierarchyTable::DEFAULT_HIERARCHY_STYLE}.",
+      "<#{SERVICE_TREE_STYLES.join('|')}>"
+    ],
+    [ '--tree-group' ] => [ false, 'Nest --tree output underneath host, port, and protocol rows instead of repeating them as columns.' ],
     [ '-h', '--help' ] => [ false, 'Show this help information.' ]
   )
 
@@ -845,6 +867,8 @@ class Db
     onlyup = false
     output_file = nil
     set_rhosts = false
+    tree_mode = nil
+    tree_style = Rex::Text::HierarchyTable::DEFAULT_HIERARCHY_STYLE
     col_search = ['port', 'proto', 'name', 'state', 'info']
     extra_columns = ['resource', 'parents']
 
@@ -916,6 +940,20 @@ class Db
       when '-S', '--search'
         search_term = val
         opts[:search_term] = search_term
+      when '-t', '--tree'
+        tree_mode ||= Rex::Text::HierarchyTable::MODE_TREE
+      when '--tree-style'
+        style = val.to_s.strip.downcase
+        unless SERVICE_TREE_STYLES.include?(style)
+          print_error("Invalid tree style. Possible values are (#{SERVICE_TREE_STYLES.join('|')})")
+          return
+        end
+        # A connector style only applies to hierarchy output, so it enables the
+        # default tree mode when no mode has been selected yet.
+        tree_mode ||= Rex::Text::HierarchyTable::MODE_TREE
+        tree_style = style.to_sym
+      when '--tree-group'
+        tree_mode = Rex::Text::HierarchyTable::MODE_GROUPED
       when '-h', '--help'
         cmd_services_help
         return
@@ -961,11 +999,61 @@ class Db
     if col_search
       col_names = col_search
     end
-    tbl = Rex::Text::Table.new({
-                                   'Header'    => "Services",
-                                   'Columns'   => extra_columns.empty? ? (['host'] + col_names) : (['host'] + col_names + extra_columns),
-                                   'SortIndex' => order_by
-                               })
+
+    if tree_mode && output_file
+      print_warning('Ignoring --tree, the tree connectors would not survive a round trip through a spreadsheet.')
+      tree_mode = nil
+    end
+
+    if tree_mode && order_by
+      print_warning('Ignoring --order, the tree output is ordered by the service hierarchy.')
+      order_by = nil
+    end
+
+    # Each service is nested underneath its parent, so a parents column would only
+    # restate the row above it.
+    display_columns = tree_mode ? extra_columns - ['parents'] : extra_columns
+
+    # Grouped output still stores complete service rows. HierarchyTable promotes
+    # these source columns to presentation-only levels when it renders the tree.
+    row_columns = if tree_mode == Rex::Text::HierarchyTable::MODE_GROUPED
+                    (SERVICE_TREE_GROUP_COLUMNS.drop(1) + ['name'] + col_names).uniq
+                  else
+                    col_names
+                  end
+    all_columns = ['host'] + row_columns + display_columns
+
+    # The name is the natural label to nest, but it is not always one of the
+    # selected columns, so fall back to whichever service column comes first.
+    if tree_mode == Rex::Text::HierarchyTable::MODE_TREE && !col_names.include?('name')
+      print_warning('The name column is hidden, so the hierarchy is drawn on the first visible service column.')
+    end
+    tree_column = if tree_mode == Rex::Text::HierarchyTable::MODE_GROUPED || col_names.include?('name')
+                    'name'
+                  else
+                    col_names.first || 'host'
+                  end
+
+    row_builder = lambda do |service|
+      _service_table_row(service, row_columns, display_columns, leading: [service.host.address])
+    end
+
+    tbl = if tree_mode
+            Rex::Text::HierarchyTable.new(
+              header: 'Services',
+              columns: all_columns,
+              hierarchy_column: tree_column,
+              hierarchy_style: tree_style,
+              max_chars: all_columns.include?('info') ? { 'info' => SERVICE_TREE_INFO_MAX_CHARS } : {},
+              group_columns: tree_mode == Rex::Text::HierarchyTable::MODE_GROUPED ? SERVICE_TREE_GROUP_COLUMNS : []
+            )
+          else
+            Rex::Text::Table.new(
+              'Header' => 'Services',
+              'Columns' => all_columns,
+              'SortIndex' => order_by
+            )
+          end
 
     # Sentinel value meaning all
     host_ranges.push(nil) if host_ranges.empty?
@@ -994,12 +1082,12 @@ class Db
           framework.db.update_service(service.as_json.symbolize_keys)
         end
 
-        columns = [host.address] + col_names.map { |n| service[n].to_s || "" }
-        unless extra_columns.empty?
-          columns << service.resource.to_json
-          columns << service.parents.map { |parent| "#{parent.name} (#{parent.port}/#{parent.proto})"}.join(', ')
+        fields = row_builder.call(service)
+        if tree_mode
+          tbl.add_row(fields, key: service.id, parent_keys: service.parents.map(&:id))
+        else
+          tbl << fields
         end
-        tbl << columns
         if set_rhosts
           addr = (host.scope.to_s != "" ? host.address + '%' + host.scope : host.address )
           rhosts << addr
@@ -1013,7 +1101,8 @@ class Db
     end
 
     if (output_file == nil)
-      print_line(tbl.to_s)
+      output = tree_mode ? tbl.render(mode: tree_mode) : tbl.to_s
+      print_line(output)
     else
       # create the output file
       ::File.open(output_file, "wb") { |f| f.write(tbl.to_csv) }
@@ -1026,6 +1115,30 @@ class Db
 
     print_status("Deleted #{delete_count} services") if delete_count > 0
 
+  end
+
+  # Builds one row of the services table.
+  #
+  # @param service [Mdm::Service] the service to render.
+  # @param col_names [Array<String>] the service columns to render.
+  # @param extra_columns [Array<String>] the derived columns to append.
+  # @param leading [Array<String>] the cells the row starts with.
+  # @return [Array<String>]
+  def _service_table_row(service, col_names, extra_columns, leading:)
+    columns = leading + col_names.map { |col_name| service[col_name].to_s }
+
+    extra_columns.each do |extra_column|
+      columns << case extra_column
+                 when 'resource'
+                   service.resource.to_json
+                 when 'parents'
+                   service.parents.map { |parent| "#{parent.name} (#{parent.port}/#{parent.proto})" }.join(', ')
+                 else
+                   ''
+                 end
+    end
+
+    columns
   end
 
   #

--- a/modules/auxiliary/scanner/discovery/udp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/udp_sweep.rb
@@ -72,6 +72,14 @@ class MetasploitModule < Msf::Auxiliary
     end
   end
 
+  def transport_parent(port, proto)
+    {
+      name: proto,
+      port: port,
+      proto: proto
+    }
+  end
+
   def scanner_postscan(_batch)
     @results.each_key do |k|
       next if !@results[k].respond_to?('keys')
@@ -83,7 +91,8 @@ class MetasploitModule < Msf::Auxiliary
         port: data[:port],
         proto: 'udp',
         name: data[:app],
-        info: data[:info]
+        info: data[:info],
+        parents: transport_parent(data[:port], 'udp')
       }
 
       if data[:hname]
@@ -111,11 +120,10 @@ class MetasploitModule < Msf::Auxiliary
     case sport
     when 5632
 
-      @results[hkey] ||= {}
-      data = @results[hkey]
-      data[:app] = 'pcAnywhere_stat'
-      data[:port] = sport
-      data[:host] = shost
+      result = (@results[hkey] ||= {})
+      result[:app] = 'pcAnywhere_stat'
+      result[:port] = sport
+      result[:host] = shost
 
       case data
 
@@ -124,8 +132,8 @@ class MetasploitModule < Msf::Auxiliary
         caps = ::Regexp.last_match(2).dup
         name = name.gsub(/_+$/, '').gsub("\x00", '').strip
         caps = caps.gsub(/_+$/, '').gsub("\x00", '').strip
-        data[:name] = name
-        data[:caps] = caps
+        result[:name] = name
+        result[:caps] = caps
 
       when /^ST(.+)/
         buff = ::Regexp.last_match(1).dup
@@ -139,21 +147,21 @@ class MetasploitModule < Msf::Auxiliary
           stat = 'Busy'
         end
 
-        data[:stat] = stat
+        result[:stat] = stat
       end
 
-      if data[:name]
-        inf << "Name: #{data[:name]} "
+      if result[:name]
+        inf << "Name: #{result[:name]} "
       end
 
-      if data[:stat]
-        inf << "- #{data[:stat]} "
+      if result[:stat]
+        inf << "- #{result[:stat]} "
       end
 
-      if data[:caps]
-        inf << "( #{data[:caps]} ) "
+      if result[:caps]
+        inf << "( #{result[:caps]} ) "
       end
-      data[:info] = inf
+      result[:info] = inf
     end
 
     # Ignore duplicates
@@ -237,14 +245,16 @@ class MetasploitModule < Msf::Auxiliary
       svc = []
       while (buf.length >= 20)
         rec = buf.slice!(0, 20).unpack('N5')
-        svc << "#{rec[1]} v#{rec[2]} #{rec[3] == 0x06 ? 'TCP' : 'UDP'}(#{rec[4]})"
+        proto = rec[3] == 0x06 ? 'tcp' : 'udp'
+        svc << "#{rec[1]} v#{rec[2]} #{proto.upcase}(#{rec[4]})"
         report_service(
           host: shost,
           port: rec[4],
-          proto: (rec[3] == 0x06 ? 'tcp' : 'udp'),
+          proto: proto,
           name: 'sunrpc',
           info: "#{rec[1]} v#{rec[2]}",
-          state: 'open'
+          state: 'open',
+          parents: transport_parent(rec[4], proto)
         )
       end
       inf = svc.join(', ')
@@ -330,6 +340,16 @@ class MetasploitModule < Msf::Auxiliary
 
     end
 
+    parents = transport_parent(sport, 'udp')
+    if app == 'Portmap'
+      parents = {
+        name: 'sunrpc',
+        port: sport,
+        proto: 'udp',
+        parents: parents
+      }
+    end
+
     report_service(
       host: shost,
       mac: (maddr && (maddr != '00:00:00:00:00:00')) ? maddr : nil,
@@ -338,7 +358,8 @@ class MetasploitModule < Msf::Auxiliary
       proto: 'udp',
       name: app,
       info: inf,
-      state: 'open'
+      state: 'open',
+      parents: parents
     )
 
     print_status("Discovered #{app} on #{shost}:#{sport} (#{inf})")

--- a/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/console/command_dispatcher/db_spec.rb
@@ -253,29 +253,161 @@ RSpec.describe Msf::Ui::Console::CommandDispatcher::Db do
       ensure
         RSpec::Expectations.configuration.max_formatted_output_length = orig
       end
+
+      describe "-t" do
+        it "nests each service underneath the service it runs on top of" do
+          db.cmd_services "-t"
+          expect(@output.join("\n")).to match_table <<~'TABLE'
+            Services
+            ========
+
+            host         port  proto  name            state  info  resource
+            ----         ----  -----  ----            -----  ----  --------
+            192.168.0.1  1024  udp    service3        open         {"base_url":"/service3"}
+            192.168.0.1  1024  udp    \- service2     open         {"base_url":"/service2"}
+            192.168.0.1  1024  udp       \- service1  open         {"base_url":"/service1"}
+          TABLE
+        end
+
+        it "drops the parents column, which would only restate the row above" do
+          db.cmd_services "-t"
+
+          expect(@output.join("\n")).to_not include 'parents'
+        end
+
+        it "warns and falls back to a flat table when writing to a file" do
+          output_file = ::Tempfile.new('services')
+
+          begin
+            db.cmd_services "-t", "-o", output_file.path
+
+            expect(@error.join("\n")).to include 'Ignoring --tree'
+            expect(::File.read(output_file.path)).to include 'parents'
+          ensure
+            output_file.close
+            output_file.unlink
+          end
+        end
+
+        it "warns that --order is ignored" do
+          db.cmd_services "-t", "-O", "2"
+
+          expect(@error.join("\n")).to include 'Ignoring --order'
+        end
+
+        it "warns when the name column is hidden" do
+          db.cmd_services "-t", "-c", "port,state"
+
+          expect(@error.join("\n")).to include 'the hierarchy is drawn on the first visible service column'
+        end
+
+        describe "--tree-style" do
+          it "draws the hierarchy with box drawing characters when asked for unicode" do
+            db.cmd_services "--tree-style", "unicode"
+
+            expect(@output.join("\n")).to match_table <<~TABLE
+              Services
+              ========
+
+              host         port  proto  name            state  info  resource
+              ----         ----  -----  ----            -----  ----  --------
+              192.168.0.1  1024  udp    service3        open         {"base_url":"/service3"}
+              192.168.0.1  1024  udp    \u2514\u2500 service2     open         {"base_url":"/service2"}
+              192.168.0.1  1024  udp       \u2514\u2500 service1  open         {"base_url":"/service1"}
+            TABLE
+          end
+
+          it "turns the tree on by itself, since it means nothing otherwise" do
+            db.cmd_services "--tree-style", "ascii"
+
+            expect(@output.join("\n")).to include '\\- service2'
+          end
+
+          it "rejects an unknown style without printing a table" do
+            db.cmd_services "--tree-style", "emoji"
+
+            expect(@error.join("\n")).to include 'Invalid tree style'
+            expect(@output.to_a.join("\n")).to_not include 'Services'
+          end
+        end
+
+        describe "--tree-group" do
+          it "nests the services underneath host, port, and protocol rows" do
+            db.cmd_services "--tree-group"
+
+            expect(@output.join("\n")).to match_table <<~'TABLE'
+              Services
+              ========
+
+              host / port / proto / name  state  info  resource
+              --------------------------  -----  ----  --------
+              192.168.0.1
+              \- 1024
+                 \- udp
+                    \- service3           open         {"base_url":"/service3"}
+                       \- service2        open         {"base_url":"/service2"}
+                          \- service1     open         {"base_url":"/service1"}
+            TABLE
+          end
+        end
+
+        context "with two services running on top of the same service" do
+          before(:example) do
+            parent = {
+              host: '192.168.0.2',
+              port: 8000,
+              name: 'http',
+              proto: 'tcp',
+              resource: { base_url: '/' }
+            }
+
+            framework.db.report_service(parent)
+            framework.db.report_service(parent.merge(name: 'jenkins', resource: { base_url: '/jenkins' }, parents: parent))
+            framework.db.report_service(parent.merge(name: 'robots.txt', resource: { base_url: '/robots.txt' }, parents: parent))
+          end
+
+          it "marks the last sibling apart from the ones with siblings below them" do
+            db.cmd_services "-t", "192.168.0.2"
+
+            expect(@output.join("\n")).to match_table <<~'TABLE'
+              Services
+              ========
+
+              host         port  proto  name           state  info  resource
+              ----         ----  -----  ----           -----  ----  --------
+              192.168.0.2  8000  tcp    http           open         {"base_url":"/"}
+              192.168.0.2  8000  tcp    +- jenkins     open         {"base_url":"/jenkins"}
+              192.168.0.2  8000  tcp    \- robots.txt  open         {"base_url":"/robots.txt"}
+            TABLE
+          end
+        end
+      end
     end
 
     describe "-h" do
       it "should show a help message" do
         db.cmd_services "-h"
         expect(@output).to match_array [
-          "Usage: services [-h] [-u] [-a] [-r <proto>] [-p <port1,port2>] [-s <name1,name2>] [-o <filename>] [addr1 addr2 ...]",
+          "Usage: services [-h] [-u] [-a] [-r <proto>] [-p <port1,port2>] [-s <name1,name2>] [-t] [-o <filename>] [addr1 addr2 ...]",
           "",
           "OPTIONS:",
           "",
-          "    -a, --add                  Add the services instead of searching.",
-          "    -c, --column <col1,col2>   Only show the given columns.",
-          "    -d, --delete               Delete the services instead of searching.",
-          "    -h, --help                 Show this help information.",
-          "    -O, --order <column id>    Order rows by specified column number.",
-          "    -o, --output <filename>    Send output to a file in csv format.",
-          "    -p, --port <ports>         Search for a list of ports.",
-          "    -r, --protocol <protocol>  Protocol type of the service being added [tcp|udp].",
-          "    -R, --rhosts               Set RHOSTS from the results of the search.",
-          "    -s, --name <name>          Name of the service to add.",
-          "    -S, --search <filter>      Search string to filter by.",
-          "    -u, --up                   Only show services which are up.",
-          "    -U, --update               Update data for existing service.",
+          "    --tree-group                  Nest --tree output underneath host, port, and protocol rows instead of repeating them as columns.",
+          "    --tree-style <ascii|unicode>  Connectors --tree draws the hierarchy with. Defaults to ascii.",
+          "    -a, --add                     Add the services instead of searching.",
+          "    -c, --column <col1,col2>      Only show the given columns.",
+          "    -d, --delete                  Delete the services instead of searching.",
+          "    -h, --help                    Show this help information.",
+          "    -O, --order <column id>       Order rows by specified column number.",
+          "    -o, --output <filename>       Send output to a file in csv format.",
+          "    -p, --port <ports>            Search for a list of ports.",
+          "    -r, --protocol <protocol>     Protocol type of the service being added [tcp|udp].",
+          "    -R, --rhosts                  Set RHOSTS from the results of the search.",
+          "    -s, --name <name>             Name of the service to add.",
+          "    -S, --search <filter>         Search string to filter by.",
+          "    -t, --tree                    Nest each service underneath the service it runs on top of.",
+          "    -u, --up                      Only show services which are up.",
+          "    -U, --update                  Update data for existing service.",
           "Available columns: created_at, info, name, port, proto, state, updated_at"
         ]
       end


### PR DESCRIPTION
## Description

This PR pulls in a custom rex-text branch, which adds a Hierarchy Table class.

This PR spikes out a new way (actually, two ways) to show the registered service hierarchy as part of the `services` command.
This PR also addressed some shortcomings of the udp_sweep module, whereby it did not register the service hierarchies at all. I used this for testing locally, but can extract this piece of work to a different PR.

The tree view itself is based on Windows's `tree` utility, which also features unicode/ASCII flags.

As a team, we should decide if we want to:
- Keep ASCII and Unicode, or remove one of them
- Keep tree and group mode, or remove one of them

## Breaking Changes

None

## Reviewer Notes

I tested this PR using the `udp_sweep` module against a metasploitable 2 VM.

## Verification Steps

1. - [ ] Check out the PR
2. - [ ] `bundle`
3. - [ ] `bundle exec msfconsole -q`
4. - [ ] `use udp_sweep`
5. - [ ] `run rhost=metasploitable2_vm_ip`
6. - [ ] `services`
7. - [ ] `services -t` <- ASCII tree view
8. - [ ] `services -t --tree-style unicode` <- Unicode tree view
9. - [ ] `services -t --tree-group` <- ASCII group view
10. - [ ] `services -t --tree-group --tree-style unicode` <- Unicode group view
11. Confirm CI passes

## Test Evidence

Example ASCII output (tree view):
```
Services
========

host             port   proto  name           state  info                                      resource
----             ----   -----  ----           -----  ----                                      --------
192.168.0.1      53     udp    udp            open                                             {}
192.168.0.1      53     udp    \- dns         open   BIND 9.4.2                                {}
192.168.0.1      111    tcp    tcp            open                                             {}
192.168.0.1      111    tcp    \- sunrpc      open   100000 v2                                 {}
192.168.0.1      111    udp    udp            open                                             {}
192.168.0.1      111    udp    \- sunrpc      open                                             {}
192.168.0.1      111    udp       \- portmap  open   100000 v2 TCP(111), 100000 v2 UDP(111...  {}
```

Example Unicode output (group view):
```
Services
========

host / port / proto / name  state  info                                      resource
--------------------------  -----  ----                                      --------
192.168.0.1
├─ 53
│  └─ udp                   open                                             {}
│     └─ dns                open   BIND 9.4.2                                {}
├─ 111
│  ├─ tcp                   open                                             {}
│  │  └─ sunrpc             open   100000 v2                                 {}
│  └─ udp                   open                                             {}
│     └─ sunrpc             open                                             {}
│        └─ portmap         open   100000 v2 TCP(111), 100000 v2 UDP(111...  {}
├─ 137
│  └─ udp                   open                                             {}
│     └─ netbios            open   METASPLOITABLE:<00>:U :METASPLOITABLE...  {}
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | MacOS |
| **Target Software/Hardware** | Metasploitable 2 VM |

## AI Usage Disclosure

I used GPT 5.6 and Claude Opus for this PR using Kiro.

## Pre-Submission Checklist

- [ ] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [ ] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [ ] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [ ] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)