### PR TITLE
Fix exists? -> directory? check in Linux persistence modules

### DIFF
--- a/modules/exploits/example_linux_persistence.rb
+++ b/modules/exploits/example_linux_persistence.rb
@@ -92,7 +92,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # Check a example app is installed
     print_warning('Payloads in /tmp will only last until reboot, you may want to choose elsewhere.') if writable_dir.start_with?('/tmp')
-    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless directory?(writable_dir)
     return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
     return CheckCode::Safe('example app is required') unless command_exists?('example')
 

--- a/modules/exploits/linux/persistence/apt_package_manager.rb
+++ b/modules/exploits/linux/persistence/apt_package_manager.rb
@@ -72,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Local
     return CheckCode::Safe("#{datastore['HOOKPATH']} not writable") unless writable?(datastore['HOOKPATH'])
 
     print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if writable_dir.start_with?('/tmp')
-    return CheckCode::Safe("#{writable_dir} not found") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} not found") unless directory?(writable_dir)
     return CheckCode::Safe("#{writable_dir} not writable") unless writable?(writable_dir)
 
     CheckCode::Appears("#{datastore['HOOKPATH']} and #{writable_dir} are writable, also found apt-get.")

--- a/modules/exploits/linux/persistence/docker_image.rb
+++ b/modules/exploits/linux/persistence/docker_image.rb
@@ -67,7 +67,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     # we don't need this check since the payload is in the docker image
     # print_warning('Payloads in /tmp will only last until reboot, you may want to choose elsewhere.') if writable_dir.start_with?('/tmp')
-    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless directory?(writable_dir)
     return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
     return CheckCode::Safe('docker is required') unless command_exists?('docker')
 

--- a/modules/exploits/linux/persistence/init_openrc.rb
+++ b/modules/exploits/linux/persistence/init_openrc.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if writable_dir.start_with?('/tmp')
-    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless directory?(writable_dir)
     return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
     return CheckCode::Safe('/etc/init.d/ doesnt exist') unless exists?('/etc/init.d/')
     return CheckCode::Safe('/etc/init.d/ isnt writable') unless writable?('/etc/init.d/')

--- a/modules/exploits/linux/persistence/init_systemd.rb
+++ b/modules/exploits/linux/persistence/init_systemd.rb
@@ -90,7 +90,7 @@ class MetasploitModule < Msf::Exploit::Local
   def check
     print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if writable_dir.start_with?('/tmp')
     print_warning('User doesnt have root permissions, yet target set to systemd, likely need to change target to systemd user.') if target.name == 'systemd' && !is_root?
-    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless directory?(writable_dir)
     return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
     return CheckCode::Safe('Likely not a systemd based system') unless command_exists?('systemctl')
 

--- a/modules/exploits/linux/persistence/udev.rb
+++ b/modules/exploits/linux/persistence/udev.rb
@@ -69,7 +69,7 @@ class MetasploitModule < Msf::Exploit::Local
 
   def check
     print_warning('Payloads in /tmp will only last until reboot, you want to choose elsewhere.') if writable_dir.start_with?('/tmp')
-    return CheckCode::Safe("#{writable_dir} doesnt exist") unless exists?(writable_dir)
+    return CheckCode::Safe("#{writable_dir} doesnt exist") unless directory?(writable_dir)
     return CheckCode::Safe("#{writable_dir} isnt writable") unless writable?(writable_dir)
     return CheckCode::Safe("#{datastore['UDEV_PATH']} doesnt exist") unless exists?(datastore['UDEV_PATH'])
     return CheckCode::Safe("#{datastore['UDEV_PATH']} isnt writable") unless writable?(datastore['UDEV_PATH'])

--- a/modules/exploits/linux/persistence/yum_package_manager.rb
+++ b/modules/exploits/linux/persistence/yum_package_manager.rb
@@ -75,7 +75,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    return CheckCode::Safe("#{datastore['WritableDir']} does not exist") unless exists? datastore['WritableDir']
+    return CheckCode::Safe("#{datastore['WritableDir']} does not exist") unless directory? datastore['WritableDir']
     return CheckCode::Safe("#{datastore['WritableDir']} not writable") unless writable? datastore['WritableDir']
 
     # checks /usr/lib/yum-plugins/PLUGIN.py exists and is writeable

--- a/modules/exploits/multi/persistence/at.rb
+++ b/modules/exploits/multi/persistence/at.rb
@@ -66,7 +66,7 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def check
-    return CheckCode::Safe("#{datastore['WritableDir']} does not exist") unless exists? datastore['WritableDir']
+    return CheckCode::Safe("#{datastore['WritableDir']} does not exist") unless directory? datastore['WritableDir']
     return CheckCode::Safe("#{datastore['WritableDir']} not writable") unless writable? datastore['WritableDir']
 
     return CheckCode::Safe('at(1) not found on system') unless command_exists? 'at'


### PR DESCRIPTION
## Description

`exists?` is a file-existence check — it returns `true` for any filesystem
object at a given path (file, symlink, or directory). Several Linux/multi
persistence modules use it to validate `WritableDir`, which should
specifically be a **directory**. This meant a plain file at that path would
incorrectly pass the check.

This PR replaces `exists?(writable_dir)` with `directory?(writable_dir)` in
the following modules:

- `modules/exploits/example_linux_persistence.rb`
- `modules/exploits/linux/persistence/apt_package_manager.rb`
- `modules/exploits/linux/persistence/docker_image.rb`
- `modules/exploits/linux/persistence/init_openrc.rb`
- `modules/exploits/linux/persistence/init_systemd.rb`
- `modules/exploits/linux/persistence/udev.rb`
- `modules/exploits/linux/persistence/yum_package_manager.rb`
- `modules/exploits/multi/persistence/at.rb`

This is the Linux/multi portion of #21833, split by OS per discussion in
the issue. A separate PR for the Windows modules is being handled by
another contributor.

## Verification

- `msftidy` — clean, no warnings on any of the 8 files
- `rubocop` — 8 files inspected, no offenses detected
- Modules load cleanly in `msfconsole` with no errors

### Functional testing (Metasploitable2 VM, SSH session)

Tested against `docker_image.rb` and `init_systemd.rb`, both of which hit
the fixed line early in `check`:

**Real directory exists (`mkdir -p /tmp/testdir`):**

check
[*] The target is not exploitable. docker is required

✅ Correctly passes the `directory?` check and proceeds to the next check.

**File exists instead of a directory (the bug scenario) (`touch /tmp/testdir`):**

check
[*] The target is not exploitable. /tmp/testdir doesnt exist

✅ `directory?` correctly rejects the file. Before this fix, `exists?` would
have wrongly let this pass.

**Nothing exists at the path (`rm -f /tmp/testdir`):**

check
[*] The target is not exploitable. /tmp/testdir doesnt exist

✅ Unchanged behavior — no regression.

Fixes #21833 (Linux portion)