### PR TITLE
Fix negated auxiliary shorthand in module search

### DIFF
--- a/lib/msf/core/modules/metadata/search.rb
+++ b/lib/msf/core/modules/metadata/search.rb
@@ -94,17 +94,20 @@ module Msf::Modules::Metadata::Search
       keyword.downcase!
       search_term.downcase!
 
-      if keyword == "type"
-        search_term = MODULE_TYPE_SHORTHANDS[search_term] if MODULE_TYPE_SHORTHANDS.key?(search_term)
+      res[keyword] ||= [[], []]
+      mode = SearchMode::INCLUDE
+      if search_term.start_with?('-')
+        next if search_term.length == 1
+
+        search_term = search_term[1..]
+        mode = SearchMode::EXCLUDE
       end
 
-      res[keyword] ||=[   [],    []   ]
-      if search_term[0,1] == "-"
-        next if search_term.length == 1
-        res[keyword][SearchMode::EXCLUDE] << search_term[1,search_term.length-1]
-      else
-        res[keyword][SearchMode::INCLUDE] << search_term
+      if keyword == 'type' && MODULE_TYPE_SHORTHANDS.key?(search_term)
+        search_term = MODULE_TYPE_SHORTHANDS[search_term]
       end
+
+      res[keyword][mode] << search_term
     end
     res
   end

--- a/spec/lib/msf/core/modules/metadata/search_spec.rb
+++ b/spec/lib/msf/core/modules/metadata/search_spec.rb
@@ -38,6 +38,10 @@ RSpec.describe Msf::Modules::Metadata::Search do
     it { expect(described_class.parse_search_string("postgres login")).to eq({"text"=>[["postgres", "login"], []]}) }
     it { expect(described_class.parse_search_string("platform:android")).to eq({"platform"=>[["android"], []]}) }
     it { expect(described_class.parse_search_string("platform:-android")).to eq({"platform"=>[[], ["android"]]}) }
+    it { expect(described_class.parse_search_string('type:aux')).to eq('type' => [['auxiliary'], []]) }
+    it { expect(described_class.parse_search_string('type:-aux')).to eq('type' => [[], ['auxiliary']]) }
+    it { expect(described_class.parse_search_string('TYPE:-AUX')).to eq('type' => [[], ['auxiliary']]) }
+    it { expect(described_class.parse_search_string('type:-')).to eq('type' => [[], []]) }
     it { expect(described_class.parse_search_string("author:egypt arch:x64")).to eq({"author"=>[["egypt"], []], "arch"=>[["x64"], []]}) }
     it { expect(described_class.parse_search_string("  author:egypt   arch:x64  ")).to eq({"author"=>[["egypt"], []], "arch"=>[["x64"], []]}) }
     it { expect(described_class.parse_search_string("postgres:")).to eq({"text"=>[["postgres"], []]}) }
@@ -395,6 +399,24 @@ RSpec.describe Msf::Modules::Metadata::Search do
     end
 
     context 'when filtering by module #type' do
+      context 'when using the auxiliary shorthand' do
+        let(:opts) { { 'type' => Msf::MODULE_AUX } }
+
+        it_should_behave_like 'search_filter', accept: ['type:aux']
+
+        it 'returns no results when the included type is also excluded by its shorthand' do
+          params = described_class.parse_search_string('type:auxiliary type:-aux')
+
+          expect(subject.find(params)).to be_empty
+        end
+      end
+
+      context 'when excluding auxiliary modules from other module types' do
+        let(:opts) { { 'type' => Msf::MODULE_EXPLOIT } }
+
+        it_should_behave_like 'search_filter', reject: ['type:aux']
+      end
+
       all_module_types = Msf::MODULE_TYPES
       all_module_types.each do |mtype|
         context "on a #{mtype} module" do


### PR DESCRIPTION
## Description

`search type:-aux` silently keeps auxiliary modules in its results, while the equivalent `type:-auxiliary` correctly excludes them. Shorthand expansion currently happens before the leading `-` is removed, so `-aux` never matches the `aux` alias.

Determine the search mode and strip the exclusion prefix before expanding module-type shorthands. Add regression coverage for positive/negative shorthand, uppercase input, a lone `-`, contradictory include/exclude filters, and preserving other module types.

## Breaking Changes

None.

## Verification Steps

1. Start `msfconsole`.
2. Run `search fullname:auxiliary/scanner/ssh/ssh_version type:aux` and verify the SSH Version Scanner is returned.
3. Run `search fullname:auxiliary/scanner/ssh/ssh_version type:auxiliary type:-auxiliary` and verify there are no results.
4. Run `search fullname:auxiliary/scanner/ssh/ssh_version type:auxiliary type:-aux` and verify there are also no results. Before this fix, the scanner is incorrectly returned.
5. Run `bundle exec rspec spec/lib/msf/core/modules/metadata/search_spec.rb` in a configured development environment.

## Test Evidence

- Regression examples failed with the original parser and passed after the fix.
- The complete search spec ran in the repository's `SPEC_HELPER_LOAD_METASPLOIT=false` mode, explicitly loading the real ActiveSupport, constants, platform and metadata classes: **387 examples, 0 failures, 8 existing pending examples**. The full database-backed suite was not run.
- RuboCop 1.75.7: no findings on added lines and no increased offense counts by cop. Existing legacy offenses remain (library: 92 to 79; spec: 266 to 266).
- Console smoke test on Framework 6.5.3-dev: loaded the changed search file into the running process through a resource script, then repeated the queries. No installed source files were modified.

Console result before loading the fix:

```text
msf > search fullname:auxiliary/scanner/ssh/ssh_version type:auxiliary type:-aux

   0  auxiliary/scanner/ssh/ssh_version  .  normal  No  SSH Version Scanner
```

After loading the fix:

```text
msf > search fullname:auxiliary/scanner/ssh/ssh_version type:auxiliary type:-aux
[-] No results from search
msf > search fullname:auxiliary/scanner/ssh/ssh_version type:auxiliary type:-auxiliary
[-] No results from search
```

## Environment

Ubuntu 26.04 on WSL2; Ruby 3.4.4; RSpec 3.13; Metasploit Framework 6.5.3-dev for the console smoke test. The changed library and spec are based on current `master` (`166881deff7072c859d4c04466cafb4c59e6c66f`).

## AI Usage Disclosure

AI assisted with investigation, the code change, regression tests, and this description. The original console behavior was also manually reproduced in WSL.

## Pre-Submission Checklist

- [x] No sensitive information in code or documentation
- [x] Tested in the environment above
- [x] Included RSpec tests for the library change
- [x] Read CONTRIBUTING.md
