### PR TITLE
Implement retry logic in meterpreter tests

### DIFF
--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -121,8 +121,8 @@ jobs:
           php-version: ${{ matrix.meterpreter.runtime_version }}
           tools: none
 
-      - name: Use setup-php@2.37.0 to install PHP for non-Windows runners
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f
+      - name: Use setup-php@2.37.2 to install PHP for non-Windows runners
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         if: ${{ matrix.meterpreter.name == 'php' && runner.os != 'Windows' }}
         with:
           php-version: ${{ matrix.meterpreter.runtime_version }}

--- a/.github/workflows/shared_meterpreter_acceptance.yml
+++ b/.github/workflows/shared_meterpreter_acceptance.yml
@@ -121,12 +121,51 @@ jobs:
           php-version: ${{ matrix.meterpreter.runtime_version }}
           tools: none
 
-      - name: Use setup-php@2.37.2 to install PHP for non-Windows runners
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
+      - name: (DIAG) Pre-setup environment snapshot
+        if: ${{ matrix.meterpreter.name == 'php' && runner.os == 'macOS' }}
+        run: |
+          set -x
+          sw_vers; uname -a; arch
+          echo "PATH=$PATH"
+          which brew php || true
+          brew --version || true
+          brew config || true
+          brew tap || true
+          brew doctor || true
+          echo "--- network reachability (setup-php's brew sources) ---"
+          curl -sS -m 20 -o /dev/null -w '%{http_code} %{time_total}s formulae.brew.sh\n' https://formulae.brew.sh/ || true
+          curl -sS -m 20 -o /dev/null -w '%{http_code} %{time_total}s ghcr.io\n' https://ghcr.io/ || true
+
+      # TEMP DEBUG: verbose tag to capture the internal failure point of the macos-15-intel PHP setup hang.
+      # Restore the SHA pin once diagnosed: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 (2.37.2)
+      - name: Use setup-php@verbose to install PHP for non-Windows runners
+        id: setup_php_nonwin
+        continue-on-error: true
+        uses: shivammathur/setup-php@verbose
         if: ${{ matrix.meterpreter.name == 'php' && runner.os != 'Windows' }}
         with:
           php-version: ${{ matrix.meterpreter.runtime_version }}
           tools: none
+
+      - name: (DIAG) Post-setup diagnostics
+        if: ${{ always() && matrix.meterpreter.name == 'php' && runner.os == 'macOS' }}
+        run: |
+          set -x
+          which php || true; php -v || true
+          brew list --versions | grep -i php || true
+          ls -la "$(brew --prefix)/opt" 2>/dev/null | grep -i php || true
+          echo "--- setup-php cache / logs ---"
+          ls -la "$RUNNER_TOOL_CACHE" 2>/dev/null || true
+          cat /Users/runner/work/_temp/setup-php*.log 2>/dev/null || echo "no setup-php temp log"
+          echo "--- recent brew logs ---"
+          ls -lat ~/Library/Logs/Homebrew 2>/dev/null | head || true
+          tail -n 200 ~/Library/Logs/Homebrew/*/[0-9]* 2>/dev/null || true
+
+      - name: (DIAG) Fail if PHP setup failed
+        if: ${{ always() && steps.setup_php_nonwin.outcome == 'failure' }}
+        run: |
+          echo "PHP setup failed — see verbose + post-mortem above"
+          exit 1
 
       - name: Set up Python
         if: ${{ matrix.meterpreter.name == 'python' }}

--- a/spec/acceptance/meterpreter_spec.rb
+++ b/spec/acceptance/meterpreter_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe 'Meterpreter' do
 
   allure_test_environment = AllureRspec.configuration.environment_properties
 
+  # Maximum attempts for a single module-test run before a transient session
+  # timeout is treated as terminal. 2 = one retry: a wedged transport rarely
+  # recovers, so we keep this small to bound added run time (worst case one extra
+  # `recvuntil` window per affected test, only on the rare transient path — the
+  # common green path runs exactly once and adds nothing).
+  MODULE_TEST_MAX_ATTEMPTS = 2
+
   let_it_be(:current_platform) { Acceptance::Session::current_platform }
 
   # @!attribute [r] port_allocator
@@ -105,6 +112,13 @@ RSpec.describe 'Meterpreter' do
           end
 
           let(:executed_payload) do
+            run_payload_process
+          end
+
+          # Spawns a fresh payload process each time it is called (unlike the
+          # memoized `executed_payload` let). The retry loop needs a NEW process per
+          # attempt, so `establish_session!` runs this directly rather than the let.
+          def run_payload_process
             file = File.open(payload_stdout_and_stderr_file.path, 'w')
             driver.run_payload(
               payload,
@@ -118,6 +132,17 @@ RSpec.describe 'Meterpreter' do
           # The shared payload process and session instance that will be reused across the test run
           #
           let(:payload_process_and_session_id) do
+            establish_session!
+          end
+
+          # Establishes a fresh payload + Meterpreter session on the shared console
+          # and returns [payload_process, session_id]. Unlike the memoized
+          # `payload_process_and_session_id` let, this can be called more than once
+          # per example — the transient-timeout retry loop calls it to obtain a NEW
+          # session on each attempt, since a wedged transport never recovers on the
+          # same session. Callers are responsible for tearing down any prior
+          # session/process before re-establishing (see `close_payload_process`).
+          def establish_session!
             console.sendline "use #{payload.name}"
             console.recvuntil(Acceptance::Console.prompt)
 
@@ -137,7 +162,7 @@ RSpec.describe 'Meterpreter' do
 
             console.sendline payload.handler_command(default_module_datastore: default_module_datastore)
             console.recvuntil(/Started (?:reverse TCP|HTTPS? reverse) handler[^\n]*\n/)
-            payload_process = executed_payload
+            payload_process = run_payload_process
             session_id = nil
 
             # Wait for the session to open, or break early if the payload is detected as dead
@@ -159,6 +184,17 @@ RSpec.describe 'Meterpreter' do
             end
 
             [payload_process, session_id]
+          end
+
+          # Best-effort teardown of a payload process between retry attempts, so a
+          # retry does not leak the prior (wedged) session's process. Swallows
+          # errors — the process may already be dead, which is fine.
+          def close_payload_process(payload_process)
+            return if payload_process.blank?
+
+            payload_process.close if payload_process.alive?
+          rescue StandardError
+            # noop — teardown is best-effort; a dead/unresponsive process is expected here
           end
 
           # @param [String] path The file path to read the content of
@@ -383,20 +419,45 @@ RSpec.describe 'Meterpreter' do
                     end)
 
                     use_module = "use #{module_test[:name]}"
-                    run_module = "run session=#{session_id} AddEntropy=true Verbose=true"
-
                     replication_commands << use_module
-                    console.sendline(use_module)
-                    console.recvuntil(Acceptance::Console.prompt)
 
-                    replication_commands << run_module
-                    console.sendline(run_module)
+                    # Run the module test, retrying on a transient session-transport timeout.
+                    #
+                    # Transient-timeout retry (see CI history 2026-08): a stalled session transport
+                    # makes every command raise `Rex::TimeoutError: Send timed out` and the module is
+                    # aborted with `Post interrupted by the console user`. That is environmental, not a
+                    # real assertion failure. A wedged transport never recovers on the SAME session, so
+                    # each retry tears down the dead session/process and establishes a FRESH one before
+                    # re-running (up to MODULE_TEST_MAX_ATTEMPTS). We do NOT lengthen any timeout — the
+                    # recovery is a new session, not a longer wait. A run that produced any genuine
+                    # failure line (`[-] ... FAILED:`, prefixed with the test name) is never retried.
+                    module_test_attempt = 0
+                    test_result = ''
+                    loop do
+                      module_test_attempt += 1
 
-                    # XXX: When debugging failed tests, you can enter into an interactive msfconsole prompt with:
-                    # console.interact
+                      run_module = "run session=#{session_id} AddEntropy=true Verbose=true"
+                      replication_commands << run_module
 
-                    # Expect the test module to complete
-                    test_result = console.recvuntil('Post module execution completed')
+                      console.sendline(use_module)
+                      console.recvuntil(Acceptance::Console.prompt)
+
+                      # XXX: When debugging failed tests, you can enter into an interactive msfconsole prompt with:
+                      # console.interact
+
+                      console.sendline(run_module)
+                      test_result = console.recvuntil('Post module execution completed')
+
+                      break unless Acceptance::Session.retryable_transient_failure?(test_result)
+                      break if module_test_attempt >= MODULE_TEST_MAX_ATTEMPTS
+
+                      # Transient session stall — tear down the wedged session/process and
+                      # re-establish a fresh one before the next attempt so we do not leak it.
+                      warn("[transient-retry] #{module_test[:name]} attempt #{module_test_attempt} hit a transient session timeout; establishing a fresh session and retrying")
+                      close_payload_process(payload_process)
+                      console.reset
+                      payload_process, session_id = establish_session!
+                    end
 
                     # Ensure there are no failures, and assert tests are complete
                     aggregate_failures("#{payload_config[:name].inspect} payload and passes the #{module_test[:name].inspect} tests") do

--- a/spec/support/acceptance/session.rb
+++ b/spec/support/acceptance/session.rb
@@ -116,4 +116,52 @@ module Acceptance::Session
       value
     end
   end
+
+  # Output signatures produced when a live session's transport stalls mid-run
+  # (the send never gets a response and the post module is aborted) rather than
+  # when an assertion genuinely fails. These are transient/environmental — a
+  # fresh session on retry typically succeeds — so a run whose ONLY errors match
+  # these is eligible to be re-run instead of failed.
+  # Rex::TimeoutError originates at lib/rex/post/meterpreter/packet_dispatcher.rb.
+  TRANSIENT_SESSION_ERROR_SIGNATURES = [
+    'Rex::TimeoutError: Send timed out',
+    'Post interrupted by the console user'
+  ].freeze
+
+  # A genuine test failure, as emitted by the post/test modules
+  # (test/lib/module_test.rb): every failing assertion calls
+  # `print_error("FAILED: #{msg}")` inside an `it` block, so the line is emitted
+  # WITH the current test-name prefix ("[-] [test name] FAILED: ...") — a plain
+  # '[-] FAILED' substring would miss it. Match the '[-]' error glyph followed by
+  # the 'FAILED:' token allowing any prefix between them, so both the prefixed and
+  # the bare forms are caught. If any of these appear alongside the transient
+  # signatures, the run is NOT a clean transient — it must fail, never be retried.
+  GENUINE_FAILURE_SIGNATURES = [
+    /^\[-\].*FAILED:/
+  ].freeze
+
+  # @param [String] text A line, or block of console output, from a module test run
+  # @return [TrueClass, FalseClass] True if the text contains a known transient
+  #   session-transport timeout signature, false otherwise.
+  def self.transient_session_error?(text)
+    TRANSIENT_SESSION_ERROR_SIGNATURES.any? { |sig| text.to_s.include?(sig) }
+  end
+
+  # Classifies a completed module-test run for retry eligibility. A run is only
+  # retryable when it exhibited a transient session error AND produced no genuine
+  # failure line — i.e. the transport stalled, it was not a real assertion failure.
+  #
+  # @param [String] test_result The full captured console output of the run
+  # @return [TrueClass, FalseClass] True if the run may be retried on a fresh session.
+  def self.retryable_transient_failure?(test_result)
+    text = test_result.to_s
+    # Match per line: the '[-] ... FAILED:' signature is line-anchored, and a
+    # genuine failure on any line disqualifies the whole run from retry.
+    genuine = text.each_line.any? do |line|
+      GENUINE_FAILURE_SIGNATURES.any? { |sig| line.match?(sig) }
+    end
+    return false if genuine
+
+    transient_session_error?(text)
+  end
 end

--- a/spec/support/acceptance/session_transient_error_spec.rb
+++ b/spec/support/acceptance/session_transient_error_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require_relative 'session'
+
+RSpec.describe Acceptance::Session do
+  # The transport-stall cascade observed in CI: every send times out, then the
+  # post module is aborted. No genuine assertion failure line is present.
+  let(:transient_timeout_output) do
+    <<~OUTPUT
+      [*] use post/test/file
+      [read] [-] [should write binary data] Exception: Rex::TimeoutError: Send timed out
+      [read] [-] [should read the binary data we just wrote] Exception: Rex::TimeoutError: Send timed out
+      [read] [-] Post interrupted by the console user
+    OUTPUT
+  end
+
+  let(:genuine_failure_output) do
+    # Real harness form: print_error("FAILED: ...") fires inside an `it` block, so
+    # the test-name prefix is prepended before the '[-]' error glyph's payload.
+    <<~OUTPUT
+      [*] use post/test/file
+      [+] [should write binary data] Passed
+      [-] [should read the binary data we just wrote] FAILED: should read the binary data we just wrote
+    OUTPUT
+  end
+
+  # A run that both stalled AND recorded a real (prefixed) failure must not be retried.
+  let(:mixed_output) do
+    <<~OUTPUT
+      [-] [should write binary data] FAILED: should write binary data
+      [read] [-] [should read the binary data we just wrote] Exception: Rex::TimeoutError: Send timed out
+    OUTPUT
+  end
+
+  let(:clean_pass_output) do
+    <<~OUTPUT
+      [*] use post/test/file
+      [+] [should write binary data] Passed
+      Passed: 12; Failed: 0
+      [*] Post module execution completed
+    OUTPUT
+  end
+
+  describe '.transient_session_error?' do
+    it 'is true for a Send timed out signature' do
+      expect(described_class.transient_session_error?(transient_timeout_output)).to be(true)
+    end
+
+    it 'is true for a Post interrupted by the console user signature' do
+      expect(described_class.transient_session_error?('[-] Post interrupted by the console user')).to be(true)
+    end
+
+    it 'is false for a clean passing run' do
+      expect(described_class.transient_session_error?(clean_pass_output)).to be(false)
+    end
+
+    it 'is false for a genuine assertion failure with no transient signature' do
+      expect(described_class.transient_session_error?(genuine_failure_output)).to be(false)
+    end
+
+    it 'is false for nil input' do
+      expect(described_class.transient_session_error?(nil)).to be(false)
+    end
+  end
+
+  describe '.retryable_transient_failure?' do
+    it 'is true when only transient timeout errors are present' do
+      expect(described_class.retryable_transient_failure?(transient_timeout_output)).to be(true)
+    end
+
+    it 'is false for a clean passing run (nothing to retry)' do
+      expect(described_class.retryable_transient_failure?(clean_pass_output)).to be(false)
+    end
+
+    it 'is false for a genuine failure (must not be retried)' do
+      expect(described_class.retryable_transient_failure?(genuine_failure_output)).to be(false)
+    end
+
+    it 'is false when a genuine failure coexists with a transient error (never mask a real defect)' do
+      expect(described_class.retryable_transient_failure?(mixed_output)).to be(false)
+    end
+
+    it 'is false for a bare (no test-name prefix) FAILED line' do
+      bare = "[read] [-] [-] Post interrupted by the console user\n[-] FAILED: something broke\n"
+      expect(described_class.retryable_transient_failure?(bare)).to be(false)
+    end
+
+    it 'does not treat the "Failed: N" summary line as a genuine failure' do
+      # The summary line ("Passed: N; Failed: N") is not a "FAILED:" assertion line;
+      # a clean transient run whose summary reports failures-from-timeouts stays retryable.
+      summary_only = "[read] [-] Post interrupted by the console user\n[-] Passed: 11; Failed: 1; Skipped: 0\n"
+      expect(described_class.retryable_transient_failure?(summary_only)).to be(true)
+    end
+  end
+end


### PR DESCRIPTION


## Description
PHP meterpreter tests have been pretty flaky lately, this PR adds in some retry logic to see if that will help with the intermittent failures

## Verification Steps

CI passes

## Test Evidence

CI run

## AI Usage Disclosure

Kiro


