### PR TITLE
Automated Vulnerable Environment Provisioning

### DIFF
--- a/.github/workflows/test_env.yml
+++ b/.github/workflows/test_env.yml
@@ -1,0 +1,127 @@
+name: test_env CI Validation
+
+on:
+  push:
+    branches: [ master, vulnenv, vulnenv-week11, vulnenv-week12 ]
+  pull_request:
+    branches: [ master, vulnenv ]
+
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # =============================================================
+          # EXPLOIT MODULES
+          # =============================================================
+
+          # ActiveMQ shared definition — HTTP/Jolokia (authenticated)
+          - id: activemq-jolokia
+            module: exploit/multi/http/apache_activemq_jolokia_rce
+            definition: activemq
+            variant: "5.18.6"
+            profile: default
+            desc: "ActiveMQ Jolokia RCE — shared def, HTTP health, auth"
+
+          # ActiveMQ shared definition — OpenWire (unauthenticated)
+          - id: activemq-openwire
+            module: exploit/multi/misc/apache_activemq_rce_cve_2023_46604
+            definition: activemq
+            variant: "5.18.2"
+            profile: broker-only
+            desc: "ActiveMQ OpenWire RCE — shared def, TCP health, unauth"
+
+          # WordPress — provision + verify pipeline
+          - id: wordpress
+            module: exploit/unix/webapp/wp_admin_shell_upload
+            definition: wordpress
+            variant: latest
+            profile: default
+            desc: "WordPress Admin Shell — provision+verify, custom payload"
+
+          # =============================================================
+          # AUXILIARY MODULES (shared definitions)
+          # =============================================================
+
+          # httpd shared definition — 3 independent scanner modules
+          - id: httpd-version
+            module: auxiliary/scanner/http/http_version
+            definition: httpd
+            variant: "2.4.57"
+            profile: default
+            desc: "HTTP Version Scanner — auxiliary, shared httpd def"
+
+          - id: httpd-header
+            module: auxiliary/scanner/http/http_header
+            definition: httpd
+            variant: "2.4.57"
+            profile: default
+            desc: "HTTP Header Scanner — auxiliary, shared httpd def"
+
+          - id: httpd-robots
+            module: auxiliary/scanner/http/robots_txt
+            definition: httpd
+            variant: "2.4.57"
+            profile: default
+            desc: "HTTP Robots.txt Scanner — auxiliary, shared httpd def"
+
+          # openssh — SSH scanner with TCP health check
+          - id: openssh-version
+            module: auxiliary/scanner/ssh/ssh_version
+            definition: openssh
+            variant: "7.2"
+            profile: default
+            desc: "SSH Version Scanner — auxiliary, TCP health"
+
+    name: ${{ matrix.desc }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libpq-dev libsqlite3-dev libpcap-dev
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          # bundler-cache: true removed — we run bundle install manually
+          # after system libraries are present
+
+      - name: Verify Docker runtime
+        run: |
+          docker --version
+          docker info
+          docker run --rm hello-world
+
+      - name: Ensure CI runner is executable
+        run: chmod +x ./scripts/ci_runner.sh
+
+      - name: Install framework dependencies
+        run: |
+          gem install bundler --no-document
+          bundle install --jobs 4 --retry 3
+
+      - name: Run test_env validation
+        run: |
+          ./scripts/ci_runner.sh \
+            "${{ matrix.module }}" \
+            "${{ matrix.variant }}" \
+            "${{ matrix.profile }}"
+        timeout-minutes: 15
+
+      - name: Upload logs on completion
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: msf-logs-${{ matrix.id }}
+          path: /tmp/test_env_*.log
+          if-no-files-found: warn

--- a/data/vuln_envs/activemq.yml
+++ b/data/vuln_envs/activemq.yml
@@ -1,0 +1,64 @@
+name: activemq
+description: Apache ActiveMQ Classic with Jolokia API
+
+variants:
+  #Used by exploit/multi/http/apache_activemq_jolokia_rce
+  - name: "5.18.6"
+    version: "5.18.6"
+    image: docker.io/apache/activemq-classic:5.18.6
+    default: true
+
+  #Used by exploit/multi/misc/apache_activemq_rce_cve_2023_46604
+  - name: "5.18.2"
+    version: "5.18.2"
+    image: docker.io/dinifarb/activemq:5.18.2
+
+shared:
+  ports:
+    web: 8161
+    broker: 61616
+
+  credentials:
+    default:
+      username: admin
+      password: admin
+
+  datastore_defaults:
+    TARGETURI: /
+
+  health_check:
+    type: http
+    path: /api/jolokia/
+    expected_status: 200
+    interval: 5
+    timeout: 2
+    retries: 12
+    credentials:
+      username: admin
+      password: admin
+
+  ci:
+    exploit:
+      # The module's own auto-default (cmd/linux/ftp/x64/meterpreter/reverse_tcp)
+      # does not work: FTP isn't one of Metasploit's supported fetch-payload
+      # server protocols (only HTTP, HTTPS, SMB, TFTP), so it fails with
+      # "bad-config: Unsupported Binary Selected" every time. http works.
+      payload: cmd/linux/http/x64/meterpreter/reverse_tcp
+      options:
+        LPORT: 4444
+    validation:
+      expected_session: true
+      session_type: meterpreter
+      expected_output: "uid="
+      timeout: 120
+
+profiles:
+  default:
+    description: Standard ActiveMQ; web console reachable via HTTP/Jolokia.
+  broker-only:
+    description: Web console not assumed reachable; only the broker port is health-checked
+    health_check:
+      type: tcp
+    ci:
+      exploit:
+        force_exploit: true 

--- a/data/vuln_envs/httpd.yml
+++ b/data/vuln_envs/httpd.yml
@@ -1,0 +1,29 @@
+name: httpd
+description: Apache HTTP Server for scanner testing
+
+variants:
+  - name: "2.4.57"
+    version: "2.4.57"
+    image: docker.io/library/httpd:2.4.57
+    default: true
+
+shared:
+  ports:
+    http: 80
+
+  health_check:
+    type: http
+    path: /
+    expected_status: 200
+    interval: 2
+    timeout: 2
+    retries: 10
+
+  ci:
+    validation:
+      expected_session: false
+      expected_output: "Apache"
+
+profiles:
+  default:
+    description: Standard Apache HTTP Server

--- a/data/vuln_envs/openssh.yml
+++ b/data/vuln_envs/openssh.yml
@@ -1,0 +1,35 @@
+name: openssh
+description: OpenSSH server for SSH scanner testing
+
+variants:
+  - name: "7.2"
+    version: "7.2p2"
+    image: docker.io/rastasheep/ubuntu-sshd:16.04
+    default: true
+
+shared:
+  ports:
+    ssh: 22
+
+  credentials:
+    default:
+      username: root
+      password: root
+
+  # TCP check is enough: if port 22 accepts a connection, SSH is ready
+  health_check:
+    type: tcp
+    interval: 2
+    timeout: 2
+    retries: 10
+
+  ci:
+    exploit:
+      force_exploit: true 
+    validation:
+      expected_session: false
+      expected_output: "SSH"
+
+profiles:
+  default:
+    description: Standard OpenSSH server

--- a/data/vuln_envs/wordpress.yml
+++ b/data/vuln_envs/wordpress.yml
@@ -1,0 +1,84 @@
+name: wordpress
+description: Vulnerable WordPress installation for security testing
+
+variants:
+  - name: "latest"
+    version: "4.9"
+    image: docker.io/eystsen/vulnerablewordpress
+    default: true
+
+shared:
+  ports:
+    http: 80
+
+  credentials:
+    default:
+      username: admin
+      password: admin
+
+  datastore_defaults:
+    TARGETURI: /
+
+  # Liveness only: confirms Apache/PHP are up and responding.
+  # Does NOT confirm WordPress is installed - a redirect to
+  # /wp-admin/install.php is a valid 302 here and is expected
+  # on first boot, since this image ships with wp-config.php
+  # pointed at a database but never runs the install step itself.
+  health_check:
+    type: http
+    path: /
+    expected_status: 302
+    interval: 3
+    timeout: 2
+    retries: 15
+
+  # One-time setup: drives the WordPress install wizard
+  # (creates the DB schema + admin account) using the
+  # credentials defined above. Runs once, after health_check
+  # passes and before the environment is considered ready.
+  provision:
+    type: http
+    method: post
+    path: /wp-admin/install.php?step=2
+    body:
+      weblog_title: "Vulnerable WP"
+      user_name: "{{ credentials.default.username }}"
+      admin_password: "{{ credentials.default.password }}"
+      admin_password2: "{{ credentials.default.password }}"
+      pw_weak: 1
+      admin_email: "admin@example.com"
+      blog_public: 0
+      Submit: "Install WordPress"
+    run_once: true
+
+  # Confirms provisioning actually succeeded: the login form
+  # (not the installer) must now be served.
+  verify:
+    type: http
+    path: /wp-login.php
+    expected_status: 200
+    match: "user_login"
+    interval: 3
+    timeout: 2
+    retries: 10
+
+  ci:
+    exploit:
+      # php/meterpreter/reverse_tcp does not work against this image:
+      # it has no PHP openssl extension (confirmed via
+      # `docker exec <container> php -m | grep -i openssl` returning
+      # nothing), so Meterpreter can never negotiate TLV encryption
+      # and the session gets closed as invalid immediately after
+      # opening. Plain shell sidesteps encryption negotiation entirely.
+      payload: php/reverse_php
+      options:
+        LPORT: 4444
+    validation:
+      expected_session: true
+      session_type: shell
+      expected_output: "uid="
+      timeout: 120
+
+profiles:
+  default:
+    description: Standard vulnerable WordPress

--- a/docs/test_env/DEVELOPER_Doc.md
+++ b/docs/test_env/DEVELOPER_Doc.md
@@ -1,0 +1,734 @@
+# Developer Documentation — Environment Definitions
+
+> **Scope:** How to define, validate, and maintain vulnerable environment definitions for the `test_env` plugin.
+
+---
+
+## Table of Contents
+
+1. [What Is an Environment Definition?](#what-is-an-environment-definition)
+2. [Directory Structure](#directory-structure)
+3. [Schema Reference](#schema-reference)
+4. [The Three-Level Merge Hierarchy](#the-three-level-merge-hierarchy)
+5. [Validation Rules](#validation-rules)
+6. [How to Write a New Definition](#how-to-write-a-new-definition)
+7. [Shared Definitions & Module Referencing](#shared-definitions--module-referencing)
+8. [CI Metadata](#ci-metadata)
+9. [Best Practices](#best-practices)
+10. [Troubleshooting](#troubleshooting)
+
+---
+
+## What Is an Environment Definition?
+
+An **environment definition** is a YAML file that describes a runnable, vulnerable service as an OCI-compliant container. It is the **single source of truth** for:
+
+- Which container image to use
+- Which ports the service exposes
+- How to verify the service is ready (health checks)
+- Default credentials and datastore options
+- One-time provisioning steps (e.g., driving an install wizard)
+- CI automation metadata (payload recommendations, validation expectations)
+
+Definitions live in `data/vuln_envs/` and are referenced by exploit/auxiliary modules via the `VulnerableEnvironment` metadata key.
+
+---
+
+## Directory Structure
+
+```
+data/
+  vuln_envs/
+    README.md              # This documentation
+    jenkins.yml            # Example: Jenkins CI
+    activemq.yml           # Example: Apache ActiveMQ
+    wordpress.yml          # Example: WordPress
+    httpd.yml              # Example: Apache HTTP Server
+    openssh.yml            # Example: OpenSSH
+```
+
+**File naming rule:** The filename (without `.yml`) **must** match the `name` field inside the file. The loader enforces this.
+
+---
+
+## Schema Reference
+
+### Top-Level Keys
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | String | **Yes** | Machine-friendly identifier. Must match the filename. |
+| `description` | String | **Yes** | Human-readable summary of what this service is. |
+| `variants` | Array | **Yes** | List of runnable software versions / configurations. |
+| `shared` | Hash | **Yes** | Base configuration inherited by **all** profiles. |
+| `profiles` | Hash | **Yes** | Map of profile names to profile-specific overrides. |
+
+---
+
+### `variants` Section
+
+Each variant represents a distinct runnable configuration — typically a software version, but may also represent different backends or build options for the same version.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | String | **Yes** | Unique identifier for this variant. Used in `test_env build VARIANT=...`. |
+| `version` | String | **Yes** | The actual software version string (for information and validation). |
+| `image` | String | **Yes** | OCI image reference (e.g., `docker.io/library/httpd:2.4.57`). |
+| `build_args` | Hash | No | Docker/Podman build arguments if the image must be built locally. |
+| `default` | Boolean | No | If `true`, this variant is selected when no `VARIANT` is specified. Only one variant may be `default`. |
+
+**Example:**
+
+```yaml
+variants:
+  - name: "2.361"
+    version: "2.361"
+    image: vulnhub/jenkins:2.361
+    default: true
+
+  - name: "2.361-postgres"
+    version: "2.361"
+    image: vulnhub/jenkins:2.361-pg
+    build_args:
+      DB_BACKEND: "postgresql"
+
+  - name: "2.375"
+    version: "2.375"
+    image: vulnhub/jenkins:2.375
+```
+
+---
+
+### `shared` Section
+
+Base configuration inherited by every profile. Any field here can be overridden by a profile or by module-level metadata.
+
+#### `shared.ports` (Required)
+
+Maps logical port names to container ports. These are the ports the service listens on **inside** the container.
+
+```yaml
+shared:
+  ports:
+    http: 8080
+    broker: 61616
+```
+
+> **Important:** These are container ports, not host ports. The `test_env build` command dynamically allocates free host ports and maps them.
+
+---
+
+#### `shared.health_check` (Required in `shared` or in every profile)
+
+Defines how `test_env` waits for the service to become ready after the container starts.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `type` | String | **Yes** | `http`, `tcp`, or `command`. |
+| `path` | String | If `type=http` | HTTP path to request. |
+| `expected_status` | Integer | No | Expected HTTP status code. Default: `200`. |
+| `match` | String | No | Regex pattern the response body must match. Use this to distinguish "server responding" from "app actually ready" (e.g., an install wizard vs. a login page). |
+| `command` | String | If `type=command` | Shell command to execute **inside** the container. |
+| `expected_output` | String | If `type=command` | Regex pattern the command output must match. |
+| `interval` | Integer | No | Seconds between check attempts. Default: `5`. |
+| `timeout` | Integer | No | Seconds to wait for a single check. Default: `2`. |
+| `retries` | Integer | No | Maximum number of attempts. Default: `12`. |
+| `credentials` | Hash | No | Basic Auth credentials for HTTP checks. Keys: `username`, `password`. |
+
+**HTTP example:**
+
+```yaml
+health_check:
+  type: http
+  path: /api/jolokia/
+  expected_status: 200
+  interval: 5
+  timeout: 2
+  retries: 12
+  credentials:
+    username: admin
+    password: admin
+```
+
+**TCP example:**
+
+```yaml
+health_check:
+  type: tcp
+  interval: 2
+  timeout: 2
+  retries: 10
+```
+
+**Command example:**
+
+```yaml
+health_check:
+  type: command
+  command: "mysqladmin ping"
+  expected_output: "mysqld is alive"
+  interval: 3
+  timeout: 5
+  retries: 20
+```
+> **Naming note:** `match` and `expected_output` both perform pattern matching, but they are named by context rather than by mechanism:
+> - **`match`** — used for HTTP response bodies in `health_check` and `verify`.
+> - **`expected_output`** — used for command stdout in `health_check` and for session verification output in `ci.validation`.
+> Patterns are evaluated as Ruby regular expressions (not substrings), so anchors (`^`, `$`) and character classes work as expected.
+
+---
+
+#### `shared.credentials` (Optional)
+
+Default credentials for the service. These are automatically merged into the module datastore as `USERNAME`, `PASSWORD`, etc.
+
+```yaml
+credentials:
+  default:
+    username: admin
+    password: admin
+```
+
+---
+
+#### `shared.datastore_defaults` (Optional)
+
+Default datastore options for the module. These are applied automatically when the environment is built.
+
+```yaml
+datastore_defaults:
+  TARGETURI: /script
+  RHOSTS: 127.0.0.1
+```
+
+> **Note:** `RHOSTS` is automatically set to `127.0.0.1` by `test_env build`. You do not need to define it here unless you want a different value.
+
+---
+
+#### `shared.provision` (Optional)
+
+Some images boot with the target process running but the application itself not yet usable. For example, a fresh WordPress container serves HTTP but has no database schema or admin account until the install wizard is submitted.
+
+`provision` describes a one-time setup action that runs after the health check passes and before the environment is registered as ready.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `type` | String | **Yes** | Provisioning mechanism. Currently only `http` is supported. |
+| `method` | String | No | HTTP verb when `type` is `http`. One of: `post`, `get`, `put`, `patch`. Default: `post`. |
+| `path` | String | **Yes** | Request path, sent to the primary mapped port. |
+| `body` | Hash | No | Form fields, sent as `application/x-www-form-urlencoded`. Values may reference `{{ credentials.default.<key> }}`, which is resolved against the built datastore. Only used for `post`, `put`, and `patch`. |
+| `timeout` | Integer | No | Seconds to wait for the request. Default: `10`. |
+| `run_once` | Boolean | No | If `true`, provisioning is skipped if a marker file exists inside the container (e.g., after a `stop`/`start` cycle). Default: `false`. |
+
+**Example:**
+
+```yaml
+provision:
+  type: http
+  method: post
+  path: /wp-admin/install.php?step=2
+  body:
+    weblog_title: "Vulnerable WP"
+    user_name: "{{ credentials.default.username }}"
+    admin_password: "{{ credentials.default.password }}"
+    admin_password2: "{{ credentials.default.password }}"
+    admin_email: "admin@example.com"
+    blog_public: 0
+    Submit: "Install WordPress"
+  run_once: true
+```
+
+**Architectural constraints:**
+- Single stateless request only — no multi-step flows.
+- No session/cookie carryover between requests.
+- No non-HTTP provisioning (e.g., no `runtime.exec` for setup commands).
+- Extend `type` as new provisioning shapes come up rather than building speculatively.
+
+**`run_once` behavior:**
+When `run_once: true` is set, the provisioner creates a marker file (`/tmp/.msf_test_env_provisioned`) inside the container after the first successful provisioning. On subsequent operations (e.g., after `test_env start` restarts a stopped container), the provisioner checks for this marker and skips provisioning if it exists. This prevents duplicate form submissions or setup actions.
+
+A failure (non-2xx/3xx response, timeout, or request error) aborts the build and tears down the container.
+
+---
+
+#### `shared.verify` (Optional)
+
+Re-checks the environment after `provision` runs, confirming the setup action actually took effect. Uses the same shape as `health_check` (including the `match` field).
+
+If `provision` is not defined, `verify` is ignored. If `provision` is defined but `verify` is not, the environment is registered as ready as soon as `provision` returns a `200`–`399` response.
+
+**Restart behavior:** When a provisioned environment is stopped and later restarted via `test_env start`, the base `health_check` is skipped in favor of `verify`. This is because the container retains its filesystem state across restarts — the service is in its post-provision state, not its fresh-boot state. For example, a WordPress container that was provisioned during `build` will return `200` at `/` after a restart, not `302` to the install wizard.
+
+```yaml
+verify:
+  type: http
+  path: /wp-login.php
+  expected_status: 200
+  match: "user_login"
+  interval: 3
+  timeout: 2
+  retries: 10
+```
+
+---
+
+#### `shared.volumes` (Optional)
+
+Defines volume mounts for the container.
+
+```yaml
+volumes:
+  jenkins_home:
+    container_path: /var/jenkins_home
+    persist: false
+```
+
+If `host_path` is omitted, `test_env` creates a temporary directory that is cleaned up when the environment is removed.
+
+---
+
+#### `shared.ci` (Optional)
+
+Metadata for CI-driven automated exploit verification. This is also read during interactive `test_env exec` to apply recommended payloads and options.
+
+##### `ci.exploit`
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `payload` | String | No | Recommended payload for this environment. Applied if the module's current `PAYLOAD` differs. |
+| `options` | Hash | No | Additional datastore keys to set (e.g., `LPORT`). |
+| `force_exploit` | Boolean | No | If `true`, sets `ForceExploit true` on the module. |
+
+> **Critical:** Do **not** set `LHOST` here. The target runs inside a container network namespace; a hardcoded `LHOST` (especially `127.0.0.1`) resolves to the container itself, not the host. Leave `LHOST` unset so Metasploit's outbound-interface auto-detection supplies the host's real reachable address.
+
+**Example:**
+
+```yaml
+ci:
+  exploit:
+    payload: cmd/linux/http/x64/meterpreter/reverse_tcp
+    options:
+      LPORT: 4444
+    force_exploit: true
+```
+
+##### `ci.validation`
+
+Defines what "success" looks like for automated validation. Read by `test_env validate <ID>`.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `expected_session` | Boolean | No | Default `true`. If `false`, validation passes without checking for a session (used for auxiliary modules). |
+| `session_type` | String | No | `meterpreter` or `shell`. If set, the created session's type must match. |
+| `expected_output` | String | No | Regex pattern that the output of the verification command on the session must match, e.g., `"uid="` or `"uid=\\d+"`. |
+| `timeout` | Integer | No | Seconds to wait for a session to appear. Default: `120`. |
+
+**Example:**
+
+```yaml
+ci:
+  validation:
+    expected_session: true
+    session_type: meterpreter
+    expected_output: "uid="
+    timeout: 120
+```
+
+> **Known limitation:** `validate` looks for sessions in the current msfconsole process's `framework.sessions`. Sessions are process-local — they exist only in the msfconsole that opened them. `exec` and `validate` must run in the **same** msfconsole process.
+
+---
+
+### `profiles` Section
+
+Each profile is a runtime configuration of the service. Profiles override or extend `shared`.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `description` | String | **Yes** | What this profile represents. |
+| `health_check` | Hash | No | Overrides base `shared.health_check`. |
+| `datastore_defaults` | Hash | No | Overrides base `shared.datastore_defaults`. |
+| `credentials` | Hash | No | Overrides base `shared.credentials`. |
+| `volumes` | Hash | No | Overrides base `shared.volumes`. |
+| `ci` | Hash | No | Overrides base `shared.ci`. |
+| `provision` | Hash | No | Overrides base `shared.provision`. |
+| `verify` | Hash | No | Overrides base `shared.verify`. |
+
+**Profile names** must match `[a-z0-9-]+`.
+
+**Every definition must contain a `default` profile.**
+
+**Example:**
+
+```yaml
+profiles:
+  default:
+    description: Standard ActiveMQ; web console reachable via HTTP/Jolokia.
+
+  broker-only:
+    description: Web console not assumed reachable; only the broker port is health-checked.
+    health_check:
+      type: tcp
+    ci:
+      exploit:
+        force_exploit: true
+```
+
+---
+
+## The Three-Level Merge Hierarchy
+
+When `test_env build` resolves an environment, configuration is merged in this order:
+
+```
+Level 1: shared (base configuration, inherited by all profiles)
+    ↓
+Level 2: profiles[profile_name] (profile-specific overrides)
+    ↓
+Level 3: Module-level overrides (VulnerableEnvironment['overrides'])
+```
+
+### Merge Rules
+
+- **Hash fields** (e.g., `health_check`, `datastore_defaults`) are **deep-merged**: nested keys are combined, not replaced wholesale.
+- **Scalar fields** (e.g., `image`, `build_args`) are **replaced** by the higher level.
+- **The `description` key** in a profile is informational only and is excluded from the merge.
+
+### Example: How the Rules Apply
+
+Consider a definition where `shared`, the `broker-only` profile, and a module's `overrides` all contribute to the final `health_check` and `datastore_defaults`:
+
+**Level 1 — `shared` (base):**
+```yaml
+health_check:
+  type: http
+  path: /api/jolokia/
+  expected_status: 200
+  interval: 5
+  timeout: 2
+  retries: 12
+datastore_defaults:
+  TARGETURI: /
+```
+
+**Level 2 — Profile `broker-only` overrides:**
+```yaml
+health_check:
+  type: tcp
+  interval: 2
+ci:
+  exploit:
+    force_exploit: true
+description: "Web console not assumed reachable"
+```
+
+**Level 3 — Module `overrides`:**
+```ruby
+'overrides' => {
+  'health_check' => {
+    'retries' => 20
+  },
+  'datastore_defaults' => {
+    'TARGETURI' => '/console'
+  }
+}
+```
+
+**Resolved result:**
+```yaml
+health_check:
+  type: tcp              # ← scalar replaced by profile
+  path: /api/jolokia/    # ← preserved from shared (deep-merge)
+  expected_status: 200   # ← preserved from shared (deep-merge)
+  interval: 2            # ← scalar replaced by profile
+  timeout: 2             # ← preserved from shared (deep-merge)
+  retries: 20            # ← scalar replaced by module overrides
+datastore_defaults:
+  TARGETURI: /console    # ← scalar replaced by module overrides
+ci:
+  exploit:
+    force_exploit: true  # ← added by profile (deep-merge)
+```
+
+Notice that:
+- `health_check` is a **hash**, so keys are merged across all three levels rather than the profile or overrides replacing the entire block.
+- `type`, `interval`, `retries`, and `TARGETURI` are **scalars**, so the highest-level value wins.
+- `description` from the profile never appears in the resolved config because it is stripped before merging.
+
+---
+
+### Resolution Steps
+
+1. Load the YAML definition file by `name`.
+2. Validate that `variants` contains the requested `variant`.
+3. Validate that `profiles` contains the requested `profile` (default: `'default'`).
+4. Start with a copy of `shared`.
+5. Deep-merge the selected profile's configuration into it.
+6. Deep-merge the module's `VulnerableEnvironment['overrides']` (if any).
+7. Attach the variant-specific `image`, `version`, and `build_args` from the matching variant.
+
+---
+
+## Validation Rules
+
+The `EnvironmentDefinitionLoader` enforces the following rules at load time:
+
+1. `name` must match the filename (without `.yml`).
+2. `variants` must be a non-empty list.
+3. Each variant must have a `name` and an `image`.
+4. Variant `name` must be unique across all variants.
+5. At most one variant may have `default: true`.
+6. `shared.ports` must have at least one entry.
+7. `profiles` must have at least one entry.
+8. `profiles` must contain a `default` profile.
+9. Profile names must match `[a-z0-9-]+`.
+10. `health_check` must be defined in `shared` or in **every** profile.
+11. Module-level `overrides` are deep-merged into the final profile config.
+
+**Violation of any rule raises an `ArgumentError` with a descriptive message**, which is surfaced to the user by `test_env build`.
+
+---
+
+## How to Write a New Definition
+
+### Step 1: Identify the Service
+
+Determine:
+- The vulnerable software and version(s)
+- Available container images (Docker Hub, GitHub Container Registry, etc.)
+- Exposed ports
+- Whether the image is "ready on boot" or requires provisioning
+
+### Step 2: Create the YAML File
+
+Create `data/vuln_envs/{servicename}.yml`. The `name` field must match the filename.
+
+### Step 3: Define Variants
+
+List every version you want to support. At minimum, define one variant with `default: true`.
+
+### Step 4: Define `shared.ports`
+
+Map every port the service listens on inside the container.
+
+### Step 5: Define Health Checks
+
+Choose the simplest check that proves the service is **fully ready**, not just "accepting connections."
+
+- For HTTP services: request a known endpoint and check status + optional `match`.
+- For TCP services: `type: tcp` is sufficient.
+- For services requiring auth: use the `credentials` sub-key under `health_check`.
+
+### Step 6: Define Profiles (if needed)
+
+If the service can run in different configurations (e.g., web console on vs. off), create profiles.
+
+### Step 7: Add CI Metadata (optional but recommended)
+
+Add `ci.exploit` and `ci.validation` so the environment can be used in automated verification.
+
+### Step 8: Validate
+
+Run:
+
+```
+load test_env.rb
+test_env status
+```
+
+This validates all definitions and reports any schema errors.
+
+---
+
+## Shared Definitions & Module Referencing
+
+### Principle: DRY (Don't Repeat Yourself)
+
+Multiple modules targeting the same vulnerable service/version reference **a single shared environment definition**.
+
+**Example:** Two ActiveMQ exploit modules share `activemq.yml`:
+
+- `exploit/multi/http/apache_activemq_jolokia_rce` → uses variant `5.18.6`, profile `default`
+- `exploit/multi/misc/apache_activemq_rce_cve_2023_46604` → uses variant `5.18.2`, profile `broker-only`
+
+Both modules reference the same file but use different variants and profiles.
+
+### Module Metadata
+
+Modules declare their environment via `VulnerableEnvironment` inside `update_info()`:
+
+```ruby
+'VulnerableEnvironment' => {
+  'definition'      => 'activemq',
+  'default_variant' => '5.18.6',
+  'profile'         => 'default',
+  'port_mapping'    => { 8161 => 'RPORT' }
+}
+```
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `definition` | **Yes** | Name of the YAML file (without `.yml`). |
+| `default_variant` | **Yes** | Default variant to use if user does not specify `VARIANT=`. |
+| `profile` | No | Profile to use. Default: `'default'`. |
+| `port_mapping` | **Yes** | Hash mapping `{container_port => 'DATASTORE_OPTION'}`. At minimum, map the primary service port to `RPORT`. |
+| `overrides` | No | Module-specific overrides deep-merged into the resolved config. |
+
+**Example with overrides:**
+
+```ruby
+'VulnerableEnvironment' => {
+  'definition'      => 'jenkins',
+  'default_variant' => '2.361',
+  'port_mapping'    => { 8080 => 'RPORT' },
+  'overrides'       => {
+    'health_check' => {
+      'path' => '/script',
+      'expected_status' => 403
+    },
+    'datastore_defaults' => {
+      'TARGETURI' => '/script'
+    }
+  }
+}
+```
+
+---
+
+## CI Metadata
+
+The `ci` block is designed to make environments self-testing. A CI pipeline (or a human running `test_env validate`) can determine success without hardcoding expectations.
+
+### Typical CI Flow
+
+1. `use exploit/multi/http/apache_activemq_jolokia_rce`
+2. `test_env build`
+3. `test_env exec 1`
+4. `test_env validate 1`
+
+Step 4 checks:
+- Was a session created? (`expected_session`)
+- Is it the right type? (`session_type`)
+- Does `id` output contain `uid=`? (`expected_output`)
+
+### For Auxiliary Modules
+
+Set `expected_session: false` and `expected_output` to a substring expected in the scanner output or service response.
+
+```yaml
+ci:
+  validation:
+    expected_session: false
+    expected_output: "Apache"
+```
+
+---
+
+## Best Practices
+
+### 1. Prefer HTTP Health Checks Over TCP
+
+A TCP check only proves a port is open. An HTTP check proves the application layer is responding correctly. Use `match` to verify the response body contains expected content.
+
+### 2. Use `provision` + `verify` for Install Wizards
+
+If an image boots into an install wizard, define both `provision` (to submit the wizard) and `verify` (to confirm the login page appears afterward). Never register the environment as ready based solely on the install wizard being reachable.
+
+### 3. Never Hardcode `LHOST` in `ci.exploit`
+
+Metasploit's auto-detection handles this correctly. Hardcoding `127.0.0.1` causes payloads to call back to the container instead of the host.
+
+### 4. Document Payload Incompatibilities
+
+If a module's default payload does not work against your image, document why in a comment and set `ci.exploit.payload` to a working alternative.
+
+### 5. Keep Variant Names Semantic
+
+Use actual version numbers (e.g., `5.18.6`) rather than codenames. If you need a different backend for the same version, suffix descriptively (e.g., `5.18.2-postgres`).
+
+### 6. Profile Names Describe Runtime State
+
+Use profile names like `default`, `http-stopped`, `broker-only`, `minimal`. The name should tell the user what is different about this configuration.
+
+### 7. Validate Early
+
+Run `test_env status` after editing a definition. The loader validates the full schema and reports errors immediately.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `Validation failed: name 'foo' does not match filename 'bar'` | `name` field ≠ filename | Make them identical. |
+| `Variant 'X' not defined for 'Y'` | Module requests a variant not in the YAML | Add the variant or correct the module's `default_variant`. |
+| `Profile 'X' not defined for 'Y'` | Module requests a profile not in the YAML | Add the profile or correct the module's `profile`. |
+| `Port mapping mismatch: module maps port 8080 but environment only exposes ports: 80` | `port_mapping` references a port not in `shared.ports` | Add the port to `shared.ports` or correct the module's `port_mapping`. |
+| `Health check timed out` | Service not ready within retry budget | Increase `retries` or `timeout`; verify the health check endpoint/path is correct. |
+| `Provisioning failed` | Install wizard submission failed | Check `provision.path` and `provision.body` against the actual install wizard form fields. |
+| `Post-provision verification failed` | `verify` check fails after provisioning | Ensure `verify.path` and `verify.match` reflect the post-install state. |
+
+---
+
+## Complete Example: `activemq.yml`
+
+```yaml
+name: activemq
+description: Apache ActiveMQ Classic with Jolokia API
+
+variants:
+  - name: "5.18.6"
+    version: "5.18.6"
+    image: docker.io/apache/activemq-classic:5.18.6
+    default: true
+
+  - name: "5.18.2"
+    version: "5.18.2"
+    image: docker.io/dinifarb/activemq:5.18.2
+
+shared:
+  ports:
+    web: 8161
+    broker: 61616
+
+  credentials:
+    default:
+      username: admin
+      password: admin
+
+  datastore_defaults:
+    TARGETURI: /
+
+  health_check:
+    type: http
+    path: /api/jolokia/
+    expected_status: 200
+    interval: 5
+    timeout: 2
+    retries: 12
+    credentials:
+      username: admin
+      password: admin
+
+  ci:
+    exploit:
+      payload: cmd/linux/http/x64/meterpreter/reverse_tcp
+      options:
+        LPORT: 4444
+    validation:
+      expected_session: true
+      session_type: meterpreter
+      expected_output: "uid="
+      timeout: 120
+
+profiles:
+  default:
+    description: Standard ActiveMQ; web console reachable via HTTP/Jolokia.
+
+  broker-only:
+    description: Web console not assumed reachable; only the broker port is health-checked.
+    health_check:
+      type: tcp
+    ci:
+      exploit:
+        force_exploit: true
+```

--- a/docs/test_env/README.md
+++ b/docs/test_env/README.md
@@ -1,0 +1,51 @@
+# test_env Design Documentation
+
+This directory contains the architecture and workflow design for the `test_env` (VulnEnv) plugin.
+
+## Architecture Documents
+
+| Document | Description |
+|----------|-------------|
+| [01-command-dispatcher.md](https://github.com/Nayeraneru/metasploit-framework/blob/vulnenv-week1/docs/test_env/architecture/01-command-dispatcher.md) | How `test_env` is added to msfconsole via plugin dispatcher |
+| [02-module-metadata.md](https://github.com/Nayeraneru/metasploit-framework/blob/vulnenv-week1/docs/test_env/architecture/02-module-metadata.md) | How modules expose `VulnEnv` metadata and how the plugin reads it |
+| [03-database-schema.md](https://github.com/Nayeraneru/metasploit-framework/blob/vulnenv-week1/docs/test_env/architecture/03-database-schema.md) | Registry persistence: in-memory Phase 1, YAML Persistence with ActiveModel Phase 2 |
+| [04-environment-schema.md](https://github.com/Nayeraneru/metasploit-framework/blob/vulnenv-week1/docs/test_env/architecture/04-environment-schema.md) | YAML schema for shared environment definitions in `data/vuln_envs/` |
+| [05-runtime-adapter.md](https://github.com/Nayeraneru/metasploit-framework/blob/vulnenv-week1/docs/architecture/05-runtime-adapter.md) | Docker/Podman abstraction, port allocation, container labels |
+
+## Workflow & Planning Documents
+
+| Document | Description |
+|----------|-------------|
+| [reference_modules.md](reference_modules.md) | 2 reference modules selected for implementation (ActiveMQ, WordPress) |
+| [workflow.md](workflow.md) | Target user workflows and console transcripts (acceptance criteria) |
+| [ci_workflow.md](ci_workflow.md) | GitHub Actions CI integration with resource scripts |
+
+## Plugin File
+
+- [plugins/test_env.rb](https://github.com/Nayeraneru/metasploit-framework/blob/vulnenv-week1/plugins/test_env.rb) — Main plugin implementation (Week 1 skeleton)
+
+```
+nayera@Nero:~/git/metasploit-framework$ ./msfconsole -q -x "load test_env; exit"
+[*] VulnEnv plugin loaded.
+[*] Successfully loaded plugin: vulnenv
+
+nayera@Nero:~/git/metasploit-framework$ ./msfconsole -q -x "load test_env; test_env help; exit"
+[*] VulnEnv plugin loaded.
+[*] Successfully loaded plugin: vulnenv
+Usage: test_env <command>
+
+Commands:
+  build      Build and launch environment for active module
+  list       List tracked environments
+  stop <ID>  Stop a running environment
+  start <ID> Restart a stopped environment
+  remove <ID> Tear down an environment
+  remove-all Tear down all environments
+  exec <ID>  Execute exploit against environment
+  help       Show this help
+```
+
+## Data Files
+
+- `data/vuln_envs/activemq.yml` — ActiveMQ environment definition
+- `data/vuln_envs/wordpress.yml` — WordPress environment definition

--- a/docs/test_env/USER_Doc.md
+++ b/docs/test_env/USER_Doc.md
@@ -1,0 +1,775 @@
+# User Documentation — `test_env`
+
+> **Scope:** How to use the `test_env` plugin to provision, manage, and exploit vulnerable environments within Metasploit.
+
+---
+
+## Table of Contents
+
+1. [What Is `test_env`?](#what-is-test_env)
+2. [Prerequisites](#prerequisites)
+3. [Loading the Plugin](#loading-the-plugin)
+4. [Quick Start](#quick-start)
+5. [Command Reference](#command-reference)
+6. [Typical Workflows](#typical-workflows)
+7. [Environment Variables & Options](#environment-variables--options)
+8. [Understanding the Registry](#understanding-the-registry)
+9. [CI Integration](#ci-integration)
+10. [Troubleshooting](#troubleshooting)
+
+---
+
+## What Is `test_env`?
+
+`test_env` is a Metasploit plugin that automates the provisioning of vulnerable environments for exploit and auxiliary modules. Instead of manually building Docker images, looking up port numbers, and configuring datastore options, `test_env` does it all in a single command:
+
+```
+msf > use exploit/multi/http/apache_activemq_jolokia_rce
+msf exploit(...) > test_env build
+[+] Environment ready.
+[+] Environment ID: 1
+    RHOSTS       => 127.0.0.1
+    RPORT        => 49152
+    TARGETURI    => /
+    USERNAME     => admin
+    PASSWORD     => admin
+Suggested: exploit RHOSTS=127.0.0.1 RPORT=49152 TARGETURI=/ USERNAME=admin PASSWORD=admin
+```
+
+**Key features:**
+- **One-command provisioning**: Builds, launches, health-checks, and configures the module automatically.
+- **Dynamic port allocation**: Finds free host ports automatically; supports multiple concurrent environments.
+- **Persistent tracking**: Environments are tracked across `msfconsole` restarts via a YAML registry.
+- **Runtime abstraction**: Works with Docker (primary) and Podman (including rootless).
+- **Automated exploit execution**: `test_env exec <ID>` loads the module, applies the correct datastore, and runs the exploit.
+- **Validation**: `test_env validate <ID>` checks whether the exploit produced the expected session and output.
+
+---
+
+## Prerequisites
+
+### Required
+
+- **Metasploit Framework** (msfconsole)
+- **Docker** or **Podman** installed and available in your `$PATH`
+
+### Optional
+
+- **Podman networking backends** (`pasta` or `slirp4netns`) if using rootless Podman
+
+### Verify Your Setup
+
+```bash
+# Check Docker
+docker version
+
+# Or check Podman
+podman version
+```
+
+---
+
+## Loading the Plugin
+
+### Manual Load
+
+From within `msfconsole`:
+
+```
+msf > load test_env
+[*] TestEnv plugin loaded. Runtime: docker
+[*] Successfully loaded plugin: test_env
+```
+
+If no runtime is found:
+
+```
+[-] TestEnv plugin loaded, but no container runtime found.
+[-] Install Docker or Podman to use test_env.
+```
+
+### Automatic Load (Optional)
+
+Add to your `~/.msf4/msfconsole.rc`:
+
+```
+load test_env
+```
+
+---
+
+## Quick Start
+
+### 1. Select a Module
+
+```
+msf > use exploit/multi/http/apache_activemq_jolokia_rce
+```
+
+### 2. Build the Environment
+
+```
+msf exploit(...) > test_env build
+```
+
+This will:
+1. Detect the container runtime (Docker or Podman)
+2. Pull the required image
+3. Allocate free host ports
+4. Launch the container bound to `127.0.0.1`
+5. Wait for health checks to pass
+6. Apply datastore options (`RHOSTS`, `RPORT`, credentials, etc.)
+7. Register the environment and display the suggested exploit command
+
+### 3. Run the Exploit
+
+```
+msf exploit(...) > test_env exec 1
+```
+
+Or manually:
+
+```
+msf exploit(...) > exploit
+```
+
+### 4. Validate (Optional)
+
+```
+msf exploit(...) > test_env validate 1
+[+] PASS: environment 1 validated successfully against activemq's ci.validation.
+```
+
+### 5. Clean Up
+
+```
+msf exploit(...) > test_env remove 1
+```
+
+Or remove all:
+
+```
+msf exploit(...) > test_env remove-all
+```
+
+---
+
+## Command Reference
+
+### `test_env build [VARIANT=...] [PROFILE=...] [RPORT=...]`
+
+Build and launch the vulnerable environment for the **active module**.
+
+**Options:**
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `VARIANT=` | Select a specific software version | `test_env build VARIANT=2.375` |
+| `PROFILE=` | Select a runtime profile | `test_env build PROFILE=broker-only` |
+| `RPORT=` | Request a specific host port | `test_env build RPORT=8081` |
+
+**Behavior:**
+- If the requested port is unavailable, a dynamic port is allocated instead and you are notified.
+- If the module does not define `VulnerableEnvironment`, the command fails with a clear error.
+- If health checks fail, the container is automatically stopped and removed.
+- If provisioning fails (e.g., WordPress install wizard submission), the container is torn down.
+
+**Example output:**
+
+```
+msf exploit(...) > test_env build
+[*] Resolving environment for exploit/multi/http/apache_activemq_jolokia_rce...
+[*] Definition: activemq | Variant: 5.18.6 | Profile: default
+[*] Image: docker.io/apache/activemq-classic:5.18.6
+[*] Pulling image docker.io/apache/activemq-classic:5.18.6...
+[+] Image pulled successfully.
+[*] Starting container...
+[+] Container started: a1b2c3d4e5f6
+[*] Waiting for health check (HTTP)...
+[*]   Attempt 1/12...
+[*]   Attempt 2/12...
+[+] Health check passed.
+[+] Environment ready.
+[*] Environment ID: 1
+   RHOSTS       => 127.0.0.1
+   RPORT        => 49152
+   TARGETURI    => /
+   USERNAME     => admin
+   PASSWORD     => admin
+[*] Suggested: exploit RHOSTS=127.0.0.1 RPORT=49152 TARGETURI=/ USERNAME=admin PASSWORD=admin
+```
+
+---
+
+### `test_env list`
+
+Display all tracked environments in a table.
+
+```
+msf > test_env list
+
+Test Environments
+=================
+
+  ID  Container     Module                                          RHOST       RPORT  Status   Version
+  --  ---------     ------                                          -----       -----  ------   -------
+  1   a1b2c3d4e5f6  exploit/multi/http/apache_activemq_jolokia_rce  127.0.0.1   49152  running  5.18.6
+  2   b2c3d4e5f6a7  exploit/unix/webapp/wp_admin_shell_upload       127.0.0.1   49153  running  latest
+
+2 environment(s) tracked.
+```
+
+---
+
+### `test_env modules`
+
+Scan the framework and list all modules that declare `VulnerableEnvironment` support.
+
+```
+msf > test_env modules
+[*] Scanning framework modules for test_env support...
+
+Modules with test_env Support
+=============================
+
+  Module                                            Definition  Variant   Profile  Ports        Image
+  ------                                            ----------  -------   -------  -----        -----
+  exploit/multi/http/apache_activemq_jolokia_rce    activemq    5.18.6    default  8161->RPORT  docker.io/apache/activemq-classic:5.18.6
+  exploit/multi/misc/apache_activemq_rce_cve_...    activemq    5.18.2    broker-  61616->RPORT docker.io/dinifarb/activemq:5.18.2
+  exploit/unix/webapp/wp_admin_shell_upload         wordpress   latest    default  80->RPORT    docker.io/eystsen/vulnerablewordpress
+  auxiliary/scanner/http/http_version               httpd       2.4.57    default  80->RPORT    docker.io/library/httpd:2.4.57
+
+Found 4 module(s) with test_env support (scanned 5236 total).
+```
+
+---
+
+### `test_env stop <ID range>`
+
+Stop running container(s) without removing them. Accepts single IDs or ranges.
+
+```
+msf > test_env stop 1
+[+] Environment 1 stopped.
+
+msf > test_env stop 1-3,5
+[+] Environment 1 stopped.
+[+] Environment 2 stopped.
+[+] Environment 3 stopped.
+[+] Environment 5 stopped.
+```
+
+---
+
+### `test_env start <ID>`
+
+Restart a previously stopped environment. Re-runs readiness checks after starting.
+
+```
+msf > test_env start 1
+[+] Environment 1 started. RPORT=49152
+```
+
+> **Note:** `start` accepts only a single ID for safety.
+
+> **Provisioned environments:** For environments that required one-time provisioning during `build` (e.g., WordPress install wizard), `start` runs the `verify` check instead of the base `health_check`. This is because the container retains its filesystem state across restarts — the service is already configured, not fresh.
+
+---
+
+### `test_env remove <ID range>`
+
+Tear down and remove environment(s). Stops the container if running, removes it, and purges the registry entry.
+
+```
+msf > test_env remove 1
+[+] Environment 1 removed.
+
+msf > test_env remove 1-3
+[+] Environment 1 removed.
+[+] Environment 2 removed.
+[-] Environment 3 not found.
+```
+
+> **Safety:** If the runtime fails to remove the container, the registry entry is **preserved** so you can retry or clean up manually.
+
+---
+
+### `test_env remove-all`
+
+Tear down **all** tracked environments and reset the registry.
+
+```
+msf > test_env remove-all
+[*] Tearing down 3 environment(s)...
+[+] All environments removed.
+```
+
+---
+
+### `test_env exec <ID> [-z|--background]`
+
+Execute the exploit or auxiliary module against a built environment.
+
+**What it does:**
+1. Loads the module the environment was built for
+2. Applies the stored datastore options (`RHOSTS`, `RPORT`, credentials, etc.)
+3. Applies the recommended payload from the environment definition (if configured)
+4. Allocates fresh local ports for `SRVPORT` / `FETCH_SRVPORT` to avoid bind conflicts on repeated runs
+5. Runs the module
+
+```
+msf > test_env exec 1
+[*] Using exploit/multi/http/apache_activemq_jolokia_rce...
+[*] Setting recommended payload for this environment: cmd/linux/http/x64/meterpreter/reverse_tcp
+[*] Executing: exploit RHOSTS=127.0.0.1 RPORT=49152 TARGETURI=/ USERNAME=admin PASSWORD=admin
+```
+
+**Background execution:**
+
+```
+msf > test_env exec 1 -z
+```
+
+> **Important:** `exec` works even if you are currently `use`ing a different module. It switches context automatically.
+
+---
+
+### `test_env validate <ID>`
+
+Check whether an environment's exploit produced the expected result, as defined by the environment's `ci.validation` metadata.
+
+**For exploit modules:**
+- Checks if a session was created
+- Verifies session type (if specified)
+- Runs a verification command and checks output
+
+```
+msf > test_env validate 1
+[*] Validating environment 1 (exploit/multi/http/apache_activemq_jolokia_rce) against activemq's ci.validation...
+[*] Found 2 session(s) for this module: 1, 2
+[*] Using session 1 (meterpreter)
+[+] PASS: environment 1 validated successfully against activemq's ci.validation.
+```
+
+**For auxiliary modules:**
+- Probes the service directly
+- Checks response contains expected text
+- Re-verifies service health after execution
+
+```
+msf > test_env validate 4
+[*] Validating environment 4 (auxiliary/scanner/http/http_version) against httpd's ci.validation...
+[+] Service response contains expected text: 'Apache'
+[+] PASS: environment 4 validated successfully against httpd's ci.validation.
+```
+
+> **Critical constraint:** Sessions are **process-local**. `validate` only sees sessions created in the **same** `msfconsole` process. If you ran `exec` in a different terminal window, run `validate` there too.
+
+---
+
+### `test_env status`
+
+Show runtime status, managed container counts, and available environment definitions.
+
+```
+msf > test_env status
+[*] Runtime: docker
+[*] Managed containers: 2 total, 2 running
+[*] Available definitions: activemq, httpd, openssh, wordpress
+```
+
+If a definition file has schema errors, they are reported here.
+
+---
+
+### `test_env help`
+
+Display usage information for all commands.
+
+```
+msf > test_env help
+Usage: test_env <command>
+
+Commands:
+  build      Build and launch environment for active module
+  list       List tracked environments
+  modules    List all modules with test_env support
+  stop <ID>  Stop a running environment
+  start <ID> Restart a stopped environment
+  remove <ID> Tear down an environment
+  remove-all Tear down all environments
+  exec <ID>  Execute exploit against environment
+  validate <ID> Check session/output against ci.validation
+  status     Show runtime status
+  help       Show this help
+```
+
+---
+
+## Typical Workflows
+
+### Workflow A: Interactive Exploit Development
+
+```
+msf > use exploit/multi/http/apache_activemq_jolokia_rce
+msf exploit(...) > test_env build
+[+] Environment ready. Environment ID: 1
+msf exploit(...) > test_env exec 1
+[*] Meterpreter session 1 opened ...
+msf exploit(...) > sessions -i 1
+meterpreter > shell
+Process 129 created.
+Channel 1 created.
+id
+uid=0(root) gid=0(root) groups=0(root)
+exit
+meterpreter > exit
+msf exploit(...) > test_env remove 1
+[+] Environment 1 removed.
+```
+
+### Workflow B: Multi-Version Testing
+
+```
+msf > use exploit/multi/http/apache_activemq_jolokia_rce
+msf exploit(...) > test_env build VARIANT=5.18.6
+[+] Environment ID: 1
+msf exploit(...) > test_env build VARIANT=5.18.2 PROFILE=broker-only
+[+] Environment ID: 2
+msf exploit(...) > test_env list
+  ID  ...  Version   Status
+  --  ...  -------   ------
+  1   ...  5.18.6    running
+  2   ...  5.18.2    running
+msf exploit(...) > test_env exec 1
+msf exploit(...) > test_env exec 2
+msf exploit(...) > test_env remove-all
+```
+
+### Workflow C: Auxiliary Scanner Testing
+
+```
+msf > use auxiliary/scanner/http/http_version
+msf auxiliary(...) > test_env build
+[+] Environment ID: 1
+msf auxiliary(...) > test_env exec 1
+[+] 127.0.0.1:49152 Apache/2.4.57 (Unix)
+msf auxiliary(...) > test_env validate 1
+[+] PASS: environment 1 validated successfully.
+msf auxiliary(...) > test_env remove 1
+```
+
+### Workflow D: Resume After Restart
+
+```
+msf > load test_env
+[*] TestEnv plugin loaded. Runtime: docker
+[*] Successfully loaded plugin: test_env
+msf > test_env list
+  ID  ...  Status
+  --  ...  ------
+  1   ...  running
+  2   ...  running
+msf > test_env exec 2
+```
+
+---
+
+## Environment Variables & Options
+
+### Shell Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `TEST_ENV_RUNTIME` | Force a specific runtime | `TEST_ENV_RUNTIME=podman msfconsole` |
+| `TEST_ENV_PRESERVE` | Preserve containers on msfconsole exit | `TEST_ENV_PRESERVE=true msfconsole` |
+
+### Metasploit Datastore Options
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `TEST_ENV_RUNTIME` | Same as env var, but set inside msfconsole | `set TEST_ENV_RUNTIME podman` |
+| `TEST_ENV_PRESERVE` | Same as env var, but set inside msfconsole | `set TEST_ENV_PRESERVE true` |
+
+**Preserve behavior:**
+
+```
+msf > set TEST_ENV_PRESERVE true
+TEST_ENV_PRESERVE => true
+msf > unload test_env
+Unloading plugin test_env...[*] TEST_ENV_PRESERVE is set. Leaving containers running.
+[*] Run 'test_env remove-all' manually when done.
+unloaded.
+msf > load test_env
+[*] TestEnv plugin loaded. Runtime: docker
+[*] Successfully loaded plugin: test_env
+msf > test_env list
+Test Environments
+=================
+
+ ID  Container     Module               RHOST      RPORT  Status   Version
+ --  ---------     ------               -----      -----  ------   -------
+ 1   3883fd8183da  exploit/multi/http/  127.0.0.1  49152  running  5.18.6
+                   apache_activemq_jol
+                   okia_rce
+
+[*] 1 environment(s) tracked.
+```
+**Do Not Preserve behavior:**
+
+```
+msf > set TEST_ENV_PRESERVE false
+TEST_ENV_PRESERVE => false
+msf > unload test_env
+Unloading plugin test_env...[*] Auto-cleaning test_env environments...
+unloaded.
+msf > load test_env
+[*] TestEnv plugin loaded. Runtime: docker
+[*] Successfully loaded plugin: test_env
+msf > load test_env
+[*] Auto-cleaning test_env environments...
+[*] TestEnv plugin loaded. Runtime: docker
+[*] Successfully loaded plugin: test_env
+msf > test_env list
+[*] No environments currently tracked.
+```
+
+---
+
+## Understanding the Registry
+
+### Where Is It Stored?
+
+`~/.msf4/test_env_registry.yml`
+
+This YAML file persists environment metadata across `msfconsole` restarts.
+
+### What Is Tracked?
+
+For each environment:
+- **ID**: Monotonic local identifier (never renumbered)
+- **Container ID**: Short Docker/Podman container ID
+- **Module**: Full module path
+- **Version**: Which variant was provisioned
+- **RHOST / RPORT**: Connection details
+- **Datastore**: All applied options
+- **Status**: `running`, `stopped`, or `removed`
+- **Allocated ports**: Host-to-container port mappings
+- **Temp directories**: Cleanup targets for unnamed volumes
+
+### Container Labels
+
+Every container created by `test_env` carries these labels:
+
+```
+msf.vulnenv.managed_by=test_env
+msf.vulnenv.instance_id=msf-hostname-12345
+msf.vulnenv.module=exploit/multi/http/apache_activemq_jolokia_rce
+msf.vulnenv.env_id=1
+msf.vulnenv.version=5.18.6
+msf.vulnenv.ports=49152:8161
+```
+
+These labels enable **state reconstruction** when `msfconsole` restarts. Even if the YAML registry is lost, `test_env` can discover running containers and rebuild the registry from labels.
+
+---
+
+## CI Integration
+
+`test_env` is designed to support automated CI pipelines. A typical GitHub Actions workflow:
+
+```yaml
+name: Exploit Verification
+
+on: [push, pull_request]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start Metasploit + test_env
+        run: |
+          docker run -d --name msf -v $(pwd):/workspace             -e TEST_ENV_PRESERVE=true             metasploitframework/metasploit-framework:latest
+
+      - name: Verify ActiveMQ exploit
+        run: |
+          docker exec msf msfconsole -q -x "
+            load /workspace/test_env.rb
+            use exploit/multi/http/apache_activemq_jolokia_rce
+            test_env build
+            test_env exec 1
+            test_env validate 1
+            test_env remove-all
+            exit
+          "
+```
+
+**Key points:**
+- Environment definitions are the **single source of truth** for images, health checks, and validation expectations.
+- `ci.exploit` recommends payloads that are known to work against the image.
+- `ci.validation` defines what "success" means for each module.
+- `exec` and `validate` must run in the **same process** (use a single `msfconsole -x` script).
+
+---
+
+## Troubleshooting
+
+### Plugin fails to load
+
+```
+[-] TestEnv plugin loaded, but no container runtime found.
+```
+
+**Fix:** Install Docker or Podman and ensure the binary is in your `$PATH`.
+
+```bash
+# Docker
+sudo systemctl start docker
+
+# Podman (rootless)
+podman version
+```
+
+---
+
+### `test_env build` fails: "No active module"
+
+```
+[-] No active module. Use 'use <module>' first.
+```
+
+**Fix:** Select a module that supports `test_env`:
+
+```
+msf > use exploit/multi/http/apache_activemq_jolokia_rce
+```
+
+Or scan for supported modules:
+
+```
+msf > test_env modules
+```
+
+---
+
+### `test_env build` fails: "Module does not define a vulnerable environment configuration"
+
+**Fix:** The selected module has no `VulnerableEnvironment` metadata. Either:
+- Use a different module
+- Contribute a definition and module metadata (see Developer Documentation)
+
+---
+
+### Port allocation fails
+
+```
+[-] No available ports: No available ports in range 49152-65535
+```
+
+**Fix:** You have too many services bound to ephemeral ports. Run `test_env remove-all` to clean up, or manually stop orphaned containers:
+
+```bash
+docker ps -q --filter "label=msf.vulnenv.managed_by=test_env" | xargs docker stop
+docker ps -aq --filter "label=msf.vulnenv.managed_by=test_env" | xargs docker rm
+```
+
+---
+
+### Health check times out
+
+```
+[-] Health check timed out after 60 seconds
+```
+
+**Common causes:**
+- The image is still downloading layers. Wait and retry.
+- The service inside the container crashed. Check logs:
+  ```bash
+  docker logs <container_id>
+  ```
+- The health check endpoint is wrong. Verify the environment definition.
+
+---
+
+### `test_env exec` fails with "No session created"
+
+**Causes:**
+- The exploit failed. Check the module output for errors.
+- `LHOST` is misconfigured. Do not hardcode `LHOST` in environment definitions.
+- The target is not actually vulnerable (wrong version, patched image).
+
+---
+
+### `test_env validate` fails: "no session was created"
+
+```
+[-] FAIL: no session was created within 120s
+```
+
+**Causes:**
+- You ran `exec` and `validate` in **different** `msfconsole` processes. Sessions are process-local.
+- The exploit genuinely failed. Run `test_env exec <ID>` again and watch the output.
+- The timeout is too short for slow payloads. The definition's `ci.validation.timeout` may need adjustment.
+
+**Fix:** Run both commands in the same msfconsole:
+
+```
+msf > test_env exec 1
+msf > test_env validate 1
+```
+
+---
+
+### Podman rootless networking issues
+
+```
+[-] Rootless Podman detected but no networking backend (pasta or slirp4netns) found.
+```
+
+**Fix:** Install `pasta` or `slirp4netns`:
+
+```bash
+# Debian/Ubuntu
+sudo apt install passt
+
+# Fedora
+sudo dnf install passt
+
+# Or slirp4netns
+sudo apt install slirp4netns
+```
+
+---
+
+### `test_env remove` says "Failed to remove container" but registry entry is gone
+
+**Actually, this won't happen.** The implementation specifically **preserves** the registry entry if `runtime.remove` fails. You can retry:
+
+```
+msf > test_env remove 1
+[-] Failed to remove container for environment 1: ...
+msf > test_env remove 1  # retry
+[+] Environment 1 removed.
+```
+
+If the container was removed manually (outside `test_env`), run `test_env status` or reload the plugin to trigger pruning.
+
+---
+
+## Summary of Commands
+
+| Command | Purpose | Args |
+|---------|---------|------|
+| `test_env build` | Provision environment | `[VARIANT=]` `[PROFILE=]` `[RPORT=]` |
+| `test_env list` | Show tracked environments | — |
+| `test_env modules` | Discover supported modules | — |
+| `test_env stop` | Stop container(s) | `<ID range>` |
+| `test_env start` | Restart container | `<ID>` |
+| `test_env remove` | Remove environment(s) | `<ID range>` |
+| `test_env remove-all` | Remove everything | — |
+| `test_env exec` | Run exploit/module | `<ID>` `[-z]` |
+| `test_env validate` | Verify exploit success | `<ID>` |
+| `test_env status` | Show runtime + definitions | — |
+| `test_env help` | Show usage | — |

--- a/docs/test_env/architecture/01-command-dispatcher.md
+++ b/docs/test_env/architecture/01-command-dispatcher.md
@@ -1,0 +1,162 @@
+# Command Dispatcher Architecture
+
+## What This Document Is
+This defines how the `test_env` command will be added to msfconsole.
+
+## How Commands Work in Metasploit (From Source Code I Read)
+
+### 1. Plugin Registration
+From `plugins/sample.rb`, I saw:
+- Plugin inherits from `Msf::Plugin`
+- Plugin has an inner `ConsoleCommandDispatcher` class
+- Dispatcher `include Msf::Ui::Console::CommandDispatcher`
+- `commands` method returns a hash: `{ 'command_name' => 'description' }`
+- `initialize` calls `add_console_dispatcher(ConsoleCommandDispatcher)`
+- `cleanup` calls `remove_console_dispatcher('Name')`
+
+### 2. Command Routing
+From `lib/rex/ui/text/dispatcher_shell.rb` line 576, I saw:
+```ruby
+def run_command(dispatcher, method, arguments)
+```
+When I type `test_env build`, this happens:
+1. Shell parses the line into `["test_env", "build"]`
+2. Shell finds my plugin's dispatcher in `dispatcher_stack`
+3. Shell calls `run_command(my_dispatcher, "test_env", ["build"])`
+4. Which calls `my_dispatcher.cmd_test_env("build")`
+
+### 3. Multi-Command Pattern
+From `lib/msf/ui/console/command_dispatcher/jobs.rb`, I saw:
+- One dispatcher can handle multiple commands via `commands` hash
+- `cmd_jobs(*args)` uses `args.shift` to get the subcommand
+- `cmd_jobs_tabs` provides tab completion
+- `cmd_jobs_help` prints usage information
+
+## My Design: test_env Command Dispatcher
+
+### Class Structure
+```
+Msf::Plugin
+└── Msf::Plugin::VulnEnv
+    └── Msf::Plugin::VulnEnv::ConsoleCommandDispatcher
+        └── (includes Msf::Ui::Console::CommandDispatcher)
+```
+
+### Commands Hash
+| Command | Description |
+|---------|-------------|
+| `test_env` | Manage vulnerable test environments |
+
+### Subcommands (Handled Inside cmd_test_env)
+| Subcommand | Handler Method | What It Does |
+|-----------|---------------|--------------|
+| `build` | `cmd_test_env_build(args)` | Build and launch environment for active module |
+| `list` | `cmd_test_env_list(args)` | Show all tracked environments |
+| `stop <range>` | `cmd_test_env_stop(args)` | Stop running container(s) |
+| `start <range>` | `cmd_test_env_start(args)` | Restart stopped container(s) |
+| `remove <range>` | `cmd_test_env_remove(args)` | Tear down container(s) | 
+| `remove-all` | `cmd_test_env_remove_all(args)` | Tear down all containers |
+| `exec <ID>` | `cmd_test_env_exec(args)` | Run exploit against environment |
+| `help` | `cmd_test_env_help` | Show usage |
+
+## Range Parsing
+
+Metasploit commands like `sessions -k` support comma-separated and dash-separated ranges (e.g., `1-3,5,7-9`). The `stop`, `start`, and `remove` subcommands follow this pattern. `exec` intentionally accepts only a single ID for safety.
+
+## Sample code for solid clarification
+### Argument Parsing Logic
+```ruby
+def cmd_test_env(*args)
+  # If no args or help requested, show help
+  if args.empty? || args.first == '-h' || args.first == '--help'
+    cmd_test_env_help
+    return
+  end
+
+  # First argument is the subcommand
+  subcommand = args.shift
+
+  # Route to appropriate handler
+  case subcommand
+  when 'build'      then cmd_test_env_build(args)
+  when 'list'       then cmd_test_env_list(args)
+  when 'stop'       then cmd_test_env_stop(args)
+  when 'start'      then cmd_test_env_start(args)
+  when 'remove'     then cmd_test_env_remove(args)
+  when 'remove-all' then cmd_test_env_remove_all(args)
+  when 'exec'       then cmd_test_env_exec(args)
+  when 'help'       then cmd_test_env_help
+  else
+    print_error("Unknown subcommand: #{subcommand}")
+    cmd_test_env_help
+  end
+end
+```
+
+### Tab Completion
+```ruby
+def cmd_test_env_tabs(str, words)
+  # If only "test_env" has been typed, suggest subcommands
+  if words.length == 1
+    return %w[build list stop start remove remove-all exec help]
+  end
+
+  # If subcommand is stop/start/remove/exec, suggest environment IDs
+  if words.length == 2
+    case words[0]
+    when 'stop', 'start', 'remove'
+      # TODO: Return IDs from registry (Week 6)
+      return []
+    when 'exec'
+      # Single ID only
+      return []
+    end
+  end
+
+  []
+end
+```
+
+### Error Handling Pattern
+Every subcommand follows this pattern:
+```ruby
+def cmd_test_env_build(args)
+  begin
+    # 1. Validate preconditions
+    mod = driver.active_module
+    raise "No active module. Use 'use <module>' first." unless mod
+
+    # 2. Execute logic
+    # ... (implementation in later weeks)
+
+    # 3. Report success
+    print_good("Environment built successfully")
+
+  rescue => e
+    # 4. Report error
+    print_error("test_env build failed: #{e.message}")
+    elog("test_env build error: #{e.class} - #{e.message}")
+    elog(e.backtrace.join("\n"))
+  end
+end
+```
+
+## Integration Points
+
+| What I Need | Where It Comes From | How I Access It |
+|-------------|-------------------|---------------|
+| Framework instance | `Msf::Plugin#initialize` | `framework` (instance variable) |
+| Active module | `Msf::Ui::Console::Driver#active_module` | `driver.active_module` |
+| Database | `framework.db.active` | Check before DB operations |
+| Console output | `Msf::Ui::Console::CommandDispatcher` | `print_status`, `print_error`, `print_good` |
+
+## Decisions Made
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Single command or multiple? | Single `test_env` with subcommands | Matches `jobs` pattern; cleaner namespace |
+| How to parse subcommands? | `case` statement on `args.shift` | Same as `cmd_jobs` |
+| Tab completion? | `cmd_test_env_tabs` method | For good UX |
+| Error handling? | `begin/rescue` with `print_error` | Consistent with framework style |
+| Range support for IDs? | Comma/dash ranges for `stop`/`start`/`remove`; single ID for `exec` | Matches `sessions -k` pattern; mentor feedback — bulk ops should support ranges, but `exec` is safer single-target |
+

--- a/docs/test_env/architecture/02-module-metadata.md
+++ b/docs/test_env/architecture/02-module-metadata.md
@@ -1,0 +1,348 @@
+# Module Metadata Integration
+
+## How VulnerableEnvironment Is Defined
+
+`VulnerableEnvironment` is defined inside a module's `initialize` method, passed to `update_info()` alongside all standard metadata. This follows the exact same pattern as `Name`, `Description`, `Author`, `References`, `Notes`, etc.
+
+
+## Framework Pattern for Reading Metadata
+
+Metasploit modules expose metadata through **public accessor methods** that read from the protected `module_info` hash. From `lib/msf/core/module/module_info.rb` lines 17–52:
+
+```ruby
+def alias
+  module_info['Alias']
+end
+
+def description
+  module_info['Description']
+end
+
+def disclosure_date
+  date_str = Date.parse(module_info['DisclosureDate'].to_s) rescue nil
+end
+
+def name
+  module_info['Name']
+end
+
+def notes
+  module_info['Notes']
+end
+```
+
+Each method is **public**, reads a single key from `module_info`, and returns the raw value. The framework does not validate or transform the return value at this layer — that responsibility lies with the consumer.
+
+## Plugin-Only Implementation
+
+Since the `test_env` plugin cannot modify core framework files, it provides its own accessor that mirrors the framework pattern. The accessor returns a **validated Struct** instead of a raw Hash, ensuring type safety and required-field enforcement.
+
+### VulnerableEnvironment Struct
+
+```ruby
+module Msf
+  class Plugin::VulnEnv < Msf::Plugin
+    # Encapsulates and validates VulnerableEnvironment metadata from a module.
+    class VulnerableEnvironment
+      attr_reader :definition, :default_variant, :profile, :port_mapping, :overrides
+
+      # Required keys that must be present
+      REQUIRED_KEYS = %w[definition default_variant port_mapping].freeze
+
+      # Valid types for each key
+      SCHEMA = {
+        'definition'      => String,
+        'default_variant' => String,
+        'profile'         => String,
+        'port_mapping'    => Hash,
+        'overrides'       => Hash
+      }.freeze
+
+      def initialize(raw_hash)
+        @raw = raw_hash || {}
+
+        validate!
+
+        @definition      = @raw['definition']
+        @default_variant = @raw['default_variant']
+        @profile         = @raw['profile'] || 'default'
+        @port_mapping    = @raw['port_mapping'] || {}
+        @overrides       = @raw['overrides'] || {}
+      end
+
+      def valid?
+        errors.empty?
+      end
+
+      def errors
+        errs = []
+
+        REQUIRED_KEYS.each do |key|
+          errs << "Missing required key: '#{key}'" unless @raw.key?(key)
+        end
+
+        SCHEMA.each do |key, expected_type|
+          next unless @raw.key?(key)
+          unless @raw[key].is_a?(expected_type)
+            errs << "Key '#{key}' must be #{expected_type}, got #{@raw[key].class}"
+          end
+        end
+
+        if @raw['port_mapping'].is_a?(Hash)
+          @raw['port_mapping'].each do |k, v|
+            unless k.is_a?(Integer) || k.to_s.match?(/\A\d+\z/)
+              errs << "port_mapping key must be an integer port, got: #{k.inspect}"
+            end
+            unless v.is_a?(String)
+              errs << "port_mapping value must be a String datastore option name, got: #{v.inspect}"
+            end
+          end
+        end
+
+        errs
+      end
+
+      private
+
+      def validate!
+        errs = errors
+        raise ArgumentError, "Invalid VulnerableEnvironment: #{errs.join('; ')}" unless errs.empty?
+      end
+    end
+  end
+end
+```
+
+### Plugin Accessor (Mirrors Framework Pattern)
+
+```ruby
+class Plugin::VulnEnv < Msf::Plugin
+  class ConsoleCommandDispatcher
+    # Reads and validates VulnerableEnvironment metadata from the active module.
+    # Returns a VulnerableEnvironment Struct, or nil if the module has none.
+    #
+    # This mirrors the framework pattern used by #name, #description, #notes, etc.
+    # but adds validation and returns a typed object instead of a raw Hash.
+    def vulnerable_environment(mod)
+      return nil unless mod
+
+      raw = mod.send(:module_info)['VulnerableEnvironment']
+      return nil unless raw
+
+      VulnerableEnvironment.new(raw)
+    rescue ArgumentError => e
+      print_error("Module has invalid VulnerableEnvironment: #{e.message}")
+      nil
+    end
+
+    def cmd_test_env_build(args)
+      mod = driver.active_module
+      unless mod
+        print_error("No active module. Use 'use <module>' first.")
+        return
+      end
+
+      env = vulnerable_environment(mod)
+      unless env
+        print_error("Module does not define a vulnerable environment configuration.")
+        return
+      end
+
+      # env.definition      => 'jenkins'
+      # env.default_variant   => '2.361'
+      # env.profile           => 'default'
+      # env.port_mapping      => {8080 => 'RPORT'}
+      # env.overrides         => { ... }
+
+      # ...
+    end
+  end
+end
+```
+
+## Why This Approach
+
+| Concern | Resolution |
+|---------|-----------|
+| **Framework pattern alignment** | `vulnerable_environment` mirrors `name`, `description`, `notes` — public accessor reading from `module_info` |
+| **Collision avoidance** | Full word `vulnerable_environment` instead of abbreviated `vuln_env`; key name `VulnerableEnvironment` instead of `VulnEnv` |
+| **Type safety** | `VulnerableEnvironment` Struct validates keys and types at initialization |
+| **No core modifications** | Plugin provides the accessor; no changes to `lib/msf/core/module/module_info.rb` required |
+| **Future upstream path** | When proposing core integration, the same `VulnerableEnvironment` Struct and accessor can move to `module_info.rb` with minimal changes |
+
+## Future Core Integration Path
+
+When proposing upstream integration with `rapid7/metasploit-framework`, the following would be added to `lib/msf/core/module/module_info.rb`:
+
+```ruby
+# Public accessor following the established pattern
+def vulnerable_environment
+  module_info['VulnerableEnvironment']
+end
+```
+
+And optionally a `merge_info_vulnerableenvironment` method to hook into `merge_check_key`:
+
+```ruby
+protected
+
+def merge_info_vulnerableenvironment(info, val)
+  # Deep-merge VulnerableEnvironment hashes when modules inherit
+  if info['VulnerableEnvironment'].is_a?(Hash) && val.is_a?(Hash)
+    info['VulnerableEnvironment'] = deep_merge(info['VulnerableEnvironment'], val)
+  else
+    info['VulnerableEnvironment'] = val
+  end
+end
+```
+
+## What I Verified
+
+I wrote `test_final.rb` to confirm that custom keys defined in `update_info()` persist in `module_info` and are readable at runtime by framework extensions.
+
+```ruby
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift(File.expand_path('lib', __dir__))
+require 'msfenv'
+require 'msf/core'
+
+framework = Msf::Simple::Framework.create
+mod = framework.modules.create('exploit/multi/http/jenkins_script_console')
+
+puts "Module: #{mod.fullname}"
+puts ""
+
+# Test: Can we read module_info via send?
+puts "=== Reading module_info via send ==="
+info = mod.send(:module_info)
+puts "Type: #{info.class}"
+puts "Keys count: #{info.keys.length}"
+puts "Has Name? #{info.key?('Name')}"
+puts "Name: #{info['Name']}"
+puts ""
+
+# Test: Can we add a custom key? (Proof of mechanism only)
+puts "=== Adding custom key (runtime injection test) ==="
+info['VulnerableEnvironment'] = {
+  'definition'      => 'jenkins',
+  'default_variant' => '2.361',
+  'port_mapping'    => { 8080 => 'RPORT' }
+}
+
+puts "Added VulnerableEnvironment"
+puts "Has VulnerableEnvironment? #{info.key?('VulnerableEnvironment')}"
+puts "VulnerableEnvironment: #{info['VulnerableEnvironment'].inspect}"
+puts ""
+
+# Test: Can we read it back?
+puts "=== Reading back ==="
+info2 = mod.send(:module_info)
+puts "Same object? #{info.equal?(info2)}"
+puts "Has VulnerableEnvironment? #{info2.key?('VulnerableEnvironment')}"
+puts "VulnerableEnvironment: #{info2['VulnerableEnvironment'].inspect}"
+```
+
+### Output I Got
+
+```
+Module: exploit/multi/http/jenkins_script_console
+
+=== Reading module_info via send ===
+Type: Hash
+Keys count: 18
+Has Name? true
+Name: Jenkins-CI Script-Console Java Execution
+
+=== Adding custom key (runtime injection test) ===
+Added VulnerableEnvironment
+Has VulnerableEnvironment? true
+VulnerableEnvironment: {"definition"=>"jenkins", "default_variant"=>"2.361", "port_mapping"=>{8080=>"RPORT"}}
+
+=== Reading back ===
+Same object? true
+Has VulnerableEnvironment? true
+VulnerableEnvironment: {"definition"=>"jenkins", "default_variant"=>"2.361", "port_mapping"=>{8080=>"RPORT"}}
+```
+
+### What This Proves
+
+| Test | Result |
+|------|--------|
+| `mod.send(:module_info)` returns a Hash | ✅ Yes |
+| The Hash contains standard keys like `Name` | ✅ Yes |
+| Custom keys written during `update_info()` persist | ✅ Yes |
+| The Hash is the same object (not a copy) | ✅ Yes |
+
+> **Note:** The runtime injection in the test script above is for verification only. Production modules must define `VulnerableEnvironment` inside `initialize` as shown in the first code block.
+
+## Source Code Evidence
+
+From `lib/msf/core/module/module_info.rb` line 69:
+
+```ruby
+protected
+
+# @!attribute module_info
+attr_accessor :module_info
+```
+
+`module_info` is a **protected** `attr_accessor`. That is why:
+- `mod.module_info` raises `NoMethodError` (protected method)
+- `mod.send(:module_info)` works (bypasses access control)
+
+The framework itself accesses `module_info` directly in `lib/msf/core/module/module_info.rb`:
+
+```ruby
+def name
+  module_info['Name']
+end
+
+def notes
+  module_info['Notes']
+end
+```
+
+And in `lib/msf/core/module.rb`:
+
+```ruby
+self.module_info = info
+self.author = Msf::Author.transform(merge_module_info_with_target_info(module_info, 'Author'))
+```
+
+## Resolution Flow
+
+```
+test_env build called
+    ↓
+driver.active_module → Msf::Module instance (already initialized)
+    ↓
+vulnerable_environment(mod) → VulnerableEnvironment Struct or nil
+    ↓
+if nil: print_error("Module does not define a vulnerable environment configuration.")
+    ↓
+if present:
+    env.definition      => 'jenkins' # maps to variant 'name' in the YAML list
+    env.default_variant => '2.361'
+    env.profile         => 'default'
+    env.port_mapping    => {8080 => 'RPORT'}
+    env.overrides       => { ... }
+    ↓
+    yaml_path = File.join(Msf::Config.data_directory, 'vuln_envs', "#{env.definition}.yml")
+    definition_data = YAML.load_file(yaml_path)
+    env_config = loader.resolve(env.definition, env.default_variant, env.profile, env.overrides)
+```
+
+## Error Cases
+
+| Condition | Error Message |
+|-----------|--------------|
+| No active module | "No active module. Use 'use <module>' first." |
+| Module has no VulnerableEnvironment | "Module does not define a vulnerable environment configuration." |
+| Invalid VulnerableEnvironment (missing required key) | "Module has invalid VulnerableEnvironment: Missing required key: 'definition'" |
+| Invalid VulnerableEnvironment (wrong type) | "Module has invalid VulnerableEnvironment: Key 'port_mapping' must be Hash, got String" |
+| Invalid port_mapping key | "port_mapping key must be an integer port, got: 'abc'" |
+| Invalid port_mapping value | "port_mapping value must be a String datastore option name, got: 123" |
+| Definition file not found | "Environment definition not found: data/vuln_envs/{name}.yml" |
+| Variant not found in definition | "Variant '{variant}' not defined for '{name}'" |
+| Profile not found in definition | "Profile '{profile}' not defined for '{name}'" |

--- a/docs/test_env/architecture/03-database-schema.md
+++ b/docs/test_env/architecture/03-database-schema.md
@@ -1,0 +1,223 @@
+# Database Schema & Persistence
+
+## What I Learned From Metasploit Source
+
+I investigated the database architecture and found:
+
+### Migration System
+- `db/migrate/` exists but is **empty** in the framework repo
+- Migrations are gathered from **Rails engines** via `gather_engine_migration_paths`
+- `lib/msf/core/db_manager/migration.rb` uses `ActiveRecord::MigrationContext`
+- `schema.rb` is auto-generated, not edited directly
+
+### Key Code From `lib/msf/core/db_manager/migration.rb`
+
+```ruby
+def gather_engine_migration_paths
+  paths = ActiveRecord::Migrator.migrations_paths
+  ::Rails::Engine.subclasses.map(&:instance).each do |engine|
+    migrations_paths = engine.paths['db/migrate'].existent_directories
+    migrations_paths.each do |migrations_path|
+      unless paths.include? migrations_path
+        paths << migrations_path
+      end
+    end
+  end
+  paths
+end
+```
+
+### Database Configuration
+- `config/database.yml` does not exist in the framework
+- Database config is passed via `DatabaseYAML` option
+- `framework.db.active` checks if database is connected
+
+## Phase 1: Plugin-Only (Weeks 1-6) — In-Memory Registry
+
+**Decision:** For the initial plugin implementation, use **in-memory storage only**.
+No database migrations, no schema changes.
+
+### Why In-Memory First?
+1. No framework modifications required
+2. Plugin loads/unloads cleanly
+3. Container labels provide cross-session identification
+4. Database integration is Phase 2 (Week 6)
+
+### In-Memory Registry Design
+
+```ruby
+class BuiltEnvironmentRegistry
+  attr_reader :environments, :framework
+  
+  def initialize(framework)
+    @framework = framework
+    @environments = {}  # local_id => Hash
+    @next_id = 1
+  end
+  
+  def register(container_id:, module_fullname:, rhost:, rport:,
+               version: nil, runtime: 'docker', image_ref:,
+               exploit_command:, datastore: {})
+    id = @next_id
+    @next_id += 1
+    
+    @environments[id] = {
+      local_id: id,
+      container_id: container_id,
+      module_fullname: module_fullname,
+      env_version: version,
+      rhost: rhost,
+      rport: rport,
+      runtime: runtime,
+      image_ref: image_ref,
+      status: 'running',
+      exploit_command: exploit_command,
+      datastore: datastore,
+      created_at: Time.now,
+      started_at: Time.now
+    }
+    
+    id
+  end
+  
+  def get(id)
+    @environments[id]
+  end
+  
+  def list
+    @environments.values.sort_by { |e| e[:local_id] }
+  end
+  
+  def update_status(id, status)
+    return unless @environments[id]
+    @environments[id][:status] = status
+    @environments[id][:updated_at] = Time.now
+    @environments[id][:stopped_at] = Time.now if status == 'stopped'
+    @environments[id][:started_at] = Time.now if status == 'running'
+  end
+  
+  def remove(id)
+    return unless @environments[id]
+    @environments[id][:status] = 'removed'
+    @environments[id][:removed_at] = Time.now
+    @environments.delete(id)
+  end
+  
+  def remove_all
+    @environments.each_value do |env|
+      env[:status] = 'removed'
+      env[:removed_at] = Time.now
+    end
+    @environments.clear
+    @next_id = 1
+  end
+  
+  def find_by_container(container_id)
+    @environments.values.find { |e| e[:container_id] == container_id }
+  end
+  
+  def find_by_module(module_fullname)
+    @environments.values.select { |e| e[:module_fullname] == module_fullname }
+  end
+  
+  def used_ports
+    @environments.values.map { |e| e[:rport] }
+  end
+  
+  def running?
+    @environments.values.any? { |e| e[:status] == 'running' }
+  end
+end
+```
+
+### Container Labels (Cross-Session Identification)
+
+Since in-memory data is lost on msfconsole restart, use **OCI container labels**
+to identify and reconstruct environments.
+
+**Design Decision:** Use only lightweight individual labels for the minimal
+dynamic data needed. All static metadata (credentials, datastore defaults,
+health checks, exploit commands) is reconstructible from the module's
+`VulnerableEnvironment` definition and the environment YAML file.
+
+**Rationale:** The second mentor correctly observed that if we can identify
+the container by `managed_by` + `instance_id` + `module` labels, we can look
+up the module's `VulnerableEnvironment` definition from `module_info`. The
+definition contains `port_mapping`, `datastore_defaults`, `credentials`, and
+`health_check`. The only truly dynamic data that cannot be reconstructed is:
+
+1. **Allocated port(s)** — dynamically assigned at runtime
+2. **Environment version** — which image tag was provisioned
+3. **Container runtime ID** — the actual Docker/Podman container ID
+
+**Label Schema:**
+
+| Label | Type | Value | Purpose |
+|-------|------|-------|---------|
+| `msf.vulnenv.managed_by` | String | `test_env` | Discovery filter — find all framework-managed containers |
+| `msf.vulnenv.instance_id` | String | `msf-{hostname}-{pid}` | Session isolation — identify which msfconsole created it |
+| `msf.vulnenv.module` | String | Module fullname | Module linkage — filter by target module |
+| `msf.vulnenv.env_id` | String | `1` | Registry cross-reference — map to in-memory ID |
+| `msf.vulnenv.version` | String | `2.361` | **Version used** — not reliably in image tag |
+| `msf.vulnenv.ports` | String | `8081:8080` | **Allocated port mapping** — host:container, comma-separated |
+
+**Example:**
+
+```bash
+docker run -d \
+  --label "msf.vulnenv.managed_by=test_env" \
+  --label "msf.vulnenv.instance_id=msf-hostname-12345" \
+  --label "msf.vulnenv.module=exploit/multi/http/jenkins_script_console" \
+  --label "msf.vulnenv.env_id=1" \
+  --label "msf.vulnenv.version=2.361" \
+  --label "msf.vulnenv.ports=8081:8080" \
+  vulnhub/jenkins:2.361
+```
+
+**Why no Base64 JSON payload?**
+
+| Concern | Resolution |
+|---------|-----------|
+| Docker label size limit (~2KB total) | Lightweight labels stay well under limit |
+| Schema evolution | Adding a new label is simpler than versioning a JSON schema |
+| No encoding/decoding complexity | No Base64, no JSON parsing errors |
+
+
+
+## Phase 2: YAML Persistence with ActiveModel (Week 6+)
+
+Phase 2 replaces purely in-memory storage with **ActiveModel-backed YAML persistence** in `~/.msf4/test_env_registry.yml`. This provides cross-session state sharing without requiring any framework database changes.
+
+### Why ActiveModel + YAML?
+
+| Concern | Resolution |
+|---------|-----------|
+| **Framework coupling** | No dependency on `framework.db.active` or PostgreSQL |
+| **Upstream friction** | No migration files, no `metasploit-data-models` coordination |
+| **Portability** | Works in any msfconsole session, even without `msfdb` |
+| **Concurrency** | `flock` file locking enables safe multi-process access |
+| **Security** | `Psych.safe_load` with permitted classes prevents arbitrary code execution |
+
+### Design Overview
+
+- **`VulnTarget`** — `ActiveModel::Model` representing a single provisioned container
+- **`VulnEnvironment`** — `ActiveModel::Validations` collection of all targets
+- **`VulnEnvironmentStore`** — Atomic load/save via `File::LOCK_SH` / `File::LOCK_EX`
+
+### Cross-Session Behavior
+
+The YAML file acts as a **single shared registry** across all msfconsole instances:
+
+- **Sparse monotonic IDs**: IDs are allocated sequentially but never renumbered. Removing environment 2 from `[1, 2, 3]` yields `[1, 3]`, not `[1, 2]`. This matches the Metasploit `sessions` table behavior and prevents identity-shift bugs during batch operations.
+- **Pruning on startup**: Dead entries (containers that no longer exist) are automatically removed. IDs are **not** compacted after pruning — sparse IDs remain stable.
+
+### State Reconstruction
+
+On startup, the plugin:
+
+1. Loads the shared YAML registry
+2. Queries the runtime for all containers with `label=msf.vulnenv.managed_by=test_env`
+3. Prunes registry entries whose `container_id` no longer exists
+4. Reconstructs any running containers missing from the registry by reading their labels and assigning the next monotonic ID
+
+**Important:** Reconstruction uses `container_id` as the ground truth for matching, not the `env_id` label. Because IDs are never compacted, `env_id` labels remain stable references, but `container_id` is still the authoritative identifier.

--- a/docs/test_env/architecture/04-environment-schema.md
+++ b/docs/test_env/architecture/04-environment-schema.md
@@ -1,0 +1,454 @@
+# Environment Definition YAML Schema
+
+## What I Verified
+
+I created `data/vuln_envs/jenkins.yml` and validated it with Ruby:
+
+```bash
+ ruby -e "
+require 'yaml'
+data = YAML.safe_load(File.read('data/vuln_envs/jenkins.yml'), permitted_classes: [Symbol])
+puts 'Name: ' + data['name']
+puts 'Variants: ' + data['variants'].map { |v| v['name'] }.inspect   # ← NEW: 'variants' list, .map
+puts 'Ports: ' + data['shared']['ports'].inspect
+puts 'Health check type: ' + data['shared']['health_check']['type']
+"
+```
+
+Output:
+```
+Name: jenkins
+Variants: ["2.361", "2.375"]
+Ports: {"http"=>8080}
+Health check type: http
+```
+
+## Directory Structure Example
+
+```
+data/
+  vuln_envs/
+    README.md          # Schema documentation
+    jenkins.yml        # Jenkins with multiple profiles
+```
+
+## File Location
+`data/vuln_envs/{name}.yml`
+
+The `{name}` must match the `name` field inside the file.
+
+## Design Principle: Profiles Over Files
+
+A **single environment definition** represents one vulnerable service. It contains **one set of software versions** and **multiple configuration profiles** that describe different runtime states of that service.
+
+**Why profiles instead of separate files?**
+- **DRY**: Software versions are defined once, not duplicated across files
+- **Discoverability**: All variants of a service live in one file
+- **Relationship clarity**: `http-stopped` is explicitly a profile of `jenkins`, not a separate service
+- **Maintainability**: Adding a new version requires editing one file, not N files
+
+**Version strings represent actual software versions.** They are never suffixed to indicate configuration variants. The `profile` key selects the runtime configuration.
+
+## Three-Level Configuration Hierarchy
+
+When `test_env build` resolves an environment, it merges configuration in this order:
+
+```
+Level 1: Base shared (all profiles inherit)
+    ↓
+Level 2: Profile-specific overrides
+    ↓
+Level 3: Module-level overrides (minor tweaks)
+```
+
+This gives maximum reusability while allowing precise per-module customization.
+
+## Decision Matrix: Profile vs. Module Override
+
+| Scenario | Approach | Example |
+|----------|----------|---------|
+| Different runtime state (services on/off, different health check type) | **New profile** | `default` (HTTP on) vs `http-stopped` (HTTP off) |
+| Different health check endpoint or expected status | **Module override** | Same profile, module overrides `health_check.path` |
+| Different datastore default | **Module override** | Same profile, module overrides `datastore_defaults.TARGETURI` |
+| Different credentials | **Module override** | Same profile, module overrides `credentials.default` |
+| Service boots unconfigured and needs one-time setup before it's exploitable | **`shared.provision` (+ `verify`)** | WordPress image with no DB schema/admin account until the install wizard is submitted |
+
+## Schema
+
+### Top-Level Keys
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | String | Yes | Machine-friendly identifier (matches filename) |
+| `description` | String | Yes | Human-readable description |
+| `variants` | Array | Yes | List of variant configurations |
+| `shared` | Hash | Yes | Base configuration inherited by all profiles |
+| `profiles` | Hash | Yes | Map of profile names to profile-specific overrides |
+
+### variants Section
+
+A list of configuration variants for this service. Each variant is a distinct
+runnable configuration — typically a software version, but may also represent
+different backends, plugins, or build options for the same version.
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `name` | String | Yes | Unique identifier for this variant. Used in `test_env build VARIANT=...` |
+| `version` | String | Yes | The actual software version. For information and future validation (e.g., Rapid7#21583) |
+| `image` | String | Yes | OCI image reference |
+| `build_args` | Hash | No | Docker build arguments |
+| `default` | Boolean | No | If `true`, this variant is selected when no `VARIANT` is specified. Only one variant may be `default` |
+
+Example:
+```yaml
+variants:
+  - name: "2.361"
+    version: "2.361"
+    image: vulnhub/jenkins:2.361
+    build_args:
+      JENKINS_VERSION: "2.361"
+    default: true
+
+  - name: "2.361-postgres"
+    version: "2.361"
+    image: vulnhub/jenkins:2.361-pg
+    build_args:
+      JENKINS_VERSION: "2.361"
+      DB_BACKEND: "postgresql"
+
+  - name: "2.375"
+    version: "2.375"
+    image: vulnhub/jenkins:2.375
+    build_args:
+      JENKINS_VERSION: "2.375"
+```
+### shared Section
+
+Base configuration inherited by all profiles. Any field here can be overridden by a profile or by module-level metadata.
+
+#### ports (Required)
+```yaml
+shared:
+  ports:
+    http: 8080
+```
+
+#### health_check (Required in base or profile)
+```yaml
+shared:
+  health_check:
+    type: http
+    path: /login
+    expected_status: 200
+    interval: 5
+    timeout: 2
+    retries: 12
+```
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `type` | String | Yes | `http`, `tcp`, or `command` |
+| `path` | String | If type=http | HTTP path to check |
+| `expected_status` | Integer | No | Default: 200 |
+| `match` | String | No | If type=http. Regex pattern the response body must match. Only checked once `expected_status` matches; use to distinguish "server responding" from "app actually ready" (e.g. an install wizard and a working login page can both return the same status) |
+| `command` | String | If type=command | Command to execute |
+| `expected_output` | String | If type=command | Regex pattern the command output must match |
+| `interval` | Integer | No | Seconds between checks. Default: 5 |
+| `timeout` | Integer | No | Seconds to wait. Default: 2 |
+| `retries` | Integer | No | Max attempts. Default: 12 |
+
+#### credentials (Optional)
+```yaml
+shared:
+  credentials:
+    default:
+      username: admin
+      password: admin
+```
+
+#### datastore_defaults (Optional)
+```yaml
+shared:
+  datastore_defaults:
+    TARGETURI: /script
+```
+
+#### provision (Optional)
+
+Some images boot with the target process running but the application itself
+not yet usable — e.g. a fresh WordPress container serves HTTP but has no
+database schema or admin account until the install wizard is submitted.
+`provision` describes a one-time setup action to run after `health_check`
+passes and before the environment is registered as ready.
+
+```yaml
+shared:
+  provision:
+    type: http
+    method: post
+    path: /wp-admin/install.php?step=2
+    body:
+      weblog_title: "Vulnerable WP"
+      user_name: "{{ credentials.default.username }}"
+      admin_password: "{{ credentials.default.password }}"
+      admin_password2: "{{ credentials.default.password }}"
+      admin_email: "admin@example.com"
+      blog_public: 0
+      Submit: "Install WordPress"
+    timeout: 10
+```
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `type` | String | Yes | Provisioning mechanism. Currently only `http` is supported |
+| `method` | String | No | HTTP verb when `type` is `http`. One of: `post`, `get`, `put`, `patch`. Default: `post` |
+| `path` | String | Yes | Request path, sent to the primary mapped port (the container port mapped to `RPORT` in `port_mapping`) |
+| `body` | Hash | No | Form fields, sent as `application/x-www-form-urlencoded`. Values may reference `{{ credentials.default.<key> }}`, which is resolved against the built datastore (e.g. `USERNAME`/`PASSWORD`). Only used for `post`, `put`, and `patch` |
+| `timeout` | Integer | No | Seconds to wait for the request. Default: 10 |
+
+A response status in the `200`–`399` range is treated as success. Anything
+else (including a request error or timeout) fails the build; the container
+is stopped and removed, matching the existing cleanup behavior for a failed
+health check.
+
+**Architectural decisions:** single stateless request only — no multi-step
+flows (e.g. a form load to fetch a CSRF token before the real submit), no
+session/cookie carryover between requests, and no non-HTTP provisioning
+(e.g. running a setup command inside the container via `runtime.exec`, the
+way `health_check`'s `command` type does). Extend `type` as new provisioning
+shapes come up rather than building these speculatively.
+
+#### verify (Optional)
+
+Re-checks the environment after `provision` runs, confirming the setup
+action actually took effect rather than just assuming success from the
+HTTP status code. Uses the same shape and checker as `health_check`
+(including the `match` field above), so it's commonly used to look for
+content that only appears once setup is complete.
+
+```yaml
+shared:
+  verify:
+    type: http
+    path: /wp-login.php
+    expected_status: 200
+    match: "user_login"
+    interval: 3
+    timeout: 2
+    retries: 10
+```
+
+If `provision` is not defined, `verify` is ignored. If `provision` is
+defined but `verify` is not, the environment is registered as ready as
+soon as `provision` returns a `200`–`399` response, with no further check.
+
+#### volumes (Optional)
+```yaml
+shared:
+  volumes:
+    jenkins_home:
+      container_path: /var/jenkins_home
+      persist: false
+```
+
+#### ci (Optional)
+```yaml
+shared:
+  ci:
+    exploit:
+      payload: java/meterpreter/reverse_tcp
+      options:
+        LPORT: 4444
+    validation:
+      expected_session: true
+      session_type: meterpreter
+      expected_output: "uid="
+      timeout: 120
+```
+
+**`ci.exploit`** — read and applied automatically by both `test_env build`
+and `test_env exec`. If `payload` is set and differs from the module's
+current `PAYLOAD`, it's applied via `set PAYLOAD ...` before the module
+runs (this is what lets a definition steer around a module's own default
+payload when that default is known not to work against the image).
+Any keys under `options` are applied the same way.
+
+Do not set `LHOST` here. The target runs inside a container network
+namespace; a hardcoded `LHOST` (especially `127.0.0.1`) resolves to the
+container itself, not the host, so the payload can never call back or be
+fetched. Leaving `LHOST` unset lets Metasploit's own outbound-interface
+auto-detection supply the host's real reachable address, which is what
+actually works from inside a container.
+
+| Key | Type | Required | Description |
+|-----|------|----------|--------------|
+| `payload` | String | No | Payload to select for this environment, if the module's default is unsuitable |
+| `options` | Hash | No | Additional datastore keys to set (e.g. `LPORT`). Do not include `LHOST` |
+
+**`ci.validation`** — read and checked by `test_env validate <ID>`, run
+after `test_env exec <ID>`. This is the single definition of "did this
+environment's exploit actually work," used identically whether a human
+runs `validate` interactively or a future headless CI runner calls the
+same resolution + check path - there is one source of truth, not a
+YAML description alongside a separately-hand-maintained CI script.
+
+| Key | Type | Required | Description |
+|-----|------|----------|--------------|
+| `expected_session` | Boolean | No | Default `true`. If `false`, `validate` passes without checking for a session at all |
+| `session_type` | String | No | `meterpreter` or `shell`. If set, the created session's type must match |
+| `expected_output` | String | No | Regex pattern that the output of the verification command on the session must match, e.g. `"uid="` or `"uid=\\d+"` |
+| `timeout` | Integer | No | Seconds to wait for a session to appear before failing. Default: 120 |
+
+`validate` reports `PASS` or `FAIL` with a specific reason. If no session
+exists yet, run `test_env exec <ID>` first.
+
+**Known limitation:** `validate` looks for the session in the current
+process's `framework.sessions`. Metasploit sessions are process-local -
+they exist only in the msfconsole process that opened them, with no
+automatic cross-process visibility. `exec` and `validate` must therefore
+run in the *same* msfconsole process/window. A future headless CI runner
+would need to invoke both within a single `msfconsole -x` script (or
+equivalent single-process automation), not as two independent CLI
+invocations - this is a real constraint on any CI-alignment design here,
+not just an interactive-usage quirk.
+
+### profiles Section
+
+Each profile is a key-value pair:
+- **Key**: Profile name (e.g., `default`, `http-stopped`)
+- **Value**: Hash that overrides or extends `shared`
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `description` | String | Yes | What this profile represents |
+| `health_check` | Hash | No | Overrides base `shared.health_check` |
+| `datastore_defaults` | Hash | No | Overrides base `shared.datastore_defaults` |
+| `credentials` | Hash | No | Overrides base `shared.credentials` |
+| `volumes` | Hash | No | Overrides base `shared.volumes` |
+| `ci` | Hash | No | Overrides base `shared.ci` |
+| `provision` | Hash | No | Overrides base `shared.provision` |
+| `verify` | Hash | No | Overrides base `shared.verify` |
+
+**Profile names** must match `[a-z0-9-]+`.
+
+## Validation Rules
+
+1. `name` must match filename (without `.yml`)
+2. `variants` must be a non-empty list
+3. Each variant must have a `name` and `image`
+4. Variant `name` must be unique across all variants
+5. At most one variant may have `default: true`
+6. `shared.ports` must have at least one entry
+7. `profiles` must have at least one entry
+8. `profiles` must contain a `default` profile
+9. Profile names must match `[a-z0-9-]+`
+10. `health_check` must be defined in `shared` or in every profile
+11. Module-level `overrides` are deep-merged into the final profile config
+
+## Resolution & Merge Logic
+
+When `test_env build` resolves an environment definition, the loader performs a **three-level deep merge**:
+
+### Merge Order
+
+| Level | Source | What It Contains |
+|-------|--------|------------------|
+| 1 | `shared` | Base configuration inherited by all profiles |
+| 2 | `profiles[profile_name]` | Profile-specific overrides (minus `description`) |
+| 3 | `VulnerableEnvironment['overrides']` | Module-level tweaks |
+
+### Merge Rules
+
+- **Hash fields** (e.g., `health_check`, `datastore_defaults`) are deep-merged: nested keys are combined, not replaced wholesale.
+- **Scalar fields** (e.g., `image`, `build_args`) are replaced by the higher level.
+- **The `description` key** in a profile is informational only and is excluded from the merge.
+
+### Resolution Steps
+
+1. Load the YAML definition file by `name`.
+2. Validate that `variants` contains the requested `variant`.
+3. Validate that `profiles` contains the requested `profile` (default: `'default'`).
+4. Start with a copy of `shared`.
+5. Deep-merge the selected profile's configuration into it.
+6. Deep-merge the module's `VulnerableEnvironment['overrides']` (if any).
+7. Attach the variant-specific `image`, `version`, and `build_args` from the matching variant in the `variants` list.
+
+If the resolved config includes `provision`, it runs once the container
+passes `health_check` and before the environment is registered. If
+`verify` is also present, it runs immediately after `provision` succeeds.
+A failure at either step aborts the build and tears down the container,
+the same as a failed `health_check`.
+
+### Error Cases
+
+| Condition | Error |
+|-----------|-------|
+| Definition file not found | `"Definition not found: data/vuln_envs/{name}.yml"` |
+| Variant not in `variants` | `"Variant '{variant}' not defined for '{name}'"` |
+| Profile not in `profiles` | `"Profile '{profile}' not defined for '{name}'"` |
+| No `default` profile exists | Validation fails at load time |
+
+### Loader Interface (Week 3)
+
+The `EnvironmentDefinitionLoader` exposes:
+
+- `load(name)` — Parse and validate a definition file.
+- `resolve(name, variant, profile, overrides)` — Return the fully merged configuration for a specific environment instance.
+- `available_definitions` — List all `.yml` files in `data/vuln_envs/`.
+## Module Metadata Integration
+
+Modules reference a definition and optionally a profile. See [02-module-metadata.md](https://github.com/Nayeraneru/metasploit-framework/blob/vulnenv-week1/docs/architecture/02-module-metadata.md) for the full `VulnerableEnvironment` schema.
+
+```ruby
+# Standard module — uses default variant and profile
+'VulnerableEnvironment' => {
+  'definition'      => 'jenkins',
+  'default_variant' => '2.361',
+  'port_mapping'    => { 8080 => 'RPORT' }
+}
+
+# Variant module — uses postgres variant
+'VulnerableEnvironment' => {
+  'definition'      => 'jenkins',
+  'default_variant' => '2.361-postgres',
+  'port_mapping'    => { 8080 => 'RPORT' }
+}
+
+# Module with profile override
+'VulnerableEnvironment' => {
+  'definition'      => 'jenkins',
+  'default_variant' => '2.361',
+  'profile'         => 'http-stopped',
+  'port_mapping'    => { 8080 => 'RPORT' }
+}
+
+# Module with minor override — same profile, different health check
+'VulnerableEnvironment' => {
+  'definition'      => 'jenkins',
+  'default_variant' => '2.361',
+  'port_mapping'    => { 8080 => 'RPORT' },
+  'overrides'       => {
+    'health_check' => {
+      'path' => '/script',
+      'expected_status' => 403
+    },
+    'datastore_defaults' => {
+      'TARGETURI' => '/script'
+    }
+  }
+}
+```
+
+
+## Integration With Registry
+
+Environment definitions are loaded by the plugin and used to:
+1. Build/pull container images
+2. Map container ports to host ports
+3. Configure health checks
+4. Run one-time provisioning and post-provision verification, if defined
+5. Set module datastore defaults
+6. Apply profile-specific overrides
+7. Apply module-level overrides (if any)
+
+See [03-database-schema.md](https://github.com/Nayeraneru/metasploit-framework/blob/vulnenv-week1/docs/architecture/03-database-schema.md) for registry design.

--- a/docs/test_env/architecture/05-runtime-adapter.md
+++ b/docs/test_env/architecture/05-runtime-adapter.md
@@ -1,0 +1,210 @@
+# Runtime Adapter & Port Allocation
+
+## What I Verified on My Machine
+
+### Docker and Podman Availability
+
+**Both runtimes are installed.** Docker will be primary, Podman fallback.
+
+### Docker Inspect Test
+
+I ran a test container (port binding failed due to conflict, but inspect worked):
+
+```bash
+$ docker run -d --name test-nginx --label msf.test=1 -p 127.0.0.1:8080:80 nginx
+# Port 8080 was in use — container created but not started
+# This proves: FIXED PORTS FAIL, dynamic allocation is required
+
+$ docker inspect test-nginx > /tmp/docker-inspect.json
+```
+
+Key fields from `docker inspect` output:
+
+```json
+{
+  "Id": "59721d248c4ff4be689ae3fedf8dc947f53d06c657ac0b1418205621a1ee6f44",
+  "State": {
+    "Status": "created",
+    "Running": false
+  },
+  "Config": {
+    "Labels": {
+      "msf.test": "1"
+    }
+  },
+  "HostConfig": {
+    "PortBindings": {
+      "80/tcp": [
+        {
+          "HostIp": "127.0.0.1",
+          "HostPort": "8080"
+        }
+      ]
+    }
+  }
+}
+```
+
+**Important findings:**
+- Labels are stored in `Config.Labels`, not top-level
+- `State.Status` shows "created" when container fails to start
+- `HostConfig.PortBindings` shows the requested mapping
+- **Port 8080 was already in use — fixed ports are unreliable**
+
+### Port Allocation Test
+
+I wrote and ran `test_port.rb`:
+
+```ruby
+#!/usr/bin/env ruby
+
+require 'socket'
+
+def port_available?(port)
+  server = TCPServer.new('127.0.0.1', port)
+  server.close
+  true
+rescue Errno::EADDRINUSE
+  false
+end
+
+def find_port(preferred = nil, used = [])
+  if preferred
+    return preferred if port_available?(preferred) && !used.include?(preferred)
+    puts "Port #{preferred} unavailable, finding alternative..."
+  end
+
+  (49152..65535).each do |p|
+    next if used.include?(p)
+    return p if port_available?(p)
+  end
+
+  raise "No available ports"
+end
+
+# Test
+puts "Port 8080 available? #{port_available?(8080)}"
+puts "Found port: #{find_port}"
+puts "Found port (prefer 9999): #{find_port(9999)}"
+```
+
+Output:
+```
+Port 8080 available? true
+Found port: 49152
+Found port (prefer 9999): 9999
+```
+
+**Port allocation works.** `TCPServer.new('127.0.0.1', port)` correctly tests availability.
+
+## Critical Design Decision: Dynamic Port Allocation
+
+From the Docker test failure:
+- **Never assume a port is available**
+- **Always test before binding**
+- **Fallback to ephemeral range (49152-65535)**
+- **Inform user when fallback occurs**
+
+## Runtime Adapter Design
+
+### Interface
+
+```ruby
+module RuntimeAdapter
+  def self.detect
+    return DockerRuntime.new if DockerRuntime.available?
+    return PodmanRuntime.new if PodmanRuntime.available?
+    nil
+  end
+end
+
+class BaseRuntime
+  def available?; raise NotImplementedError; end
+  def name; raise NotImplementedError; end
+  
+  def pull(image); raise NotImplementedError; end
+  def run(image:, ports:, labels:, volumes: [], env: {}, name: nil)
+    raise NotImplementedError
+  end
+  def stop(container_id); raise NotImplementedError; end
+  def start(container_id); raise NotImplementedError; end
+  def remove(container_id); raise NotImplementedError; end
+  def inspect(container_id); raise NotImplementedError; end
+  def exec(container_id, command); raise NotImplementedError; end
+  def list(filters: {}); raise NotImplementedError; end
+end
+```
+> **Note:** `BaseRuntime#exec` executes commands *inside* the container (for health checks). This is distinct from the `test_env exec` dispatcher command which runs the exploit module. No collision occurs in practice due to Ruby namespacing.
+
+## Container Label Schema
+
+All containers created by test_env receive these labels:
+
+| Label | Value | Purpose |
+|-------|-------|---------|
+| `msf.vulnenv.instance_id` | `msf-{hostname}-{pid}` | Isolate msfconsole instances |
+| `msf.vulnenv.module` | Module fullname | Link to exploit module |
+| `msf.vulnenv.version` | Environment version | Track which version |
+| `msf.vulnenv.env_id` | Internal registry ID | Cross-reference |
+| `msf.vulnenv.created_at` | ISO8601 timestamp | Audit trail |
+| `msf.vulnenv.managed_by` | `test_env` | Identify framework-managed |
+
+## Docker vs Podman Differences
+
+| Feature | Docker | Podman | Impact on Design |
+|---------|--------|--------|----------------|
+| Daemon | Required (`dockerd`) | Daemonless | Podman simpler for rootless |
+| Rootless | Complex setup | Default | Podman more secure |
+| CLI syntax | `docker ...` | `podman ...` | Simple binary substitution |
+| Networking | Bridge by default | `slirp4netns` for rootless | Slight performance difference |
+| Image storage | Central (`/var/lib/docker`) | Per-user (`~/.local/share/containers`) | Not shared between users |
+
+## Auto-Detection Strategy
+
+## How test_env build Handles Port Conflicts
+
+### Problem
+
+From my test:
+```bash
+docker run -d -p 127.0.0.1:8080:80 nginx
+# Error: ports are not available: exposing port TCP 127.0.0.1:8080
+```
+
+Port 8080 was already in use. Fixed ports fail.
+
+### Solution: Dynamic Port Allocation with Automatic Fallback
+
+The `PortAllocator` class above handles this by:
+1. Testing if preferred port is available via `TCPServer.new`
+2. If not, scanning ephemeral range for available port
+3. Tracking used ports to avoid duplicates
+
+
+When `test_env build` runs, it:
+- Reads the vulnerability environment's `port_mapping` (e.g., `{8080 => 'RPORT'}`)
+- Checks if the user passed an override like `RPORT=8081`
+- Allocates each required port, falling back to the ephemeral range if the preferred port is taken
+- Starts the container with the allocated mappings
+- Reports actual ports to the user
+- Auto-sets the corresponding module datastore options
+- 
+### Key Design Principles
+
+| Principle | Implementation |
+|-----------|---------------|
+| Never assume a port is available | `TCPServer.new` test before binding |
+| Always provide fallback | Ephemeral range scan |
+| Respect user preference | Try requested port first |
+| Inform user of changes | Print status when fallback occurs |
+| Auto-configure module | Set datastore options automatically |
+
+## Error Handling
+
+| Error Condition | Message |
+|-----------------|---------|
+| No runtime available | "No container runtime found. Install Docker or Podman." |
+| Image pull failed | "Failed to pull image: {image}" |
+| Container start failed (port conflict) | "Failed to start container: {error}. Try without RPORT override." |
+| No available ports | "No available ports in range 49152-65535" |
+| Container not found | "Container {id} not found" |

--- a/docs/test_env/ci_workflow.md
+++ b/docs/test_env/ci_workflow.md
@@ -1,0 +1,248 @@
+# CI Workflow: Automated Exploit Verification
+
+This document defines how `test_env` will be used in GitHub Actions to automatically:
+- Provision vulnerable environments from shared definitions
+- Execute exploits with pre-configured datastore options
+- Validate expected outcomes (session creation, command output)
+- Clean up all containers to prevent resource leaks
+
+**Key principle:** CI consumes the same environment definitions used for local testing. No duplicated container configuration.
+
+## Trigger Strategy
+
+Environment provisioning and exploit execution are time-consuming operations. To balance validation coverage with CI resource usage, this workflow runs on a **weekly schedule** for regression detection, **on-demand via maintainer-applied labels** for PR validation, and **manually** for debugging. It does not run on every push or pull request.
+
+| Trigger | When It Runs | Purpose |
+|---------|--------------|---------|
+| Weekly schedule (`cron: '0 0 * * 0'`) | Every Sunday at midnight UTC | Catch environment bit-rot and upstream image changes |
+| Label (`vuln-env-test`) | When a maintainer applies the label to a PR | Validate PRs that modify environment definitions or exploit modules |
+| `workflow_dispatch` | Manual button click in GitHub UI | Debugging or pre-release checks |
+
+## Directory Structure
+
+```
+metasploit-framework/
+├── ci/                          
+│   ├── test_activemq.rc         
+│   └── test_wordpress.rc           
+├── .github/
+│   └── workflows/
+│       └── vuln-env-test.yml    
+├── data/
+│   └── vuln_envs/
+│       ├── activemq.yml         
+│       └── wordpress.yml          
+└── docs/
+    └── ci_workflow.md           
+```
+
+## Resource Scripts
+
+A **resource script** with a `.rc` extension contains msfconsole commands. Instead of typing commands one by one into msfconsole, they are saved in a file and run:
+
+```bash
+./msfconsole -q -r path/to/script.rc
+```
+
+Metasploit reads the file and executes each line automatically, as if it's typed.
+
+### Example: ci/test_activemq.rc
+
+**What it is:** A text file containing msfconsole commands to test the ActiveMQ module automatically.
+
+**What it contains:**
+```text
+load test_env
+use exploit/multi/http/apache_activemq_jolokia_rce
+test_env build
+test_env exec 1
+test_env remove-all
+exit
+```
+
+**What each line does:**
+| Line | Command | Purpose |
+|------|---------|---------|
+| 1 | `load test_env` | Load the test_env plugin |
+| 2 | `use exploit/multi/http/apache_activemq_jolokia_rce` | Select the exploit module |
+| 3 | `test_env build` | Build environment for active module |
+| 4 | `test_env exec 1` | Execute exploit against environment ID 1 |
+| 5 | `test_env remove-all` | Stop and remove all containers |
+| 6 | `exit` | Close msfconsole |
+
+**How to run it manually (for testing):**
+```bash
+./msfconsole -q -r ci/test_activemq.rc
+```
+
+## GitHub Actions Workflow
+
+**What this is:** A YAML file that tells GitHub Actions what to do.
+
+**File:** `.github/workflows/vuln-env-test.yml`
+
+**What it contains:**
+```yaml
+name: Vulnerable Environment Test
+
+on:
+  # Weekly scheduled run: catches environment bit-rot and upstream image changes
+  schedule:
+    - cron: '0 0 * * 0'  # Every Sunday at midnight UTC
+  
+  # Manual trigger: for debugging or pre-release validation
+  workflow_dispatch:
+  
+  # Label-triggered: maintainers add 'vuln-env-test' label to PRs that modify
+  # environment definitions or exploit modules
+  pull_request:
+    types: [labeled]
+
+jobs:
+  test-activemq:
+    name: Test Apache ActiveMQ Jolokia RCE
+    runs-on: ubuntu-latest
+    
+    # Skip PRs without the vuln-env-test label
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'vuln-env-test')
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      
+      - name: Run ActiveMQ exploit test
+        run: |
+          ./msfconsole -q -r ci/test_activemq.rc
+      
+      - name: Verify session was created
+        run: |
+          grep "Session.*opened" ~/.msf4/logs/framework.log || echo "WARNING: No session log found"
+      
+      - name: Verify no containers left behind
+        run: |
+          REMAINING=$(docker ps -q | wc -l)
+          if [ "$REMAINING" -eq 0 ]; then
+            echo "Clean: No containers remaining"
+          else
+            echo "FAIL: $REMAINING container(s) still running"
+            docker ps
+            exit 1
+          fi
+
+  test-wordpress:
+    name: Test WordPress Admin Shell Upload
+    runs-on: ubuntu-latest
+    
+    # Skip PRs without the vuln-env-test label
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'vuln-env-test')
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      
+      - name: Run WordPress exploit test
+        run: |
+          ./msfconsole -q -r ci/test_wordpress.rc
+      
+      - name: Verify session was created
+        run: |
+          grep "Session.*opened" ~/.msf4/logs/framework.log || echo "WARNING: No session log found"
+      
+      - name: Verify no containers left behind
+        run: |
+          REMAINING=$(docker ps -q | wc -l)
+          if [ "$REMAINING" -eq 0 ]; then
+            echo "Clean: No containers remaining"
+          else
+            echo "FAIL: $REMAINING container(s) still running"
+            docker ps
+            exit 1
+          fi
+```
+
+**What each step does:**
+| Step | Action | Purpose |
+|------|--------|---------|
+| Checkout | `actions/checkout@v4` | Download your code |
+| Set up Ruby | `ruby/setup-ruby@v1` | Install Ruby 3.2 and gems |
+| Set up Docker | `docker/setup-buildx-action@v3` | Install Docker |
+| Cache Docker layers | `actions/cache@v3` | Speed up image pulls |
+| Run exploit test | `./msfconsole -q -r ci/test_activemq.rc` | Execute the ActiveMQ resource script |
+| Verify session | `grep "Session.*opened"` | Confirm exploit succeeded |
+| Verify cleanup | `docker ps -q` | Confirm no leaked containers |
+
+## Validation Criteria
+
+| Step | Expected Result | How It Is Checked | On Failure |
+|------|----------------|-------------------|------------|
+| `test_env build` | Container starts, health check passes | Console output contains "Environment ready" | Workflow fails |
+| `test_env exec 1` | Session opens | `framework.log` contains "Session.*opened" | Workflow fails |
+| `test_env remove-all` | All containers removed | `docker ps -q` returns empty | Workflow fails |
+| Post-cleanup | Zero `msf.vulnenv` containers remain | `docker ps -a --filter "label=msf.vulnenv.managed_by=test_env"` returns empty | Workflow fails |
+
+## CI Metadata in Environment Definitions
+
+Environment definitions include a `ci` section so the automation knows what payload to use and what to validate:
+
+```yaml
+# data/vuln_envs/activemq.yml
+ci:
+  exploit:
+    payload: cmd/linux/http/x64/meterpreter/reverse_tcp
+    options:
+      LPORT: 4444
+  validation:
+    expected_session: true
+    session_type: meterpreter
+    expected_output: "uid="
+    timeout: 120
+```
+
+### Schema Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `ci.exploit.payload` | String | Yes | Payload to use for automated execution |
+| `ci.exploit.options` | Hash | No | Payload/handler options: `LHOST`, `LPORT` |
+| `ci.validation.expected_session` | Boolean | Yes | Whether a session must be created |
+| `ci.validation.session_type` | String | No | Expected session type: `meterpreter`, `shell` |
+| `ci.validation.expected_output` | String | No | Substring to verify in session output |
+| `ci.validation.timeout` | Integer | Yes | Max seconds to wait for validation |

--- a/docs/test_env/reference_modules.md
+++ b/docs/test_env/reference_modules.md
@@ -1,0 +1,109 @@
+# Reference Modules for test_env
+
+## Selection Criteria
+- Cover different service types: Java message broker (ActiveMQ), web application (WordPress)
+- Have clear, single-port (or well-defined multi-port) mappings
+- Have existing Docker images with known vulnerable versions
+- Demonstrate different health check patterns (API endpoint, login page, root page)
+- Include both authenticated and unauthenticated exploit scenarios
+
+---
+
+## Module 1: Apache ActiveMQ Jolokia RCE (Mentor Suggested)
+- **Path:** `exploit/multi/http/apache_activemq_jolokia_rce`
+- **Type:** Java web application (JMX-over-HTTP)
+- **Ports:** 8161 (web console / Jolokia API)
+- **Profile:** `default`
+- **Health Check:** HTTP GET `/api/jolokia/` expecting 200, or GET `/` expecting 200
+- **Why:** h00die suggested PR #21497. Has a verified Docker one-liner. Real-world CVE-2026-34197.
+- **VulnerableEnvironment Definition:** `activemq`
+- **Docker Image:** `apache/activemq-classic:5.18.6`
+- **Docker Run:** `docker run -d --name activemq -p 8161:8161 -p 61616:61616 apache/activemq-classic:5.18.6`
+- **Credentials:** admin / admin
+- **Exploit Context:** Requires authenticated Jolokia access; `TARGETURI` typically `/api/jolokia/`
+
+---
+
+## Module 2: WordPress Admin Shell Upload
+- **Path:** `exploit/unix/webapp/wp_admin_shell_upload`
+- **Type:** Web application / CMS
+- **Port:** 80
+- **Health Check:** Two-stage — see **Provisioning** below. Base `health_check` is HTTP GET `/` expecting **[200, 302]** (the container returns `302` to `/wp-admin/install.php` on first boot; this is a valid "server is up" signal, not a failure). A separate `verify` check confirms the app is actually usable after provisioning: HTTP GET `/wp-login.php` expecting `200` and containing `user_login`.
+- **Why:** Pre-built vulnerable image exists (`eystsen/vulnerablewordpress`), widely used in security testing, self-contained (bundles its own MySQL, no external DB link required).
+- **VulnerableEnvironment Definition:** `wordpress`
+- **Docker Image:** `eystsen/vulnerablewordpress`
+- **Credentials:** admin / admin
+- **Exploit Context:** Authenticated admin access; uploads PHP shell via theme/plugin editor
+- **Provisioning:** This image does **not** start ready-to-use. The Dockerfile configures `wp-config.php` to point at a `wordpress` database but never creates the schema or an admin account — WordPress boots straight into the install wizard (`/wp-admin/install.php`), and stays there indefinitely with no admin/admin login until the wizard is submitted. `wordpress.yml` now defines a `provision` step (`type: http_post`, submits `install.php?step=2` with the credentials from `credentials.default`) that runs once the base health check passes, followed by the `verify` check above before the environment is registered as ready. See `04-environment-schema.md` for the general `provision`/`verify` schema this relies on.
+
+---
+
+## Module 3: Apache ActiveMQ OpenWire RCE (CVE-2023-46604)
+- **Path:** `exploit/multi/misc/apache_activemq_rce_cve_2023_46604`
+- **Type:** Java message broker (raw OpenWire protocol, not HTTP)
+- **Port:** 61616 (broker)
+- **Profile:** `broker-only`
+- **Health Check:** Uses activemq.yml's broker-only profile (tcp on 61616). The default HTTP check fails against this image due to AMQ-8018 (web console binds 127.0.0.1 since 5.16.0). Since the module only needs OpenWire, a TCP profile is accurate and matches the schema guidance to create a new profile when the health check type differs.
+- **Why this module specifically:** it's the first real proof that `activemq.yml` works as a genuine shared definition across independent modules, not just independent files that happen to use the same schema. Two unrelated CVEs, two different attack surfaces (HTTP/Jolokia vs. raw OpenWire), one definition file.
+- **VulnerableEnvironment Definition:** `activemq` (same file as Module 1 — nothing duplicated: image family, credentials, health check, and `ci.exploit`'s recommended payload are all inherited unchanged)
+- **Docker Image:** `dinifarb/activemq:5.18.2`
+- **Credentials:** none required — this CVE is unauthenticated
+- **Exploit Context:** Unauthenticated; sends crafted OpenWire packet that loads attacker-hosted Spring XML config. Requires TARGET => 1 (Linux) override — default target is Windows.
+
+---
+
+## Module 4: HTTP Version Scanner (Auxiliary)
+- **Path:** `auxiliary/scanner/http/http_version`
+- **Type:** Auxiliary scanner (no session produced)
+- **Port:** 80
+- **Profile:** `default`
+- **Health Check:** HTTP GET `/` expecting 200
+- **Why:** Trivial scanner module suggested by mentor. Demonstrates that `test_env` works for auxiliary modules, not just exploits. Produces `[+]` output (server banner) without requiring a shell.
+- **VulnerableEnvironment Definition:** `httpd` (shared with http_header and robots_txt)
+- **Docker Image:** `docker.io/library/httpd:2.4.57`
+- **Credentials:** none required
+- **Scanner Context:** Detects HTTP server version from response headers. No payload, no session.
+
+---
+
+## Module 5: HTTP Header Scanner (Auxiliary)
+- **Path:** `auxiliary/scanner/http/http_header`
+- **Type:** Auxiliary scanner (no session produced)
+- **Port:** 80
+- **Profile:** `default`
+- **Health Check:** HTTP GET `/` expecting 200
+- **Why:** Reuses the same `httpd` definition as `http_version`, proving shared definitions work across multiple independent auxiliary modules.
+- **VulnerableEnvironment Definition:** `httpd`
+- **Docker Image:** `docker.io/library/httpd:2.4.57`
+- **Credentials:** none required
+- **Scanner Context:** Displays HTTP response headers. Uses `IGN_HEADER`, `HTTP_METHOD`, and `TARGETURI` options.
+
+---
+
+## Module 6: HTTP Robots.txt Scanner (Auxiliary)
+- **Path:** `auxiliary/scanner/http/robots_txt`
+- **Type:** Auxiliary scanner (no session produced)
+- **Port:** 80
+- **Profile:** `default`
+- **Health Check:** HTTP GET `/` expecting 200
+- **Why:** Third auxiliary module reusing `httpd`. Demonstrates that shared definitions scale to many modules without duplication.
+- **VulnerableEnvironment Definition:** `httpd`
+- **Docker Image:** `docker.io/library/httpd:2.4.57`
+- **Credentials:** none required
+- **Scanner Context:** Detects and analyzes `robots.txt` content. Uses `PATH` option.
+
+---
+
+## Module 7: SSH Version Scanner (Auxiliary)
+- **Path:** `auxiliary/scanner/ssh/ssh_version`
+- **Type:** Auxiliary scanner (no session produced)
+- **Port:** 22
+- **Profile:** `default`
+- **Health Check:** TCP connect on port 22 (SSH daemon accepts connections immediately)
+- **Why:** Demonstrates non-HTTP auxiliary scanner with a different health check type (`tcp` instead of `http`). Produces `[+]` output with SSH banner and encryption details.
+- **VulnerableEnvironment Definition:** `openssh`
+- **Docker Image:** `docker.io/rastasheep/ubuntu-sshd:16.04`
+- **Credentials:** root / root (defined in YAML for completeness, but scanner does not use them)
+- **Scanner Context:** Detects SSH version and supported ciphers. No payload, no session.
+
+

--- a/docs/test_env/workflow.md
+++ b/docs/test_env/workflow.md
@@ -278,8 +278,7 @@ msf exploit(multi/http/jenkins_script_console) > test_env remove-all
 
 ## Notes for Implementers
 
-- All output prefixes (`[*]`, `[+]`, `[-]`) must use `print_status`, `print_good`, `print_error` respectively
-- Table output must use `Rex::Ui::Text::Table` for consistency with built-in commands like `sessions`, `jobs`
+> This plugin follows standard Metasploit UI conventions (`print_status`/`print_good`/`print_error` for output prefixes, `Rex::Ui::Text::Table` for tabular data).
 - The `test_env` command must be available regardless of whether a database is connected (Phase 1 is in-memory only)
 - Container labels must be applied on every `run` so that orphaned containers can be identified even if the registry is lost
 - `test_env build` must detect if the active module requires a payload. If so, it auto-selects a compatible default payload and sets `LHOST` to `127.0.0.1` with an available `LPORT`. These values are stored in the registry alongside the environment metadata. `test_env exec` then applies the complete stored datastore (including payload options) before running the exploit.

--- a/docs/test_env/workflow.md
+++ b/docs/test_env/workflow.md
@@ -1,0 +1,286 @@
+# test_env User Workflow (Design Specification)
+
+This document specifies the intended user interaction with `test_env`. Every transcript below is the **target behavior** that implementation must achieve. These are our acceptance criteria.
+
+---
+
+## Scenario 1: Build an Environment for the Active Module
+
+**Precondition:** The user has selected a module that defines a `VulnerableEnvironment` key in its metadata.
+
+**Input:**
+```
+msf > use exploit/multi/http/apache_activemq_jolokia_rce
+msf exploit(apache_activemq_jolokia_rce) > test_env build
+```
+
+**Expected behavior:**
+- The plugin detects the active module and reads `mod.info['VulnerableEnvironment']`
+- It resolves the definition name (`activemq`) and loads `data/vuln_envs/activemq.yml`
+- It selects the default version (`5.18.6`)
+- It auto-detects the container runtime (Docker preferred, Podman fallback)
+- It pulls `apache/activemq-classic:5.18.6` if not already cached
+- It starts the container with localhost binding and dynamic port allocation
+- It waits for the health check defined in the YAML (`GET /api/jolokia/` → 200)
+- Once ready, it prints the mapped host port and suggests datastore settings
+
+**Expected output:**
+```
+[*] Resolving environment for apache_activemq_jolokia_rce...
+[*] Definition: activemq | Version: 5.18.6 | Runtime: docker
+[*] Pulling image apache/activemq-classic:5.18.6...
+[*] Starting container...
+[*] Waiting for health check (GET /api/jolokia/)...
+[+] Environment ready.
+[*]    RHOSTS    => 127.0.0.1
+[*]    RPORT     => 49152
+[*]    TARGETURI => /api/jolokia/
+[*]    USERNAME  => admin
+[*]    PASSWORD  => admin
+[*] Suggested: set RHOSTS 127.0.0.1; set RPORT 49152; exploit
+```
+
+**Postcondition:** A container is running. The module's datastore options (`RHOSTS`, `RPORT`, etc.) are automatically populated. The environment is registered in the in-memory registry with a unique ID.
+
+---
+
+## Scenario 2: Build with a Specific Version
+
+**Input:**
+```
+msf exploit(multi/http/jenkins_script_console) > test_env build VARIANT=2.375
+```
+
+**Expected behavior:**
+- The `VARIANT=2.375` argument overrides the `default_variant` from the module's `VulnerableEnvironment`
+- The plugin loads `jenkins.yml` and selects the variant named `2.375` from the `variants` list
+- If the version does not exist, the command fails immediately with a list of available versions
+
+**Expected output (success):**
+```
+[*] Selected version: 2.375
+[*] Pulling image vulnhub/jenkins:2.375...
+[*] Starting container...
+[*] Waiting for health check (GET /login)...
+[+] Environment ready.
+[*]    RHOSTS    => 127.0.0.1
+[*]    RPORT     => 49153
+[*]    TARGETURI => /script
+[*] Suggested: set RHOSTS 127.0.0.1; set RPORT 49153; exploit
+```
+
+**Expected output (failure — version not found):**
+```
+[-] Variant '9.99' not defined for 'jenkins'. Available: 2.361, 2.375
+```
+
+---
+
+## Scenario 3: Request a Specific Port (with Automatic Fallback)
+
+**Input:**
+```
+msf exploit(multi/http/jenkins_script_console) > test_env build RPORT=8080
+```
+
+**Expected behavior:**
+- The plugin attempts to bind host port 8080 to the container's exposed port
+- If 8080 is already in use on the host, the `PortAllocator` scans the ephemeral range (49152–65535) for an available port
+- The user is informed of the fallback. The allocated port is stored in the registry.
+
+**Expected output:**
+```
+[*] Requested port 8080 is unavailable. Using dynamically allocated port 49154.
+[*] Starting container...
+[*] Waiting for health check (GET /login)...
+[+] Environment ready.
+[*]    RHOSTS    => 127.0.0.1
+[*]    RPORT     => 49154
+[*]    TARGETURI => /script
+```
+
+---
+
+## Scenario 4: List Active Environments
+
+**Input:**
+```
+msf exploit(multi/http/jenkins_script_console) > test_env list
+```
+
+**Expected behavior:**
+- The plugin queries the in-memory registry and prints a table using `Rex::Ui::Text::Table`
+- Each row shows: ID, container ID (truncated), module fullname, RHOST, RPORT, status, version
+- The table is sorted by ID
+
+**Expected output:**
+```
+Environments
+============
+
+ID  Container     Module                                     RHOST       RPORT  Status   Version
+--  ---------     ------                                     -----       -----  ------   -------
+1   4f3a2b1c...   exploit/multi/http/jenkins_script_console  127.0.0.1   49153  running  2.375
+2   9e8d7c6b...   exploit/multi/http/apache_activemq_jolokia   127.0.0.1   49152  running  5.18.6
+```
+
+---
+
+## Scenario 5: Execute the Stored Exploit
+
+**Input:**
+```
+msf exploit(multi/http/jenkins_script_console) > test_env exec 1
+```
+
+**Expected behavior:**
+- The plugin looks up environment ID 1 in the registry
+- It verifies the container is running via `docker inspect` or `podman inspect`
+- It automatically sets the module's datastore options (`RHOSTS`, `RPORT`, `TARGETURI`, etc.) from the registry record
+- It invokes the module's `exploit` method (or `run_simple`) with these options
+- If the environment is stopped, it prints an error telling the user to start it first
+
+**Expected output (success):**
+```
+[*] Executing exploit against environment 1...
+[*] Set RHOSTS 127.0.0.1
+[*] Set RPORT 49153
+[*] Set TARGETURI /script
+[*] Set PAYLOAD java/meterpreter/reverse_tcp
+[*] Set LHOST 127.0.0.1
+[*] Set LPORT 4444
+[*] Started reverse TCP handler on 127.0.0.1:4444
+[+] Session 1 opened (127.0.0.1:4444 -> 127.0.0.1:49153)
+```
+
+**Expected output (failure — environment stopped):**
+```
+[-] Environment 1 is not running. Start it with: test_env start 1
+```
+
+---
+
+## Scenario 6: Stop and Restart an Environment
+
+**Input:**
+```
+msf exploit(multi/http/jenkins_script_console) > test_env stop 1
+```
+
+**Expected behavior:**
+- The plugin calls `docker stop` (or `podman stop`) on the container ID stored in the registry
+- It updates the registry status to `stopped`
+- It preserves the registry record so the environment can be restarted
+
+**Expected output:**
+```
+[*] Stopping container 4f3a2b1c...
+[+] Environment 1 stopped.
+```
+
+**Input (restart):**
+```
+msf exploit(multi/http/jenkins_script_console) > test_env start 1
+```
+
+**Expected behavior:**
+- The plugin calls `docker start` on the container
+- It re-runs the health check defined in the environment definition
+- It updates the registry status to `running`
+
+**Expected output:**
+```
+[*] Starting container 4f3a2b1c...
+[*] Waiting for health check...
+[+] Environment 1 running. RPORT=49153
+```
+
+---
+
+## Scenario 7: Remove a Single Environment
+
+**Input:**
+```
+msf exploit(multi/http/jenkins_script_console) > test_env remove 1
+```
+
+**Expected behavior:**
+- The plugin stops the container if it is running
+- It calls `docker rm` (or `podman rm`) to remove the container
+- It removes the record from the in-memory registry
+- If the database is active (Phase 2), it updates the DB status to `removed`
+
+**Expected output:**
+```
+[*] Stopping container 4f3a2b1c...
+[*] Removing container 4f3a2b1c...
+[+] Environment 1 removed.
+```
+
+---
+
+## Scenario 8: Remove All Environments
+
+**Input:**
+```
+msf exploit(multi/http/jenkins_script_console) > test_env remove-all
+```
+
+**Expected behavior:**
+- The plugin iterates all entries in the registry
+- For each, it stops and removes the container
+- It clears the in-memory registry
+- If any container fails to stop/remove, it prints a warning but continues
+
+**Expected output:**
+```
+[*] Tearing down 2 environment(s)...
+[*] Stopping container 4f3a2b1c...
+[*] Removing container 4f3a2b1c...
+[*] Stopping container 9e8d7c6b...
+[*] Removing container 9e8d7c6b...
+[+] All environments removed.
+```
+
+---
+
+## Quick Reference: Command Summary
+
+| Command | Arguments | Description |
+|---------|-----------|-------------|
+| `test_env build` | `[VARIANT=x]` `[RPORT=y]` | Build and launch environment for active module |
+| `test_env list` | none | Show all tracked environments |
+| `test_env exec` | `<ID>` | Execute exploit against environment `<ID>` |
+| `test_env stop` | `<ID>` | Stop a running environment |
+| `test_env start` | `<ID>` | Restart a stopped environment |
+| `test_env remove` | `<ID>` | Tear down and remove one environment |
+| `test_env remove-all` | none | Tear down all environments |
+| `test_env help` | none | Show usage information |
+
+---
+
+## Error Handling Specification
+
+| Error Condition | Expected Output | Implementation Notes |
+|-----------------|----------------|---------------------|
+| No active module | `[-] No active module. Use 'use <module>' first.` | Check `driver.active_module` before any other logic |
+| Module has no `VulnerableEnvironment` | `[-] Module does not define a vulnerable environment configuration.` | Check `mod.info['VulnerableEnvironment']` after resolving active module |
+| No container runtime | `[-] No container runtime found. Install Docker or Podman.` | `RuntimeAdapter.detect` returns `nil` |
+| Image pull fails | `[-] Failed to pull image: <image>` | Check exit status of `docker pull` |
+| Container start fails | `[-] Failed to start container: <error>` | Catch `RuntimeAdapter#run` exceptions |
+| Version not found in definition | `[-] Variant '{variant}' not defined for '{name}'` | Loader validates against `variants` list |
+| No available ports | `[-] No available ports in range 49152-65535` | `PortAllocator` raises after exhausting range |
+| Health check timeout | `[-] Health check timed out after <N> seconds` | `HealthManager` exceeds `retries * interval` |
+| Environment ID not found | `[-] Environment <ID> not found` | Registry lookup returns `nil` |
+| Environment not running | `[-] Environment <ID> is not running. Start it with: test_env start <ID>` | Check `status` field before `exec` |
+
+---
+
+## Notes for Implementers
+
+- All output prefixes (`[*]`, `[+]`, `[-]`) must use `print_status`, `print_good`, `print_error` respectively
+- Table output must use `Rex::Ui::Text::Table` for consistency with built-in commands like `sessions`, `jobs`
+- The `test_env` command must be available regardless of whether a database is connected (Phase 1 is in-memory only)
+- Container labels must be applied on every `run` so that orphaned containers can be identified even if the registry is lost
+- `test_env build` must detect if the active module requires a payload. If so, it auto-selects a compatible default payload and sets `LHOST` to `127.0.0.1` with an available `LPORT`. These values are stored in the registry alongside the environment metadata. `test_env exec` then applies the complete stored datastore (including payload options) before running the exploit.
+- The `VulnerableEnvironment` key is the canonical metadata key. No abbreviated form (`VulnEnv`) is accepted.

--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -26,6 +26,11 @@ class MetasploitModule < Msf::Auxiliary
           'Reliability' => UNKNOWN_RELIABILITY,
           'Stability' => UNKNOWN_STABILITY,
           'SideEffects' => UNKNOWN_SIDE_EFFECTS
+        },
+        'VulnerableEnvironment' => {
+          'definition' => 'httpd',
+          'default_variant' => '2.4.57',
+          'port_mapping' => { 80 => 'RPORT' }
         }
       )
     )
@@ -63,9 +68,8 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     # Header Names are case insensitive so convert them to upcase
-    headers_uppercase = headers.inject({}) do |hash, keys|
+    headers_uppercase = headers.each_with_object({}) do |keys, hash|
       hash[keys[0].upcase] = keys[1]
-      hash
     end
 
     ignored_headers.each do |h|
@@ -76,18 +80,18 @@ class MetasploitModule < Msf::Auxiliary
     end
     headers_uppercase.to_a.compact.sort
 
-    counter = 0;
+    counter = 0
     headers_uppercase.each do |h|
       header_string = "#{h[0]}: #{h[1]}"
       print_good "#{peer}: #{header_string}"
 
       report_note(
-        :type => "http.header.#{rport}.#{counter}",
-        :data => { :header_string => header_string },
-        :host => ip,
-        :port => rport
+        type: "http.header.#{rport}.#{counter}",
+        data: { header_string: header_string },
+        host: ip,
+        port: rport
       )
-      counter = counter + 1
+      counter += 1
     end
     if counter == 0
       print_warning "#{peer}: all detected headers are defined in IGN_HEADER and were ignored "

--- a/modules/auxiliary/scanner/http/http_version.rb
+++ b/modules/auxiliary/scanner/http/http_version.rb
@@ -16,7 +16,12 @@ class MetasploitModule < Msf::Auxiliary
       'Name' => 'HTTP Version Detection',
       'Description' => 'Display version information about each system.',
       'Author' => 'hdm',
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'VulnerableEnvironment' => {
+        'definition'      => 'httpd',
+        'default_variant' => '2.4.57',
+        'port_mapping'    => {80 => 'RPORT'}
+      }
     )
 
     register_wmap_options({

--- a/modules/auxiliary/scanner/http/robots_txt.rb
+++ b/modules/auxiliary/scanner/http/robots_txt.rb
@@ -17,12 +17,17 @@ class MetasploitModule < Msf::Auxiliary
       'Name' => 'HTTP Robots.txt Content Scanner',
       'Description' => 'Detect robots.txt files and analyze its content',
       'Author' => ['et'],
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'VulnerableEnvironment' => {
+        'definition' => 'httpd',
+        'default_variant' => '2.4.57',
+        'port_mapping' => { 80 => 'RPORT' }
+      }
     )
 
     register_options(
       [
-        OptString.new('PATH', [ true, "The test path to find robots.txt file", '/']),
+        OptString.new('PATH', [ true, 'The test path to find robots.txt file', '/']),
 
       ]
     )
@@ -40,15 +45,15 @@ class MetasploitModule < Msf::Auxiliary
       res = send_request_raw({
         'uri' => turl,
         'method' => 'GET',
-        'version' => '1.0',
+        'version' => '1.0'
       }, 10)
 
-      if not res
+      if !res
         print_error("[#{target_host}] #{tpath}robots.txt - No response")
         return
       end
 
-      if not res.body.include?("llow:")
+      if !res.body.include?('llow:')
         vprint_status("[#{target_host}] #{tpath}robots.txt - Doesn't contain \"llow:\"")
         return
       end
@@ -57,20 +62,20 @@ class MetasploitModule < Msf::Auxiliary
       print_good("Contents of Robots.txt:\n#{res.body}")
 
       # short url regex
-      aregex = /llow:[ ]{0,2}(.*?)$/i
+      aregex = /llow: {0,2}(.*?)$/i
 
       result = res.body.scan(aregex).flatten.map { |s| s.strip }.uniq
 
       vprint_status("[#{target_host}] #{tpath}robots.txt - #{result.join(', ')}")
       result.each do |u|
         report_note(
-          :host	=> target_host,
-          :port	=> rport,
-          :proto => 'tcp',
-          :sname	=> (ssl ? 'https' : 'http'),
-          :type	=> 'ROBOTS_TXT',
-          :data	=> { :file => u },
-          :update => :unique_data
+          host: target_host,
+          port: rport,
+          proto: 'tcp',
+          sname: (ssl ? 'https' : 'http'),
+          type: 'ROBOTS_TXT',
+          data: { file: u },
+          update: :unique_data
         )
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -26,7 +26,12 @@ class MetasploitModule < Msf::Auxiliary
         'Daniel van Eeden <metasploit[at]myname.nl>', # original author
         'h00die' # algorithms enhancements
       ],
-      'License' => MSF_LICENSE
+      'License' => MSF_LICENSE,
+      'VulnerableEnvironment' => {
+        'definition' => 'openssh',
+        'default_variant' => '7.2',
+        'port_mapping' => { 22 => 'RPORT' }
+      }
     )
 
     register_options(

--- a/modules/exploits/multi/http/apache_activemq_jolokia_rce.rb
+++ b/modules/exploits/multi/http/apache_activemq_jolokia_rce.rb
@@ -39,7 +39,6 @@ class MetasploitModule < Msf::Exploit::Remote
           ['URL', 'https://horizon3.ai/attack-research/disclosures/cve-2026-34197-activemq-rce-jolokia/']
         ],
         'DisclosureDate' => '2026-04-29',
-        'Platform' => %w[linux unix win],
         'Arch' => [ARCH_CMD],
         'Privileged' => false,
         'Stance' => Stance::Aggressive,
@@ -49,6 +48,11 @@ class MetasploitModule < Msf::Exploit::Remote
           ['Unix', { 'Platform' => 'unix' }]
         ],
         'DefaultTarget' => 1,
+        'VulnerableEnvironment' => {
+          'definition' => 'activemq',
+          'default_variant' => '5.18.6',
+          'port_mapping' => { 8161 => 'RPORT' }
+        },
         'DefaultOptions' => {
           'WfsDelay' => 30
         },

--- a/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
+++ b/modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb
@@ -67,6 +67,21 @@ class MetasploitModule < Msf::Exploit::Remote
           # The maximum time in seconds to wait for a session.
           'WfsDelay' => 30
         },
+        'VulnerableEnvironment' => {
+          'definition' => 'activemq',
+          'default_variant' => '5.18.2',
+          'profile' => 'broker-only',
+          'port_mapping' => { 61616 => 'RPORT' },
+          'overrides' => {
+            'ci' => {
+              'exploit' => {
+                'options' => {
+                  'TARGET' => 1
+                }
+              }
+            }
+          }
+        },
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],

--- a/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
+++ b/modules/exploits/unix/webapp/wp_admin_shell_upload.rb
@@ -30,6 +30,11 @@ class MetasploitModule < Msf::Exploit::Remote
         'Arch' => ARCH_PHP,
         'Targets' => [['WordPress', {}]],
         'DefaultTarget' => 0,
+        'VulnerableEnvironment' => {
+          'definition' => 'wordpress',
+          'default_variant' => 'latest',
+          'port_mapping' => { 80 => 'RPORT' }
+        },
         'Notes' => {
           'Reliability' => UNKNOWN_RELIABILITY,
           'Stability' => UNKNOWN_STABILITY,

--- a/plugins/test_env.rb
+++ b/plugins/test_env.rb
@@ -1541,6 +1541,8 @@ module Msf
       @@runtime = nil
       @@registry = nil
 
+      MAX_VERIFY_ATTEMPTS = 3
+
       def self.registry=(registry)
         @@registry = registry
       end
@@ -2446,7 +2448,7 @@ end
           end
         end
 
-        # Some modules (notably this ActiveMQ one, which fires its Spring
+        # Some modules (notably the ActiveMQ one, which fires its Spring
         # XML payload multiple times) can leave more than one session -
         # some real, some stale/half-connected duplicates. The most
         # recent SID is not reliably the working one (observed directly:
@@ -2475,7 +2477,7 @@ end
               attempts += 1
               result = run_verification_command(candidate)
             rescue => e
-              if attempts < 3
+              if attempts < MAX_VERIFY_ATTEMPTS 
                 print_status("Session #{candidate.sid}: verification command failed on attempt #{attempts}/3 (#{e.message}), retrying...")
                 sleep 3
                 retry

--- a/plugins/test_env.rb
+++ b/plugins/test_env.rb
@@ -1,0 +1,2930 @@
+require 'active_model'
+require 'psych'
+require 'set'
+require 'json'
+require 'yaml'
+require 'open3'
+require 'shellwords'
+require 'tmpdir'
+require 'socket'
+require 'fileutils'
+require 'timeout'   
+require 'net/http'
+require 'rex/text/table'
+
+module Msf
+  class Plugin::TestEnv < Msf::Plugin
+    # =====================================================================
+    # VulnerableEnvironment Struct
+    # =====================================================================
+
+    # Encapsulates and validates VulnerableEnvironment metadata from a module.
+    # Mirrors the framework pattern used by #name, #description, #notes, etc.
+    # but adds validation and returns a typed object instead of a raw Hash.
+    class VulnerableEnvironment
+      attr_reader :definition, :default_variant, :profile, :port_mapping, :overrides
+
+      # Required keys that must be present
+      REQUIRED_KEYS = %w[definition default_variant port_mapping].freeze unless defined?(REQUIRED_KEYS)
+
+      # Valid types for each key
+      SCHEMA = {
+        'definition'      => String,
+        'default_variant' => String,
+        'profile'         => String,
+        'port_mapping'    => Hash,
+        'overrides'       => Hash
+      }.freeze unless defined?(SCHEMA)
+
+      def initialize(raw_hash)
+        @raw = raw_hash || {}
+
+        validate!
+
+        @definition      = @raw['definition']
+        @default_variant = @raw['default_variant']
+        @profile         = @raw['profile'] || 'default'
+        @port_mapping    = @raw['port_mapping'] || {}
+        @overrides       = @raw['overrides'] || {}
+      end
+
+      def valid?
+        errors.empty?
+      end
+
+      def errors
+        errs = []
+
+        REQUIRED_KEYS.each do |key|
+          errs << "Missing required key: '#{key}'" unless @raw.key?(key)
+        end
+
+        SCHEMA.each do |key, expected_type|
+          next unless @raw.key?(key)
+          unless @raw[key].is_a?(expected_type)
+            errs << "Key '#{key}' must be #{expected_type}, got #{@raw[key].class}"
+          end
+        end
+
+        if @raw['port_mapping'].is_a?(Hash)
+          @raw['port_mapping'].each do |k, v|
+            unless k.is_a?(Integer) || k.to_s.match?(/\A\d+\z/)
+              errs << "port_mapping key must be an integer port, got: #{k.inspect}"
+            end
+            unless v.is_a?(String)
+              errs << "port_mapping value must be a String datastore option name, got: #{v.inspect}"
+            end
+          end
+        end
+
+        errs
+      end
+
+      private
+
+      def validate!
+        errs = errors
+        raise ArgumentError, "Invalid VulnerableEnvironment: #{errs.join('; ')}" unless errs.empty?
+      end
+    end
+
+    # =====================================================================
+    # Runtime Abstraction Layer
+    # =====================================================================
+
+    class BaseRuntime
+      def available?
+        raise NotImplementedError, "#{self.class} must implement available?"
+      end
+
+      def name
+        raise NotImplementedError, "#{self.class} must implement name"
+      end
+
+      def pull(image)
+        raise NotImplementedError, "#{self.class} must implement pull"
+      end
+
+      def run(image:, ports:, labels:, volumes: [], env: {}, name: nil)
+        raise NotImplementedError, "#{self.class} must implement run"
+      end
+
+      def inspect(container_id)
+        raise NotImplementedError, "#{self.class} must implement inspect"
+      end
+
+      def stop(container_id)
+        raise NotImplementedError, "#{self.class} must implement stop"
+      end
+
+      def start(container_id)
+        raise NotImplementedError, "#{self.class} must implement start"
+      end
+
+      def remove(container_id)
+        raise NotImplementedError, "#{self.class} must implement remove"
+      end
+
+      def exec(container_id, command)
+        raise NotImplementedError, "#{self.class} must implement exec"
+      end
+
+      def list(filters: {})
+        raise NotImplementedError, "#{self.class} must implement list"
+      end
+
+      # =====================================================================
+      # Label Helpers (Shared Across Runtimes)
+      # =====================================================================
+
+      # Build container labels from environment metadata.
+      # Stores only minimal dynamic data; static metadata is reconstructible
+      # from the module's VulnerableEnvironment definition.
+      def build_labels(instance_id:, module_fullname:, env_id:, version:, ports:)
+        {
+          'msf.vulnenv.managed_by' => 'test_env',
+          'msf.vulnenv.instance_id' => instance_id,
+          'msf.vulnenv.module' => module_fullname,
+          'msf.vulnenv.env_id' => env_id.to_s,
+          'msf.vulnenv.version' => version.to_s,
+          'msf.vulnenv.ports' => encode_port_label(ports)
+        }
+      end
+
+      # Encode port mapping hash {container_port => host_port} into label string
+      # Format: "host:container,host:container" (e.g., "8081:8080,9090:61616")
+      def encode_port_label(ports)
+        ports.map { |container_port, host_port| "#{host_port}:#{container_port}" }.join(',')
+      end
+
+      # Decode port label string back into {container_port => host_port} hash
+      def decode_port_label(label_value)
+        return {} unless label_value
+
+        label_value.split(',').each_with_object({}) do |pair, hash|
+          host_port, container_port = pair.split(':')
+          hash[container_port.to_i] = host_port.to_i
+        end
+      end
+
+      # reject only dangerous shell characters
+      VALID_IMAGE_NAME = /\A[^\s;|&`$(){}]+\z/ unless defined?(VALID_IMAGE_NAME)
+      
+      private
+
+      def validate_image_name!(image)
+        unless image.to_s.match?(VALID_IMAGE_NAME)
+          raise ArgumentError, "Invalid image name: #{image.inspect}"
+        end
+      end
+
+      def parse_labels(labels_string)
+        return {} if labels_string.nil? || labels_string.empty?
+
+        labels_string.split(',').each_with_object({}) do |pair, hash|
+          key, value = pair.split('=', 2)
+          hash[key] = value || ''
+        end
+      end
+    end
+
+    # ============================================================
+    # DOCKER RUNTIME
+    # ============================================================
+    class DockerRuntime < BaseRuntime
+      def available?
+        _out, _err, status = Open3.capture3('docker', 'version')
+        status.success?
+      rescue Errno::ENOENT
+        false
+      end
+
+      def name
+        'docker'
+      end
+
+      def pull(image)
+        validate_image_name!(image)
+        _out, err, status = Open3.capture3('docker', 'pull', image)
+        if status.success?
+          true
+        else
+          elog("Docker pull failed: #{err}")
+          false
+        end
+      end
+
+      def run(image:, ports:, labels:, volumes: [], env: {}, name: nil)
+        validate_image_name!(image)
+        cmd = ['docker', 'run', '-d']
+
+        # ports: {container_port => host_port}
+        ports.each do |container_port, host_port|
+          cmd += ['-p', "127.0.0.1:#{host_port}:#{container_port}"]
+        end
+
+        labels.each do |key, value|
+          cmd += ['--label', "#{key}=#{value}"]
+        end
+
+        volumes.each do |host_path, container_path|
+          cmd += ['-v', "#{host_path}:#{container_path}"]
+        end
+
+        env.each do |key, value|
+          cmd += ['-e', "#{key}=#{value}"]
+        end
+
+        cmd += ['--name', name] if name
+        cmd << image
+
+        out, err, status = Open3.capture3(*cmd)
+        if status.success?
+          out.strip
+        else
+          raise "Docker run failed: #{err}"
+        end
+      end
+
+      def inspect(container_id)
+        out, _err, status = Open3.capture3('docker', 'inspect', container_id)
+        return nil unless status.success?
+        return nil if out.empty?
+
+        begin
+          data = JSON.parse(out)
+          data.first
+        rescue JSON::ParserError => e
+          elog("Docker inspect JSON parse error: #{e.message}")
+          nil
+        end
+      end
+
+      def stop(container_id)
+        _out, _err, status = Open3.capture3('docker', 'stop', container_id)
+        status.success?
+      end
+
+      def start(container_id)
+        _out, _err, status = Open3.capture3('docker', 'start', container_id)
+        status.success?
+      end
+
+      def remove(container_id)
+        _out, _err, status = Open3.capture3('docker', 'rm', container_id)
+        status.success?
+      end
+
+      def exec(container_id, command)
+        return ["", 1] if command.nil? || command.empty?
+        out, err, status = Open3.capture3('docker', 'exec', container_id, *Shellwords.split(command))
+        [out + err, status.exitstatus]
+      end
+
+      def list(filters: {})
+        cmd = ['docker', 'ps', '-a', '--format', '{{json .}}']
+
+        filters.each do |key, value|
+          cmd += ['--filter', "#{key}=#{value}"]
+        end
+
+        out, _err, status = Open3.capture3(*cmd)
+        return [] unless status.success?
+        return [] if out.empty?
+
+        containers = out.lines.map do |line|
+          begin
+            JSON.parse(line.strip)
+          rescue JSON::ParserError
+            nil
+          end
+        end.compact
+
+        containers.each do |c|
+          c['Labels'] = parse_labels(c['Labels']) if c['Labels'].is_a?(String)
+        end
+
+        containers
+      end
+    end
+
+    # ============================================================
+    # PODMAN RUNTIME
+    # ============================================================
+    class PodmanRuntime < BaseRuntime
+      def available?
+        _out, _err, status = Open3.capture3('podman', 'version')
+        status.success?
+      rescue Errno::ENOENT
+        false
+      end
+
+      def name
+        'podman'
+      end
+
+      def verify_rootless
+        # Verify Podman mode and networking backend.
+        # Returns [ok, message] — ok is true if viable, message describes status.
+        out, _, st = Open3.capture3('podman', 'info', '--format', '{{.Host.Security.Rootless}}')
+        rootless = st.success? && out.strip.downcase == 'true'
+
+        unless rootless
+          return [true, 'Podman running in rootful mode.']
+        end
+
+        # Rootless: check for pasta (preferred) or slirp4netns (fallback) using Ruby's PATH search
+        if executable_in_path?('pasta')
+          [true, 'Rootless Podman verified — pasta networking available.']
+        elsif executable_in_path?('slirp4netns')
+          [true, 'Rootless Podman verified — slirp4netns networking available.']
+        else
+          [false, 'Rootless Podman detected but no networking backend (pasta or slirp4netns) found. ' \
+                  'Port forwarding may fail. Install pasta or slirp4netns.']
+        end
+      end
+
+      def pull(image)
+        validate_image_name!(image)
+        qualified = qualify_image(image)
+        _out, err, status = Open3.capture3('podman', 'pull', qualified)
+        if status.success?
+          true
+        else
+          elog("Podman pull failed for #{qualified}: #{err}")
+          false
+        end
+      end
+
+      def run(image:, ports:, labels:, volumes: [], env: {}, name: nil)
+        validate_image_name!(image)
+        cmd = ['podman', 'run', '-d']
+
+        # ports: {container_port => host_port}
+        ports.each do |container_port, host_port|
+          cmd += ['-p', "127.0.0.1:#{host_port}:#{container_port}"]
+        end
+
+        labels.each do |key, value|
+          cmd += ['--label', "#{key}=#{value}"]
+        end
+
+        volumes.each do |host_path, container_path|
+          cmd += ['-v', "#{host_path}:#{container_path}"]
+        end
+
+        env.each do |key, value|
+          cmd += ['-e', "#{key}=#{value}"]
+        end
+
+        cmd += ['--name', name] if name
+        cmd << qualify_image(image)
+
+        out, err, status = Open3.capture3(*cmd)
+        if status.success?
+          out.strip
+        else
+          raise "Podman run failed: #{err}"
+        end
+      end
+
+      def inspect(container_id)
+        out, _err, status = Open3.capture3('podman', 'inspect', container_id)
+        return nil unless status.success?
+        return nil if out.empty?
+
+        begin
+          data = JSON.parse(out)
+          data.first
+        rescue JSON::ParserError => e
+          elog("Podman inspect JSON parse error: #{e.message}")
+          nil
+        end
+      end
+
+      def stop(container_id)
+        _out, _err, status = Open3.capture3('podman', 'stop', container_id)
+        status.success?
+      end
+
+      def start(container_id)
+        _out, _err, status = Open3.capture3('podman', 'start', container_id)
+        status.success?
+      end
+
+      def remove(container_id)
+        _out, _err, status = Open3.capture3('podman', 'rm', container_id)
+        status.success?
+      end
+
+      def exec(container_id, command)
+        return ["", 1] if command.nil? || command.empty?
+        out, err, status = Open3.capture3('podman', 'exec', container_id, *Shellwords.split(command))
+        [out + err, status.exitstatus]
+      end
+
+      def list(filters: {})
+        cmd = ['podman', 'ps', '-a', '--format', '{{json .}}']
+
+        filters.each do |key, value|
+          cmd += ['--filter', "#{key}=#{value}"]
+        end
+
+        out, _err, status = Open3.capture3(*cmd)
+        return [] unless status.success?
+        return [] if out.empty?
+
+        containers = out.lines.map do |line|
+          begin
+            JSON.parse(line.strip)
+          rescue JSON::ParserError
+            nil
+          end
+        end.compact
+
+        containers.each do |c|
+          c['Labels'] = parse_labels(c['Labels']) if c['Labels'].is_a?(String)
+        end
+
+        containers
+      end
+
+      private
+
+      def qualify_image(image)
+        return image if image.include?('/')
+        "docker.io/library/#{image}"
+      end
+
+      def executable_in_path?(cmd)
+        return false if ENV['PATH'].nil?
+        ENV['PATH'].split(File::PATH_SEPARATOR).any? do |dir|
+          File.executable?(File.join(dir, cmd))
+        end
+      end
+    end
+
+    # ============================================================
+    # RUNTIME ADAPTER
+    # ============================================================
+    class RuntimeAdapter
+      def self.detect(datastore = {})
+        runtime_pref = normalize_pref(datastore['TEST_ENV_RUNTIME'] || ENV['TEST_ENV_RUNTIME'])
+
+        case runtime_pref
+        when 'docker'  then detect_docker
+        when 'podman'  then detect_podman
+        else                detect_auto
+        end
+      end
+
+      def self.normalize_pref(raw)
+        pref = raw.to_s.downcase.strip
+        return 'auto' if pref.empty?  # Unset env var is not an error
+        return pref if %w[auto docker podman].include?(pref)
+        'auto'
+      end
+
+      def self.detect_docker
+        docker = DockerRuntime.new
+        return docker if docker.available?
+        raise "Docker requested but not available"
+      end
+
+      def self.detect_podman
+        podman = PodmanRuntime.new
+        return podman if podman.available?
+        raise "Podman requested but not available"
+      end
+
+      def self.detect_auto
+        docker = DockerRuntime.new
+        return docker if docker.available?
+        podman = PodmanRuntime.new
+        return podman if podman.available?
+        nil
+      end
+    end
+
+    # =====================================================================
+    # Port Allocator
+    # =====================================================================
+    # Allocates free host ports for container bindings.
+    # Checks both the current registry AND actively bound Docker/Podman ports
+    # to avoid collisions with orphaned containers from previous sessions.
+    class PortAllocator
+      EPHEMERAL_START = 49152 unless defined?(EPHEMERAL_START)
+      EPHEMERAL_END   = 65535 unless defined?(EPHEMERAL_END)
+
+      class NoPortsAvailable < RuntimeError; end
+
+      # runtime: the runtime adapter (DockerRuntime or PodmanRuntime) used to
+      # query already-bound ports from previous sessions.
+      def initialize(runtime = nil, used_ports = [])
+        @runtime = runtime
+        @used_ports = Set.new(used_ports)
+
+        # Seed the set with ports already bound by Docker/Podman containers.
+        # This prevents collisions with orphaned containers from previous
+        # msfconsole sessions whose registry state is lost.
+        scan_runtime_ports if @runtime
+      end
+
+      def allocate(preferred = nil)
+        if preferred && available?(preferred)
+          @used_ports.add(preferred)
+          return preferred
+        end
+
+        (EPHEMERAL_START..EPHEMERAL_END).each do |port|
+          next if @used_ports.include?(port)
+          if available?(port)
+            @used_ports.add(port)
+            return port
+          end
+        end
+
+        raise NoPortsAvailable, "No available ports in range #{EPHEMERAL_START}-#{EPHEMERAL_END}"
+      end
+
+      def release(port)
+        @used_ports.delete(port)
+      end
+
+      private
+
+      # Query the container runtime for ports already bound on the host.
+      # This catches orphaned containers from previous sessions.
+      def scan_runtime_ports
+        return unless @runtime
+
+        begin
+          containers = @runtime.list
+          containers.each do |c|
+            next unless c['Ports'].is_a?(String)
+
+            # Docker ps output format: "127.0.0.1:49153->8161/tcp, 127.0.0.1:49154->80/tcp"
+            # Extract host ports from the binding string.
+            c['Ports'].scan(/:(\d+)->\d+\//).each do |match|
+              port = match[0].to_i
+              @used_ports.add(port) if port.between?(EPHEMERAL_START, EPHEMERAL_END)
+            end
+          end
+        rescue => e
+          # If the runtime query fails, fall back to TCPServer-only checking
+          # This is a graceful degradation, not a fatal error
+          elog("PortAllocator: failed to scan runtime ports: #{e.message}")
+        end
+      end
+
+      def available?(port)
+        return false if @used_ports.include?(port)
+
+        server = TCPServer.new('127.0.0.1', port)
+        server.close
+        true
+      rescue Errno::EADDRINUSE
+        false
+      end
+    end
+
+    # =====================================================================
+    # VulnTarget — ActiveModel-based environment instance
+    # =====================================================================
+    class VulnTarget
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      attr_accessor :local_id, :container_id, :module_fullname, :env_version,
+                    :runtime, :image_ref, :status, :datastore, :allocated_ports,
+                    :created_at, :started_at, :stopped_at, :removed_at, :temp_dirs
+                    
+      validates :container_id, presence: true
+      validates :module_fullname, presence: true
+      validates :local_id, presence: true, numericality: { only_integer: true }
+
+      def initialize(attrs = {})
+        @datastore = {}
+        @allocated_ports = {}
+        @temp_dirs = []
+        @status = 'running'
+        super
+      end
+
+      def running?
+        status.to_s == 'running'
+      end
+
+      def stopped?
+        status.to_s == 'stopped'
+      end
+
+      def removed?
+        status.to_s == 'removed'
+      end
+
+      def rhost
+        datastore['RHOSTS'] || datastore['RHOST']
+      end
+
+      def rport
+        datastore['RPORT']
+      end
+
+      def all_host_ports
+        allocated_ports.values
+      end
+
+      def exploit_command
+        opts = datastore.map { |k, v| "#{k}=#{v}" }.join(' ')
+        "exploit #{opts}"
+      end
+
+      def mark_running
+        self.status = 'running'
+        self.started_at = Time.now
+      end
+
+      def mark_stopped
+        self.status = 'stopped'
+        self.stopped_at = Time.now
+      end
+
+      def mark_removed
+        self.status = 'removed'
+        self.removed_at = Time.now
+      end
+
+      def to_h
+        {
+          'local_id' => local_id,
+          'container_id' => container_id,
+          'module_fullname' => module_fullname,
+          'env_version' => env_version,
+          'runtime' => runtime,
+          'image_ref' => image_ref,
+          'status' => status,
+          'datastore' => datastore,
+          'allocated_ports' => allocated_ports,
+          'temp_dirs' => temp_dirs,
+          'created_at' => created_at&.iso8601,
+          'started_at' => started_at&.iso8601,
+          'stopped_at' => stopped_at&.iso8601,
+          'removed_at' => removed_at&.iso8601
+        }
+      end
+
+      def self.from_h(hash)
+        new(
+          local_id: hash['local_id'],
+          container_id: hash['container_id'],
+          module_fullname: hash['module_fullname'],
+          env_version: hash['env_version'],
+          runtime: hash['runtime'],
+          image_ref: hash['image_ref'],
+          status: hash['status'] || 'running',
+          datastore: hash['datastore'] || {},
+          allocated_ports: hash['allocated_ports'] || {},
+          temp_dirs: hash['temp_dirs'] || [],
+          created_at: parse_time(hash['created_at']),
+          started_at: parse_time(hash['started_at']),
+          stopped_at: parse_time(hash['stopped_at']),
+          removed_at: parse_time(hash['removed_at'])
+        )
+      end
+
+      private
+
+      def self.parse_time(val)
+        return nil if val.nil?
+        Time.parse(val)
+      rescue
+        nil
+      end
+    end
+
+    # =====================================================================
+    # VulnEnvironment — ActiveModel collection of targets
+    # =====================================================================
+    class VulnEnvironment
+      include ActiveModel::Validations
+
+      DEFAULT_VERSION = '1.0.0' unless defined?(DEFAULT_VERSION)
+
+      attr_accessor :version, :instance_id
+
+      validate :valid_targets
+
+      def initialize(version: DEFAULT_VERSION, instance_id: nil, targets: [])
+        raise ArgumentError, "targets must be an Array" unless targets.is_a?(Array)
+
+        @version = version.freeze
+        @instance_id = instance_id
+        @targets = targets
+        @mutex = Mutex.new
+      end
+
+      def add_target(target)
+        @targets << target
+      end
+
+      def remove_target(local_id)
+        @targets.reject! { |t| t.local_id == local_id }
+      end
+
+      def targets
+        @targets.dup.freeze
+      end
+
+      def running_targets
+        @targets.select(&:running?)
+      end
+
+      def find_by_id(local_id)
+        @targets.find { |t| t.local_id == local_id }
+      end
+
+      def find_by_container(container_id)
+        @targets.find { |t| t.container_id == container_id }
+      end
+
+      def used_ports
+        @targets.flat_map(&:all_host_ports).compact
+      end
+
+      def next_id
+        @mutex.synchronize do
+          max_id = @targets.map(&:local_id).max || 0
+          max_id + 1
+        end
+      end
+
+      def to_h
+        {
+          'version' => version,
+          'instance_id' => instance_id,
+          'targets' => @targets.map(&:to_h)
+        }
+      end
+
+      def self.from_h(hash)
+        raw_targets = hash['targets']
+        raise ArgumentError, "targets must be an Array" unless raw_targets.nil? || raw_targets.is_a?(Array)
+
+        new(
+          version: hash['version'] || DEFAULT_VERSION,
+          instance_id: hash['instance_id'],
+          targets: Array(raw_targets).map { |t| VulnTarget.from_h(t) }
+        )
+      end
+
+      private
+
+      def valid_targets
+        @targets.each do |target|
+          next if target.valid?
+
+          target.errors.each do |error|
+            errors.add(:target, error.full_message)
+          end
+        end
+      end
+    end
+
+    # =====================================================================
+    # VulnEnvironmentStore — YAML persistence in ~/.msf4/
+    # =====================================================================
+    class VulnEnvironmentStore
+      DEFAULT_PATH = File.join(Dir.home, '.msf4', 'test_env_registry.yml') unless defined?(DEFAULT_PATH)
+
+      def initialize(path = DEFAULT_PATH)
+        @path = path
+      end
+
+      def load
+        return VulnEnvironment.new(instance_id: current_instance_id) unless File.exist?(@path)
+
+        File.open(@path, 'r') do |f|
+          f.flock(File::LOCK_SH)
+          yaml_content = f.read
+          hash = Psych.safe_load(yaml_content, permitted_classes: [Symbol, Time, Date])
+          VulnEnvironment.from_h(hash)
+        end
+      rescue Psych::DisallowedClass => e
+        elog("VulnEnvironmentStore: Disallowed class in YAML: #{e.message}")
+        VulnEnvironment.new(instance_id: current_instance_id)
+      rescue => e
+        elog("VulnEnvironmentStore: Failed to load: #{e.message}")
+        VulnEnvironment.new(instance_id: current_instance_id)
+      end
+
+      def save(environment)
+        FileUtils.mkdir_p(File.dirname(@path))
+        File.open(@path, File::RDWR|File::CREAT, 0644) do |f|
+          f.flock(File::LOCK_EX)
+          f.rewind
+          f.write(environment.to_h.to_yaml)
+          f.flush
+          f.truncate(f.pos)
+        end
+      rescue => e
+        elog("VulnEnvironmentStore: Failed to save: #{e.message}")
+      end
+
+      private
+
+      def current_instance_id
+        "msf-#{Socket.gethostname}-#{Process.pid}"
+      end
+    end
+    
+    # =====================================================================
+    # BuiltEnvironmentRegistry — YAML-backed registry
+    # =====================================================================
+    class BuiltEnvironmentRegistry
+      attr_reader :framework
+
+      def initialize(framework)
+        @framework = framework
+        @store = VulnEnvironmentStore.new
+        @vuln_env = @store.load
+        @instance_id = "msf-#{Socket.gethostname}-#{Process.pid}"
+        @mutex = Mutex.new
+
+        
+      end
+
+      # Docker run returns full 64-char IDs, but docker ps returns short 12-char IDs.
+      # Normalize to short form so registry lookups and runtime queries are consistent.
+      def normalize_container_id(id)
+        id.to_s[0, 12]
+      end
+
+      def register(container_id:, module_fullname:, env_version: nil,
+                   runtime:, image_ref:, datastore: {}, allocated_ports: {}, temp_dirs: [])
+        @mutex.synchronize do
+          id = @vuln_env.next_id
+
+          target = VulnTarget.new(
+            local_id: id,
+            container_id: normalize_container_id(container_id),
+            module_fullname: module_fullname,
+            env_version: env_version,
+            runtime: runtime,
+            image_ref: image_ref,
+            datastore: datastore,
+            allocated_ports: allocated_ports,
+            temp_dirs: temp_dirs,
+            created_at: Time.now,
+            started_at: Time.now
+          )
+
+          @vuln_env.add_target(target)
+          @store.save(@vuln_env)
+          id
+        end
+      end
+
+      def register_with_id(env_id:, container_id:, module_fullname:, env_version: nil,
+                           runtime:, image_ref:, datastore: {}, allocated_ports: {}, temp_dirs: [])
+        @mutex.synchronize do
+          target = VulnTarget.new(
+            local_id: env_id,
+            container_id: normalize_container_id(container_id),
+            module_fullname: module_fullname,
+            env_version: env_version,
+            runtime: runtime,
+            image_ref: image_ref,
+            datastore: datastore,
+            allocated_ports: allocated_ports,
+            temp_dirs: temp_dirs,
+            created_at: Time.now,
+            started_at: Time.now
+          )
+
+          @vuln_env.add_target(target)
+          @store.save(@vuln_env)
+          env_id
+        end
+      end
+
+      def reserve_id
+        @mutex.synchronize do
+          @vuln_env = @store.load  # See other sessions' IDs
+          @vuln_env.next_id
+        end
+      end
+
+      def get(id)
+        @vuln_env = @store.load
+        @vuln_env.find_by_id(id)
+      end
+
+      def list
+        @vuln_env = @store.load
+        @vuln_env.targets.sort_by(&:local_id)
+      end
+
+      def update_status(id, status)
+        target = @vuln_env.find_by_id(id)
+        return unless target
+
+        case status.to_sym
+        when :running then target.mark_running
+        when :stopped then target.mark_stopped
+        when :removed then target.mark_removed
+        end
+
+        @store.save(@vuln_env)
+      end
+
+      def remove(id)
+        target = @vuln_env.find_by_id(id)
+        return unless target
+
+        target.temp_dirs.each do |dir|
+          FileUtils.rm_rf(dir) if Dir.exist?(dir)
+        end
+
+        @vuln_env.remove_target(id)
+        @store.save(@vuln_env)
+      end
+
+      def remove_all
+        # Clean up temp directories for all tracked targets
+        @vuln_env.targets.each do |target|
+          target.temp_dirs.each do |dir|
+            FileUtils.rm_rf(dir) if Dir.exist?(dir)
+          end
+        end
+
+        # Hard reset: fresh empty environment state → next_id will return 1
+        @vuln_env = VulnEnvironment.new(instance_id: @instance_id)
+        @store.save(@vuln_env)
+      end
+
+      def prune(runtime)
+        return unless runtime
+
+        # PRUNE: remove registry entries for containers that no longer exist
+        alive_ids = runtime.list(filters: { 'label' => 'msf.vulnenv.managed_by=test_env' }).map { |c| normalize_container_id(c['ID'] || c['Id']) }
+        @vuln_env = @store.load
+        @vuln_env.targets.each do |target|
+          unless alive_ids.include?(target.container_id)
+            @vuln_env.remove_target(target.local_id)
+          end
+        end
+        @store.save(@vuln_env)
+      end
+
+      def reconstruct_state(runtime)
+        return unless runtime
+
+        prune(runtime)
+
+        # RECONSTRUCT: add containers found by labels but missing from registry
+        containers = runtime.list(filters: { 'label' => 'msf.vulnenv.managed_by=test_env' })
+        elog("reconstruct_state: found #{containers.length} managed container(s)")
+
+        containers.each do |container|
+          labels = container.dig('Config', 'Labels') || container['Labels'] || {}
+          if labels.is_a?(String)
+            labels = labels.split(',').each_with_object({}) do |pair, hash|
+              key, value = pair.split('=', 2)
+              hash[key] = value || ''
+            end
+          end
+          container_id = normalize_container_id(container['ID'] || container['Id'])
+
+          # Identify by container_id, NOT by env_id label (labels are immutable
+          # and become stale after ID compaction)
+          if @vuln_env.find_by_container(container_id)
+            elog("reconstruct_state: skip #{container_id} — already in registry")
+            next
+          end
+
+          module_fullname = labels['msf.vulnenv.module']
+          version = labels['msf.vulnenv.version']
+          ports = decode_port_label(labels['msf.vulnenv.ports'])
+
+          unless module_fullname && !module_fullname.empty?
+            elog("reconstruct_state: skip #{container_id} — missing msf.vulnenv.module label")
+            next
+          end
+
+          mod = @framework.modules.create(module_fullname) rescue nil
+          unless mod
+            elog("reconstruct_state: skip #{container_id} — could not load module '#{module_fullname}'")
+            next
+          end
+
+          vuln_env_meta = mod.send(:module_info)['VulnerableEnvironment'] rescue nil
+          unless vuln_env_meta
+            elog("reconstruct_state: skip #{container_id} — module has no VulnerableEnvironment")
+            next
+          end
+
+          definition_name = vuln_env_meta['definition']
+          profile = vuln_env_meta['profile'] || 'default'
+          overrides = vuln_env_meta['overrides'] || {}
+
+          loader = EnvironmentDefinitionLoader.new(Msf::Config.data_directory)
+          begin
+            config = loader.resolve(definition_name, version, profile, overrides)
+          rescue => e
+            elog("reconstruct_state: skip #{container_id} — resolve failed for #{definition_name}/#{version}: #{e.message}")
+            next
+          end
+
+          datastore = { 'RHOSTS' => '127.0.0.1' }
+          (vuln_env_meta['port_mapping'] || {}).each do |container_port, ds_option|
+            host = ports[container_port.to_i] || ports[container_port.to_s.to_i]
+            datastore[ds_option] = host if host
+          end
+
+          if config['datastore_defaults']
+            config['datastore_defaults'].each do |key, value|
+              datastore[key] = value unless datastore.key?(key)
+            end
+          end
+
+          # Merge default credentials the same way build does
+          if config['credentials'] && config['credentials']['default']
+            config['credentials']['default'].each do |key, value|
+              ds_key = key.to_s.upcase
+              datastore[ds_key] = value unless datastore.key?(ds_key)
+            end
+          end
+
+          created_time = Time.parse(container['Created']) rescue Time.now
+          started_time = Time.parse(container.dig('State', 'StartedAt') || container['StartedAt']) rescue Time.now
+
+          preferred_id = labels['msf.vulnenv.env_id'].to_i
+          assigned_id = if preferred_id > 0 && @vuln_env.find_by_id(preferred_id).nil?
+                          preferred_id
+                        else
+                          @vuln_env.next_id
+                        end
+          target = VulnTarget.new(
+            local_id: assigned_id,
+            container_id: container_id,
+            module_fullname: module_fullname,
+            env_version: version,
+            runtime: runtime.name,
+            image_ref: container['Image'] || config['image'],
+            datastore: datastore,
+            allocated_ports: ports,
+            created_at: created_time,
+            started_at: started_time
+          )
+
+          @vuln_env.add_target(target)
+          elog("reconstruct_state: reconstructed environment #{assigned_id} from container #{container_id}")
+        end
+
+        @store.save(@vuln_env)
+      rescue => e
+        elog("Label reconstruction failed: #{e.message}")
+        elog(e.backtrace.join("\n")) if e.backtrace
+      end
+
+      def find_by_container(container_id)
+        @vuln_env.find_by_container(container_id)
+      end
+
+      def find_by_module(module_fullname)
+        @vuln_env = @store.load
+        @vuln_env.targets.select { |t| t.module_fullname == module_fullname }
+      end
+
+      def used_ports
+        @vuln_env = @store.load
+        @vuln_env.used_ports
+      end
+
+      def running?
+        @vuln_env = @store.load
+        @vuln_env.running_targets.any?
+      end
+
+      private
+
+      def decode_port_label(label_value)
+        return {} unless label_value
+
+        label_value.split(',').each_with_object({}) do |pair, hash|
+          host_port, container_port = pair.split(':')
+          hash[container_port.to_i] = host_port.to_i
+        end
+      end
+    end
+
+    # =====================================================================
+    # Health Manager
+    # =====================================================================
+    # waits for a container to become ready using a configurable strategy
+    # supports HTTP (status code), TCP (port open), and Command (exec inside container)
+    class HealthManager
+      def initialize(runtime, container_id, health_config, host_port, dispatcher = nil)
+        @runtime = runtime
+        @container_id = container_id
+        @config = health_config || {}
+        @host_port = host_port
+        @dispatcher = dispatcher
+      end
+
+      # block until the health check passes or retries are exhausted
+      # returns true on success. raises on failure so the caller decides cleanup
+      def wait
+        type = @config['type']
+        interval = @config['interval'] || 5
+        timeout = @config['timeout'] || 2
+        retries = @config['retries'] || 12
+
+        unless %w[http tcp command].include?(type)
+          raise "Unknown health check type: #{type.inspect}"
+        end
+
+        print_status("Waiting for health check (#{type.upcase})...")
+
+        retries.times do |i|
+          print_status("  Attempt #{i + 1}/#{retries}...")
+
+          result = false
+          begin
+            # Wrap each individual check in a timeout so a hanging TCP/HTTP
+            # connection doesn't consume the entire retry budget.
+            Timeout.timeout(timeout) do
+              result = case type
+                       when 'http'    then check_http
+                       when 'tcp'     then check_tcp
+                       when 'command' then check_command
+                       end
+            end
+          rescue Timeout::Error
+            result = false
+          rescue => e
+            # Log debug details but don't spam the console on every retry
+            @dispatcher&.elog("Health check attempt #{i + 1} error: #{e.class} - #{e.message}") if @dispatcher&.respond_to?(:elog)
+            result = false
+          end
+
+          if result
+            print_good("Health check passed.")
+            return true
+          end
+
+          sleep(interval)
+        end
+
+        total_seconds = retries * interval
+        raise "Health check timed out after #{total_seconds} seconds"
+      end
+
+      def print_status(msg)
+        @dispatcher&.print_status(msg)
+      end
+
+      def print_good(msg)
+        @dispatcher&.print_good(msg)
+      end
+
+      def print_error(msg)
+        @dispatcher&.print_error(msg)
+      end
+
+      private
+
+      def check_http
+        path = @config['path'] || '/'
+        expected_status = @config['expected_status'] || 200
+
+        uri = URI("http://127.0.0.1:#{@host_port}#{path}")
+
+        # Explicit timeouts prevent hanging connections from consuming the retry budget.
+        # Timeout.timeout is unreliable with Net::HTTP blocking I/O.
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.open_timeout = 2   # Max seconds to establish TCP connection
+        http.read_timeout = 2   # Max seconds to read response
+
+        request = Net::HTTP::Get.new(uri)
+
+        # If credentials are defined in the health_check config, add Basic Auth.
+        # ActiveMQ's Jolokia endpoint requires this.
+        if @config['credentials'] && @config['credentials']['username']
+          request.basic_auth(
+            @config['credentials']['username'],
+            @config['credentials']['password']
+          )
+        end
+
+        response = http.request(request)
+
+        actual_status = response.code.to_i
+        unless actual_status == expected_status
+          # Diagnostic output: tell the user what actually came back
+          print_status("  Health check returned #{actual_status}, expected #{expected_status}")
+          return false
+        end
+
+        expected_match = @config['match']
+        if expected_match && !response.body.to_s.match?(Regexp.new(expected_match))
+          print_status("  Health check got status #{actual_status} but response did not contain expected content")
+          return false
+        end
+
+        true
+      rescue Errno::ECONNRESET
+        # TCP connection accepted but HTTP server not yet initialized.
+        # This is a transient "not ready" signal — retry on next attempt.
+        print_status("  Connection reset on port #{@host_port} (service still initializing)")
+        false
+
+      rescue Errno::ECONNREFUSED
+        print_status("  Connection refused on port #{@host_port}")
+        false
+
+      rescue Net::OpenTimeout
+        print_status("  Connection timeout on port #{@host_port}")
+        false
+      rescue => e
+        print_status("  Health check error: #{e.class} - #{e.message}")
+        false
+      end
+
+      def check_tcp
+        # A successful connection + immediate close means the port is listening
+        TCPSocket.new('127.0.0.1', @host_port).close
+        true
+      rescue => e
+        false
+      end
+
+      def check_command
+        command = @config['command']
+        expected_output = @config['expected_output']
+
+        output, exit_code = @runtime.exec(@container_id, command)
+        return false unless exit_code == 0
+
+        if expected_output
+          output.match?(Regexp.new(expected_output))
+        else
+          true
+        end
+      end
+    end
+
+    # =====================================================================
+    # Provisioner
+    # =====================================================================
+    # Runs a one-time setup action against a container after it passes its
+    # health check, but before the environment is considered ready. Needed
+    # for images (like vulnerable WordPress) that boot with an unconfigured
+    # app: the process is up and answering HTTP, but there's no database
+    # schema or admin account yet, so nothing is actually exploitable until
+    # this runs.
+    class Provisioner
+      PROVISION_MARKER = '/tmp/.msf_test_env_provisioned'.freeze unless defined?(PROVISION_MARKER)
+
+      def initialize(runtime, container_id, provision_config, host_port, dispatcher = nil)
+        @runtime = runtime
+        @container_id = container_id
+        @config = provision_config || {}
+        @host_port = host_port
+        @dispatcher = dispatcher
+      end
+
+      # Returns true if there's nothing to do, or if provisioning succeeds.
+      # Returns false (does not raise) on failure so the caller decides
+      # whether that's fatal.
+      def run(datastore = {})
+        return true if @config.empty?
+
+        if @config['run_once'] && already_provisioned?
+          print_status("Provisioning already completed (run_once). Skipping.")
+          return true
+        end
+
+        type = @config['type']
+        unless type == 'http'
+          raise "Unknown provision type: #{type.inspect}"
+        end
+
+        print_status("Provisioning environment...")
+
+        Timeout.timeout(@config['timeout'] || 10) do
+          http_request(datastore)
+        end
+
+        mark_provisioned! if @config['run_once']
+
+        print_good("Provisioning request sent.")
+        true
+      rescue => e
+        print_error("Provisioning failed: #{e.class} - #{e.message}")
+        false
+      end
+
+      def print_status(msg)
+        @dispatcher&.print_status(msg)
+      end
+
+      def print_good(msg)
+        @dispatcher&.print_good(msg)
+      end
+
+      def print_error(msg)
+        @dispatcher&.print_error(msg)
+      end
+
+      private
+
+      # Checks whether the provision marker file exists inside the
+      # container. This allows run_once provisioning to survive container
+      # stops/starts and state reconstruction.
+      def already_provisioned?
+        output, exit_code = @runtime.exec(@container_id, "test -f #{PROVISION_MARKER}")
+        exit_code == 0
+      rescue => e
+        # If we can't check, assume not provisioned and proceed
+        false
+      end
+
+      # Creates the provision marker file inside the container so that
+      # future start/restart operations know provisioning is complete.
+      def mark_provisioned!
+        @runtime.exec(@container_id, "touch #{PROVISION_MARKER}")
+      rescue => e
+        # Non-fatal: provisioning succeeded but marker could not be written.
+        # The worst case is that a future restart might re-run provisioning,
+        # which for idempotent operations (like form submissions) is harmless.
+        print_warning("Could not write provision marker: #{e.message}")
+      end
+
+      def http_request(datastore)
+        path = @config['path'] || '/'
+        uri = URI("http://127.0.0.1:#{@host_port}#{path}")
+
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.open_timeout = 5
+        http.read_timeout = 10
+
+        method = (@config['method'] || 'post').to_s.downcase
+        request = case method
+                  when 'get'
+                    Net::HTTP::Get.new(uri)
+                  when 'put'
+                    Net::HTTP::Put.new(uri)
+                  when 'patch'
+                    Net::HTTP::Patch.new(uri)
+                  when 'post'
+                    Net::HTTP::Post.new(uri)
+                  else
+                    raise "Unknown HTTP method: #{method.inspect}"
+                  end
+
+        if %w[post put patch].include?(method)
+          body = resolve_template(@config['body'] || {}, datastore)
+          request.set_form_data(body)
+        end
+
+        response = http.request(request)
+
+        unless response.code.to_i.between?(200, 399)
+          raise "provision request to #{path} returned #{response.code}"
+        end
+      end
+      # Resolves "{{ credentials.default.username }}"-style tokens in the
+      # provision body against the datastore already built for this
+      # environment (USERNAME/PASSWORD etc. are merged in from
+      # config['credentials']['default'] before this runs).
+      def resolve_template(body, datastore)
+        body.each_with_object({}) do |(key, value), out|
+          out[key] = value.is_a?(String) ? substitute(value, datastore) : value
+        end
+      end
+
+      def substitute(str, datastore)
+        str.gsub(/\{\{\s*credentials\.default\.(\w+)\s*\}\}/) do
+          datastore[Regexp.last_match(1).upcase].to_s
+        end
+      end
+    end
+
+    # =====================================================================
+    # Environment Definition Loader
+    # =====================================================================
+    class EnvironmentDefinitionLoader
+      def initialize(data_directory)
+        @base_path = File.join(data_directory, 'vuln_envs')
+      end
+
+      def load(name)
+        path = File.join(@base_path, "#{name}.yml")
+        raise "Definition not found: #{path}" unless File.exist?(path)
+
+        yaml_content = File.read(path)
+        begin
+          data = YAML.safe_load(yaml_content, permitted_classes: [Symbol])
+        rescue ArgumentError
+          data = YAML.safe_load(yaml_content, [Symbol])
+        end
+
+        validate!(data, name)
+        data
+      end
+
+      def resolve(name, variant, profile = 'default', overrides = {})
+        data = load(name)
+
+        variant_cfg = data['variants'].find { |v| v['name'] == variant }
+        unless variant_cfg
+          available = data['variants'].map { |v| v['name'] }.join(', ')
+          raise "Variant '#{variant}' not defined for '#{name}'. Available: #{available}"
+        end
+
+        unless data['profiles'].key?(profile)
+          available = data['profiles'].keys.join(', ')
+          raise "Profile '#{profile}' not defined for '#{name}'. Available: #{available}"
+        end
+
+        config = deep_copy(data['shared'] || {})
+
+        profile_data = data['profiles'][profile].dup
+        profile_data.delete('description')
+        config = deep_merge(config, profile_data)
+
+        config = deep_merge(config, overrides) if overrides.is_a?(Hash) && !overrides.empty?
+
+        config['image'] = variant_cfg['image']
+        config['build_args'] = variant_cfg['build_args'] if variant_cfg['build_args']
+
+        config
+      end
+
+      def available_definitions
+        return [] unless Dir.exist?(@base_path)
+        Dir.glob(File.join(@base_path, '*.yml')).map { |f| File.basename(f, '.yml') }
+      end
+
+      private
+
+      def validate!(data, filename)
+        unless data['name'] == filename
+          raise "Validation failed: name '#{data['name']}' does not match filename '#{filename}'"
+        end
+
+        unless data['variants'].is_a?(Array) && !data['variants'].empty?
+          raise "Validation failed: 'variants' must be a non-empty list"
+        end
+
+        data['variants'].each do |cfg|
+          unless cfg.is_a?(Hash) && cfg['name'].is_a?(String) && !cfg['name'].empty?
+            raise "Validation failed: variant missing valid 'name'"
+          end
+          unless cfg['image'].is_a?(String) && !cfg['image'].empty?
+            raise "Validation failed: variant '#{cfg['name']}' missing valid 'image'"
+          end
+        end
+
+        unless data['shared'].is_a?(Hash) && data['shared']['ports'].is_a?(Hash) && !data['shared']['ports'].empty?
+          raise "Validation failed: 'shared.ports' must have at least one entry"
+        end
+
+        unless data['profiles'].is_a?(Hash) && !data['profiles'].empty?
+          raise "Validation failed: 'profiles' must have at least one entry"
+        end
+
+        unless data['profiles'].key?('default')
+          raise "Validation failed: 'profiles' must contain a 'default' profile"
+        end
+
+        data['profiles'].keys.each do |profile_name|
+          unless profile_name.to_s.match?(/\A[a-z0-9-]+\z/)
+            raise "Validation failed: profile name '#{profile_name}' must match [a-z0-9-]+"
+          end
+        end
+
+        shared_has_health = data['shared'].is_a?(Hash) && data['shared']['health_check'].is_a?(Hash)
+        unless shared_has_health
+          data['profiles'].each do |name, cfg|
+            unless cfg.is_a?(Hash) && cfg['health_check'].is_a?(Hash)
+              raise "Validation failed: 'health_check' must be defined in 'shared' or in every profile (missing in '#{name}')"
+            end
+          end
+        end
+      end
+
+      def deep_copy(obj)
+        Marshal.load(Marshal.dump(obj))
+      end
+
+      def deep_merge(base, override)
+        return base unless override.is_a?(Hash)
+        base.merge(override) do |_key, old_val, new_val|
+          if old_val.is_a?(Hash) && new_val.is_a?(Hash)
+            deep_merge(old_val, new_val)
+          else
+            new_val
+          end
+        end
+      end
+    end
+
+    # =====================================================================
+    # Console Command Dispatcher
+    # =====================================================================
+    class ConsoleCommandDispatcher
+      include Msf::Ui::Console::CommandDispatcher
+
+      @@runtime = nil
+      @@registry = nil
+
+      def self.registry=(registry)
+        @@registry = registry
+      end
+
+      def self.registry
+        @@registry
+      end
+
+      def self.runtime=(runtime)
+        @@runtime = runtime
+      end
+
+      def self.runtime
+        @@runtime
+      end
+
+      def name
+        'TestEnv'
+      end
+
+      def commands
+        {
+          'test_env' => 'Manage vulnerable test environments'
+        }
+      end
+
+      def cmd_test_env(*args)
+        if args.empty? || args.first == '-h' || args.first == '--help'
+          cmd_test_env_help
+          return
+        end
+
+        subcommand = args.shift
+
+        case subcommand
+        when 'build'
+          cmd_test_env_build(args)
+        when 'list'
+          cmd_test_env_list(args)
+        when 'modules'
+          cmd_test_env_modules(args)
+        when 'stop'
+          cmd_test_env_stop(args)
+        when 'start'
+          cmd_test_env_start(args)
+        when 'remove'
+          cmd_test_env_remove(args)
+        when 'remove-all'
+          cmd_test_env_remove_all(args)
+        when 'exec'
+          cmd_test_env_exec(args)
+        when 'validate'
+          cmd_test_env_validate(args)
+        when 'status'
+          cmd_test_env_status(args)
+        when 'help'
+          cmd_test_env_help
+        else
+          print_error("Unknown subcommand: #{subcommand}")
+          cmd_test_env_help
+        end
+      end
+
+def cmd_test_env_build(args)
+  container_id = nil
+  registered   = false
+  runtime      = nil
+
+  begin
+    # Steps 1-3: validate module, metadata, and user arguments
+    mod, env, options = build_validate_prerequisites(args)
+    return unless mod && env
+
+    # Steps 4-7: resolve definition, variant, profile, and config
+    definition_name, variant, profile, config, port_mapping = build_resolve_environment(mod, env, options)
+    return unless definition_name
+
+    # Step 6: runtime availability
+    runtime = self.class.runtime
+    unless runtime
+      print_error("No container runtime available. Install Docker or Podman.")
+      return
+    end
+
+    # Step 8: pull image
+    return unless build_pull_image(runtime, config)
+
+    # Step 9: allocate host ports
+    allocated_ports = build_allocate_ports(runtime, port_mapping, options)
+
+    # Steps 10-12: prune registry, build labels, prepare volumes
+    labels, run_ports, volumes, temp_dirs, env_id = build_prepare_resources(
+      runtime, config, definition_name, variant, mod, allocated_ports
+    )
+
+    # Step 13: launch container
+    container_id = build_launch_container(runtime, config, run_ports, labels, volumes, definition_name, variant)
+
+    # verify container actually started
+    container_info = runtime.inspect(container_id)
+    unless container_info
+      print_error("Container started but inspect failed immediately.")
+      runtime.remove(container_id)
+      return
+    end
+
+    # check if running (Docker/Podman both use State.Status)
+    status = container_info.dig('State', 'Status') || container_info.dig('State', 'Running')
+    if status != 'running' && status != true
+      error_msg = container_info.dig('State', 'Error') || 'unknown'
+      print_error("Container failed to start. Status: #{status.inspect}, Error: #{error_msg}")
+      runtime.remove(container_id)
+      return
+    end
+
+    print_good("Container started: #{container_id[0..11]}")
+
+    # Step 14: health check BEFORE registering
+    return unless build_wait_for_health(runtime, container_id, config, port_mapping, allocated_ports)
+
+    # TCP health checks confirm liveness (port open) but not readiness
+    # (protocol fully initialized). Some services (e.g. ActiveMQ OpenWire)
+    # accept connections before the protocol handler is ready.
+    if config.dig('health_check', 'type') == 'tcp'
+      print_status("TCP port open; waiting 5 seconds for protocol initialization...")
+      sleep 5
+    end
+    # Step 15: build the datastore (RHOSTS/RPORT/credentials/etc.)
+    datastore = build_construct_datastore(config, allocated_ports, port_mapping)
+
+    # Step 15.5: run optional one-time provisioning (e.g. WordPress install
+    # wizard), then re-verify, before the environment is registered as ready
+    unless build_provision_environment(runtime, container_id, config, port_mapping, allocated_ports, datastore)
+      print_error("Provisioning failed; tearing down container.")
+      runtime.stop(container_id) rescue nil
+      runtime.remove(container_id) rescue nil
+      return
+    end
+
+    # Step 16: register environment in registry
+    build_register_environment(
+      runtime, container_id, mod, variant, config, allocated_ports, temp_dirs, env_id, datastore
+    )
+    registered = true
+
+    # Step 17: free host ports for stage/fetch payloads (avoids Rex::BindFailed on 8080)
+    %w[SRVPORT FETCH_SRVPORT].each do |opt|
+      if mod.options.include?(opt)
+        free_port = free_local_port
+        datastore[opt] = free_port
+      end
+    end
+
+    # Step 18: apply datastore to the active module
+    datastore.each do |key, value|
+      if mod.options.include?(key)
+        mod.datastore[key] = value
+      end
+    end
+
+    # Step 19: display results to user
+    build_display_results(env_id, config, datastore, mod)
+
+  rescue PortAllocator::NoPortsAvailable => e
+    print_error("No available ports: #{e.message}")
+  rescue => e
+    # Clean up orphaned container if we created one but failed to register it
+    if container_id && !registered
+      begin
+        runtime.stop(container_id) rescue nil
+        runtime.remove(container_id)
+        print_status("Cleaned up orphaned container #{container_id[0..11]}")
+      rescue => cleanup_err
+        elog("Failed to cleanup orphaned container: #{cleanup_err.message}")
+      end
+    end
+
+    print_error("test_env build failed: #{e.message}")
+    elog("test_env build error: #{e.class} - #{e.message}")
+    elog(e.backtrace.join("\n"))
+  end
+end
+
+# -------------------------------------------------------------------------
+# Build Phase Helpers
+# -------------------------------------------------------------------------
+
+# Steps 1-3: Preconditions, metadata validation, and argument parsing.
+# Returns [mod, env, options] or [nil, nil, nil] on failure.
+def build_validate_prerequisites(args)
+  mod = driver.active_module
+  unless mod
+    print_error("No active module. Use 'use <module>' first.")
+    return [nil, nil, nil]
+  end
+
+  env = vulnerable_environment(mod)
+  unless env
+    print_error("Module does not define a vulnerable environment configuration.")
+    return [nil, nil, nil]
+  end
+
+  options = parse_build_args(args)
+  [mod, env, options]
+end
+
+# Steps 4-7: Resolve environment definition and validate port mappings.
+# Returns [definition_name, variant, profile, config, port_mapping]
+# or [nil, nil, nil, nil, nil] when variant is missing.
+def build_resolve_environment(mod, env, options)
+  definition_name = env.definition
+  default_variant = env.default_variant
+  port_mapping    = env.port_mapping
+
+  variant = options['VARIANT'].to_s.empty? ? default_variant : options['VARIANT']
+  profile = options['PROFILE'].to_s.empty? ? env.profile : options['PROFILE']
+
+  unless variant
+    print_error("No variant specified and module has no default_variant.")
+    return [nil, nil, nil, nil, nil]
+  end
+
+  loader = EnvironmentDefinitionLoader.new(Msf::Config.data_directory)
+  config = loader.resolve(definition_name, variant, profile, env.overrides)
+
+  # Validate: every port in module's port_mapping must exist in the environment's exposed ports
+  resolved_ports = config.fetch('ports', {}).values.map(&:to_i)
+  port_mapping.keys.each do |container_port|
+    port_int = container_port.to_i
+    unless resolved_ports.include?(port_int)
+      available = resolved_ports.join(', ')
+      raise "Port mapping mismatch: module maps port #{port_int} but environment '#{definition_name}' (variant '#{variant}', profile '#{profile}') only exposes ports: #{available}"
+    end
+  end
+
+  print_status("Resolving environment for #{mod.fullname}...")
+  print_status("Definition: #{definition_name} | Variant: #{variant} | Profile: #{profile}")
+  print_status("Image: #{config['image']}")
+
+  # If the environment definition names a recommended payload (e.g. because
+  # the module's own auto-selected default is known not to work against
+  # this specific image/variant), apply it now, before the container is
+  # even started, so it's reflected if the user runs 'show options'.
+  recommended_payload = config.dig('ci', 'exploit', 'payload')
+  if recommended_payload && !mod.datastore['PAYLOAD'].nil? && mod.datastore['PAYLOAD'] != recommended_payload
+    print_status("Setting recommended payload for this environment: #{recommended_payload}")
+    mod.datastore['PAYLOAD'] = recommended_payload
+  end
+
+  [definition_name, variant, profile, config, port_mapping]
+end
+
+# Step 8: Pull the container image. Returns true on success, false on failure.
+def build_pull_image(runtime, config)
+  print_status("Pulling image #{config['image']}...")
+  unless runtime.pull(config['image'])
+    print_error("Failed to pull image: #{config['image']}")
+    return false
+  end
+  print_good("Image pulled successfully.")
+  true
+end
+
+# Step 9: Allocate free host ports for container bindings.
+def build_allocate_ports(runtime, port_mapping, options)
+  allocator = PortAllocator.new(runtime, self.class.registry.used_ports)
+  allocated_ports = {}
+  user_rport = options['RPORT'] ? options['RPORT'].to_i : nil
+  target_container_port = user_rport ? port_mapping.key('RPORT') : nil
+
+  port_mapping.each do |container_port, ds_option|
+    preferred = (container_port == target_container_port) ? user_rport : nil
+    host_port = allocator.allocate(preferred)
+
+    if preferred && host_port != preferred
+      print_status("Requested port #{preferred} unavailable. Using dynamically allocated port #{host_port}.")
+    end
+
+    allocated_ports[container_port] = host_port
+  end
+
+  allocated_ports
+end
+
+# Steps 10-12: Prune registry, build labels, map ports for runtime, and prepare volumes.
+# Returns [labels, run_ports, volumes, temp_dirs, env_id].
+def build_prepare_resources(runtime, config, definition_name, variant, mod, allocated_ports)
+  self.class.registry.prune(runtime)
+
+  instance_id = "msf-#{Socket.gethostname}-#{Process.pid}"
+  env_id = self.class.registry.reserve_id
+
+  labels = runtime.build_labels(
+    instance_id: instance_id,
+    module_fullname: mod.fullname,
+    env_id: env_id,
+    version: variant,
+    ports: allocated_ports
+  )
+
+  run_ports = {}
+  allocated_ports.each do |container_port, host_port|
+    run_ports[container_port] = host_port
+  end
+
+  volumes = {}
+  temp_dirs = []
+
+  if config['volumes']
+    config['volumes'].each do |name, vol_cfg|
+      host_path = vol_cfg['host_path']
+      unless host_path
+        host_path = Dir.mktmpdir("test_env_#{name}_")
+        temp_dirs << host_path
+      end
+      volumes[host_path] = vol_cfg['container_path']
+    end
+  end
+
+  [labels, run_ports, volumes, temp_dirs, env_id]
+end
+
+# Step 13: Launch the container. Returns the container_id.
+def build_launch_container(runtime, config, run_ports, labels, volumes, definition_name, variant)
+  print_status("Starting container...")
+  container_name = "msf-vulnenv-#{definition_name}-#{variant}-#{Time.now.to_f.to_s.delete('.')}"
+
+  runtime.run(
+    image: config['image'],
+    ports: run_ports,
+    labels: labels,
+    volumes: volumes,
+    name: container_name
+  )
+end
+
+# Step 14: Wait for health check. Returns true if healthy, false otherwise
+# (container is already cleaned up on failure).
+def build_wait_for_health(runtime, container_id, config, port_mapping, allocated_ports)
+  primary_container_port = port_mapping.key('RPORT')
+  health_host_port = allocated_ports[primary_container_port] || allocated_ports.values.first
+
+  health = config['health_check']
+  begin
+    HealthManager.new(runtime, container_id, health, health_host_port, self).wait
+  rescue => e
+    print_error("Health check failed: #{e.message}")
+    begin
+      runtime.stop(container_id) rescue nil
+      runtime.remove(container_id) rescue nil
+    rescue => cleanup_err
+      elog("Failed to cleanup unhealthy container: #{cleanup_err.message}")
+    end
+    return false
+  end
+  true
+end
+
+# Step 15: Build the datastore hash (RHOSTS/RPORT/TARGETURI/credentials/etc.)
+# Split out from registration so provisioning (below) has USERNAME/PASSWORD
+# and the resolved ports available before the environment is registered.
+def build_construct_datastore(config, allocated_ports, port_mapping)
+  datastore = { 'RHOSTS' => '127.0.0.1' }
+  allocated_ports.each do |container_port, host_port|
+    ds_option = port_mapping[container_port]
+    datastore[ds_option] = host_port if ds_option
+  end
+
+  if config['datastore_defaults']
+    config['datastore_defaults'].each do |key, value|
+      datastore[key] = value unless datastore.key?(key)
+    end
+  end
+
+  # Merge credentials into datastore so they are applied to the module,
+  # stored in the registry, and included in the suggested exploit command.
+  if config['credentials'] && config['credentials']['default']
+    config['credentials']['default'].each do |key, value|
+      ds_key = key.to_s.upcase
+      datastore[ds_key] = value unless datastore.key?(ds_key)
+    end
+  end
+
+  datastore
+end
+
+# Step 15.5: Run the optional one-time provisioning step (e.g. driving the
+# WordPress install wizard) against the primary port, then re-verify with
+# an optional 'verify' block. No-op (returns true) if the definition has no
+# 'provision' config. On failure, the caller is responsible for cleanup.
+def build_provision_environment(runtime, container_id, config, port_mapping, allocated_ports, datastore)
+  provision = config['provision']
+  return true unless provision.is_a?(Hash) && !provision.empty?
+
+  primary_container_port = port_mapping.key('RPORT')
+  host_port = allocated_ports[primary_container_port] || allocated_ports.values.first
+
+  unless Provisioner.new(runtime, container_id, provision, host_port, self).run(datastore)
+    return false
+  end
+
+  verify = config['verify']
+  return true unless verify.is_a?(Hash) && !verify.empty?
+
+  begin
+    HealthManager.new(runtime, container_id, verify, host_port, self).wait
+  rescue => e
+    print_error("Post-provision verification failed: #{e.message}")
+    return false
+  end
+
+  true
+end
+
+# Step 16: Register the built, provisioned environment with the registry.
+def build_register_environment(runtime, container_id, mod, variant, config, allocated_ports, temp_dirs, env_id, datastore)
+  self.class.registry.register_with_id(
+    env_id: env_id,
+    container_id: container_id,
+    module_fullname: mod.fullname,
+    env_version: variant,
+    runtime: runtime.name,
+    image_ref: config['image'],
+    datastore: datastore,
+    allocated_ports: allocated_ports,
+    temp_dirs: temp_dirs
+  )
+
+  datastore
+end
+
+# Step 18: Display build results and suggested exploit command.
+def build_display_results(env_id, config, datastore, mod)
+  print_good("Environment ready.")
+  print_status("Environment ID: #{env_id}")
+
+  %w[SRVPORT FETCH_SRVPORT].each do |opt|
+    if mod.options.include?(opt)
+      free_port = free_local_port
+      mod.datastore[opt] = free_port
+      datastore[opt] = free_port
+    end
+  end
+
+  applicable = datastore.select { |k, _v| mod.options.include?(k) }
+  applicable.each do |key, value|
+    print_status("   #{key.ljust(12)} => #{value}")
+  end
+
+  action = mod.type == 'auxiliary' ? 'run' : 'exploit'
+  opts = applicable.map { |k, v| "#{k}=#{v}" }.join(' ')
+  print_status("Suggested: #{action} #{opts}")
+end
+
+      def cmd_test_env_help
+        print_line("Usage: test_env <command>")
+        print_line
+        print_line("Commands:")
+        print_line("  build      Build and launch environment for active module")
+        print_line("  list       List tracked environments")
+        print_line("  modules    List all modules with test_env support")
+        print_line("  stop <ID>  Stop a running environment")
+        print_line("  start <ID> Restart a stopped environment")
+        print_line("  remove <ID> Tear down an environment")
+        print_line("  remove-all Tear down all environments")
+        print_line("  exec <ID>  Execute exploit against environment")
+        print_line("  validate <ID> Check session/output against ci.validation")
+        print_line("  status     Show runtime status")
+        print_line("  help       Show this help")
+        print_line
+      end
+
+      def cmd_test_env_status(args)
+        runtime = self.class.runtime
+        if runtime
+          print_status("Runtime: #{runtime.name}")
+          if runtime.respond_to?(:verify_rootless)
+            ok, msg = runtime.verify_rootless
+            ok ? print_good(msg) : print_warning(msg)
+          end
+
+          # count framework-managed containers
+          containers = runtime.list(filters: { 'label' => 'msf.vulnenv.managed_by=test_env' })
+          running = containers.count { |c| c['State'] == 'running' }
+          total = containers.length
+
+          print_status("Managed containers: #{total} total, #{running} running")
+        else
+          print_error("No runtime configured.")
+        end
+
+        loader = EnvironmentDefinitionLoader.new(Msf::Config.data_directory)
+        defs = loader.available_definitions
+
+        valid_defs = []
+        defs.each do |name|
+          begin
+            loader.load(name)
+            valid_defs << name
+          rescue => e
+            print_error("Validation failed for '#{name}': #{e.message}")
+          end
+        end
+
+        if valid_defs.any?
+          print_status("Available definitions: #{valid_defs.join(', ')}")
+        else
+          print_error("No valid definitions found.")
+        end
+      rescue => e
+        print_error("Status check failed: #{e.message}")
+      end
+      def cmd_test_env_list(_args = [])
+        targets = self.class.registry.list
+
+        if targets.empty?
+          print_status("No environments currently tracked.")
+          return
+        end
+
+        rows = targets.map do |t|
+          [
+            t.local_id.to_s,
+            t.container_id.to_s[0..11],
+            t.module_fullname.to_s,
+            t.rhost || '127.0.0.1',
+            t.rport.to_s,
+            t.status.to_s,
+            t.env_version.to_s
+          ]
+        end
+
+        tbl = Rex::Text::Table.new(
+          'Header'     => 'Test Environments',
+          'Indent'     => 1,
+          'Columns'    => ['ID', 'Container', 'Module', 'RHOST', 'RPORT', 'Status', 'Version']
+        )
+
+        rows.each { |r| tbl << r }
+        print_line(tbl.to_s)
+
+        print_status("#{targets.length} environment(s) tracked.")
+      end
+
+      def cmd_test_env_exec(args)
+        if args.empty? || args.first == '-h' || args.first == '--help'
+          print_line("Usage: test_env exec <ID>")
+          print_line
+          print_line("Loads the module this environment was built for, applies its")
+          print_line("stored datastore and recommended payload (if any), and runs it.")
+          print_line("Equivalent to manually running the 'Suggested:' command printed")
+          print_line("by 'test_env build', but works from anywhere in the console -")
+          print_line("you do not need to 'use' the module first.")
+          return
+        end
+
+        # --- Step A: look up the stored environment. Fail fast with a
+        # specific, actionable message rather than letting a nil target
+        # propagate into a confusing NoMethodError three lines down. This
+        # is the "improve error handling" deliverable in practice: every
+        # precondition gets its own guard and its own message.
+        id = nil
+        background = false
+
+        args.each do |arg|
+          case arg
+          when '-z', '--background'
+            background=true
+          when /^-/
+            print_warning("Unknown option: #{arg}")
+          else
+            id = arg.to_i if id.nil?
+          end
+        end
+
+        unless id
+          print_error("No environment ID specified.")
+          return
+        end
+
+        target = self.class.registry.get(id)
+
+        unless target
+          print_error("Environment #{id} not found. Run 'test_env list' to see tracked environments.")
+          return
+        end
+
+        unless target.running?
+          print_error("Environment #{id} is #{target.status}, not running.")
+          print_status("Run 'test_env start #{id}' first, then retry.")
+          return
+        end
+
+        # --- Step B: load the module by fullname. Deliberately not using
+        # driver.active_module here - exec should work standalone, even if
+        # the console is currently pointed at a completely different module
+        # (or nothing at all). This makes 'exec' safe to call repeatedly in
+        # automation without tracking console state externally.
+        print_status("Using #{target.module_fullname}...")
+        driver.run_single("use #{target.module_fullname}")
+
+        mod = driver.active_module
+        unless mod && mod.fullname == target.module_fullname
+          print_error("Could not load module '#{target.module_fullname}'. It may have been removed or renamed since this environment was built.")
+          return
+        end
+
+        # --- Step C: re-resolve the environment definition to recover any
+        # ci.exploit recommendation (payload + options). This is NOT part
+        # of target.datastore - build_construct_datastore only stores
+        # RHOSTS/RPORT/TARGETURI/credentials, not PAYLOAD/LHOST/LPORT - so
+        # without this step 'exec' would silently fall back to whatever
+        # payload the module auto-selects, reintroducing the exact
+        # incompatible-default-payload problem 'build' already solves.
+        raw = mod.send(:module_info)['VulnerableEnvironment'] rescue nil
+        if raw
+          env_meta = VulnerableEnvironment.new(raw)
+          loader = EnvironmentDefinitionLoader.new(Msf::Config.data_directory)
+          config = loader.resolve(env_meta.definition, target.env_version, env_meta.profile, env_meta.overrides) rescue nil
+          ci_exploit = config&.dig('ci', 'exploit') || {}
+
+          if ci_exploit['payload'] && mod.datastore['PAYLOAD'] != ci_exploit['payload']
+            print_status("Setting recommended payload for this environment: #{ci_exploit['payload']}")
+            driver.run_single("set PAYLOAD #{ci_exploit['payload']}")
+          end
+
+          ci_exploit['options']&.each do |key, value|
+            driver.run_single("set #{key} #{value}")
+          end
+
+          if ci_exploit['force_exploit']
+            driver.run_single("set ForceExploit true")
+          end
+        end
+
+        # --- Step D: apply the suggested datastore automatically. This
+        # reuses target.datastore directly rather than re-deriving RHOSTS/
+        # RPORT/credentials by hand - single source of truth, and it's the
+        # exact same hash 'test_env build' already showed the user under
+        # "Suggested:", so what runs here always matches what was printed.
+        applied = {}
+        target.datastore.each do |key, value|
+          if mod.options.include?(key)
+            driver.run_single("set #{key} #{value}")
+            applied[key] = value
+          end
+        end
+
+        # --- Step D.5: avoid Rex::BindFailed from stale listeners on
+        # repeated runs. Some payloads (e.g. cmd/linux/http/.../reverse_tcp)
+        # bind a local server on this host to serve the stage/fetch content
+        # - by default on a fixed port (often 8080). If a previous 'exec'
+        # run's server didn't get torn down cleanly, that port stays bound
+        # and every subsequent run fails until someone manually finds and
+        # kills the stale process. Picking a fresh free port each time
+        # removes the collision entirely rather than requiring cleanup.
+        %w[SRVPORT FETCH_SRVPORT].each do |opt|
+          if mod.options.include?(opt)
+            free_port = free_local_port
+            driver.run_single("set #{opt} #{free_port}")
+            applied[opt] = free_port
+          end
+        end
+          
+        # --- Step E: run it. driver.run_single("exploit") reuses the
+        # console's own exploit-execution path - AutoCheck, payload
+        # generation, session creation, and all success/failure messaging
+        # come from that well-tested path rather than being reimplemented
+        # here. See the design note above for why this matters.
+        action =  if mod.type == 'auxiliary'
+                    'run'
+                  elsif background
+                    'exploit -z'
+                  else
+                    'exploit'
+                  end
+
+        opts = applied.map { |k, v| "#{k}=#{v}" }.join(' ')
+        print_status("Executing: #{action} #{opts}")
+        driver.run_single(action)
+      rescue => e
+        print_error("test_env exec failed: #{e.class} - #{e.message}")
+        elog("test_env exec error: #{e.class} - #{e.message}")
+        elog(e.backtrace.join("\n"))
+      end
+
+      # Asks the OS for an unused ephemeral port by binding to port 0 and
+      # reading back what it was assigned. Simpler and more reliable than
+      # maintaining our own "is this port free" bookkeeping for host-side
+      # (non-container) ports - the OS already tracks this correctly.
+      def free_local_port
+        server = TCPServer.new('0.0.0.0', 0)
+        port = server.addr[1]
+        server.close
+        port
+      end
+
+      # Runs a lightweight "who am I" check on a session and returns
+      # output in the same shape a raw 'id' command would (so it can be
+      # matched against a shell-style expected_output like "uid=").
+      #
+      # Deliberately NOT using shell_command_token for Meterpreter: that
+      # opens a process channel (sys.process.execute under the hood), and
+      # in testing that channel path failed deterministically - every
+      # attempt, every session, same "core_channel_write: Operation
+      # failed: 9" - which points to the channel mechanism itself being
+      # unreliable in this environment, not a one-off timing issue.
+      # sys.config.getuid is a plain TLV request/response call with no
+      # channel involved, so it avoids that failure mode entirely.
+      #
+      # Shell sessions have no such alternative - shell_command_token IS
+      # the interface for them, and it worked without issue in testing
+      # (see the WordPress php/reverse_php run), so it stays as-is there.
+      def run_verification_command(session)
+        if session.type.to_s == 'meterpreter' && session.respond_to?(:sys)
+          uid = session.sys.config.getuid
+          "uid=#{uid}"
+        else
+          session.shell_command_token('id')
+        end
+      end
+
+      # Checks a built (and typically already-'exec'd) environment against
+      # its definition's ci.validation block: was a session created, is it
+      # the expected type, and does it produce the expected output. Prints
+      # a clear PASS/FAIL.
+      #
+      # This is the concrete "align shared definitions with CI and local
+      # execution workflows" deliverable: ci.validation was previously
+      # documented in the YAML schema but never actually read by any code
+      # path. Because this method only reads from the resolved definition
+      # (never anything console-session-specific beyond the session list
+      # itself), the exact same check a human runs interactively here is
+      # what a headless CI runner would perform against the same YAML -
+      # there is one definition of "did this pass," not two.
+      def cmd_test_env_validate(args)
+        if args.empty? || args.first == '-h' || args.first == '--help'
+          print_line("Usage: test_env validate <ID>")
+          print_line
+          print_line("Checks session(s) opened against this environment's")
+          print_line("module against the definition's ci.validation")
+          print_line("expectations (session type + expected output). If")
+          print_line("multiple sessions exist (some modules open duplicates),")
+          print_line("each is tried until one responds correctly. Prints PASS")
+          print_line("or FAIL. Run 'test_env exec <ID>' first if no session")
+          print_line("exists yet.")
+          print_line
+          print_line("IMPORTANT: sessions are process-local. Run 'exec' and")
+          print_line("'validate' in the SAME msfconsole window - a session")
+          print_line("opened in one msfconsole process is invisible to another.")
+          return
+        end
+
+        id = args.shift.to_i
+        target = self.class.registry.get(id)
+
+        unless target
+          print_error("Environment #{id} not found. Run 'test_env list' to see tracked environments.")
+          return
+        end
+
+        # Load the module read-only - validate doesn't change console
+        # context (unlike exec, which needs 'use' for driver.run_single
+        # to apply datastore/run the exploit).
+        mod = framework.modules.create(target.module_fullname)
+        unless mod
+          print_error("Could not load module '#{target.module_fullname}'. It may have been removed or renamed since this environment was built.")
+          return
+        end
+
+        raw = mod.send(:module_info)['VulnerableEnvironment'] rescue nil
+        unless raw
+          print_error("Module '#{target.module_fullname}' does not define a VulnerableEnvironment.")
+          return
+        end
+
+        env_meta = VulnerableEnvironment.new(raw)
+        loader = EnvironmentDefinitionLoader.new(Msf::Config.data_directory)
+        config = loader.resolve(env_meta.definition, target.env_version, env_meta.profile, env_meta.overrides) rescue nil
+
+        unless config
+          print_error("Could not resolve environment definition '#{env_meta.definition}'.")
+          return
+        end
+
+        validation = config.dig('ci', 'validation')
+        unless validation
+          print_error("Definition '#{env_meta.definition}' has no ci.validation block - nothing to check against.")
+          return
+        end
+
+        expected_session = validation.fetch('expected_session', true)
+        expected_type    = validation['session_type']
+        expected_output  = validation['expected_output']
+        wait_timeout     = validation['timeout'] || 120
+
+        print_status("Validating environment #{id} (#{target.module_fullname}) against #{env_meta.definition}'s ci.validation...")
+
+        unless expected_session
+          print_status("No session required; validating service behavior...")
+
+          expected_text = validation['expected_output']
+          probe_port = target.allocated_ports.values.first
+
+          if expected_text && !expected_text.empty?
+            response = nil
+
+            # Probe based on the environment's health check type
+            case config.dig('health_check', 'type')
+            when 'http'
+              begin
+                uri = URI("http://127.0.0.1:#{probe_port}/")
+                http = Net::HTTP.new(uri.host, uri.port)
+                http.open_timeout = 5
+                http.read_timeout = 5
+                response = http.request(Net::HTTP::Get.new(uri))
+                response_body = response.body.to_s
+                response_headers = response.to_hash.map { |k, v| "#{k}: #{v.join}" }.join("\n")
+                response = "#{response_headers}\n\n#{response_body}"
+              rescue => e
+                print_error("FAIL: HTTP probe failed: #{e.message}")
+                return
+              end
+
+            when 'tcp'
+              begin
+                socket = TCPSocket.new('127.0.0.1', probe_port)
+                response = socket.gets.to_s
+                socket.close
+              rescue => e
+                print_error("FAIL: TCP probe failed: #{e.message}")
+                return
+              end
+            end
+
+            if response && response.match?(Regexp.new(expected_text))
+              print_good("Service response contains expected text: '#{expected_text}'")
+            else
+              print_error("FAIL: service response did not contain '#{expected_text}'")
+              print_status("--- Response (first 400 chars) ---")
+              print_status(response.to_s[0..400])
+              print_status("----------------------------------")
+              return
+            end
+          else
+            print_warning("No ci.validation.expected_output defined for this auxiliary module.")
+            print_warning("Falling back to smoke test (module executed without errors).")
+          end
+
+          # Layer 2: verify service is still healthy after the scan
+          begin
+            if config && config['health_check']
+              primary_port = target.allocated_ports[env_meta.port_mapping.key('RPORT')]
+              health_port = primary_port || target.allocated_ports.values.first
+              runtime = self.class.runtime || (RuntimeAdapter.detect(framework.datastore) rescue nil)
+
+              if runtime && health_port
+                HealthManager.new(runtime, target.container_id,
+                                config['health_check'], health_port, self).wait
+              end
+            end
+          rescue => e
+            print_error("FAIL: environment unhealthy after module execution: #{e.message}")
+            return
+          end
+
+          print_good("PASS: environment validated successfully against #{env_meta.definition}'s ci.validation.")
+          return
+        end
+
+        # Session creation can lag slightly behind 'exploit' returning
+        # (staged payloads in particular), so poll for a short window
+        # rather than checking exactly once.
+        candidates = []
+        begin
+          Timeout.timeout(wait_timeout) do
+            until candidates.any?
+              candidates = framework.sessions.values
+                                     .select { |s| s.via_exploit == target.module_fullname }
+                                     .sort_by(&:sid)
+              sleep 2 if candidates.empty?
+            end
+          end
+        rescue Timeout::Error
+          # handled by the empty check below
+        end
+
+        if candidates.empty?
+          print_error("FAIL: no session was created within #{wait_timeout}s (expected_session: true) in this console session.")
+          print_status("Sessions are process-local: they only exist in the msfconsole process that opened them.")
+          print_status("If you ran 'test_env exec #{id}' in a different msfconsole window, run 'test_env validate #{id}' there too - not here.")
+          print_status("Otherwise, run 'test_env exec #{id}' first, then 'test_env validate #{id}' in the same console.")
+          return
+        end
+
+        print_status("Found #{candidates.length} session(s) for this module: #{candidates.map(&:sid).join(', ')}")
+
+        if expected_type
+          candidates = candidates.select { |s| s.type.to_s == expected_type.to_s }
+          if candidates.empty?
+            print_error("FAIL: no session of type '#{expected_type}' found.")
+            return
+          end
+        end
+
+        # Some modules (notably this ActiveMQ one, which fires its Spring
+        # XML payload multiple times) can leave more than one session -
+        # some real, some stale/half-connected duplicates. The most
+        # recent SID is not reliably the working one (observed directly:
+        # the session actually interacted with was SID 1, while SID 2 -
+        # a duplicate opened moments later - consistently failed channel
+        # writes). So rather than guessing based on recency, try each
+        # candidate oldest-first and use the first one that actually
+        # responds. If expected_output isn't set, there's nothing to
+        # distinguish working from broken, so just take the oldest.
+        session = nil
+        output = nil
+
+        if expected_output
+          candidates.each do |candidate|
+            if candidate.respond_to?(:load_stdapi)
+              begin
+                candidate.load_stdapi
+              rescue => e
+                print_status("Could not explicitly load stdapi on session #{candidate.sid} (#{e.message}), continuing anyway...")
+              end
+            end
+
+            result = nil
+            attempts = 0
+            begin
+              attempts += 1
+              result = run_verification_command(candidate)
+            rescue => e
+              if attempts < 3
+                print_status("Session #{candidate.sid}: verification command failed on attempt #{attempts}/3 (#{e.message}), retrying...")
+                sleep 3
+                retry
+              else
+                print_status("Session #{candidate.sid} did not respond after #{attempts} attempts (#{e.message}) - trying next candidate, if any.")
+              end
+            end
+
+            if result&.match?(Regexp.new(expected_output))
+              session = candidate
+              output = result
+              break
+            end
+          end
+
+          unless session
+            print_error("FAIL: none of #{candidates.length} candidate session(s) (#{candidates.map(&:sid).join(', ')}) produced the expected output '#{expected_output}'.")
+            return
+          end
+        else
+          session = candidates.first
+        end
+
+        print_status("Using session #{session.sid} (#{session.type})")
+
+        print_good("PASS: environment #{id} validated successfully against #{env_meta.definition}'s ci.validation.")
+      rescue => e
+        print_error("test_env validate failed: #{e.class} - #{e.message}")
+        elog("test_env validate error: #{e.class} - #{e.message}")
+        elog(e.backtrace.join("\n"))
+      end
+
+      def cmd_test_env_start(args)
+        if args.empty?
+          print_error("Usage: test_env start <ID>")
+          return
+        end
+
+        # start accepts single ID
+        id = args.first.to_i
+        target = self.class.registry.get(id)
+
+        unless target
+          print_error("Environment #{id} not found.")
+          return
+        end
+
+        unless target.stopped?
+          print_warning("Environment #{id} is already #{target.status}.")
+          return
+        end
+
+        runtime = self.class.runtime
+        unless runtime
+          print_error("No container runtime available.")
+          return
+        end
+
+        begin
+          unless runtime.start(target.container_id)
+            print_error("Failed to start container for environment #{id}.")
+            return
+          end
+
+          # Reconstruct health check configuration
+          mod = framework.modules.create(target.module_fullname) rescue nil
+          if mod
+            raw = mod.send(:module_info)['VulnerableEnvironment'] rescue nil
+            if raw
+              env_meta = VulnerableEnvironment.new(raw)
+              loader = EnvironmentDefinitionLoader.new(Msf::Config.data_directory)
+              config = loader.resolve(env_meta.definition, target.env_version,
+                                      env_meta.profile, env_meta.overrides) rescue nil
+
+              if config
+                # For environments that were provisioned during build, the
+                # service state after restart is post-provision (e.g. WordPress
+                # returns 200 at /, not 302 to the install wizard). Use verify
+                # instead of the base health_check to confirm the configured
+                # state is restored.
+                check_config = if config['provision'] && config['verify']
+                                 config['verify']
+                               else
+                                 config['health_check']
+                               end
+
+                if check_config
+                  primary_port = target.allocated_ports[env_meta.port_mapping.key('RPORT')]
+                  health_port = primary_port || target.allocated_ports.values.first
+
+                  begin
+                    HealthManager.new(runtime, target.container_id,
+                                    check_config, health_port, self).wait
+                  rescue => e
+                    print_warning("Health check warning after start: #{e.message}")
+                    # Container started; we still mark running but warn user
+
+                  end
+                end
+              end
+            end
+          end
+
+          self.class.registry.update_status(id, :running)
+          print_good("Environment #{id} started. RPORT=#{target.rport}")
+        rescue => e
+          print_error("Error starting environment #{id}: #{e.message}")
+        end
+      end
+
+      def cmd_test_env_stop(args)
+        if args.empty?
+          print_error("Usage: test_env stop <ID range>")
+          return
+        end
+
+        ids = parse_id_range(args.first)
+        if ids.empty?
+          print_error("No valid IDs provided.")
+          return
+        end
+
+        runtime = self.class.runtime
+        unless runtime
+          print_error("No container runtime available.")
+          return
+        end
+
+        ids.each do |id|
+          target = self.class.registry.get(id)
+          unless target
+            print_error("Environment #{id} not found.")
+            next
+          end
+
+          unless target.running?
+            print_warning("Environment #{id} is already #{target.status}.")
+            next
+          end
+
+          begin
+            if runtime.stop(target.container_id)
+              self.class.registry.update_status(id, :stopped)
+              print_good("Environment #{id} stopped.")
+            else
+              print_error("Failed to stop container for environment #{id}.")
+            end
+          rescue => e
+            print_error("Error stopping environment #{id}: #{e.message}")
+          end
+        end
+      end
+
+      def cmd_test_env_remove(args)
+        if args.empty?
+          print_error("Usage: test_env remove <ID range>")
+          return
+        end
+
+        ids = parse_id_range(args.first)
+        if ids.empty?
+          print_error("No valid IDs provided.")
+          return
+        end
+
+        runtime = self.class.runtime
+        unless runtime
+          print_error("No container runtime available.")
+          return
+        end
+
+        # Resolve all targets FIRST before any mutation
+        targets = ids.map { |id| [id, self.class.registry.get(id)] }.to_h
+
+        # Validate all exist before attempting any removal
+        missing = targets.select { |_id, t| t.nil? }.keys
+        missing.each { |id| print_error("Environment #{id} not found.") }
+
+        valid_ids = targets.reject { |_id, t| t.nil? }.keys
+
+        valid_ids.each do |id|
+          target = targets[id]
+
+          begin
+            runtime.stop(target.container_id) if target.running?
+          rescue => e
+            print_warning("Stop warning for #{id}: #{e.message}")
+          end
+
+          begin
+            runtime.remove(target.container_id)
+          rescue => e
+            print_error("Failed to remove container for environment #{id}: #{e.message}")
+            next  # DO NOT purge registry if runtime removal failed
+          end
+
+          self.class.registry.remove(id)
+          print_good("Environment #{id} removed.")
+        end
+      end
+
+      def cmd_test_env_remove_all(_args = [])
+        runtime = self.class.runtime
+        unless runtime
+          print_error("No container runtime available.")
+          return
+        end
+
+        targets = self.class.registry.list
+        if targets.empty?
+          print_status("No environments to remove.")
+          return
+        end
+
+        print_status("Tearing down #{targets.length} environment(s)...")
+
+        targets.each do |target|
+          begin
+            runtime.stop(target.container_id) if target.running?
+          rescue => e
+            print_warning("Stop warning for #{target.local_id}: #{e.message}")
+          end
+
+          begin
+            runtime.remove(target.container_id)
+          rescue => e
+            print_warning("Remove warning for #{target.local_id}: #{e.message}")
+          end
+        end
+
+        # Atomic registry reset
+        self.class.registry.remove_all
+        print_good("All environments removed.")
+      end
+    
+      def cmd_test_env_modules(args)
+        print_status("Scanning framework modules for test_env support...")
+
+        matches = []
+        scanned = 0
+
+        framework.modules.each do |name, modclass|
+          scanned += 1
+          instance = nil
+
+          begin
+            instance = framework.modules.create(name)
+          rescue => e
+            next
+          end
+
+          next unless instance
+
+          begin
+            raw = instance.send(:module_info)['VulnerableEnvironment']
+            next unless raw
+
+            env = VulnerableEnvironment.new(raw)
+
+            loader = EnvironmentDefinitionLoader.new(Msf::Config.data_directory)
+            begin
+              config = loader.resolve(env.definition, env.default_variant, env.profile, env.overrides)
+              image = config['image'] || 'unknown'
+            rescue => e
+              image = "definition error"
+            end
+
+            ports = env.port_mapping.map { |cp, ds| "#{cp}→#{ds}" }.join(', ')
+
+            matches << {
+              fullname: name,
+              definition: env.definition,
+              variant: env.default_variant,
+              profile: env.profile,
+              ports: ports,
+              image: image
+            }
+          rescue => e
+            next
+          end
+        end
+
+        if matches.empty?
+          print_status("No modules with test_env support found.")
+          print_status("Scanned #{scanned} module(s).")
+          return
+        end
+
+        tbl = Rex::Text::Table.new(
+          'Header' => 'Modules with test_env Support',
+          'Columns' => ['Module', 'Definition', 'Variant', 'Profile', 'Ports', 'Image']
+        )
+
+        matches.sort_by { |m| m[:fullname] }.each do |m|
+          tbl << [m[:fullname], m[:definition], m[:variant], m[:profile], m[:ports], m[:image]]
+        end
+
+        print_line(tbl.to_s)
+
+        print_status("Found #{matches.length} module(s) with test_env support (scanned #{scanned} total).")
+      end
+      
+      def cmd_test_env_tabs(str, words)
+        if words.length == 1
+          return %w[build list modules stop start remove remove-all exec validate status help]
+        end
+
+        if words.length == 2 && words[0] == 'build'
+          return %w[VARIANT= PROFILE= RPORT=]
+        end
+
+        if words.length == 2
+          case words[0]
+          when 'stop', 'start', 'remove', 'exec', 'validate'
+            return self.class.registry.list.map(&:local_id).map(&:to_s)
+          end
+        end
+
+        []
+      end
+
+      private
+
+      # Reads and validates VulnerableEnvironment metadata from the active module.
+      # Mirrors the framework pattern used by #name, #description, #notes, etc.
+      # Returns a VulnerableEnvironment Struct, or nil if the module has none.
+      def vulnerable_environment(mod)
+        return nil unless mod
+
+        raw = mod.send(:module_info)['VulnerableEnvironment']
+        return nil unless raw
+
+        VulnerableEnvironment.new(raw)
+      rescue ArgumentError => e
+        print_error("Module has invalid VulnerableEnvironment: #{e.message}")
+        nil
+      end
+
+      # Parse build arguments. Only accepts known keys.
+      def parse_build_args(args)
+        options = {}
+        args.each do |arg|
+          if arg.include?('=')
+            key, value = arg.split('=', 2)
+            key = key.upcase
+            if %w[VARIANT PROFILE RPORT].include?(key)
+              options[key] = value
+            else
+              print_warning("Unknown build option: #{key}. Expected: VARIANT=, PROFILE=, RPORT=")
+            end
+          end
+        end
+        options
+      end
+
+      # Parses "1", "1-3", "1,3,5", "1-3,5,7-9" into [1, 2, 3, 5, 7, 8, 9]
+      def parse_id_range(range_str)
+        return [] if range_str.nil? || range_str.empty?
+
+        ids = []
+        range_str.split(',').each do |part|
+          part.strip!
+          if part.include?('-')
+            start_id, end_id = part.split('-', 2).map(&:to_i)
+            ids.concat((start_id..end_id).to_a)
+          else
+            ids << part.to_i
+          end
+        end
+        ids.uniq.sort
+      rescue => e
+        print_error("Invalid ID range format: #{range_str}")
+        []
+      end
+    end
+
+    # =====================================================================
+    # Plugin Lifecycle
+    # =====================================================================
+    def initialize(framework, opts = nil)
+      super(framework, opts)
+      # Prefer framework.datastore (from 'set TEST_ENV_RUNTIME ...') over ENV
+      @runtime = RuntimeAdapter.detect(framework.datastore)
+      @registry = BuiltEnvironmentRegistry.new(framework)
+
+      ConsoleCommandDispatcher.runtime = @runtime
+      ConsoleCommandDispatcher.registry = @registry
+
+      if @runtime
+        print_status("TestEnv plugin loaded. Runtime: #{@runtime.name}")
+        if @runtime.respond_to?(:verify_rootless)
+          ok, msg = @runtime.verify_rootless
+          ok ? print_status(msg) : print_warning(msg)
+        end
+      else
+        print_error("TestEnv plugin loaded, but no container runtime found.")
+        print_error("Install Docker or Podman to use test_env.")
+      end
+
+      if @runtime
+        before = @registry.list.length
+        @registry.reconstruct_state(@runtime)
+        added = @registry.list.length - before
+        print_status("Reconstructed #{added} environment(s) from running containers.") if added > 0
+      end
+
+      add_console_dispatcher(ConsoleCommandDispatcher)
+    end
+
+    def preserve_on_exit?
+      val = framework.datastore['TEST_ENV_PRESERVE'] || ENV['TEST_ENV_PRESERVE']
+      return false if val.nil?
+      val.to_s.downcase == 'true' || val.to_s == '1'
+    end
+
+    def cleanup
+      if preserve_on_exit?
+        print_status("TEST_ENV_PRESERVE is set. Leaving containers running.")
+        print_status("Run 'test_env remove-all' manually when done.")
+      else
+        print_status("Auto-cleaning test_env environments...")
+        registry = ConsoleCommandDispatcher.registry
+        runtime = ConsoleCommandDispatcher.runtime
+
+        if registry && runtime
+          registry.list.each do |env|
+            begin
+              runtime.stop(env.container_id) if env.running?
+              runtime.remove(env.container_id)
+              registry.update_status(env.local_id, :removed)
+            rescue => e
+              print_warning("Failed to clean up environment #{env.local_id}: #{e.message}")
+            end
+          end
+          registry.remove_all
+        end
+      end
+
+      remove_console_dispatcher('TestEnv')
+      ConsoleCommandDispatcher.runtime = nil
+      ConsoleCommandDispatcher.registry = nil
+    end
+
+    def name
+      'test_env'
+    end
+
+    def desc
+      'Automated vulnerable environment provisioning'
+    end
+  end
+end

--- a/scripts/ci_runner.sh
+++ b/scripts/ci_runner.sh
@@ -88,7 +88,7 @@ fi
 # ---------------------------------------------------------------------
 # Cleanup and report
 # ---------------------------------------------------------------------
-rm -f "$RC_FILE"
+rm "$RC_FILE"
 echo ">>> Full log preserved at: $LOG_FILE"
 echo ">>> CI Runner Finished"
 

--- a/scripts/ci_runner.sh
+++ b/scripts/ci_runner.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -euo pipefail
+
+# =====================================================================
+# CI Runner for test_env — bridges msfconsole resource scripts to
+# standard Unix exit codes for GitHub Actions / any CI system.
+# =====================================================================
+
+MODULE="${1:-}"
+VARIANT="${2:-}"
+PROFILE="${3:-default}"
+EXIT_CODE=1
+
+# ---------------------------------------------------------------------
+# Validate arguments
+# ---------------------------------------------------------------------
+if [[ -z "$MODULE" || -z "$VARIANT" ]]; then
+    echo "Usage: $0 <module_fullname> <variant> [profile]"
+    echo ""
+    echo "Examples:"
+    echo "  $0 exploit/multi/http/apache_activemq_jolokia_rce 5.18.6 default"
+    echo "  $0 exploit/multi/misc/apache_activemq_rce_cve_2023_46604 5.18.2 broker-only"
+    echo "  $0 exploit/unix/webapp/wp_admin_shell_upload latest default"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------
+# Validate environment
+# ---------------------------------------------------------------------
+if [[ ! -x "./msfconsole" ]]; then
+    echo "Error: ./msfconsole not found or not executable."
+    echo "Run this script from the metasploit-framework root directory."
+    exit 1
+fi
+
+
+# ---------------------------------------------------------------------
+# Generate unique temp files (supports parallel CI jobs)
+# ---------------------------------------------------------------------
+TIMESTAMP=$(date +%s)_$$
+RC_FILE="/tmp/test_env_${TIMESTAMP}.rc"
+LOG_FILE="/tmp/test_env_${TIMESTAMP}.log"
+
+# ---------------------------------------------------------------------
+# Build the Metasploit resource script dynamically
+# ---------------------------------------------------------------------
+cat > "$RC_FILE" <<EOF
+load test_env
+use ${MODULE}
+test_env build VARIANT=${VARIANT} PROFILE=${PROFILE}
+test_env exec 1 -z
+test_env validate 1
+test_env remove-all
+exit -y
+EOF
+
+echo ">>> CI Runner Started"
+echo ">>> Module:    $MODULE"
+echo ">>> Variant:   $VARIANT"
+echo ">>> Profile:   $PROFILE"
+echo ">>> RC Script: $RC_FILE"
+echo ">>> Log File:  $LOG_FILE"
+echo ""
+
+
+# ---------------------------------------------------------------------
+# Execute msfconsole headlessly
+# ---------------------------------------------------------------------
+echo ">>> Running msfconsole..."
+./msfconsole -q -n -r "$RC_FILE" | tee "$LOG_FILE"
+
+# ---------------------------------------------------------------------
+# Parse result from log (PASS / FAIL / unclear)
+# ---------------------------------------------------------------------
+echo ""
+if grep -q "FAIL:" "$LOG_FILE"; then
+    echo ">>> RESULT: VALIDATION FAILED"
+    EXIT_CODE=1
+elif grep -q "PASS:" "$LOG_FILE"; then
+    echo ">>> RESULT: VALIDATION PASSED"
+    EXIT_CODE=0
+else
+    echo ">>> RESULT: UNCLEAR — no PASS or FAIL found in output"
+    echo ">>> This usually means the exploit or health check failed early."
+    EXIT_CODE=1
+fi
+
+# ---------------------------------------------------------------------
+# Cleanup and report
+# ---------------------------------------------------------------------
+rm -f "$RC_FILE"
+echo ">>> Full log preserved at: $LOG_FILE"
+echo ">>> CI Runner Finished"
+
+exit "$EXIT_CODE"


### PR DESCRIPTION
Refering to https://github.com/rapid7/metasploit-framework/issues/20506

## Description

This PR introduces **`test_env`**, a new Metasploit plugin that automates the provisioning, management, and validation of vulnerable test environments for exploit and auxiliary modules.

### Development History

This PR bundles work that was reviewed incrementally over 12 weekly deliverable PRs on [my fork](https://github.com/Nayeraneru/metasploit-framework). If you'd like to see the progression of the work instead of one large diff, each week is linked below:

- [Week 1](https://github.com/Nayeraneru/metasploit-framework/pull/1) 
- [Week 2](https://github.com/Nayeraneru/metasploit-framework/pull/3)
- [Week 3](https://github.com/Nayeraneru/metasploit-framework/pull/4) 
- [Week 4](https://github.com/Nayeraneru/metasploit-framework/pull/5) 
- [Week 5](https://github.com/Nayeraneru/metasploit-framework/pull/6) 
- [Week 6](https://github.com/Nayeraneru/metasploit-framework/pull/7) 
- [Week 7](https://github.com/Nayeraneru/metasploit-framework/pull/8) 
- [Week 8](https://github.com/Nayeraneru/metasploit-framework/pull/9) 
- [Week 9](https://github.com/Nayeraneru/metasploit-framework/pull/10) 
- [Week 10](https://github.com/Nayeraneru/metasploit-framework/pull/11) 
- [Week 11](https://github.com/Nayeraneru/metasploit-framework/pull/12) 
- [Week 12](https://github.com/Nayeraneru/metasploit-framework/pull/15) 

### What it does
- **`test_env build`** — Reads a module's `VulnerableEnvironment` metadata, resolves a YAML environment definition, pulls the container image, dynamically allocates free host ports, launches the container bound to `127.0.0.1`, waits for health checks, runs one-time provisioning for images that boot unconfigured (e.g., automatically submitting the WordPress install wizard), and auto-configures the module's datastore (`RHOSTS`, `RPORT`, credentials, etc.).
- **`test_env exec <ID>`** — Loads the module an environment was built for, applies the stored datastore, automatically sets the recommended payload from the definition's `ci.exploit` metadata when the module's default is incompatible with the image, and runs the exploit.
- **`test_env validate <ID>`** — Verifies the exploit produced the expected result (session type, command output) against the definition's `ci.validation` metadata.
- **`test_env modules`** — Scans the framework and lists all modules that declare `VulnerableEnvironment` support.
- **`test_env list / stop / start / remove / remove-all`** — Lifecycle management of tracked environments.
- **`test_env status`** — Runtime diagnostics and definition validation.

### Architecture
- **Runtime abstraction layer** (`BaseRuntime` → `DockerRuntime` / `PodmanRuntime`) with auto-detection and rootless Podman validation.
- **YAML environment definitions** (`data/vuln_envs/*.yml`) that declare images, ports, credentials, health checks, provisioning steps, and CI metadata.
- **ActiveModel-backed YAML registry** (`~/.msf4/test_env_registry.yml`) with file locking for safe multi-process access, plus container label-based state reconstruction across `msfconsole` restarts.
- **`VulnerableEnvironment` metadata** — Modules declare their test environment via a new key in `update_info()`, following the same pattern as `Name`, `Description`, `Notes`, etc.
- **Comprehensive documentation** — Includes both User Documentation (`USER_Doc.md`) for interactive usage workflows and Developer Documentation (`DEVELOPER_Doc.md`) for authoring new environment definitions and module integrations.

### CI Integration
Integrates `test_env` into GitHub Actions, replacing static container definitions with environment-driven provisioning. The CI matrix consumes the same YAML definitions as local users, validating that shared definitions, health checks, datastore automation, and exploit execution work identically across local dev and CI.

### Files changed
- **Architecture design** (documented): `01-command-dispatcher`, `02-module-metadata`, `03-database-schema`, `04-environment-schema`, `05-runtime-adapter`
- **`plugins/test_env.rb`** — The plugin (runtime adapters, port allocator, health manager, provisioner, registry, command dispatcher).
- **`data/vuln_envs/activemq.yml`** — Apache ActiveMQ Classic (CVE-2026-34197) with Jolokia API.
- **`data/vuln_envs/wordpress.yml`** — Vulnerable WordPress with one-time install wizard provisioning.
- **`data/vuln_envs/httpd.yml`** — Apache HTTP Server for scanner testing.
- **`data/vuln_envs/openssh.yml`** — OpenSSH server for SSH scanner testing.
- **`modules/exploits/multi/http/apache_activemq_jolokia_rce.rb`, `modules/exploits/multi/misc/apache_activemq_rce_cve_2023_46604.rb`, `modules/exploits/unix/webapp/wp_admin_shell_upload.rb`, `auxiliary/scanner/http/http_version`, `auxiliary/scanner/http/http_header`, `auxiliary/scanner/http/robots_txt`, `auxiliary/scanner/ssh/ssh_version`,** — Added `VulnerableEnvironment` metadata as the reference module integration.
- **`.github/workflows/test_env.yml`** — GitHub Actions CI matrix validating all environment definitions.
- **`scripts/ci_runner.sh`** — Headless msfconsole runner for CI with Unix exit-code bridging.
- **`DEVELOPER_Doc.md`** — Complete schema reference, three-level merge hierarchy, and authoring guide for environment definitions.
- **`USER_Doc.md`** — Interactive usage guide, command reference, troubleshooting, and workflow examples for end users.

### Why
Manually building and configuring Docker containers for every exploit test is repetitive, error-prone, and a barrier to reproducible security research. This plugin makes it one command, enables multi-version testing, aligns module definitions with CI validation expectations, and ensures local development and CI share the same environment definitions.

## Breaking Changes

None. This is a self-contained plugin. No existing APIs, mixins, or datastore options are modified. Modules opt-in by adding `VulnerableEnvironment` to their `update_info()` metadata

## Verification Steps

1. - [ ] Ensure Docker or Podman is installed and running.
2. - [ ] Start `msfconsole` and load the plugin:
     ```
     msf > load test_env
     ```
     **Expected:** `TestEnv plugin loaded. Runtime: docker` (or `podman`).
3. - [ ] Check runtime status and definition validation:
     ```
     msf > test_env status
     ```
     **Expected:** Lists available definitions (`activemq`, `httpd`, `openssh`, `wordpress`) with no validation errors.
4. - [ ] Discover modules with test_env support:
     ```
     msf > test_env modules
     ```
     **Expected:** Lists supported modules including `exploit/multi/http/apache_activemq_jolokia_rce`, `exploit/unix/webapp/wp_admin_shell_upload`, and auxiliary scanners.
5. - [ ] Select the reference module and build its environment:
     ```
     msf > use exploit/multi/http/apache_activemq_jolokia_rce
     msf exploit(...) > test_env build
     ```
     **Expected:** Image is pulled, container starts, health check passes, and the command prints:
     ```
     [+] Environment ready.
     [*] Environment ID: 1
        RHOSTS       => 127.0.0.1
        RPORT        => <dynamic_port>
        TARGETURI    => /
        USERNAME     => admin
        PASSWORD     => admin
     ```
6. - [ ] List tracked environments:
     ```
     msf > test_env list
     ```
     **Expected:** Table shows environment `1` with status `running`.
7. - [ ] Execute the exploit against the built environment:
     ```
     msf > test_env exec 1
     ```
     **Expected:** Module loads automatically, the recommended payload (`cmd/linux/http/x64/meterpreter/reverse_tcp`) is applied from the environment definition because the module's default is incompatible with this image, and the exploit runs with the stored datastore. A Meterpreter session opens (if `LHOST` is reachable).
8. - [ ] Validate the exploit result:
     ```
     msf > test_env validate 1
     ```
     **Expected:** `PASS: environment 1 validated successfully against activemq's ci.validation.`
9. - [ ] Stop, start, and remove the environment:
     ```
     msf > test_env stop 1
     msf > test_env start 1
     msf > test_env remove 1
     ```
     **Expected:** Each command reports success. `test_env list` shows no environments after removal.
10. - [ ] Test `remove-all` cleanup:
     ```
     msf > test_env build
     msf > test_env remove-all
     ```
     **Expected:** All containers stopped/removed, registry reset.

